### PR TITLE
[V26-1153]: Compact long Opening Review lists

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 11385 nodes · 13960 edges · 2675 communities detected
+- 11381 nodes · 13955 edges · 2675 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2805,36 +2805,36 @@ Cohesion: 0.07
 Nodes (14): addConflictLink(), arrayDetail(), buildActivityReadModelPage(), buildActivitySummary(), buildContinueCursor(), buildEventSummary(), buildRegisterSessionActivityPage(), countLabel() (+6 more)
 
 ### Community 23 - "Community 23"
-Cohesion: 0.07
-Nodes (19): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatOperationalWorkTypeLabel(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue() (+11 more)
-
-### Community 24 - "Community 24"
 Cohesion: 0.13
 Nodes (34): addDays(), addField(), contextWindowsForDate(), dayOfWeek(), exceptionWindowsOverlap(), findNextWindow(), getFormatter(), getMissingStoreScheduleContext() (+26 more)
 
-### Community 25 - "Community 25"
+### Community 24 - "Community 24"
 Cohesion: 0.07
 Nodes (18): applyTodayRefreshSnapshot(), buildDailyCloseSearch(), DailyOperationsConnectedRuntimeView(), formatOnlineOrderTimelineFallbackMessage(), formatPendingApprovalsLabel(), formatTimelineMessage(), getDailyOperationsApi(), getPendingApprovalsCountLabel() (+10 more)
 
-### Community 26 - "Community 26"
+### Community 25 - "Community 25"
 Cohesion: 0.08
 Nodes (22): cleanInventoryMetadataValue(), formatInventoryItemPriceLabel(), formatInventoryNumber(), formatReservationSourceSummary(), getCountScopeLabel(), getInventoryItemDisplayName(), getInventoryItemOperationalPrice(), getReservationLabels() (+14 more)
 
-### Community 27 - "Community 27"
+### Community 26 - "Community 26"
 Cohesion: 0.11
 Nodes (34): assertIdempotentReplayMatches(), assertProductSkuBelongsToStore(), assertSkuActivityArgs(), boundedNumber(), buildActiveReservationEntries(), buildAvailabilityWarnings(), buildInventoryImportEvidenceSource(), buildPendingCheckoutEvidenceSource() (+26 more)
 
-### Community 28 - "Community 28"
+### Community 27 - "Community 27"
 Cohesion: 0.14
 Nodes (35): asRecord(), calculateLocalSaleExpectedCashDelta(), canUploadedRegisterOpenReplaceBlockedDrawer(), cartItemSourceKey(), createMappingIndex(), errorFor(), errorMessage(), getCompletedSale() (+27 more)
 
-### Community 29 - "Community 29"
+### Community 28 - "Community 28"
 Cohesion: 0.1
 Nodes (24): addLocalAvailabilityConsumption(), addLocalAvailabilityDeltaConsumption(), buildCatalogRepresentedPendingCheckoutProductSignatures(), buildLocalAvailabilityEventIndex(), buildLocalPendingCheckoutDefinitionEventIdsByItemId(), cartItemLineEventKey(), cartItemLineKey(), cartItemsFromLocalRegisterModel() (+16 more)
 
-### Community 30 - "Community 30"
+### Community 29 - "Community 29"
 Cohesion: 0.1
 Nodes (31): applyStockAdjustmentBatchWithCtx(), assertDistinctStockAdjustmentLineItems(), buildInventorySnapshotRowsForProductSkusWithCtx(), buildResolvedStockAdjustmentStatus(), buildStockAdjustmentDecisionEventType(), buildStockAdjustmentOperationalEventMessage(), buildStockAdjustmentSourceId(), buildStockAdjustmentTitle() (+23 more)
+
+### Community 30 - "Community 30"
+Cohesion: 0.08
+Nodes (17): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatOperationalWorkTypeLabel(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue() (+9 more)
 
 ### Community 31 - "Community 31"
 Cohesion: 0.12
@@ -3618,47 +3618,47 @@ Nodes (2): isValidEmail(), validateCustomerInfo()
 
 ### Community 226 - "Community 226"
 Cohesion: 0.33
-Nodes (8): landingFunnelHourlyLimit(), parseBoundedPositiveInteger(), resolveWalkthroughAllowedOrigins(), walkthroughAllowedOrigins(), walkthroughDailyPerEmailLimit(), walkthroughHourlyGlobalLimit(), walkthroughHourlyNotificationLimit(), walkthroughMaxBodyBytes()
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 227 - "Community 227"
+Cohesion: 0.33
+Nodes (8): landingFunnelHourlyLimit(), parseBoundedPositiveInteger(), resolveWalkthroughAllowedOrigins(), walkthroughAllowedOrigins(), walkthroughDailyPerEmailLimit(), walkthroughHourlyGlobalLimit(), walkthroughHourlyNotificationLimit(), walkthroughMaxBodyBytes()
+
+### Community 228 - "Community 228"
 Cohesion: 0.36
 Nodes (8): costOverlayStoreWriteOperation(), cycleCountDraftStoreWriteOperation(), defineOperation(), inventoryImportReviewPayloadWriteOperation(), notificationSubscriptionRowWriteOperation(), orderStoreWriteOperation(), storeWriteOperation(), transactionStoreWriteOperation()
 
-### Community 228 - "Community 228"
+### Community 229 - "Community 229"
 Cohesion: 0.29
 Nodes (7): adjustmentSalesDelta(), adjustmentSettlementAmount(), buildAdjustmentPaymentTotals(), buildAdjustmentReportTotals(), listAppliedTransactionAdjustmentsForDay(), readAppliedTransactionAdjustmentsForDay(), sourceCompletenessEntry()
 
-### Community 229 - "Community 229"
+### Community 230 - "Community 230"
 Cohesion: 0.38
 Nodes (7): assertNoBusinessEventConflict(), buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
-### Community 230 - "Community 230"
+### Community 231 - "Community 231"
 Cohesion: 0.33
 Nodes (8): buildOperationalEvent(), buildTraceMetadata(), isRecord(), matchesExistingEvent(), metadataDedupeKeysMatch(), normalizeOperationalEventTraceFields(), recordOperationalEventWithCtx(), shouldNormalizePosTrace()
 
-### Community 231 - "Community 231"
+### Community 232 - "Community 232"
 Cohesion: 0.58
 Nodes (9): amendRepairWithCtx(), createRepairWithCtx(), pauseRepair(), processRepairBatchWithCtx(), readCurrentGroup(), recordRepairAuditEvent(), requireEvidence(), resumeRepairWithCtx() (+1 more)
 
-### Community 232 - "Community 232"
+### Community 233 - "Community 233"
 Cohesion: 0.38
 Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
-### Community 233 - "Community 233"
+### Community 234 - "Community 234"
 Cohesion: 0.33
 Nodes (8): classifyFinalizedLineageRepairConflicts(), classifyRepairCandidate(), countRepairableFinalizedLineageLines(), getProvisionalImportSku(), isClosedRegisterRepairReplayConflict(), isFinalizedLineageRepairConflict(), isProvisionalRowChangedConflict(), skipped()
 
-### Community 234 - "Community 234"
+### Community 235 - "Community 235"
 Cohesion: 0.27
 Nodes (5): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository(), dedupeRecoveryConflictsById(), listTerminalRecoveryConflictsForRepair(), listTerminalRecoveryConflictSources()
 
-### Community 235 - "Community 235"
+### Community 236 - "Community 236"
 Cohesion: 0.36
 Nodes (9): aggregateSkuDays(), computeRange(), computeRequestKey(), inclusiveDaySpan(), isValidOperatingDate(), requestRangeCore(), sumDays(), utcMillisForLabel() (+1 more)
-
-### Community 236 - "Community 236"
-Cohesion: 0.33
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 237 - "Community 237"
 Cohesion: 0.31
@@ -3849,20 +3849,20 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 284 - "Community 284"
-Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
-
-### Community 285 - "Community 285"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 286 - "Community 286"
+### Community 285 - "Community 285"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 287 - "Community 287"
+### Community 286 - "Community 286"
 Cohesion: 0.22
 Nodes (0):
+
+### Community 287 - "Community 287"
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
 ### Community 288 - "Community 288"
 Cohesion: 0.39
@@ -5289,40 +5289,40 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 644 - "Community 644"
-Cohesion: 0.83
-Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
+Cohesion: 0.5
+Nodes (1): buildCtx()
 
 ### Community 645 - "Community 645"
 Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
+Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
 ### Community 646 - "Community 646"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 647 - "Community 647"
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+
+### Community 648 - "Community 648"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 648 - "Community 648"
+### Community 649 - "Community 649"
 Cohesion: 0.67
 Nodes (2): buildActivity(), buildReport()
 
-### Community 649 - "Community 649"
+### Community 650 - "Community 650"
 Cohesion: 0.83
 Nodes (3): advanceRegisterCatalogRevision(), readRegisterCatalogRevision(), readRegisterCatalogRevisionRow()
 
-### Community 650 - "Community 650"
+### Community 651 - "Community 651"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 651 - "Community 651"
-Cohesion: 0.83
-Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 652 - "Community 652"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 653 - "Community 653"
 Cohesion: 0.5
@@ -5334,7 +5334,7 @@ Nodes (0):
 
 ### Community 655 - "Community 655"
 Cohesion: 0.5
-Nodes (1): buildCtx()
+Nodes (0):
 
 ### Community 656 - "Community 656"
 Cohesion: 0.5

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -12604,18 +12604,6 @@
       "weight": 1
     },
     {
-      "_src": "dailyopeningview_getvisiblebucketconfigs",
-      "_tgt": "dailyopeningview_getbucketconfigs",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "calls",
-      "source": "dailyopeningview_getbucketconfigs",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L1021",
-      "target": "dailyopeningview_getvisiblebucketconfigs",
-      "weight": 1
-    },
-    {
       "_src": "dailyopeningview_isoperatorfacingopeningmetadata",
       "_tgt": "dailyopeningview_normalizemetadatalabel",
       "confidence": "EXTRACTED",
@@ -86831,7 +86819,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L1513",
+      "source_location": "L1523",
       "target": "dailyopeningview_cn",
       "weight": 1
     },
@@ -86953,18 +86941,6 @@
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
       "source_location": "L490",
       "target": "dailyopeningview_getarraymetadatastringvalue",
-      "weight": 1
-    },
-    {
-      "_src": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
-      "_tgt": "dailyopeningview_getbucketconfigs",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "contains",
-      "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L974",
-      "target": "dailyopeningview_getbucketconfigs",
       "weight": 1
     },
     {
@@ -87113,18 +87089,6 @@
     },
     {
       "_src": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
-      "_tgt": "dailyopeningview_getselectedbucketvalue",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "contains",
-      "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L1028",
-      "target": "dailyopeningview_getselectedbucketvalue",
-      "weight": 1
-    },
-    {
-      "_src": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
       "_tgt": "dailyopeningview_getstatussignatureclassname",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
@@ -87149,18 +87113,6 @@
     },
     {
       "_src": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
-      "_tgt": "dailyopeningview_getvisiblebucketconfigs",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "contains",
-      "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L1017",
-      "target": "dailyopeningview_getvisiblebucketconfigs",
-      "weight": 1
-    },
-    {
-      "_src": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
       "_tgt": "dailyopeningview_getvisibleopeningautomationstatus",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
@@ -87179,7 +87131,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L1212",
+      "source_location": "L1222",
       "target": "dailyopeningview_handlepagechange",
       "weight": 1
     },
@@ -87205,18 +87157,6 @@
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
       "source_location": "L560",
       "target": "dailyopeningview_isoperatorfacingopeningmetadata",
-      "weight": 1
-    },
-    {
-      "_src": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
-      "_tgt": "dailyopeningview_normalizebucketpage",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "contains",
-      "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L963",
-      "target": "dailyopeningview_normalizebucketpage",
       "weight": 1
     },
     {
@@ -87275,7 +87215,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L1424",
+      "source_location": "L1434",
       "target": "dailyopeningview_toggleallacknowledgements",
       "weight": 1
     },
@@ -208398,92 +208338,92 @@
     {
       "community": 226,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_marketing_walkthroughconfig_ts",
-      "label": "walkthroughConfig.ts",
-      "norm_label": "walkthroughconfig.ts",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "id": "index_resolveverificationcoderecipient",
+      "label": "resolveVerificationCodeRecipient()",
+      "norm_label": "resolveverificationcoderecipient()",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 226,
+      "file_type": "code",
+      "id": "index_senddailymanagerreportemail",
+      "label": "sendDailyManagerReportEmail()",
+      "norm_label": "senddailymanagerreportemail()",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "source_location": "L373"
+    },
+    {
+      "community": 226,
+      "file_type": "code",
+      "id": "index_senddiscountcodeemail",
+      "label": "sendDiscountCodeEmail()",
+      "norm_label": "senddiscountcodeemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L255"
+    },
+    {
+      "community": 226,
+      "file_type": "code",
+      "id": "index_senddiscountreminderemail",
+      "label": "sendDiscountReminderEmail()",
+      "norm_label": "senddiscountreminderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L334"
+    },
+    {
+      "community": 226,
+      "file_type": "code",
+      "id": "index_sendfeedbackrequestemail",
+      "label": "sendFeedbackRequestEmail()",
+      "norm_label": "sendfeedbackrequestemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 226,
+      "file_type": "code",
+      "id": "index_sendneworderemail",
+      "label": "sendNewOrderEmail()",
+      "norm_label": "sendneworderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L117"
+    },
+    {
+      "community": 226,
+      "file_type": "code",
+      "id": "index_sendorderemail",
+      "label": "sendOrderEmail()",
+      "norm_label": "sendorderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 226,
+      "file_type": "code",
+      "id": "index_sendverificationcode",
+      "label": "sendVerificationCode()",
+      "norm_label": "sendverificationcode()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 226,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
       "source_location": "L1"
     },
     {
       "community": 226,
       "file_type": "code",
-      "id": "walkthroughconfig_landingfunnelhourlylimit",
-      "label": "landingFunnelHourlyLimit()",
-      "norm_label": "landingfunnelhourlylimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 226,
-      "file_type": "code",
-      "id": "walkthroughconfig_parseboundedpositiveinteger",
-      "label": "parseBoundedPositiveInteger()",
-      "norm_label": "parseboundedpositiveinteger()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 226,
-      "file_type": "code",
-      "id": "walkthroughconfig_resolvewalkthroughallowedorigins",
-      "label": "resolveWalkthroughAllowedOrigins()",
-      "norm_label": "resolvewalkthroughallowedorigins()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 226,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughallowedorigins",
-      "label": "walkthroughAllowedOrigins()",
-      "norm_label": "walkthroughallowedorigins()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 226,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughdailyperemaillimit",
-      "label": "walkthroughDailyPerEmailLimit()",
-      "norm_label": "walkthroughdailyperemaillimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L55"
-    },
-    {
-      "community": 226,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughhourlygloballimit",
-      "label": "walkthroughHourlyGlobalLimit()",
-      "norm_label": "walkthroughhourlygloballimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 226,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughhourlynotificationlimit",
-      "label": "walkthroughHourlyNotificationLimit()",
-      "norm_label": "walkthroughhourlynotificationlimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 226,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughmaxbodybytes",
-      "label": "walkthroughMaxBodyBytes()",
-      "norm_label": "walkthroughmaxbodybytes()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 226,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughprivacycontact",
-      "label": "walkthroughPrivacyContact()",
-      "norm_label": "walkthroughprivacycontact()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L95"
+      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L1"
     },
     {
       "community": 2260,
@@ -208578,92 +208518,92 @@
     {
       "community": 227,
       "file_type": "code",
-      "id": "definitions_costoverlaystorewriteoperation",
-      "label": "costOverlayStoreWriteOperation()",
-      "norm_label": "costoverlaystorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L486"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "definitions_cyclecountdraftstorewriteoperation",
-      "label": "cycleCountDraftStoreWriteOperation()",
-      "norm_label": "cyclecountdraftstorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L375"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "definitions_defineoperation",
-      "label": "defineOperation()",
-      "norm_label": "defineoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "definitions_inventoryimportreviewpayloadwriteoperation",
-      "label": "inventoryImportReviewPayloadWriteOperation()",
-      "norm_label": "inventoryimportreviewpayloadwriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L461"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "definitions_notificationsubscriptionrowwriteoperation",
-      "label": "notificationSubscriptionRowWriteOperation()",
-      "norm_label": "notificationsubscriptionrowwriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L546"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "definitions_orderstorewriteoperation",
-      "label": "orderStoreWriteOperation()",
-      "norm_label": "orderstorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L155"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "definitions_storewriteoperation",
-      "label": "storeWriteOperation()",
-      "norm_label": "storewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L108"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "definitions_transactionstorewriteoperation",
-      "label": "transactionStoreWriteOperation()",
-      "norm_label": "transactionstorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "definitions_validateoperationdefinition",
-      "label": "validateOperationDefinition()",
-      "norm_label": "validateoperationdefinition()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L635"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operationadmission_definitions_ts",
-      "label": "definitions.ts",
-      "norm_label": "definitions.ts",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "id": "packages_athena_webapp_convex_marketing_walkthroughconfig_ts",
+      "label": "walkthroughConfig.ts",
+      "norm_label": "walkthroughconfig.ts",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 227,
+      "file_type": "code",
+      "id": "walkthroughconfig_landingfunnelhourlylimit",
+      "label": "landingFunnelHourlyLimit()",
+      "norm_label": "landingfunnelhourlylimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 227,
+      "file_type": "code",
+      "id": "walkthroughconfig_parseboundedpositiveinteger",
+      "label": "parseBoundedPositiveInteger()",
+      "norm_label": "parseboundedpositiveinteger()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 227,
+      "file_type": "code",
+      "id": "walkthroughconfig_resolvewalkthroughallowedorigins",
+      "label": "resolveWalkthroughAllowedOrigins()",
+      "norm_label": "resolvewalkthroughallowedorigins()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 227,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughallowedorigins",
+      "label": "walkthroughAllowedOrigins()",
+      "norm_label": "walkthroughallowedorigins()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 227,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughdailyperemaillimit",
+      "label": "walkthroughDailyPerEmailLimit()",
+      "norm_label": "walkthroughdailyperemaillimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 227,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughhourlygloballimit",
+      "label": "walkthroughHourlyGlobalLimit()",
+      "norm_label": "walkthroughhourlygloballimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 227,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughhourlynotificationlimit",
+      "label": "walkthroughHourlyNotificationLimit()",
+      "norm_label": "walkthroughhourlynotificationlimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 227,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughmaxbodybytes",
+      "label": "walkthroughMaxBodyBytes()",
+      "norm_label": "walkthroughmaxbodybytes()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 227,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughprivacycontact",
+      "label": "walkthroughPrivacyContact()",
+      "norm_label": "walkthroughprivacycontact()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L95"
     },
     {
       "community": 2270,
@@ -208758,91 +208698,91 @@
     {
       "community": 228,
       "file_type": "code",
-      "id": "adjustmentreports_adjustmentappliedat",
-      "label": "adjustmentAppliedAt()",
-      "norm_label": "adjustmentappliedat()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L101"
+      "id": "definitions_costoverlaystorewriteoperation",
+      "label": "costOverlayStoreWriteOperation()",
+      "norm_label": "costoverlaystorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L486"
     },
     {
       "community": 228,
       "file_type": "code",
-      "id": "adjustmentreports_adjustmentsalesdelta",
-      "label": "adjustmentSalesDelta()",
-      "norm_label": "adjustmentsalesdelta()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L116"
+      "id": "definitions_cyclecountdraftstorewriteoperation",
+      "label": "cycleCountDraftStoreWriteOperation()",
+      "norm_label": "cyclecountdraftstorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L375"
     },
     {
       "community": 228,
       "file_type": "code",
-      "id": "adjustmentreports_adjustmentsettlementamount",
-      "label": "adjustmentSettlementAmount()",
-      "norm_label": "adjustmentsettlementamount()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L143"
+      "id": "definitions_defineoperation",
+      "label": "defineOperation()",
+      "norm_label": "defineoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L11"
     },
     {
       "community": 228,
       "file_type": "code",
-      "id": "adjustmentreports_adjustmenttransactionid",
-      "label": "adjustmentTransactionId()",
-      "norm_label": "adjustmenttransactionid()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L110"
+      "id": "definitions_inventoryimportreviewpayloadwriteoperation",
+      "label": "inventoryImportReviewPayloadWriteOperation()",
+      "norm_label": "inventoryimportreviewpayloadwriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L461"
     },
     {
       "community": 228,
       "file_type": "code",
-      "id": "adjustmentreports_buildadjustmentpaymenttotals",
-      "label": "buildAdjustmentPaymentTotals()",
-      "norm_label": "buildadjustmentpaymenttotals()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L242"
+      "id": "definitions_notificationsubscriptionrowwriteoperation",
+      "label": "notificationSubscriptionRowWriteOperation()",
+      "norm_label": "notificationsubscriptionrowwriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L546"
     },
     {
       "community": 228,
       "file_type": "code",
-      "id": "adjustmentreports_buildadjustmentreporttotals",
-      "label": "buildAdjustmentReportTotals()",
-      "norm_label": "buildadjustmentreporttotals()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L275"
+      "id": "definitions_orderstorewriteoperation",
+      "label": "orderStoreWriteOperation()",
+      "norm_label": "orderstorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L155"
     },
     {
       "community": 228,
       "file_type": "code",
-      "id": "adjustmentreports_listappliedtransactionadjustmentsforday",
-      "label": "listAppliedTransactionAdjustmentsForDay()",
-      "norm_label": "listappliedtransactionadjustmentsforday()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L229"
+      "id": "definitions_storewriteoperation",
+      "label": "storeWriteOperation()",
+      "norm_label": "storewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L108"
     },
     {
       "community": 228,
       "file_type": "code",
-      "id": "adjustmentreports_readappliedtransactionadjustmentsforday",
-      "label": "readAppliedTransactionAdjustmentsForDay()",
-      "norm_label": "readappliedtransactionadjustmentsforday()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L173"
+      "id": "definitions_transactionstorewriteoperation",
+      "label": "transactionStoreWriteOperation()",
+      "norm_label": "transactionstorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L128"
     },
     {
       "community": 228,
       "file_type": "code",
-      "id": "adjustmentreports_sourcecompletenessentry",
-      "label": "sourceCompletenessEntry()",
-      "norm_label": "sourcecompletenessentry()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L76"
+      "id": "definitions_validateoperationdefinition",
+      "label": "validateOperationDefinition()",
+      "norm_label": "validateoperationdefinition()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L635"
     },
     {
       "community": 228,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_dailyclose_adjustmentreports_ts",
-      "label": "adjustmentReports.ts",
-      "norm_label": "adjustmentreports.ts",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "id": "packages_athena_webapp_convex_operationadmission_definitions_ts",
+      "label": "definitions.ts",
+      "norm_label": "definitions.ts",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
       "source_location": "L1"
     },
     {
@@ -208938,91 +208878,91 @@
     {
       "community": 229,
       "file_type": "code",
-      "id": "inventorymovements_assertnobusinesseventconflict",
-      "label": "assertNoBusinessEventConflict()",
-      "norm_label": "assertnobusinesseventconflict()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L178"
+      "id": "adjustmentreports_adjustmentappliedat",
+      "label": "adjustmentAppliedAt()",
+      "norm_label": "adjustmentappliedat()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L101"
     },
     {
       "community": 229,
       "file_type": "code",
-      "id": "inventorymovements_buildinventorymovement",
-      "label": "buildInventoryMovement()",
-      "norm_label": "buildinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L124"
+      "id": "adjustmentreports_adjustmentsalesdelta",
+      "label": "adjustmentSalesDelta()",
+      "norm_label": "adjustmentsalesdelta()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L116"
     },
     {
       "community": 229,
       "file_type": "code",
-      "id": "inventorymovements_buildskuactivityforinventorymovement",
-      "label": "buildSkuActivityForInventoryMovement()",
-      "norm_label": "buildskuactivityforinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L66"
+      "id": "adjustmentreports_adjustmentsettlementamount",
+      "label": "adjustmentSettlementAmount()",
+      "norm_label": "adjustmentsettlementamount()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L143"
     },
     {
       "community": 229,
       "file_type": "code",
-      "id": "inventorymovements_getskuactivitytypeformovement",
-      "label": "getSkuActivityTypeForMovement()",
-      "norm_label": "getskuactivitytypeformovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L49"
+      "id": "adjustmentreports_adjustmenttransactionid",
+      "label": "adjustmentTransactionId()",
+      "norm_label": "adjustmenttransactionid()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L110"
     },
     {
       "community": 229,
       "file_type": "code",
-      "id": "inventorymovements_matchesexistingmovement",
-      "label": "matchesExistingMovement()",
-      "norm_label": "matchesexistingmovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L150"
+      "id": "adjustmentreports_buildadjustmentpaymenttotals",
+      "label": "buildAdjustmentPaymentTotals()",
+      "norm_label": "buildadjustmentpaymenttotals()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L242"
     },
     {
       "community": 229,
       "file_type": "code",
-      "id": "inventorymovements_recordinventorymovementwithctx",
-      "label": "recordInventoryMovementWithCtx()",
-      "norm_label": "recordinventorymovementwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L200"
+      "id": "adjustmentreports_buildadjustmentreporttotals",
+      "label": "buildAdjustmentReportTotals()",
+      "norm_label": "buildadjustmentreporttotals()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L275"
     },
     {
       "community": 229,
       "file_type": "code",
-      "id": "inventorymovements_recordinventorymovementwithdispositionwithctx",
-      "label": "recordInventoryMovementWithDispositionWithCtx()",
-      "norm_label": "recordinventorymovementwithdispositionwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L245"
+      "id": "adjustmentreports_listappliedtransactionadjustmentsforday",
+      "label": "listAppliedTransactionAdjustmentsForDay()",
+      "norm_label": "listappliedtransactionadjustmentsforday()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L229"
     },
     {
       "community": 229,
       "file_type": "code",
-      "id": "inventorymovements_recordskuactivityforinventorymovementwithctx",
-      "label": "recordSkuActivityForInventoryMovementWithCtx()",
-      "norm_label": "recordskuactivityforinventorymovementwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L111"
+      "id": "adjustmentreports_readappliedtransactionadjustmentsforday",
+      "label": "readAppliedTransactionAdjustmentsForDay()",
+      "norm_label": "readappliedtransactionadjustmentsforday()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L173"
     },
     {
       "community": 229,
       "file_type": "code",
-      "id": "inventorymovements_summarizeinventorymovements",
-      "label": "summarizeInventoryMovements()",
-      "norm_label": "summarizeinventorymovements()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L135"
+      "id": "adjustmentreports_sourcecompletenessentry",
+      "label": "sourceCompletenessEntry()",
+      "norm_label": "sourcecompletenessentry()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L76"
     },
     {
       "community": 229,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
-      "label": "inventoryMovements.ts",
-      "norm_label": "inventorymovements.ts",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "id": "packages_athena_webapp_convex_operations_dailyclose_adjustmentreports_ts",
+      "label": "adjustmentReports.ts",
+      "norm_label": "adjustmentreports.ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
       "source_location": "L1"
     },
     {
@@ -209118,442 +209058,433 @@
     {
       "community": 23,
       "file_type": "code",
-      "id": "dailyopeningview_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L1343"
+      "id": "packages_athena_webapp_convex_lib_storescheduletime_ts",
+      "label": "storeScheduleTime.ts",
+      "norm_label": "storescheduletime.ts",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L1"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "dailyopeningview_dailyopeningstatustitle",
-      "label": "DailyOpeningStatusTitle()",
-      "norm_label": "dailyopeningstatustitle()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L666"
+      "id": "storescheduletime_adddays",
+      "label": "addDays()",
+      "norm_label": "adddays()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L199"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "dailyopeningview_formatmetadatadisplayvalue",
-      "label": "formatMetadataDisplayValue()",
-      "norm_label": "formatmetadatadisplayvalue()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L504"
+      "id": "storescheduletime_addfield",
+      "label": "addField()",
+      "norm_label": "addfield()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L157"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "dailyopeningview_formatmetadatavalue",
-      "label": "formatMetadataValue()",
-      "norm_label": "formatmetadatavalue()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L430"
+      "id": "storescheduletime_contextwindowsfordate",
+      "label": "contextWindowsForDate()",
+      "norm_label": "contextwindowsfordate()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L690"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "dailyopeningview_formatopeningitemtitle",
-      "label": "formatOpeningItemTitle()",
-      "norm_label": "formatopeningitemtitle()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L328"
+      "id": "storescheduletime_dayofweek",
+      "label": "dayOfWeek()",
+      "norm_label": "dayofweek()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L212"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "dailyopeningview_formatoperatingdate",
-      "label": "formatOperatingDate()",
-      "norm_label": "formatoperatingdate()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L272"
+      "id": "storescheduletime_exceptionwindowsoverlap",
+      "label": "exceptionWindowsOverlap()",
+      "norm_label": "exceptionwindowsoverlap()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L450"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "dailyopeningview_formatoperatingdatewithweekday",
-      "label": "formatOperatingDateWithWeekday()",
-      "norm_label": "formatoperatingdatewithweekday()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L288"
+      "id": "storescheduletime_expandedwindowrange",
+      "label": "expandedWindowRange()",
+      "norm_label": "expandedwindowrange()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L410"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "dailyopeningview_formatoperationalworktypelabel",
-      "label": "formatOperationalWorkTypeLabel()",
-      "norm_label": "formatoperationalworktypelabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "id": "storescheduletime_findnextwindow",
+      "label": "findNextWindow()",
+      "norm_label": "findnextwindow()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L700"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "storescheduletime_getformatter",
+      "label": "getFormatter()",
+      "norm_label": "getformatter()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L137"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "storescheduletime_getmissingstoreschedulecontext",
+      "label": "getMissingStoreScheduleContext()",
+      "norm_label": "getmissingstoreschedulecontext()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L719"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "storescheduletime_hasoverlaps",
+      "label": "hasOverlaps()",
+      "norm_label": "hasoverlaps()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L424"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "storescheduletime_isvalidstoretimezone",
+      "label": "isValidStoreTimezone()",
+      "norm_label": "isvalidstoretimezone()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L462"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "storescheduletime_iswholenumber",
+      "label": "isWholeNumber()",
+      "norm_label": "iswholenumber()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L168"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "storescheduletime_localdateat",
+      "label": "localDateAt()",
+      "norm_label": "localdateat()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L208"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "storescheduletime_localdatefromutc",
+      "label": "localDateFromUtc()",
+      "norm_label": "localdatefromutc()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L195"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "storescheduletime_localdateminutetoutc",
+      "label": "localDateMinuteToUtc()",
+      "norm_label": "localdateminutetoutc()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L326"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "storescheduletime_localdateminutetoutccandidates",
+      "label": "localDateMinuteToUtcCandidates()",
+      "norm_label": "localdateminutetoutccandidates()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L270"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "storescheduletime_localdatestartat",
+      "label": "localDateStartAt()",
+      "norm_label": "localdatestartat()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L336"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "storescheduletime_localdatetimeat",
+      "label": "localDateTimeAt()",
+      "norm_label": "localdatetimeat()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L345"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "storescheduletime_localminuteat",
+      "label": "localMinuteAt()",
+      "norm_label": "localminuteat()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L250"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "storescheduletime_localpartsat",
+      "label": "localPartsAt()",
+      "norm_label": "localpartsat()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L221"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "storescheduletime_localtimeat",
+      "label": "localTimeAt()",
+      "norm_label": "localtimeat()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L260"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "storescheduletime_minutestolabel",
+      "label": "minutesToLabel()",
+      "norm_label": "minutestolabel()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L371"
+    },
+    {
+      "community": 23,
+      "file_type": "code",
+      "id": "storescheduletime_nextreportingcycleboundary",
+      "label": "nextReportingCycleBoundary()",
+      "norm_label": "nextreportingcycleboundary()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
       "source_location": "L360"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "dailyopeningview_formattimestamp",
-      "label": "formatTimestamp()",
-      "norm_label": "formattimestamp()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L305"
+      "id": "storescheduletime_parselocaldate",
+      "label": "parseLocalDate()",
+      "norm_label": "parselocaldate()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L172"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "dailyopeningview_getacknowledgementkey",
-      "label": "getAcknowledgementKey()",
-      "norm_label": "getacknowledgementkey()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L407"
+      "id": "storescheduletime_rangesoverlap",
+      "label": "rangesOverlap()",
+      "norm_label": "rangesoverlap()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L905"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "dailyopeningview_getarraymetadatastringvalue",
-      "label": "getArrayMetadataStringValue()",
-      "norm_label": "getarraymetadatastringvalue()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L490"
+      "id": "storescheduletime_resolvestorecalendarrangefordate",
+      "label": "resolveStoreCalendarRangeForDate()",
+      "norm_label": "resolvestorecalendarrangefordate()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L475"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "dailyopeningview_getbucketconfigs",
-      "label": "getBucketConfigs()",
-      "norm_label": "getbucketconfigs()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L974"
+      "id": "storescheduletime_resolvestoreoperatingrangefordate",
+      "label": "resolveStoreOperatingRangeForDate()",
+      "norm_label": "resolvestoreoperatingrangefordate()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L824"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "dailyopeningview_getdailyopeningapi",
-      "label": "getDailyOpeningApi()",
-      "norm_label": "getdailyopeningapi()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L262"
+      "id": "storescheduletime_resolvestoreoperatingwindowsfordate",
+      "label": "resolveStoreOperatingWindowsForDate()",
+      "norm_label": "resolvestoreoperatingwindowsfordate()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L861"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "dailyopeningview_getitemcontextlabel",
-      "label": "getItemContextLabel()",
-      "norm_label": "getitemcontextlabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L422"
+      "id": "storescheduletime_resolvestoreschedulecontext",
+      "label": "resolveStoreScheduleContext()",
+      "norm_label": "resolvestoreschedulecontext()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L734"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "dailyopeningview_getitemdescription",
-      "label": "getItemDescription()",
-      "norm_label": "getitemdescription()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L418"
+      "id": "storescheduletime_tocontextwindow",
+      "label": "toContextWindow()",
+      "norm_label": "tocontextwindow()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L653"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "dailyopeningview_getitemid",
-      "label": "getItemId()",
-      "norm_label": "getitemid()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L399"
+      "id": "storescheduletime_validatedayofweek",
+      "label": "validateDayOfWeek()",
+      "norm_label": "validatedayofweek()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L387"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "dailyopeningview_getmetadataentries",
-      "label": "getMetadataEntries()",
-      "norm_label": "getmetadataentries()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L564"
+      "id": "storescheduletime_validateminute",
+      "label": "validateMinute()",
+      "norm_label": "validateminute()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L377"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "dailyopeningview_getmetadatalabel",
-      "label": "getMetadataLabel()",
-      "norm_label": "getmetadatalabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L443"
+      "id": "storescheduletime_validatenoeffectiverangeoverlap",
+      "label": "validateNoEffectiveRangeOverlap()",
+      "norm_label": "validatenoeffectiverangeoverlap()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L915"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "dailyopeningview_getmetadatavalue",
-      "label": "getMetadataValue()",
-      "norm_label": "getmetadatavalue()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L465"
+      "id": "storescheduletime_validatestorescheduledraft",
+      "label": "validateStoreScheduleDraft()",
+      "norm_label": "validatestorescheduledraft()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L494"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "dailyopeningview_getopeningautomationmessage",
-      "label": "getOpeningAutomationMessage()",
-      "norm_label": "getopeningautomationmessage()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L701"
+      "id": "storescheduletime_validatewindowshape",
+      "label": "validateWindowShape()",
+      "norm_label": "validatewindowshape()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L397"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "dailyopeningview_getopeningreviewevidence",
-      "label": "getOpeningReviewEvidence()",
-      "norm_label": "getopeningreviewevidence()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L779"
+      "id": "storescheduletime_weeklywindowsoverlap",
+      "label": "weeklyWindowsOverlap()",
+      "norm_label": "weeklywindowsoverlap()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L435"
     },
     {
       "community": 23,
       "file_type": "code",
-      "id": "dailyopeningview_getopeningstartedbylabel",
-      "label": "getOpeningStartedByLabel()",
-      "norm_label": "getopeningstartedbylabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L787"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "dailyopeningview_getopeningstatus",
-      "label": "getOpeningStatus()",
-      "norm_label": "getopeningstatus()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L385"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "dailyopeningview_getrequiredacknowledgementkeys",
-      "label": "getRequiredAcknowledgementKeys()",
-      "norm_label": "getrequiredacknowledgementkeys()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L411"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "dailyopeningview_getselectedbucketvalue",
-      "label": "getSelectedBucketValue()",
-      "norm_label": "getselectedbucketvalue()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L1028"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "dailyopeningview_getstatussignatureclassname",
-      "label": "getStatusSignatureClassName()",
-      "norm_label": "getstatussignatureclassname()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L626"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "dailyopeningview_getstatussignatureiconclassname",
-      "label": "getStatusSignatureIconClassName()",
-      "norm_label": "getstatussignatureiconclassname()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L635"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "dailyopeningview_getvisiblebucketconfigs",
-      "label": "getVisibleBucketConfigs()",
-      "norm_label": "getvisiblebucketconfigs()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L1017"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "dailyopeningview_getvisibleopeningautomationstatus",
-      "label": "getVisibleOpeningAutomationStatus()",
-      "norm_label": "getvisibleopeningautomationstatus()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L737"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "dailyopeningview_handlepagechange",
-      "label": "handlePageChange()",
-      "norm_label": "handlepagechange()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L822"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "dailyopeningview_humanizemetadatalabel",
-      "label": "humanizeMetadataLabel()",
-      "norm_label": "humanizemetadatalabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L317"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "dailyopeningview_isoperatorfacingopeningmetadata",
-      "label": "isOperatorFacingOpeningMetadata()",
-      "norm_label": "isoperatorfacingopeningmetadata()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L560"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "dailyopeningview_normalizebucketpage",
-      "label": "normalizeBucketPage()",
-      "norm_label": "normalizebucketpage()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L963"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "dailyopeningview_normalizecommandmessage",
-      "label": "normalizeCommandMessage()",
-      "norm_label": "normalizecommandmessage()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L606"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "dailyopeningview_normalizemetadatalabel",
-      "label": "normalizeMetadataLabel()",
-      "norm_label": "normalizemetadatalabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L324"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "dailyopeningview_openingautomationstatuspanel",
-      "label": "OpeningAutomationStatusPanel()",
-      "norm_label": "openingautomationstatuspanel()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L754"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "dailyopeningview_successcheckicon",
-      "label": "SuccessCheckIcon()",
-      "norm_label": "successcheckicon()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L644"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "dailyopeningview_toggleallacknowledgements",
-      "label": "toggleAllAcknowledgements()",
-      "norm_label": "toggleallacknowledgements()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L1424"
-    },
-    {
-      "community": 23,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
-      "label": "DailyOpeningView.tsx",
-      "norm_label": "dailyopeningview.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L1"
+      "id": "storescheduletime_windowsforlocaldate",
+      "label": "windowsForLocalDate()",
+      "norm_label": "windowsforlocaldate()",
+      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "source_location": "L630"
     },
     {
       "community": 230,
       "file_type": "code",
-      "id": "operationalevents_buildoperationalevent",
-      "label": "buildOperationalEvent()",
-      "norm_label": "buildoperationalevent()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L43"
+      "id": "inventorymovements_assertnobusinesseventconflict",
+      "label": "assertNoBusinessEventConflict()",
+      "norm_label": "assertnobusinesseventconflict()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L178"
     },
     {
       "community": 230,
       "file_type": "code",
-      "id": "operationalevents_buildtracemetadata",
-      "label": "buildTraceMetadata()",
-      "norm_label": "buildtracemetadata()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L96"
+      "id": "inventorymovements_buildinventorymovement",
+      "label": "buildInventoryMovement()",
+      "norm_label": "buildinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L124"
     },
     {
       "community": 230,
       "file_type": "code",
-      "id": "operationalevents_isrecord",
-      "label": "isRecord()",
-      "norm_label": "isrecord()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L145"
+      "id": "inventorymovements_buildskuactivityforinventorymovement",
+      "label": "buildSkuActivityForInventoryMovement()",
+      "norm_label": "buildskuactivityforinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L66"
     },
     {
       "community": 230,
       "file_type": "code",
-      "id": "operationalevents_listproductoperationaltimelinewithctx",
-      "label": "listProductOperationalTimelineWithCtx()",
-      "norm_label": "listproductoperationaltimelinewithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L246"
+      "id": "inventorymovements_getskuactivitytypeformovement",
+      "label": "getSkuActivityTypeForMovement()",
+      "norm_label": "getskuactivitytypeformovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L49"
     },
     {
       "community": 230,
       "file_type": "code",
-      "id": "operationalevents_matchesexistingevent",
-      "label": "matchesExistingEvent()",
-      "norm_label": "matchesexistingevent()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L149"
+      "id": "inventorymovements_matchesexistingmovement",
+      "label": "matchesExistingMovement()",
+      "norm_label": "matchesexistingmovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L150"
     },
     {
       "community": 230,
       "file_type": "code",
-      "id": "operationalevents_metadatadedupekeysmatch",
-      "label": "metadataDedupeKeysMatch()",
-      "norm_label": "metadatadedupekeysmatch()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L205"
+      "id": "inventorymovements_recordinventorymovementwithctx",
+      "label": "recordInventoryMovementWithCtx()",
+      "norm_label": "recordinventorymovementwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L200"
     },
     {
       "community": 230,
       "file_type": "code",
-      "id": "operationalevents_normalizeoperationaleventtracefields",
-      "label": "normalizeOperationalEventTraceFields()",
-      "norm_label": "normalizeoperationaleventtracefields()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L60"
+      "id": "inventorymovements_recordinventorymovementwithdispositionwithctx",
+      "label": "recordInventoryMovementWithDispositionWithCtx()",
+      "norm_label": "recordinventorymovementwithdispositionwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L245"
     },
     {
       "community": 230,
       "file_type": "code",
-      "id": "operationalevents_recordoperationaleventwithctx",
-      "label": "recordOperationalEventWithCtx()",
-      "norm_label": "recordoperationaleventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L215"
+      "id": "inventorymovements_recordskuactivityforinventorymovementwithctx",
+      "label": "recordSkuActivityForInventoryMovementWithCtx()",
+      "norm_label": "recordskuactivityforinventorymovementwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L111"
     },
     {
       "community": 230,
       "file_type": "code",
-      "id": "operationalevents_shouldnormalizepostrace",
-      "label": "shouldNormalizePosTrace()",
-      "norm_label": "shouldnormalizepostrace()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L118"
+      "id": "inventorymovements_summarizeinventorymovements",
+      "label": "summarizeInventoryMovements()",
+      "norm_label": "summarizeinventorymovements()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L135"
     },
     {
       "community": 230,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
-      "label": "operationalEvents.ts",
-      "norm_label": "operationalevents.ts",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
+      "label": "inventoryMovements.ts",
+      "norm_label": "inventorymovements.ts",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
       "source_location": "L1"
     },
     {
@@ -209649,91 +209580,91 @@
     {
       "community": 231,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_amendrepairwithctx",
-      "label": "amendRepairWithCtx()",
-      "norm_label": "amendrepairwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L430"
+      "id": "operationalevents_buildoperationalevent",
+      "label": "buildOperationalEvent()",
+      "norm_label": "buildoperationalevent()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L43"
     },
     {
       "community": 231,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_createrepairwithctx",
-      "label": "createRepairWithCtx()",
-      "norm_label": "createrepairwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L160"
+      "id": "operationalevents_buildtracemetadata",
+      "label": "buildTraceMetadata()",
+      "norm_label": "buildtracemetadata()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L96"
     },
     {
       "community": 231,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_pauserepair",
-      "label": "pauseRepair()",
-      "norm_label": "pauserepair()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L231"
+      "id": "operationalevents_isrecord",
+      "label": "isRecord()",
+      "norm_label": "isrecord()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L145"
     },
     {
       "community": 231,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_processrepairbatchwithctx",
-      "label": "processRepairBatchWithCtx()",
-      "norm_label": "processrepairbatchwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L249"
+      "id": "operationalevents_listproductoperationaltimelinewithctx",
+      "label": "listProductOperationalTimelineWithCtx()",
+      "norm_label": "listproductoperationaltimelinewithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L246"
     },
     {
       "community": 231,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_readcurrentgroup",
-      "label": "readCurrentGroup()",
-      "norm_label": "readcurrentgroup()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L49"
+      "id": "operationalevents_matchesexistingevent",
+      "label": "matchesExistingEvent()",
+      "norm_label": "matchesexistingevent()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L149"
     },
     {
       "community": 231,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_recordrepairauditevent",
-      "label": "recordRepairAuditEvent()",
-      "norm_label": "recordrepairauditevent()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L85"
+      "id": "operationalevents_metadatadedupekeysmatch",
+      "label": "metadataDedupeKeysMatch()",
+      "norm_label": "metadatadedupekeysmatch()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L205"
     },
     {
       "community": 231,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_requireevidence",
-      "label": "requireEvidence()",
-      "norm_label": "requireevidence()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L37"
+      "id": "operationalevents_normalizeoperationaleventtracefields",
+      "label": "normalizeOperationalEventTraceFields()",
+      "norm_label": "normalizeoperationaleventtracefields()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L60"
     },
     {
       "community": 231,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_resumerepairwithctx",
-      "label": "resumeRepairWithCtx()",
-      "norm_label": "resumerepairwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L472"
+      "id": "operationalevents_recordoperationaleventwithctx",
+      "label": "recordOperationalEventWithCtx()",
+      "norm_label": "recordoperationaleventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L215"
     },
     {
       "community": 231,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_schedulenextbatch",
-      "label": "scheduleNextBatch()",
-      "norm_label": "schedulenextbatch()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L153"
+      "id": "operationalevents_shouldnormalizepostrace",
+      "label": "shouldNormalizePosTrace()",
+      "norm_label": "shouldnormalizepostrace()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L118"
     },
     {
       "community": 231,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_oversizedoperationalworkrepair_ts",
-      "label": "oversizedOperationalWorkRepair.ts",
-      "norm_label": "oversizedoperationalworkrepair.ts",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
+      "label": "operationalEvents.ts",
+      "norm_label": "operationalevents.ts",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
       "source_location": "L1"
     },
     {
@@ -209829,92 +209760,92 @@
     {
       "community": 232,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
-      "label": "registerSessionTracing.ts",
-      "norm_label": "registersessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "id": "oversizedoperationalworkrepair_amendrepairwithctx",
+      "label": "amendRepairWithCtx()",
+      "norm_label": "amendrepairwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L430"
+    },
+    {
+      "community": 232,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_createrepairwithctx",
+      "label": "createRepairWithCtx()",
+      "norm_label": "createrepairwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L160"
+    },
+    {
+      "community": 232,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_pauserepair",
+      "label": "pauseRepair()",
+      "norm_label": "pauserepair()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L231"
+    },
+    {
+      "community": 232,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_processrepairbatchwithctx",
+      "label": "processRepairBatchWithCtx()",
+      "norm_label": "processrepairbatchwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L249"
+    },
+    {
+      "community": 232,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_readcurrentgroup",
+      "label": "readCurrentGroup()",
+      "norm_label": "readcurrentgroup()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 232,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_recordrepairauditevent",
+      "label": "recordRepairAuditEvent()",
+      "norm_label": "recordrepairauditevent()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 232,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_requireevidence",
+      "label": "requireEvidence()",
+      "norm_label": "requireevidence()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 232,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_resumerepairwithctx",
+      "label": "resumeRepairWithCtx()",
+      "norm_label": "resumerepairwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L472"
+    },
+    {
+      "community": 232,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_schedulenextbatch",
+      "label": "scheduleNextBatch()",
+      "norm_label": "schedulenextbatch()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L153"
+    },
+    {
+      "community": 232,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_oversizedoperationalworkrepair_ts",
+      "label": "oversizedOperationalWorkRepair.ts",
+      "norm_label": "oversizedoperationalworkrepair.ts",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 232,
-      "file_type": "code",
-      "id": "registersessiontracing_buildactorrefs",
-      "label": "buildActorRefs()",
-      "norm_label": "buildactorrefs()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 232,
-      "file_type": "code",
-      "id": "registersessiontracing_buildtraceevent",
-      "label": "buildTraceEvent()",
-      "norm_label": "buildtraceevent()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L196"
-    },
-    {
-      "community": 232,
-      "file_type": "code",
-      "id": "registersessiontracing_buildtracerecord",
-      "label": "buildTraceRecord()",
-      "norm_label": "buildtracerecord()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L161"
-    },
-    {
-      "community": 232,
-      "file_type": "code",
-      "id": "registersessiontracing_displaytraceamount",
-      "label": "displayTraceAmount()",
-      "norm_label": "displaytraceamount()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L114"
-    },
-    {
-      "community": 232,
-      "file_type": "code",
-      "id": "registersessiontracing_formattransactionlabel",
-      "label": "formatTransactionLabel()",
-      "norm_label": "formattransactionlabel()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L132"
-    },
-    {
-      "community": 232,
-      "file_type": "code",
-      "id": "registersessiontracing_recordregistersessiontracebesteffort",
-      "label": "recordRegisterSessionTraceBestEffort()",
-      "norm_label": "recordregistersessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L407"
-    },
-    {
-      "community": 232,
-      "file_type": "code",
-      "id": "registersessiontracing_resolveoccurredat",
-      "label": "resolveOccurredAt()",
-      "norm_label": "resolveoccurredat()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L76"
-    },
-    {
-      "community": 232,
-      "file_type": "code",
-      "id": "registersessiontracing_resolvestorecurrency",
-      "label": "resolveStoreCurrency()",
-      "norm_label": "resolvestorecurrency()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L146"
-    },
-    {
-      "community": 232,
-      "file_type": "code",
-      "id": "registersessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L92"
     },
     {
       "community": 2320,
@@ -210009,92 +209940,92 @@
     {
       "community": 233,
       "file_type": "code",
-      "id": "finalizedlineageremediation_classifyfinalizedlineagerepairconflicts",
-      "label": "classifyFinalizedLineageRepairConflicts()",
-      "norm_label": "classifyfinalizedlineagerepairconflicts()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L222"
-    },
-    {
-      "community": 233,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_classifyrepaircandidate",
-      "label": "classifyRepairCandidate()",
-      "norm_label": "classifyrepaircandidate()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L164"
-    },
-    {
-      "community": 233,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_countrepairablefinalizedlineagelines",
-      "label": "countRepairableFinalizedLineageLines()",
-      "norm_label": "countrepairablefinalizedlineagelines()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L284"
-    },
-    {
-      "community": 233,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_getprovisionalimportsku",
-      "label": "getProvisionalImportSku()",
-      "norm_label": "getprovisionalimportsku()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L318"
-    },
-    {
-      "community": 233,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_isclosedregisterrepairreplayconflict",
-      "label": "isClosedRegisterRepairReplayConflict()",
-      "norm_label": "isclosedregisterrepairreplayconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L273"
-    },
-    {
-      "community": 233,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_isfinalizedlineagerepairconflict",
-      "label": "isFinalizedLineageRepairConflict()",
-      "norm_label": "isfinalizedlineagerepairconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L258"
-    },
-    {
-      "community": 233,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_isprovisionalrowchangedconflict",
-      "label": "isProvisionalRowChangedConflict()",
-      "norm_label": "isprovisionalrowchangedconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L265"
-    },
-    {
-      "community": 233,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_recordfinalizedlineagerepairevent",
-      "label": "recordFinalizedLineageRepairEvent()",
-      "norm_label": "recordfinalizedlineagerepairevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L358"
-    },
-    {
-      "community": 233,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_skipped",
-      "label": "skipped()",
-      "norm_label": "skipped()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L346"
-    },
-    {
-      "community": 233,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sync_finalizedlineageremediation_ts",
-      "label": "finalizedLineageRemediation.ts",
-      "norm_label": "finalizedlineageremediation.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "id": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
+      "label": "registerSessionTracing.ts",
+      "norm_label": "registersessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 233,
+      "file_type": "code",
+      "id": "registersessiontracing_buildactorrefs",
+      "label": "buildActorRefs()",
+      "norm_label": "buildactorrefs()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 233,
+      "file_type": "code",
+      "id": "registersessiontracing_buildtraceevent",
+      "label": "buildTraceEvent()",
+      "norm_label": "buildtraceevent()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L196"
+    },
+    {
+      "community": 233,
+      "file_type": "code",
+      "id": "registersessiontracing_buildtracerecord",
+      "label": "buildTraceRecord()",
+      "norm_label": "buildtracerecord()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L161"
+    },
+    {
+      "community": 233,
+      "file_type": "code",
+      "id": "registersessiontracing_displaytraceamount",
+      "label": "displayTraceAmount()",
+      "norm_label": "displaytraceamount()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L114"
+    },
+    {
+      "community": 233,
+      "file_type": "code",
+      "id": "registersessiontracing_formattransactionlabel",
+      "label": "formatTransactionLabel()",
+      "norm_label": "formattransactionlabel()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L132"
+    },
+    {
+      "community": 233,
+      "file_type": "code",
+      "id": "registersessiontracing_recordregistersessiontracebesteffort",
+      "label": "recordRegisterSessionTraceBestEffort()",
+      "norm_label": "recordregistersessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L407"
+    },
+    {
+      "community": 233,
+      "file_type": "code",
+      "id": "registersessiontracing_resolveoccurredat",
+      "label": "resolveOccurredAt()",
+      "norm_label": "resolveoccurredat()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 233,
+      "file_type": "code",
+      "id": "registersessiontracing_resolvestorecurrency",
+      "label": "resolveStoreCurrency()",
+      "norm_label": "resolvestorecurrency()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L146"
+    },
+    {
+      "community": 233,
+      "file_type": "code",
+      "id": "registersessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L92"
     },
     {
       "community": 2330,
@@ -210189,92 +210120,92 @@
     {
       "community": 234,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_terminalrecoveryrepository_ts",
-      "label": "terminalRecoveryRepository.ts",
-      "norm_label": "terminalrecoveryrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 234,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_createterminalrecoverycommandreadrepository",
-      "label": "createTerminalRecoveryCommandReadRepository()",
-      "norm_label": "createterminalrecoverycommandreadrepository()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 234,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_createterminalrecoverycommandrepository",
-      "label": "createTerminalRecoveryCommandRepository()",
-      "norm_label": "createterminalrecoverycommandrepository()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L127"
-    },
-    {
-      "community": 234,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_deduperecoverycommandsbyid",
-      "label": "dedupeRecoveryCommandsById()",
-      "norm_label": "deduperecoverycommandsbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 234,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_deduperecoveryconflictsbyid",
-      "label": "dedupeRecoveryConflictsById()",
-      "norm_label": "deduperecoveryconflictsbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L193"
-    },
-    {
-      "community": 234,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_getterminalrecoverysourceevent",
-      "label": "getTerminalRecoverySourceEvent()",
-      "norm_label": "getterminalrecoverysourceevent()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "id": "finalizedlineageremediation_classifyfinalizedlineagerepairconflicts",
+      "label": "classifyFinalizedLineageRepairConflicts()",
+      "norm_label": "classifyfinalizedlineagerepairconflicts()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
       "source_location": "L222"
     },
     {
       "community": 234,
       "file_type": "code",
-      "id": "terminalrecoveryrepository_iscurrentterminalrecoveryconflict",
-      "label": "isCurrentTerminalRecoveryConflict()",
-      "norm_label": "iscurrentterminalrecoveryconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L206"
+      "id": "finalizedlineageremediation_classifyrepaircandidate",
+      "label": "classifyRepairCandidate()",
+      "norm_label": "classifyrepaircandidate()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L164"
     },
     {
       "community": 234,
       "file_type": "code",
-      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsforrepair",
-      "label": "listTerminalRecoveryConflictsForRepair()",
-      "norm_label": "listterminalrecoveryconflictsforrepair()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L141"
+      "id": "finalizedlineageremediation_countrepairablefinalizedlineagelines",
+      "label": "countRepairableFinalizedLineageLines()",
+      "norm_label": "countrepairablefinalizedlineagelines()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L284"
     },
     {
       "community": 234,
       "file_type": "code",
-      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsources",
-      "label": "listTerminalRecoveryConflictSources()",
-      "norm_label": "listterminalrecoveryconflictsources()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L162"
+      "id": "finalizedlineageremediation_getprovisionalimportsku",
+      "label": "getProvisionalImportSku()",
+      "norm_label": "getprovisionalimportsku()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L318"
     },
     {
       "community": 234,
       "file_type": "code",
-      "id": "terminalrecoveryrepository_patchterminalrecoveryconflict",
-      "label": "patchTerminalRecoveryConflict()",
-      "norm_label": "patchterminalrecoveryconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L241"
+      "id": "finalizedlineageremediation_isclosedregisterrepairreplayconflict",
+      "label": "isClosedRegisterRepairReplayConflict()",
+      "norm_label": "isclosedregisterrepairreplayconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L273"
+    },
+    {
+      "community": 234,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_isfinalizedlineagerepairconflict",
+      "label": "isFinalizedLineageRepairConflict()",
+      "norm_label": "isfinalizedlineagerepairconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L258"
+    },
+    {
+      "community": 234,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_isprovisionalrowchangedconflict",
+      "label": "isProvisionalRowChangedConflict()",
+      "norm_label": "isprovisionalrowchangedconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L265"
+    },
+    {
+      "community": 234,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_recordfinalizedlineagerepairevent",
+      "label": "recordFinalizedLineageRepairEvent()",
+      "norm_label": "recordfinalizedlineagerepairevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L358"
+    },
+    {
+      "community": 234,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_skipped",
+      "label": "skipped()",
+      "norm_label": "skipped()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L346"
+    },
+    {
+      "community": 234,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_sync_finalizedlineageremediation_ts",
+      "label": "finalizedLineageRemediation.ts",
+      "norm_label": "finalizedlineageremediation.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L1"
     },
     {
       "community": 2340,
@@ -210369,92 +210300,92 @@
     {
       "community": 235,
       "file_type": "code",
-      "id": "customrange_aggregateskudays",
-      "label": "aggregateSkuDays()",
-      "norm_label": "aggregateskudays()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L217"
-    },
-    {
-      "community": 235,
-      "file_type": "code",
-      "id": "customrange_computerange",
-      "label": "computeRange()",
-      "norm_label": "computerange()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L253"
-    },
-    {
-      "community": 235,
-      "file_type": "code",
-      "id": "customrange_computerequestkey",
-      "label": "computeRequestKey()",
-      "norm_label": "computerequestkey()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L84"
-    },
-    {
-      "community": 235,
-      "file_type": "code",
-      "id": "customrange_inclusivedayspan",
-      "label": "inclusiveDaySpan()",
-      "norm_label": "inclusivedayspan()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 235,
-      "file_type": "code",
-      "id": "customrange_isvalidoperatingdate",
-      "label": "isValidOperatingDate()",
-      "norm_label": "isvalidoperatingdate()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 235,
-      "file_type": "code",
-      "id": "customrange_requestrangecore",
-      "label": "requestRangeCore()",
-      "norm_label": "requestrangecore()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L112"
-    },
-    {
-      "community": 235,
-      "file_type": "code",
-      "id": "customrange_sumdays",
-      "label": "sumDays()",
-      "norm_label": "sumdays()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L189"
-    },
-    {
-      "community": 235,
-      "file_type": "code",
-      "id": "customrange_utcmillisforlabel",
-      "label": "utcMillisForLabel()",
-      "norm_label": "utcmillisforlabel()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 235,
-      "file_type": "code",
-      "id": "customrange_validaterangeargs",
-      "label": "validateRangeArgs()",
-      "norm_label": "validaterangeargs()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 235,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_customrange_ts",
-      "label": "customRange.ts",
-      "norm_label": "customrange.ts",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_terminalrecoveryrepository_ts",
+      "label": "terminalRecoveryRepository.ts",
+      "norm_label": "terminalrecoveryrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 235,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_createterminalrecoverycommandreadrepository",
+      "label": "createTerminalRecoveryCommandReadRepository()",
+      "norm_label": "createterminalrecoverycommandreadrepository()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 235,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_createterminalrecoverycommandrepository",
+      "label": "createTerminalRecoveryCommandRepository()",
+      "norm_label": "createterminalrecoverycommandrepository()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L127"
+    },
+    {
+      "community": 235,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_deduperecoverycommandsbyid",
+      "label": "dedupeRecoveryCommandsById()",
+      "norm_label": "deduperecoverycommandsbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L116"
+    },
+    {
+      "community": 235,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_deduperecoveryconflictsbyid",
+      "label": "dedupeRecoveryConflictsById()",
+      "norm_label": "deduperecoveryconflictsbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L193"
+    },
+    {
+      "community": 235,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_getterminalrecoverysourceevent",
+      "label": "getTerminalRecoverySourceEvent()",
+      "norm_label": "getterminalrecoverysourceevent()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L222"
+    },
+    {
+      "community": 235,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_iscurrentterminalrecoveryconflict",
+      "label": "isCurrentTerminalRecoveryConflict()",
+      "norm_label": "iscurrentterminalrecoveryconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L206"
+    },
+    {
+      "community": 235,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsforrepair",
+      "label": "listTerminalRecoveryConflictsForRepair()",
+      "norm_label": "listterminalrecoveryconflictsforrepair()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L141"
+    },
+    {
+      "community": 235,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsources",
+      "label": "listTerminalRecoveryConflictSources()",
+      "norm_label": "listterminalrecoveryconflictsources()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L162"
+    },
+    {
+      "community": 235,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_patchterminalrecoveryconflict",
+      "label": "patchTerminalRecoveryConflict()",
+      "norm_label": "patchterminalrecoveryconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L241"
     },
     {
       "community": 2350,
@@ -210549,91 +210480,91 @@
     {
       "community": 236,
       "file_type": "code",
-      "id": "index_resolveverificationcoderecipient",
-      "label": "resolveVerificationCodeRecipient()",
-      "norm_label": "resolveverificationcoderecipient()",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
-      "source_location": "L19"
+      "id": "customrange_aggregateskudays",
+      "label": "aggregateSkuDays()",
+      "norm_label": "aggregateskudays()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L217"
     },
     {
       "community": 236,
       "file_type": "code",
-      "id": "index_senddailymanagerreportemail",
-      "label": "sendDailyManagerReportEmail()",
-      "norm_label": "senddailymanagerreportemail()",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
-      "source_location": "L373"
+      "id": "customrange_computerange",
+      "label": "computeRange()",
+      "norm_label": "computerange()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L253"
     },
     {
       "community": 236,
       "file_type": "code",
-      "id": "index_senddiscountcodeemail",
-      "label": "sendDiscountCodeEmail()",
-      "norm_label": "senddiscountcodeemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L255"
+      "id": "customrange_computerequestkey",
+      "label": "computeRequestKey()",
+      "norm_label": "computerequestkey()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L84"
     },
     {
       "community": 236,
       "file_type": "code",
-      "id": "index_senddiscountreminderemail",
-      "label": "sendDiscountReminderEmail()",
-      "norm_label": "senddiscountreminderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L334"
+      "id": "customrange_inclusivedayspan",
+      "label": "inclusiveDaySpan()",
+      "norm_label": "inclusivedayspan()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L52"
     },
     {
       "community": 236,
       "file_type": "code",
-      "id": "index_sendfeedbackrequestemail",
-      "label": "sendFeedbackRequestEmail()",
-      "norm_label": "sendfeedbackrequestemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L167"
+      "id": "customrange_isvalidoperatingdate",
+      "label": "isValidOperatingDate()",
+      "norm_label": "isvalidoperatingdate()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L35"
     },
     {
       "community": 236,
       "file_type": "code",
-      "id": "index_sendneworderemail",
-      "label": "sendNewOrderEmail()",
-      "norm_label": "sendneworderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L117"
+      "id": "customrange_requestrangecore",
+      "label": "requestRangeCore()",
+      "norm_label": "requestrangecore()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L112"
     },
     {
       "community": 236,
       "file_type": "code",
-      "id": "index_sendorderemail",
-      "label": "sendOrderEmail()",
-      "norm_label": "sendorderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L43"
+      "id": "customrange_sumdays",
+      "label": "sumDays()",
+      "norm_label": "sumdays()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L189"
     },
     {
       "community": 236,
       "file_type": "code",
-      "id": "index_sendverificationcode",
-      "label": "sendVerificationCode()",
-      "norm_label": "sendverificationcode()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L3"
+      "id": "customrange_utcmillisforlabel",
+      "label": "utcMillisForLabel()",
+      "norm_label": "utcmillisforlabel()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L46"
     },
     {
       "community": 236,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
-      "source_location": "L1"
+      "id": "customrange_validaterangeargs",
+      "label": "validateRangeArgs()",
+      "norm_label": "validaterangeargs()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L58"
     },
     {
       "community": 236,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "id": "packages_athena_webapp_convex_reports_customrange_ts",
+      "label": "customRange.ts",
+      "norm_label": "customrange.ts",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
       "source_location": "L1"
     },
     {
@@ -211269,344 +211200,344 @@
     {
       "community": 24,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_lib_storescheduletime_ts",
-      "label": "storeScheduleTime.ts",
-      "norm_label": "storescheduletime.ts",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "storescheduletime_adddays",
-      "label": "addDays()",
-      "norm_label": "adddays()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
-      "source_location": "L199"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "storescheduletime_addfield",
-      "label": "addField()",
-      "norm_label": "addfield()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
-      "source_location": "L157"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "storescheduletime_contextwindowsfordate",
-      "label": "contextWindowsForDate()",
-      "norm_label": "contextwindowsfordate()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
-      "source_location": "L690"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "storescheduletime_dayofweek",
-      "label": "dayOfWeek()",
-      "norm_label": "dayofweek()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
-      "source_location": "L212"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "storescheduletime_exceptionwindowsoverlap",
-      "label": "exceptionWindowsOverlap()",
-      "norm_label": "exceptionwindowsoverlap()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
-      "source_location": "L450"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "storescheduletime_expandedwindowrange",
-      "label": "expandedWindowRange()",
-      "norm_label": "expandedwindowrange()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
-      "source_location": "L410"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "storescheduletime_findnextwindow",
-      "label": "findNextWindow()",
-      "norm_label": "findnextwindow()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "id": "dailyoperationsview_applyautomationsnapshot",
+      "label": "applyAutomationSnapshot()",
+      "norm_label": "applyautomationsnapshot()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
       "source_location": "L700"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "storescheduletime_getformatter",
-      "label": "getFormatter()",
-      "norm_label": "getformatter()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
-      "source_location": "L137"
+      "id": "dailyoperationsview_applytodayrefreshsnapshot",
+      "label": "applyTodayRefreshSnapshot()",
+      "norm_label": "applytodayrefreshsnapshot()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L668"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "storescheduletime_getmissingstoreschedulecontext",
-      "label": "getMissingStoreScheduleContext()",
-      "norm_label": "getmissingstoreschedulecontext()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
+      "id": "dailyoperationsview_builddailyclosesearch",
+      "label": "buildDailyCloseSearch()",
+      "norm_label": "builddailyclosesearch()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L557"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "dailyoperationsview_builddailyoperationssearch",
+      "label": "buildDailyOperationsSearch()",
+      "norm_label": "builddailyoperationssearch()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L563"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "dailyoperationsview_buildoperationsexpensesearch",
+      "label": "buildOperationsExpenseSearch()",
+      "norm_label": "buildoperationsexpensesearch()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L600"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "dailyoperationsview_buildoperationstransactionsearch",
+      "label": "buildOperationsTransactionSearch()",
+      "norm_label": "buildoperationstransactionsearch()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L586"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "dailyoperationsview_buildparams",
+      "label": "buildParams()",
+      "norm_label": "buildparams()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L1855"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "dailyoperationsview_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L3644"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "dailyoperationsview_dailyoperationsconnectedruntimeview",
+      "label": "DailyOperationsConnectedRuntimeView()",
+      "norm_label": "dailyoperationsconnectedruntimeview()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L4808"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "dailyoperationsview_dailyoperationsruntimeview",
+      "label": "DailyOperationsRuntimeView()",
+      "norm_label": "dailyoperationsruntimeview()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L4856"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "dailyoperationsview_dailyoperationstopbandshell",
+      "label": "DailyOperationsTopBandShell()",
+      "norm_label": "dailyoperationstopbandshell()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L1724"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "dailyoperationsview_formateventtime",
+      "label": "formatEventTime()",
+      "norm_label": "formateventtime()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L776"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "dailyoperationsview_formatonlineordertimelinefallbackmessage",
+      "label": "formatOnlineOrderTimelineFallbackMessage()",
+      "norm_label": "formatonlineordertimelinefallbackmessage()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L826"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "dailyoperationsview_formatoperatingdate",
+      "label": "formatOperatingDate()",
+      "norm_label": "formatoperatingdate()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L524"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "dailyoperationsview_formatoperatingdatewithweekday",
+      "label": "formatOperatingDateWithWeekday()",
+      "norm_label": "formatoperatingdatewithweekday()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L540"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "dailyoperationsview_formatpendingapprovalslabel",
+      "label": "formatPendingApprovalsLabel()",
+      "norm_label": "formatpendingapprovalslabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L757"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "dailyoperationsview_formattimelinemessage",
+      "label": "formatTimelineMessage()",
+      "norm_label": "formattimelinemessage()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L842"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "dailyoperationsview_getdailyoperationsapi",
+      "label": "getDailyOperationsApi()",
+      "norm_label": "getdailyoperationsapi()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L481"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "dailyoperationsview_getdailyoperationscompletionattributiondetail",
+      "label": "getDailyOperationsCompletionAttributionDetail()",
+      "norm_label": "getdailyoperationscompletionattributiondetail()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L1809"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "dailyoperationsview_getdailyoperationsmetriclabels",
+      "label": "getDailyOperationsMetricLabels()",
+      "norm_label": "getdailyoperationsmetriclabels()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L607"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "dailyoperationsview_getoperatingtimezoneoffsetminutes",
+      "label": "getOperatingTimezoneOffsetMinutes()",
+      "norm_label": "getoperatingtimezoneoffsetminutes()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L516"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "dailyoperationsview_getpendingapprovalscountlabel",
+      "label": "getPendingApprovalsCountLabel()",
+      "norm_label": "getpendingapprovalscountlabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L751"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "dailyoperationsview_getpendingapprovalslanefromlanes",
+      "label": "getPendingApprovalsLaneFromLanes()",
+      "norm_label": "getpendingapprovalslanefromlanes()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L728"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "dailyoperationsview_getsaturdayweekendoperatingdate",
+      "label": "getSaturdayWeekEndOperatingDate()",
+      "norm_label": "getsaturdayweekendoperatingdate()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L509"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "dailyoperationsview_getsundayweekstartoperatingdate",
+      "label": "getSundayWeekStartOperatingDate()",
+      "norm_label": "getsundayweekstartoperatingdate()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L500"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "dailyoperationsview_getweekendoperatingdatefromsearch",
+      "label": "getWeekEndOperatingDateFromSearch()",
+      "norm_label": "getweekendoperatingdatefromsearch()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L620"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "dailyoperationsview_getworkflowsearch",
+      "label": "getWorkflowSearch()",
+      "norm_label": "getworkflowsearch()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L764"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "dailyoperationsview_handleoperatingdatechange",
+      "label": "handleOperatingDateChange()",
+      "norm_label": "handleoperatingdatechange()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L4516"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "dailyoperationsview_handletimelinesheetopenchange",
+      "label": "handleTimelineSheetOpenChange()",
+      "norm_label": "handletimelinesheetopenchange()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L4530"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "dailyoperationsview_ishistoricaloperatingdate",
+      "label": "isHistoricalOperatingDate()",
+      "norm_label": "ishistoricaloperatingdate()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L616"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "dailyoperationsview_replaceapprovalslane",
+      "label": "replaceApprovalsLane()",
+      "norm_label": "replaceapprovalslane()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L736"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "dailyoperationsview_replaceweekmetricforoperatingdate",
+      "label": "replaceWeekMetricForOperatingDate()",
+      "norm_label": "replaceweekmetricforoperatingdate()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L641"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "dailyoperationsview_selectweekmetricsforoperatingdate",
+      "label": "selectWeekMetricsForOperatingDate()",
+      "norm_label": "selectweekmetricsforoperatingdate()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L631"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "dailyoperationsview_settimelinesheetopen",
+      "label": "setTimelineSheetOpen()",
+      "norm_label": "settimelinesheetopen()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L3371"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "dailyoperationsview_shiftlocaloperatingdate",
+      "label": "shiftLocalOperatingDate()",
+      "norm_label": "shiftlocaloperatingdate()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L491"
+    },
+    {
+      "community": 24,
+      "file_type": "code",
+      "id": "dailyoperationsview_shouldshowhistoricaleodreviewaction",
+      "label": "shouldShowHistoricalEodReviewAction()",
+      "norm_label": "shouldshowhistoricaleodreviewaction()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
       "source_location": "L719"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "storescheduletime_hasoverlaps",
-      "label": "hasOverlaps()",
-      "norm_label": "hasoverlaps()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
-      "source_location": "L424"
+      "id": "dailyoperationsview_shouldshowprimaryaction",
+      "label": "shouldShowPrimaryAction()",
+      "norm_label": "shouldshowprimaryaction()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L715"
     },
     {
       "community": 24,
       "file_type": "code",
-      "id": "storescheduletime_isvalidstoretimezone",
-      "label": "isValidStoreTimezone()",
-      "norm_label": "isvalidstoretimezone()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
-      "source_location": "L462"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "storescheduletime_iswholenumber",
-      "label": "isWholeNumber()",
-      "norm_label": "iswholenumber()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
-      "source_location": "L168"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "storescheduletime_localdateat",
-      "label": "localDateAt()",
-      "norm_label": "localdateat()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
-      "source_location": "L208"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "storescheduletime_localdatefromutc",
-      "label": "localDateFromUtc()",
-      "norm_label": "localdatefromutc()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
-      "source_location": "L195"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "storescheduletime_localdateminutetoutc",
-      "label": "localDateMinuteToUtc()",
-      "norm_label": "localdateminutetoutc()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
-      "source_location": "L326"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "storescheduletime_localdateminutetoutccandidates",
-      "label": "localDateMinuteToUtcCandidates()",
-      "norm_label": "localdateminutetoutccandidates()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
-      "source_location": "L270"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "storescheduletime_localdatestartat",
-      "label": "localDateStartAt()",
-      "norm_label": "localdatestartat()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
-      "source_location": "L336"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "storescheduletime_localdatetimeat",
-      "label": "localDateTimeAt()",
-      "norm_label": "localdatetimeat()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
-      "source_location": "L345"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "storescheduletime_localminuteat",
-      "label": "localMinuteAt()",
-      "norm_label": "localminuteat()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
-      "source_location": "L250"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "storescheduletime_localpartsat",
-      "label": "localPartsAt()",
-      "norm_label": "localpartsat()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
-      "source_location": "L221"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "storescheduletime_localtimeat",
-      "label": "localTimeAt()",
-      "norm_label": "localtimeat()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
-      "source_location": "L260"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "storescheduletime_minutestolabel",
-      "label": "minutesToLabel()",
-      "norm_label": "minutestolabel()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
-      "source_location": "L371"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "storescheduletime_nextreportingcycleboundary",
-      "label": "nextReportingCycleBoundary()",
-      "norm_label": "nextreportingcycleboundary()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
-      "source_location": "L360"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "storescheduletime_parselocaldate",
-      "label": "parseLocalDate()",
-      "norm_label": "parselocaldate()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
-      "source_location": "L172"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "storescheduletime_rangesoverlap",
-      "label": "rangesOverlap()",
-      "norm_label": "rangesoverlap()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
-      "source_location": "L905"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "storescheduletime_resolvestorecalendarrangefordate",
-      "label": "resolveStoreCalendarRangeForDate()",
-      "norm_label": "resolvestorecalendarrangefordate()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
-      "source_location": "L475"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "storescheduletime_resolvestoreoperatingrangefordate",
-      "label": "resolveStoreOperatingRangeForDate()",
-      "norm_label": "resolvestoreoperatingrangefordate()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
-      "source_location": "L824"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "storescheduletime_resolvestoreoperatingwindowsfordate",
-      "label": "resolveStoreOperatingWindowsForDate()",
-      "norm_label": "resolvestoreoperatingwindowsfordate()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
-      "source_location": "L861"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "storescheduletime_resolvestoreschedulecontext",
-      "label": "resolveStoreScheduleContext()",
-      "norm_label": "resolvestoreschedulecontext()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
-      "source_location": "L734"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "storescheduletime_tocontextwindow",
-      "label": "toContextWindow()",
-      "norm_label": "tocontextwindow()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
-      "source_location": "L653"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "storescheduletime_validatedayofweek",
-      "label": "validateDayOfWeek()",
-      "norm_label": "validatedayofweek()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
-      "source_location": "L387"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "storescheduletime_validateminute",
-      "label": "validateMinute()",
-      "norm_label": "validateminute()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
-      "source_location": "L377"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "storescheduletime_validatenoeffectiverangeoverlap",
-      "label": "validateNoEffectiveRangeOverlap()",
-      "norm_label": "validatenoeffectiverangeoverlap()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
-      "source_location": "L915"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "storescheduletime_validatestorescheduledraft",
-      "label": "validateStoreScheduleDraft()",
-      "norm_label": "validatestorescheduledraft()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
-      "source_location": "L494"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "storescheduletime_validatewindowshape",
-      "label": "validateWindowShape()",
-      "norm_label": "validatewindowshape()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
-      "source_location": "L397"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "storescheduletime_weeklywindowsoverlap",
-      "label": "weeklyWindowsOverlap()",
-      "norm_label": "weeklywindowsoverlap()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
-      "source_location": "L435"
-    },
-    {
-      "community": 24,
-      "file_type": "code",
-      "id": "storescheduletime_windowsforlocaldate",
-      "label": "windowsForLocalDate()",
-      "norm_label": "windowsforlocaldate()",
-      "source_file": "packages/athena-webapp/convex/lib/storeScheduleTime.ts",
-      "source_location": "L630"
+      "id": "packages_athena_webapp_src_components_operations_dailyoperationsview_tsx",
+      "label": "DailyOperationsView.tsx",
+      "norm_label": "dailyoperationsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "source_location": "L1"
     },
     {
       "community": 240,
@@ -213411,344 +213342,344 @@
     {
       "community": 25,
       "file_type": "code",
-      "id": "dailyoperationsview_applyautomationsnapshot",
-      "label": "applyAutomationSnapshot()",
-      "norm_label": "applyautomationsnapshot()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L700"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "dailyoperationsview_applytodayrefreshsnapshot",
-      "label": "applyTodayRefreshSnapshot()",
-      "norm_label": "applytodayrefreshsnapshot()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L668"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "dailyoperationsview_builddailyclosesearch",
-      "label": "buildDailyCloseSearch()",
-      "norm_label": "builddailyclosesearch()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L557"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "dailyoperationsview_builddailyoperationssearch",
-      "label": "buildDailyOperationsSearch()",
-      "norm_label": "builddailyoperationssearch()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L563"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "dailyoperationsview_buildoperationsexpensesearch",
-      "label": "buildOperationsExpenseSearch()",
-      "norm_label": "buildoperationsexpensesearch()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L600"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "dailyoperationsview_buildoperationstransactionsearch",
-      "label": "buildOperationsTransactionSearch()",
-      "norm_label": "buildoperationstransactionsearch()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L586"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "dailyoperationsview_buildparams",
-      "label": "buildParams()",
-      "norm_label": "buildparams()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L1855"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "dailyoperationsview_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L3644"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "dailyoperationsview_dailyoperationsconnectedruntimeview",
-      "label": "DailyOperationsConnectedRuntimeView()",
-      "norm_label": "dailyoperationsconnectedruntimeview()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L4808"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "dailyoperationsview_dailyoperationsruntimeview",
-      "label": "DailyOperationsRuntimeView()",
-      "norm_label": "dailyoperationsruntimeview()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L4856"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "dailyoperationsview_dailyoperationstopbandshell",
-      "label": "DailyOperationsTopBandShell()",
-      "norm_label": "dailyoperationstopbandshell()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L1724"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "dailyoperationsview_formateventtime",
-      "label": "formatEventTime()",
-      "norm_label": "formateventtime()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L776"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "dailyoperationsview_formatonlineordertimelinefallbackmessage",
-      "label": "formatOnlineOrderTimelineFallbackMessage()",
-      "norm_label": "formatonlineordertimelinefallbackmessage()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L826"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "dailyoperationsview_formatoperatingdate",
-      "label": "formatOperatingDate()",
-      "norm_label": "formatoperatingdate()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L524"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "dailyoperationsview_formatoperatingdatewithweekday",
-      "label": "formatOperatingDateWithWeekday()",
-      "norm_label": "formatoperatingdatewithweekday()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L540"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "dailyoperationsview_formatpendingapprovalslabel",
-      "label": "formatPendingApprovalsLabel()",
-      "norm_label": "formatpendingapprovalslabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L757"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "dailyoperationsview_formattimelinemessage",
-      "label": "formatTimelineMessage()",
-      "norm_label": "formattimelinemessage()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L842"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "dailyoperationsview_getdailyoperationsapi",
-      "label": "getDailyOperationsApi()",
-      "norm_label": "getdailyoperationsapi()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L481"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "dailyoperationsview_getdailyoperationscompletionattributiondetail",
-      "label": "getDailyOperationsCompletionAttributionDetail()",
-      "norm_label": "getdailyoperationscompletionattributiondetail()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L1809"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "dailyoperationsview_getdailyoperationsmetriclabels",
-      "label": "getDailyOperationsMetricLabels()",
-      "norm_label": "getdailyoperationsmetriclabels()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L607"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "dailyoperationsview_getoperatingtimezoneoffsetminutes",
-      "label": "getOperatingTimezoneOffsetMinutes()",
-      "norm_label": "getoperatingtimezoneoffsetminutes()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L516"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "dailyoperationsview_getpendingapprovalscountlabel",
-      "label": "getPendingApprovalsCountLabel()",
-      "norm_label": "getpendingapprovalscountlabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L751"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "dailyoperationsview_getpendingapprovalslanefromlanes",
-      "label": "getPendingApprovalsLaneFromLanes()",
-      "norm_label": "getpendingapprovalslanefromlanes()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L728"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "dailyoperationsview_getsaturdayweekendoperatingdate",
-      "label": "getSaturdayWeekEndOperatingDate()",
-      "norm_label": "getsaturdayweekendoperatingdate()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L509"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "dailyoperationsview_getsundayweekstartoperatingdate",
-      "label": "getSundayWeekStartOperatingDate()",
-      "norm_label": "getsundayweekstartoperatingdate()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L500"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "dailyoperationsview_getweekendoperatingdatefromsearch",
-      "label": "getWeekEndOperatingDateFromSearch()",
-      "norm_label": "getweekendoperatingdatefromsearch()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L620"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "dailyoperationsview_getworkflowsearch",
-      "label": "getWorkflowSearch()",
-      "norm_label": "getworkflowsearch()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L764"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "dailyoperationsview_handleoperatingdatechange",
-      "label": "handleOperatingDateChange()",
-      "norm_label": "handleoperatingdatechange()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L4516"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "dailyoperationsview_handletimelinesheetopenchange",
-      "label": "handleTimelineSheetOpenChange()",
-      "norm_label": "handletimelinesheetopenchange()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L4530"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "dailyoperationsview_ishistoricaloperatingdate",
-      "label": "isHistoricalOperatingDate()",
-      "norm_label": "ishistoricaloperatingdate()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L616"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "dailyoperationsview_replaceapprovalslane",
-      "label": "replaceApprovalsLane()",
-      "norm_label": "replaceapprovalslane()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L736"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "dailyoperationsview_replaceweekmetricforoperatingdate",
-      "label": "replaceWeekMetricForOperatingDate()",
-      "norm_label": "replaceweekmetricforoperatingdate()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L641"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "dailyoperationsview_selectweekmetricsforoperatingdate",
-      "label": "selectWeekMetricsForOperatingDate()",
-      "norm_label": "selectweekmetricsforoperatingdate()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L631"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "dailyoperationsview_settimelinesheetopen",
-      "label": "setTimelineSheetOpen()",
-      "norm_label": "settimelinesheetopen()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L3371"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "dailyoperationsview_shiftlocaloperatingdate",
-      "label": "shiftLocalOperatingDate()",
-      "norm_label": "shiftlocaloperatingdate()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L491"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "dailyoperationsview_shouldshowhistoricaleodreviewaction",
-      "label": "shouldShowHistoricalEodReviewAction()",
-      "norm_label": "shouldshowhistoricaleodreviewaction()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L719"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "dailyoperationsview_shouldshowprimaryaction",
-      "label": "shouldShowPrimaryAction()",
-      "norm_label": "shouldshowprimaryaction()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L715"
-    },
-    {
-      "community": 25,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_dailyoperationsview_tsx",
-      "label": "DailyOperationsView.tsx",
-      "norm_label": "dailyoperationsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
+      "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
+      "label": "StockAdjustmentWorkspace.tsx",
+      "norm_label": "stockadjustmentworkspace.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_buildcameraattempts",
+      "label": "buildCameraAttempts()",
+      "norm_label": "buildcameraattempts()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L1043"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_buildcyclecountdrafts",
+      "label": "buildCycleCountDrafts()",
+      "norm_label": "buildcyclecountdrafts()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L298"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_buildmanualdrafts",
+      "label": "buildManualDrafts()",
+      "norm_label": "buildmanualdrafts()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L294"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_buildstockadjustmentsubmissionkey",
+      "label": "buildStockAdjustmentSubmissionKey()",
+      "norm_label": "buildstockadjustmentsubmissionkey()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L316"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_cleaninventorymetadatavalue",
+      "label": "cleanInventoryMetadataValue()",
+      "norm_label": "cleaninventorymetadatavalue()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L327"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_formatcategorylist",
+      "label": "formatCategoryList()",
+      "norm_label": "formatcategorylist()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L341"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_formatinventoryitempricelabel",
+      "label": "formatInventoryItemPriceLabel()",
+      "norm_label": "formatinventoryitempricelabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L449"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_formatinventorynumber",
+      "label": "formatInventoryNumber()",
+      "norm_label": "formatinventorynumber()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L337"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_formatreservationsourcesummary",
+      "label": "formatReservationSourceSummary()",
+      "norm_label": "formatreservationsourcesummary()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L385"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_getcountscopelabel",
+      "label": "getCountScopeLabel()",
+      "norm_label": "getcountscopelabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L278"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_getinventoryitemdisplayname",
+      "label": "getInventoryItemDisplayName()",
+      "norm_label": "getinventoryitemdisplayname()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L348"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_getinventoryitemoperationalprice",
+      "label": "getInventoryItemOperationalPrice()",
+      "norm_label": "getinventoryitemoperationalprice()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L445"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_getreservationlabels",
+      "label": "getReservationLabels()",
+      "norm_label": "getreservationlabels()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L352"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_getskudetailentries",
+      "label": "getSkuDetailEntries()",
+      "norm_label": "getskudetailentries()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L407"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_getstockadjustmentavailabilityfilteroptions",
+      "label": "getStockAdjustmentAvailabilityFilterOptions()",
+      "norm_label": "getstockadjustmentavailabilityfilteroptions()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L490"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_getstockadjustmentcategorykey",
+      "label": "getStockAdjustmentCategoryKey()",
+      "norm_label": "getstockadjustmentcategorykey()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L282"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_getstockadjustmentcategorylabel",
+      "label": "getStockAdjustmentCategoryLabel()",
+      "norm_label": "getstockadjustmentcategorylabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L286"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_getstockadjustmentsearchterms",
+      "label": "getStockAdjustmentSearchTerms()",
+      "norm_label": "getstockadjustmentsearchterms()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L465"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_getvideoelementstream",
+      "label": "getVideoElementStream()",
+      "norm_label": "getvideoelementstream()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L1096"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_getvideotracks",
+      "label": "getVideoTracks()",
+      "norm_label": "getvideotracks()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L1102"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_handledraftchange",
+      "label": "handleDraftChange()",
+      "norm_label": "handledraftchange()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L2622"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_handlevideoevent",
+      "label": "handleVideoEvent()",
+      "norm_label": "handlevideoevent()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L938"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_if",
+      "label": "if()",
+      "norm_label": "if()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L2261"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_iscancelled",
+      "label": "isCancelled()",
+      "norm_label": "iscancelled()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L990"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_isstockadjustmentblocked",
+      "label": "isStockAdjustmentBlocked()",
+      "norm_label": "isstockadjustmentblocked()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L290"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_pluralize",
+      "label": "pluralize()",
+      "norm_label": "pluralize()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L333"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_preparevideoelement",
+      "label": "prepareVideoElement()",
+      "norm_label": "preparevideoelement()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L1130"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_rowmatchesavailabilityfilter",
+      "label": "rowMatchesAvailabilityFilter()",
+      "norm_label": "rowmatchesavailabilityfilter()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L504"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_rowmatchescategoryfilter",
+      "label": "rowMatchesCategoryFilter()",
+      "norm_label": "rowmatchescategoryfilter()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L483"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_scannextframe",
+      "label": "scanNextFrame()",
+      "norm_label": "scannextframe()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L1485"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_scorestockadjustmentsearchrow",
+      "label": "scoreStockAdjustmentSearchRow()",
+      "norm_label": "scorestockadjustmentsearchrow()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L459"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_setdraftvalue",
+      "label": "setDraftValue()",
+      "norm_label": "setdraftvalue()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L2612"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_startframecapturescanner",
+      "label": "startFrameCaptureScanner()",
+      "norm_label": "startframecapturescanner()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L1282"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_stopvideoelementstream",
+      "label": "stopVideoElementStream()",
+      "norm_label": "stopvideoelementstream()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L1107"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L322"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_waitforvideopreview",
+      "label": "waitForVideoPreview()",
+      "norm_label": "waitforvideopreview()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L1143"
+    },
+    {
+      "community": 25,
+      "file_type": "code",
+      "id": "stockadjustmentworkspace_waitforvideosurfacepaint",
+      "label": "waitForVideoSurfacePaint()",
+      "norm_label": "waitforvideosurfacepaint()",
+      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "source_location": "L1118"
     },
     {
       "community": 250,
@@ -215517,344 +215448,335 @@
     {
       "community": 26,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_tsx",
-      "label": "StockAdjustmentWorkspace.tsx",
-      "norm_label": "stockadjustmentworkspace.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "id": "packages_athena_webapp_convex_operations_skuactivity_ts",
+      "label": "skuActivity.ts",
+      "norm_label": "skuactivity.ts",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
       "source_location": "L1"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_buildcameraattempts",
-      "label": "buildCameraAttempts()",
-      "norm_label": "buildcameraattempts()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L1043"
+      "id": "skuactivity_assertidempotentreplaymatches",
+      "label": "assertIdempotentReplayMatches()",
+      "norm_label": "assertidempotentreplaymatches()",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
+      "source_location": "L165"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_buildcyclecountdrafts",
-      "label": "buildCycleCountDrafts()",
-      "norm_label": "buildcyclecountdrafts()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L298"
+      "id": "skuactivity_assertproductskubelongstostore",
+      "label": "assertProductSkuBelongsToStore()",
+      "norm_label": "assertproductskubelongstostore()",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
+      "source_location": "L196"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_buildmanualdrafts",
-      "label": "buildManualDrafts()",
-      "norm_label": "buildmanualdrafts()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L294"
+      "id": "skuactivity_assertskuactivityargs",
+      "label": "assertSkuActivityArgs()",
+      "norm_label": "assertskuactivityargs()",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
+      "source_location": "L123"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_buildstockadjustmentsubmissionkey",
-      "label": "buildStockAdjustmentSubmissionKey()",
-      "norm_label": "buildstockadjustmentsubmissionkey()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L316"
+      "id": "skuactivity_boundednumber",
+      "label": "boundedNumber()",
+      "norm_label": "boundednumber()",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
+      "source_location": "L582"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_cleaninventorymetadatavalue",
-      "label": "cleanInventoryMetadataValue()",
-      "norm_label": "cleaninventorymetadatavalue()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L327"
+      "id": "skuactivity_buildactivereservationentries",
+      "label": "buildActiveReservationEntries()",
+      "norm_label": "buildactivereservationentries()",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
+      "source_location": "L430"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_formatcategorylist",
-      "label": "formatCategoryList()",
-      "norm_label": "formatcategorylist()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
+      "id": "skuactivity_buildavailabilitywarnings",
+      "label": "buildAvailabilityWarnings()",
+      "norm_label": "buildavailabilitywarnings()",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
+      "source_location": "L509"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "skuactivity_buildinventoryimportevidencesource",
+      "label": "buildInventoryImportEvidenceSource()",
+      "norm_label": "buildinventoryimportevidencesource()",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
+      "source_location": "L648"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "skuactivity_buildpendingcheckoutevidencesource",
+      "label": "buildPendingCheckoutEvidenceSource()",
+      "norm_label": "buildpendingcheckoutevidencesource()",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
+      "source_location": "L697"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "skuactivity_buildskuactivityevent",
+      "label": "buildSkuActivityEvent()",
+      "norm_label": "buildskuactivityevent()",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
+      "source_location": "L150"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "skuactivity_buildtimeline",
+      "label": "buildTimeline()",
+      "norm_label": "buildtimeline()",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
+      "source_location": "L533"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "skuactivity_builduntrustedsourcetransactionhistory",
+      "label": "buildUntrustedSourceTransactionHistory()",
+      "norm_label": "builduntrustedsourcetransactionhistory()",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
+      "source_location": "L887"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "skuactivity_getimpactquantities",
+      "label": "getImpactQuantities()",
+      "norm_label": "getimpactquantities()",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "skuactivity_getimportstatusesforreviewstatus",
+      "label": "getImportStatusesForReviewStatus()",
+      "norm_label": "getimportstatusesforreviewstatus()",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
+      "source_location": "L594"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "skuactivity_getinventoryimportevidencereviewstate",
+      "label": "getInventoryImportEvidenceReviewState()",
+      "norm_label": "getinventoryimportevidencereviewstate()",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
+      "source_location": "L638"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "skuactivity_getpendingcheckoutstatusesforreviewstatus",
+      "label": "getPendingCheckoutStatusesForReviewStatus()",
+      "norm_label": "getpendingcheckoutstatusesforreviewstatus()",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
+      "source_location": "L614"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "skuactivity_getreservationgroupkey",
+      "label": "getReservationGroupKey()",
+      "norm_label": "getreservationgroupkey()",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
+      "source_location": "L382"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "skuactivity_getreservationsourcekind",
+      "label": "getReservationSourceKind()",
+      "norm_label": "getreservationsourcekind()",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
+      "source_location": "L357"
+    },
+    {
+      "community": 26,
+      "file_type": "code",
+      "id": "skuactivity_getreservationsourcekindfromfields",
+      "label": "getReservationSourceKindFromFields()",
+      "norm_label": "getreservationsourcekindfromfields()",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
       "source_location": "L341"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_formatinventoryitempricelabel",
-      "label": "formatInventoryItemPriceLabel()",
-      "norm_label": "formatinventoryitempricelabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L449"
+      "id": "skuactivity_getskuactivityforproductskuwithctx",
+      "label": "getSkuActivityForProductSkuWithCtx()",
+      "norm_label": "getskuactivityforproductskuwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
+      "source_location": "L1121"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_formatinventorynumber",
-      "label": "formatInventoryNumber()",
-      "norm_label": "formatinventorynumber()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L337"
+      "id": "skuactivity_getsourcelabel",
+      "label": "getSourceLabel()",
+      "norm_label": "getsourcelabel()",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
+      "source_location": "L361"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_formatreservationsourcesummary",
-      "label": "formatReservationSourceSummary()",
-      "norm_label": "formatreservationsourcesummary()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L385"
+      "id": "skuactivity_getsourcereviewstate",
+      "label": "getSourceReviewState()",
+      "norm_label": "getsourcereviewstate()",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
+      "source_location": "L631"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_getcountscopelabel",
-      "label": "getCountScopeLabel()",
-      "norm_label": "getcountscopelabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L278"
+      "id": "skuactivity_getuntrustedskusaleevidencewithctx",
+      "label": "getUntrustedSkuSaleEvidenceWithCtx()",
+      "norm_label": "getuntrustedskusaleevidencewithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
+      "source_location": "L1052"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_getinventoryitemdisplayname",
-      "label": "getInventoryItemDisplayName()",
-      "norm_label": "getinventoryitemdisplayname()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L348"
+      "id": "skuactivity_hasarchivedlinkedproduct",
+      "label": "hasArchivedLinkedProduct()",
+      "norm_label": "hasarchivedlinkedproduct()",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
+      "source_location": "L676"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_getinventoryitemoperationalprice",
-      "label": "getInventoryItemOperationalPrice()",
-      "norm_label": "getinventoryitemoperationalprice()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L445"
+      "id": "skuactivity_islivereservationstillactive",
+      "label": "isLiveReservationStillActive()",
+      "norm_label": "islivereservationstillactive()",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
+      "source_location": "L393"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_getreservationlabels",
-      "label": "getReservationLabels()",
-      "norm_label": "getreservationlabels()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L352"
+      "id": "skuactivity_listinventoryimportevidencesources",
+      "label": "listInventoryImportEvidenceSources()",
+      "norm_label": "listinventoryimportevidencesources()",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
+      "source_location": "L731"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_getskudetailentries",
-      "label": "getSkuDetailEntries()",
-      "norm_label": "getskudetailentries()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L407"
+      "id": "skuactivity_listpendingcheckoutevidencesources",
+      "label": "listPendingCheckoutEvidenceSources()",
+      "norm_label": "listpendingcheckoutevidencesources()",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
+      "source_location": "L771"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_getstockadjustmentavailabilityfilteroptions",
-      "label": "getStockAdjustmentAvailabilityFilterOptions()",
-      "norm_label": "getstockadjustmentavailabilityfilteroptions()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L490"
+      "id": "skuactivity_listskuactivityeventsforsourcewithctx",
+      "label": "listSkuActivityEventsForSourceWithCtx()",
+      "norm_label": "listskuactivityeventsforsourcewithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
+      "source_location": "L284"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_getstockadjustmentcategorykey",
-      "label": "getStockAdjustmentCategoryKey()",
-      "norm_label": "getstockadjustmentcategorykey()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L282"
+      "id": "skuactivity_listtransactionitemsforuntrustedsource",
+      "label": "listTransactionItemsForUntrustedSource()",
+      "norm_label": "listtransactionitemsforuntrustedsource()",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
+      "source_location": "L799"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_getstockadjustmentcategorylabel",
-      "label": "getStockAdjustmentCategoryLabel()",
-      "norm_label": "getstockadjustmentcategorylabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L286"
+      "id": "skuactivity_loadselecteduntrustedevidencesource",
+      "label": "loadSelectedUntrustedEvidenceSource()",
+      "norm_label": "loadselecteduntrustedevidencesource()",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
+      "source_location": "L965"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_getstockadjustmentsearchterms",
-      "label": "getStockAdjustmentSearchTerms()",
-      "norm_label": "getstockadjustmentsearchterms()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L465"
+      "id": "skuactivity_recordskuactivityeventwithctx",
+      "label": "recordSkuActivityEventWithCtx()",
+      "norm_label": "recordskuactivityeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
+      "source_location": "L215"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_getvideoelementstream",
-      "label": "getVideoElementStream()",
-      "norm_label": "getvideoelementstream()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L1096"
+      "id": "skuactivity_recordskuactivityeventwithdb",
+      "label": "recordSkuActivityEventWithDb()",
+      "norm_label": "recordskuactivityeventwithdb()",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
+      "source_location": "L277"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_getvideotracks",
-      "label": "getVideoTracks()",
-      "norm_label": "getvideotracks()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L1102"
+      "id": "skuactivity_requireskuactivitystoreaccess",
+      "label": "requireSkuActivityStoreAccess()",
+      "norm_label": "requireskuactivitystoreaccess()",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
+      "source_location": "L561"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_handledraftchange",
-      "label": "handleDraftChange()",
-      "norm_label": "handledraftchange()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L2622"
+      "id": "skuactivity_resolveproductskuforactivity",
+      "label": "resolveProductSkuForActivity()",
+      "norm_label": "resolveproductskuforactivity()",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
+      "source_location": "L311"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_handlevideoevent",
-      "label": "handleVideoEvent()",
-      "norm_label": "handlevideoevent()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L938"
+      "id": "skuactivity_summarizeactivereservations",
+      "label": "summarizeActiveReservations()",
+      "norm_label": "summarizeactivereservations()",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
+      "source_location": "L477"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_if",
-      "label": "if()",
-      "norm_label": "if()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L2261"
+      "id": "skuactivity_summarizetransactionitemadjustments",
+      "label": "summarizeTransactionItemAdjustments()",
+      "norm_label": "summarizetransactionitemadjustments()",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
+      "source_location": "L831"
     },
     {
       "community": 26,
       "file_type": "code",
-      "id": "stockadjustmentworkspace_iscancelled",
-      "label": "isCancelled()",
-      "norm_label": "iscancelled()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L990"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_isstockadjustmentblocked",
-      "label": "isStockAdjustmentBlocked()",
-      "norm_label": "isstockadjustmentblocked()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L290"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_pluralize",
-      "label": "pluralize()",
-      "norm_label": "pluralize()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L333"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_preparevideoelement",
-      "label": "prepareVideoElement()",
-      "norm_label": "preparevideoelement()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L1130"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_rowmatchesavailabilityfilter",
-      "label": "rowMatchesAvailabilityFilter()",
-      "norm_label": "rowmatchesavailabilityfilter()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L504"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_rowmatchescategoryfilter",
-      "label": "rowMatchesCategoryFilter()",
-      "norm_label": "rowmatchescategoryfilter()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L483"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_scannextframe",
-      "label": "scanNextFrame()",
-      "norm_label": "scannextframe()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L1485"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_scorestockadjustmentsearchrow",
-      "label": "scoreStockAdjustmentSearchRow()",
-      "norm_label": "scorestockadjustmentsearchrow()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L459"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_setdraftvalue",
-      "label": "setDraftValue()",
-      "norm_label": "setdraftvalue()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L2612"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_startframecapturescanner",
-      "label": "startFrameCaptureScanner()",
-      "norm_label": "startframecapturescanner()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L1282"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_stopvideoelementstream",
-      "label": "stopVideoElementStream()",
-      "norm_label": "stopvideoelementstream()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L1107"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L322"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_waitforvideopreview",
-      "label": "waitForVideoPreview()",
-      "norm_label": "waitforvideopreview()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L1143"
-    },
-    {
-      "community": 26,
-      "file_type": "code",
-      "id": "stockadjustmentworkspace_waitforvideosurfacepaint",
-      "label": "waitForVideoSurfacePaint()",
-      "norm_label": "waitforvideosurfacepaint()",
-      "source_file": "packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx",
-      "source_location": "L1118"
+      "id": "skuactivity_trimrequired",
+      "label": "trimRequired()",
+      "norm_label": "trimrequired()",
+      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
+      "source_location": "L107"
     },
     {
       "community": 260,
@@ -217344,335 +217266,335 @@
     {
       "community": 27,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_skuactivity_ts",
-      "label": "skuActivity.ts",
-      "norm_label": "skuactivity.ts",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registerreadmodel_ts",
+      "label": "registerReadModel.ts",
+      "norm_label": "registerreadmodel.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
       "source_location": "L1"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "skuactivity_assertidempotentreplaymatches",
-      "label": "assertIdempotentReplayMatches()",
-      "norm_label": "assertidempotentreplaymatches()",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
-      "source_location": "L165"
+      "id": "registerreadmodel_asrecord",
+      "label": "asRecord()",
+      "norm_label": "asrecord()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "source_location": "L1038"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "skuactivity_assertproductskubelongstostore",
-      "label": "assertProductSkuBelongsToStore()",
-      "norm_label": "assertproductskubelongstostore()",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
-      "source_location": "L196"
+      "id": "registerreadmodel_calculatelocalsaleexpectedcashdelta",
+      "label": "calculateLocalSaleExpectedCashDelta()",
+      "norm_label": "calculatelocalsaleexpectedcashdelta()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "source_location": "L904"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "skuactivity_assertskuactivityargs",
-      "label": "assertSkuActivityArgs()",
-      "norm_label": "assertskuactivityargs()",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
-      "source_location": "L123"
+      "id": "registerreadmodel_canuploadedregisteropenreplaceblockeddrawer",
+      "label": "canUploadedRegisterOpenReplaceBlockedDrawer()",
+      "norm_label": "canuploadedregisteropenreplaceblockeddrawer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "source_location": "L1088"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "skuactivity_boundednumber",
-      "label": "boundedNumber()",
-      "norm_label": "boundednumber()",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
-      "source_location": "L582"
+      "id": "registerreadmodel_cartitemsourcekey",
+      "label": "cartItemSourceKey()",
+      "norm_label": "cartitemsourcekey()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "source_location": "L957"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "skuactivity_buildactivereservationentries",
-      "label": "buildActiveReservationEntries()",
-      "norm_label": "buildactivereservationentries()",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
-      "source_location": "L430"
+      "id": "registerreadmodel_createmappingindex",
+      "label": "createMappingIndex()",
+      "norm_label": "createmappingindex()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "source_location": "L549"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "skuactivity_buildavailabilitywarnings",
-      "label": "buildAvailabilityWarnings()",
-      "norm_label": "buildavailabilitywarnings()",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
-      "source_location": "L509"
+      "id": "registerreadmodel_errorfor",
+      "label": "errorFor()",
+      "norm_label": "errorfor()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "source_location": "L1012"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "skuactivity_buildinventoryimportevidencesource",
-      "label": "buildInventoryImportEvidenceSource()",
-      "norm_label": "buildinventoryimportevidencesource()",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
-      "source_location": "L648"
+      "id": "registerreadmodel_errormessage",
+      "label": "errorMessage()",
+      "norm_label": "errormessage()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "source_location": "L1025"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "skuactivity_buildpendingcheckoutevidencesource",
-      "label": "buildPendingCheckoutEvidenceSource()",
-      "norm_label": "buildpendingcheckoutevidencesource()",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
-      "source_location": "L697"
+      "id": "registerreadmodel_getcompletedsale",
+      "label": "getCompletedSale()",
+      "norm_label": "getcompletedsale()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "source_location": "L711"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "skuactivity_buildskuactivityevent",
-      "label": "buildSkuActivityEvent()",
-      "norm_label": "buildskuactivityevent()",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
-      "source_location": "L150"
+      "id": "registerreadmodel_getorcreatesale",
+      "label": "getOrCreateSale()",
+      "norm_label": "getorcreatesale()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "source_location": "L669"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "skuactivity_buildtimeline",
-      "label": "buildTimeline()",
-      "norm_label": "buildtimeline()",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
-      "source_location": "L533"
+      "id": "registerreadmodel_getphase",
+      "label": "getPhase()",
+      "norm_label": "getphase()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "source_location": "L658"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "skuactivity_builduntrustedsourcetransactionhistory",
-      "label": "buildUntrustedSourceTransactionHistory()",
-      "norm_label": "builduntrustedsourcetransactionhistory()",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
-      "source_location": "L887"
+      "id": "registerreadmodel_getsaleblockreason",
+      "label": "getSaleBlockReason()",
+      "norm_label": "getsaleblockreason()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "source_location": "L526"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "skuactivity_getimpactquantities",
-      "label": "getImpactQuantities()",
-      "norm_label": "getimpactquantities()",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
-      "source_location": "L115"
+      "id": "registerreadmodel_hassettledregistercloseout",
+      "label": "hasSettledRegisterCloseout()",
+      "norm_label": "hassettledregistercloseout()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "source_location": "L502"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "skuactivity_getimportstatusesforreviewstatus",
-      "label": "getImportStatusesForReviewStatus()",
-      "norm_label": "getimportstatusesforreviewstatus()",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
-      "source_location": "L594"
+      "id": "registerreadmodel_isopenlocalregistersessionstatus",
+      "label": "isOpenLocalRegisterSessionStatus()",
+      "norm_label": "isopenlocalregistersessionstatus()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "source_location": "L1075"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "skuactivity_getinventoryimportevidencereviewstate",
-      "label": "getInventoryImportEvidenceReviewState()",
-      "norm_label": "getinventoryimportevidencereviewstate()",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
-      "source_location": "L638"
+      "id": "registerreadmodel_isuploadedregisteropenlifecycleevent",
+      "label": "isUploadedRegisterOpenLifecycleEvent()",
+      "norm_label": "isuploadedregisteropenlifecycleevent()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "source_location": "L1081"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "skuactivity_getpendingcheckoutstatusesforreviewstatus",
-      "label": "getPendingCheckoutStatusesForReviewStatus()",
-      "norm_label": "getpendingcheckoutstatusesforreviewstatus()",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
-      "source_location": "L614"
+      "id": "registerreadmodel_numberfield",
+      "label": "numberField()",
+      "norm_label": "numberfield()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "source_location": "L1055"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "skuactivity_getreservationgroupkey",
-      "label": "getReservationGroupKey()",
-      "norm_label": "getreservationgroupkey()",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
-      "source_location": "L382"
+      "id": "registerreadmodel_optionalstring",
+      "label": "optionalString()",
+      "norm_label": "optionalstring()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "source_location": "L1049"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "skuactivity_getreservationsourcekind",
-      "label": "getReservationSourceKind()",
-      "norm_label": "getreservationsourcekind()",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
-      "source_location": "L357"
+      "id": "registerreadmodel_parsecartitem",
+      "label": "parseCartItem()",
+      "norm_label": "parsecartitem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "source_location": "L766"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "skuactivity_getreservationsourcekindfromfields",
-      "label": "getReservationSourceKindFromFields()",
-      "norm_label": "getreservationsourcekindfromfields()",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
-      "source_location": "L341"
+      "id": "registerreadmodel_parsecartitempayload",
+      "label": "parseCartItemPayload()",
+      "norm_label": "parsecartitempayload()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "source_location": "L775"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "skuactivity_getskuactivityforproductskuwithctx",
-      "label": "getSkuActivityForProductSkuWithCtx()",
-      "norm_label": "getskuactivityforproductskuwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
-      "source_location": "L1121"
+      "id": "registerreadmodel_parsepayments",
+      "label": "parsePayments()",
+      "norm_label": "parsepayments()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "source_location": "L875"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "skuactivity_getsourcelabel",
-      "label": "getSourceLabel()",
-      "norm_label": "getsourcelabel()",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
-      "source_location": "L361"
+      "id": "registerreadmodel_parseserviceline",
+      "label": "parseServiceLine()",
+      "norm_label": "parseserviceline()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "source_location": "L870"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "skuactivity_getsourcereviewstate",
-      "label": "getSourceReviewState()",
-      "norm_label": "getsourcereviewstate()",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
-      "source_location": "L631"
+      "id": "registerreadmodel_parseservicelines",
+      "label": "parseServiceLines()",
+      "norm_label": "parseservicelines()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "source_location": "L822"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "skuactivity_getuntrustedskusaleevidencewithctx",
-      "label": "getUntrustedSkuSaleEvidenceWithCtx()",
-      "norm_label": "getuntrustedskusaleevidencewithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
-      "source_location": "L1052"
+      "id": "registerreadmodel_pricingmodelfield",
+      "label": "pricingModelField()",
+      "norm_label": "pricingmodelfield()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "source_location": "L1127"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "skuactivity_hasarchivedlinkedproduct",
-      "label": "hasArchivedLinkedProduct()",
-      "norm_label": "hasarchivedlinkedproduct()",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
-      "source_location": "L676"
+      "id": "registerreadmodel_projectlocalregisterreadmodel",
+      "label": "projectLocalRegisterReadModel()",
+      "norm_label": "projectlocalregisterreadmodel()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "source_location": "L159"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "skuactivity_islivereservationstillactive",
-      "label": "isLiveReservationStillActive()",
-      "norm_label": "islivereservationstillactive()",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
-      "source_location": "L393"
+      "id": "registerreadmodel_registerlifecycleeventmatchesactivesession",
+      "label": "registerLifecycleEventMatchesActiveSession()",
+      "norm_label": "registerlifecycleeventmatchesactivesession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "source_location": "L570"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "skuactivity_listinventoryimportevidencesources",
-      "label": "listInventoryImportEvidenceSources()",
-      "norm_label": "listinventoryimportevidencesources()",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
-      "source_location": "L731"
+      "id": "registerreadmodel_registerlifecycleeventmatchessession",
+      "label": "registerLifecycleEventMatchesSession()",
+      "norm_label": "registerlifecycleeventmatchessession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "source_location": "L577"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "skuactivity_listpendingcheckoutevidencesources",
-      "label": "listPendingCheckoutEvidenceSources()",
-      "norm_label": "listpendingcheckoutevidencesources()",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
-      "source_location": "L771"
+      "id": "registerreadmodel_registerstatus",
+      "label": "registerStatus()",
+      "norm_label": "registerstatus()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "source_location": "L1063"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "skuactivity_listskuactivityeventsforsourcewithctx",
-      "label": "listSkuActivityEventsForSourceWithCtx()",
-      "norm_label": "listskuactivityeventsforsourcewithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
-      "source_location": "L284"
+      "id": "registerreadmodel_servicemodefield",
+      "label": "serviceModeField()",
+      "norm_label": "servicemodefield()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "source_location": "L1116"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "skuactivity_listtransactionitemsforuntrustedsource",
-      "label": "listTransactionItemsForUntrustedSource()",
-      "norm_label": "listtransactionitemsforuntrustedsource()",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
-      "source_location": "L799"
+      "id": "registerreadmodel_stringfield",
+      "label": "stringField()",
+      "norm_label": "stringfield()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "source_location": "L1044"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "skuactivity_loadselecteduntrustedevidencesource",
-      "label": "loadSelectedUntrustedEvidenceSource()",
-      "norm_label": "loadselecteduntrustedevidencesource()",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
-      "source_location": "L965"
+      "id": "registerreadmodel_terminalfromevent",
+      "label": "terminalFromEvent()",
+      "norm_label": "terminalfromevent()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "source_location": "L646"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "skuactivity_recordskuactivityeventwithctx",
-      "label": "recordSkuActivityEventWithCtx()",
-      "norm_label": "recordskuactivityeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
-      "source_location": "L215"
+      "id": "registerreadmodel_terminalfromseed",
+      "label": "terminalFromSeed()",
+      "norm_label": "terminalfromseed()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "source_location": "L629"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "skuactivity_recordskuactivityeventwithdb",
-      "label": "recordSkuActivityEventWithDb()",
-      "norm_label": "recordskuactivityeventwithdb()",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
-      "source_location": "L277"
+      "id": "registerreadmodel_toregisterstatedrawer",
+      "label": "toRegisterStateDrawer()",
+      "norm_label": "toregisterstatedrawer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "source_location": "L595"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "skuactivity_requireskuactivitystoreaccess",
-      "label": "requireSkuActivityStoreAccess()",
-      "norm_label": "requireskuactivitystoreaccess()",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
-      "source_location": "L561"
+      "id": "registerreadmodel_toregisterstatesession",
+      "label": "toRegisterStateSession()",
+      "norm_label": "toregisterstatesession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "source_location": "L613"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "skuactivity_resolveproductskuforactivity",
-      "label": "resolveProductSkuForActivity()",
-      "norm_label": "resolveproductskuforactivity()",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
-      "source_location": "L311"
+      "id": "registerreadmodel_totalsfromitems",
+      "label": "totalsFromItems()",
+      "norm_label": "totalsfromitems()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "source_location": "L988"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "skuactivity_summarizeactivereservations",
-      "label": "summarizeActiveReservations()",
-      "norm_label": "summarizeactivereservations()",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
-      "source_location": "L477"
+      "id": "registerreadmodel_totalsfromitemsandservices",
+      "label": "totalsFromItemsAndServices()",
+      "norm_label": "totalsfromitemsandservices()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "source_location": "L996"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "skuactivity_summarizetransactionitemadjustments",
-      "label": "summarizeTransactionItemAdjustments()",
-      "norm_label": "summarizetransactionitemadjustments()",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
-      "source_location": "L831"
+      "id": "registerreadmodel_upsertcartitem",
+      "label": "upsertCartItem()",
+      "norm_label": "upsertcartitem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "source_location": "L919"
     },
     {
       "community": 27,
       "file_type": "code",
-      "id": "skuactivity_trimrequired",
-      "label": "trimRequired()",
-      "norm_label": "trimrequired()",
-      "source_file": "packages/athena-webapp/convex/operations/skuActivity.ts",
-      "source_location": "L107"
+      "id": "registerreadmodel_upsertserviceline",
+      "label": "upsertServiceLine()",
+      "norm_label": "upsertserviceline()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "source_location": "L974"
     },
     {
       "community": 270,
@@ -218487,335 +218409,335 @@
     {
       "community": 28,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registerreadmodel_ts",
-      "label": "registerReadModel.ts",
-      "norm_label": "registerreadmodel.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registercartprojection_ts",
+      "label": "registerCartProjection.ts",
+      "norm_label": "registercartprojection.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
       "source_location": "L1"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "registerreadmodel_asrecord",
-      "label": "asRecord()",
-      "norm_label": "asrecord()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
-      "source_location": "L1038"
+      "id": "registercartprojection_addlocalavailabilityconsumption",
+      "label": "addLocalAvailabilityConsumption()",
+      "norm_label": "addlocalavailabilityconsumption()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "source_location": "L562"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "registerreadmodel_calculatelocalsaleexpectedcashdelta",
-      "label": "calculateLocalSaleExpectedCashDelta()",
-      "norm_label": "calculatelocalsaleexpectedcashdelta()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
-      "source_location": "L904"
+      "id": "registercartprojection_addlocalavailabilitydeltaconsumption",
+      "label": "addLocalAvailabilityDeltaConsumption()",
+      "norm_label": "addlocalavailabilitydeltaconsumption()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "source_location": "L630"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "registerreadmodel_canuploadedregisteropenreplaceblockeddrawer",
-      "label": "canUploadedRegisterOpenReplaceBlockedDrawer()",
-      "norm_label": "canuploadedregisteropenreplaceblockeddrawer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
-      "source_location": "L1088"
+      "id": "registercartprojection_buildcatalogrepresentedpendingcheckoutitemids",
+      "label": "buildCatalogRepresentedPendingCheckoutItemIds()",
+      "norm_label": "buildcatalogrepresentedpendingcheckoutitemids()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "source_location": "L79"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "registerreadmodel_cartitemsourcekey",
-      "label": "cartItemSourceKey()",
-      "norm_label": "cartitemsourcekey()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
-      "source_location": "L957"
+      "id": "registercartprojection_buildcatalogrepresentedpendingcheckoutlocaleventids",
+      "label": "buildCatalogRepresentedPendingCheckoutLocalEventIds()",
+      "norm_label": "buildcatalogrepresentedpendingcheckoutlocaleventids()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "source_location": "L109"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "registerreadmodel_createmappingindex",
-      "label": "createMappingIndex()",
-      "norm_label": "createmappingindex()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
-      "source_location": "L549"
+      "id": "registercartprojection_buildcatalogrepresentedpendingcheckoutproductsignatures",
+      "label": "buildCatalogRepresentedPendingCheckoutProductSignatures()",
+      "norm_label": "buildcatalogrepresentedpendingcheckoutproductsignatures()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "source_location": "L175"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "registerreadmodel_errorfor",
-      "label": "errorFor()",
-      "norm_label": "errorfor()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
-      "source_location": "L1012"
+      "id": "registercartprojection_buildlocalavailabilityeventindex",
+      "label": "buildLocalAvailabilityEventIndex()",
+      "norm_label": "buildlocalavailabilityeventindex()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "source_location": "L590"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "registerreadmodel_errormessage",
-      "label": "errorMessage()",
-      "norm_label": "errormessage()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
-      "source_location": "L1025"
+      "id": "registercartprojection_buildlocalcartitempayload",
+      "label": "buildLocalCartItemPayload()",
+      "norm_label": "buildlocalcartitempayload()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "source_location": "L34"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "registerreadmodel_getcompletedsale",
-      "label": "getCompletedSale()",
-      "norm_label": "getcompletedsale()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
-      "source_location": "L711"
+      "id": "registercartprojection_buildlocalcartitempayloadfromcartitem",
+      "label": "buildLocalCartItemPayloadFromCartItem()",
+      "norm_label": "buildlocalcartitempayloadfromcartitem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "source_location": "L231"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "registerreadmodel_getorcreatesale",
-      "label": "getOrCreateSale()",
-      "norm_label": "getorcreatesale()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
-      "source_location": "L669"
+      "id": "registercartprojection_buildlocalpendingcheckoutdefinitioneventidsbyitemid",
+      "label": "buildLocalPendingCheckoutDefinitionEventIdsByItemId()",
+      "norm_label": "buildlocalpendingcheckoutdefinitioneventidsbyitemid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "source_location": "L136"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "registerreadmodel_getphase",
-      "label": "getPhase()",
-      "norm_label": "getphase()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
-      "source_location": "L658"
+      "id": "registercartprojection_cartitemlineeventkey",
+      "label": "cartItemLineEventKey()",
+      "norm_label": "cartitemlineeventkey()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "source_location": "L525"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "registerreadmodel_getsaleblockreason",
-      "label": "getSaleBlockReason()",
-      "norm_label": "getsaleblockreason()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
-      "source_location": "L526"
+      "id": "registercartprojection_cartitemlinekey",
+      "label": "cartItemLineKey()",
+      "norm_label": "cartitemlinekey()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "source_location": "L544"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "registerreadmodel_hassettledregistercloseout",
-      "label": "hasSettledRegisterCloseout()",
-      "norm_label": "hassettledregistercloseout()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
-      "source_location": "L502"
+      "id": "registercartprojection_cartitemsfromlocalregistermodel",
+      "label": "cartItemsFromLocalRegisterModel()",
+      "norm_label": "cartitemsfromlocalregistermodel()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "source_location": "L702"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "registerreadmodel_isopenlocalregistersessionstatus",
-      "label": "isOpenLocalRegisterSessionStatus()",
-      "norm_label": "isopenlocalregistersessionstatus()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
-      "source_location": "L1075"
+      "id": "registercartprojection_cartitemskuentry",
+      "label": "cartItemSkuEntry()",
+      "norm_label": "cartitemskuentry()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "source_location": "L518"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "registerreadmodel_isuploadedregisteropenlifecycleevent",
-      "label": "isUploadedRegisterOpenLifecycleEvent()",
-      "norm_label": "isuploadedregisteropenlifecycleevent()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
-      "source_location": "L1081"
+      "id": "registercartprojection_cartlinesourcekey",
+      "label": "cartLineSourceKey()",
+      "norm_label": "cartlinesourcekey()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "source_location": "L199"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "registerreadmodel_numberfield",
-      "label": "numberField()",
-      "norm_label": "numberfield()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
-      "source_location": "L1055"
+      "id": "registercartprojection_formatlocalpendingcheckoutsku",
+      "label": "formatLocalPendingCheckoutSku()",
+      "norm_label": "formatlocalpendingcheckoutsku()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "source_location": "L466"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "registerreadmodel_optionalstring",
-      "label": "optionalString()",
-      "norm_label": "optionalstring()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
-      "source_location": "L1049"
+      "id": "registercartprojection_getproductavailabilitystatus",
+      "label": "getProductAvailabilityStatus()",
+      "norm_label": "getproductavailabilitystatus()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "source_location": "L266"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "registerreadmodel_parsecartitem",
-      "label": "parseCartItem()",
-      "norm_label": "parsecartitem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
-      "source_location": "L766"
+      "id": "registercartprojection_localavailabilityconsumptionfromreadmodel",
+      "label": "localAvailabilityConsumptionFromReadModel()",
+      "norm_label": "localavailabilityconsumptionfromreadmodel()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "source_location": "L653"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "registerreadmodel_parsecartitempayload",
-      "label": "parseCartItemPayload()",
-      "norm_label": "parsecartitempayload()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
-      "source_location": "L775"
+      "id": "registercartprojection_localpossessionidfromevent",
+      "label": "localPosSessionIdFromEvent()",
+      "norm_label": "localpossessionidfromevent()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "source_location": "L575"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "registerreadmodel_parsepayments",
-      "label": "parsePayments()",
-      "norm_label": "parsepayments()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
-      "source_location": "L875"
+      "id": "registercartprojection_maplocalcartitemtocartitem",
+      "label": "mapLocalCartItemToCartItem()",
+      "norm_label": "maplocalcartitemtocartitem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "source_location": "L280"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "registerreadmodel_parseserviceline",
-      "label": "parseServiceLine()",
-      "norm_label": "parseserviceline()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
-      "source_location": "L870"
+      "id": "registercartprojection_maplocalpendingcheckouteventstoproducts",
+      "label": "mapLocalPendingCheckoutEventsToProducts()",
+      "norm_label": "maplocalpendingcheckouteventstoproducts()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "source_location": "L386"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "registerreadmodel_parseservicelines",
-      "label": "parseServiceLines()",
-      "norm_label": "parseservicelines()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
-      "source_location": "L822"
+      "id": "registercartprojection_mappendingcheckoutcartitemtoproduct",
+      "label": "mapPendingCheckoutCartItemToProduct()",
+      "norm_label": "mappendingcheckoutcartitemtoproduct()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "source_location": "L356"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "registerreadmodel_pricingmodelfield",
-      "label": "pricingModelField()",
-      "norm_label": "pricingmodelfield()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
-      "source_location": "L1127"
+      "id": "registercartprojection_mapproducttooptimisticcartitem",
+      "label": "mapProductToOptimisticCartItem()",
+      "norm_label": "mapproducttooptimisticcartitem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "source_location": "L10"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "registerreadmodel_projectlocalregisterreadmodel",
-      "label": "projectLocalRegisterReadModel()",
-      "norm_label": "projectlocalregisterreadmodel()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
-      "source_location": "L159"
+      "id": "registercartprojection_mergecartitemsbysku",
+      "label": "mergeCartItemsBySku()",
+      "norm_label": "mergecartitemsbysku()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "source_location": "L788"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "registerreadmodel_registerlifecycleeventmatchesactivesession",
-      "label": "registerLifecycleEventMatchesActiveSession()",
-      "norm_label": "registerlifecycleeventmatchesactivesession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
-      "source_location": "L570"
+      "id": "registercartprojection_normalizependingcheckoutsearchtext",
+      "label": "normalizePendingCheckoutSearchText()",
+      "norm_label": "normalizependingcheckoutsearchtext()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "source_location": "L305"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "registerreadmodel_registerlifecycleeventmatchessession",
-      "label": "registerLifecycleEventMatchesSession()",
-      "norm_label": "registerlifecycleeventmatchessession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
-      "source_location": "L577"
+      "id": "registercartprojection_numberfromrecord",
+      "label": "numberFromRecord()",
+      "norm_label": "numberfromrecord()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "source_location": "L494"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "registerreadmodel_registerstatus",
-      "label": "registerStatus()",
-      "norm_label": "registerstatus()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
-      "source_location": "L1063"
+      "id": "registercartprojection_optimisticcartproductkeyfromcartitem",
+      "label": "optimisticCartProductKeyFromCartItem()",
+      "norm_label": "optimisticcartproductkeyfromcartitem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "source_location": "L224"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "registerreadmodel_servicemodefield",
-      "label": "serviceModeField()",
-      "norm_label": "servicemodefield()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
-      "source_location": "L1116"
+      "id": "registercartprojection_pendingcheckoutaliasproductsignature",
+      "label": "pendingCheckoutAliasProductSignature()",
+      "norm_label": "pendingcheckoutaliasproductsignature()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "source_location": "L158"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "registerreadmodel_stringfield",
-      "label": "stringField()",
-      "norm_label": "stringfield()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
-      "source_location": "L1044"
+      "id": "registercartprojection_pendingcheckoutcartitemmatchessearch",
+      "label": "pendingCheckoutCartItemMatchesSearch()",
+      "norm_label": "pendingcheckoutcartitemmatchessearch()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "source_location": "L340"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "registerreadmodel_terminalfromevent",
-      "label": "terminalFromEvent()",
-      "norm_label": "terminalfromevent()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
-      "source_location": "L646"
+      "id": "registercartprojection_pendingcheckoutfieldsmatchsearch",
+      "label": "pendingCheckoutFieldsMatchSearch()",
+      "norm_label": "pendingcheckoutfieldsmatchsearch()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "source_location": "L313"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "registerreadmodel_terminalfromseed",
-      "label": "terminalFromSeed()",
-      "norm_label": "terminalfromseed()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
-      "source_location": "L629"
+      "id": "registercartprojection_productcartsourcekey",
+      "label": "productCartSourceKey()",
+      "norm_label": "productcartsourcekey()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "source_location": "L62"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "registerreadmodel_toregisterstatedrawer",
-      "label": "toRegisterStateDrawer()",
-      "norm_label": "toregisterstatedrawer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
-      "source_location": "L595"
+      "id": "registercartprojection_recordfrompayload",
+      "label": "recordFromPayload()",
+      "norm_label": "recordfrompayload()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "source_location": "L504"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "registerreadmodel_toregisterstatesession",
-      "label": "toRegisterStateSession()",
-      "norm_label": "toregisterstatesession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
-      "source_location": "L613"
+      "id": "registercartprojection_recordornull",
+      "label": "recordOrNull()",
+      "norm_label": "recordornull()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "source_location": "L478"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "registerreadmodel_totalsfromitems",
-      "label": "totalsFromItems()",
-      "norm_label": "totalsfromitems()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
-      "source_location": "L988"
+      "id": "registercartprojection_renderedcartlinesourcekey",
+      "label": "renderedCartLineSourceKey()",
+      "norm_label": "renderedcartlinesourcekey()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "source_location": "L207"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "registerreadmodel_totalsfromitemsandservices",
-      "label": "totalsFromItemsAndServices()",
-      "norm_label": "totalsfromitemsandservices()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
-      "source_location": "L996"
+      "id": "registercartprojection_stringfrompayload",
+      "label": "stringFromPayload()",
+      "norm_label": "stringfrompayload()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "source_location": "L510"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "registerreadmodel_upsertcartitem",
-      "label": "upsertCartItem()",
-      "norm_label": "upsertcartitem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
-      "source_location": "L919"
+      "id": "registercartprojection_stringfromrecord",
+      "label": "stringFromRecord()",
+      "norm_label": "stringfromrecord()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "source_location": "L484"
     },
     {
       "community": 28,
       "file_type": "code",
-      "id": "registerreadmodel_upsertserviceline",
-      "label": "upsertServiceLine()",
-      "norm_label": "upsertserviceline()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts",
-      "source_location": "L974"
+      "id": "registercartprojection_totalsfromcartitems",
+      "label": "totalsFromCartItems()",
+      "norm_label": "totalsfromcartitems()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "source_location": "L780"
     },
     {
       "community": 280,
@@ -219144,87 +219066,6 @@
     {
       "community": 284,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 284,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 284,
-      "file_type": "code",
-      "id": "productutils_getpreferredsku",
-      "label": "getPreferredSku()",
-      "norm_label": "getpreferredsku()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 284,
-      "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 284,
-      "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 284,
-      "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 284,
-      "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L82"
-    },
-    {
-      "community": 284,
-      "file_type": "code",
-      "id": "productutils_sortskusbyavailabilitythenlength",
-      "label": "sortSkusByAvailabilityThenLength()",
-      "norm_label": "sortskusbyavailabilitythenlength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 284,
-      "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 285,
-      "file_type": "code",
       "id": "applyremoteassistcontrolintent_applyacceptedcontrolresult",
       "label": "applyAcceptedControlResult()",
       "norm_label": "applyacceptedcontrolresult()",
@@ -219232,7 +219073,7 @@
       "source_location": "L84"
     },
     {
-      "community": 285,
+      "community": 284,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_applykeyevent",
       "label": "applyKeyEvent()",
@@ -219241,7 +219082,7 @@
       "source_location": "L155"
     },
     {
-      "community": 285,
+      "community": 284,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_applypointerevent",
       "label": "applyPointerEvent()",
@@ -219250,7 +219091,7 @@
       "source_location": "L116"
     },
     {
-      "community": 285,
+      "community": 284,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_applyremoteassistcontrolintent",
       "label": "applyRemoteAssistControlIntent()",
@@ -219259,7 +219100,7 @@
       "source_location": "L17"
     },
     {
-      "community": 285,
+      "community": 284,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_getrecentcontrolresult",
       "label": "getRecentControlResult()",
@@ -219268,7 +219109,7 @@
       "source_location": "L95"
     },
     {
-      "community": 285,
+      "community": 284,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_getremoteassistcontroltarget",
       "label": "getRemoteAssistControlTarget()",
@@ -219277,7 +219118,7 @@
       "source_location": "L145"
     },
     {
-      "community": 285,
+      "community": 284,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_prepareremoteassistcontrolintent",
       "label": "prepareRemoteAssistControlIntent()",
@@ -219286,7 +219127,7 @@
       "source_location": "L27"
     },
     {
-      "community": 285,
+      "community": 284,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_remembercontrolresult",
       "label": "rememberControlResult()",
@@ -219295,7 +219136,7 @@
       "source_location": "L101"
     },
     {
-      "community": 285,
+      "community": 284,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_remote_assist_runtime_applyremoteassistcontrolintent_ts",
       "label": "applyRemoteAssistControlIntent.ts",
@@ -219304,7 +219145,7 @@
       "source_location": "L1"
     },
     {
-      "community": 286,
+      "community": 285,
       "file_type": "code",
       "id": "packages_athena_webapp_src_offline_posofflinereadiness_ts",
       "label": "posOfflineReadiness.ts",
@@ -219313,7 +219154,7 @@
       "source_location": "L1"
     },
     {
-      "community": 286,
+      "community": 285,
       "file_type": "code",
       "id": "posofflinereadiness_buildposofflinereadinesssummary",
       "label": "buildPosOfflineReadinessSummary()",
@@ -219322,7 +219163,7 @@
       "source_location": "L152"
     },
     {
-      "community": 286,
+      "community": 285,
       "file_type": "code",
       "id": "posofflinereadiness_buildsignal",
       "label": "buildSignal()",
@@ -219331,7 +219172,7 @@
       "source_location": "L178"
     },
     {
-      "community": 286,
+      "community": 285,
       "file_type": "code",
       "id": "posofflinereadiness_formatage",
       "label": "formatAge()",
@@ -219340,7 +219181,7 @@
       "source_location": "L290"
     },
     {
-      "community": 286,
+      "community": 285,
       "file_type": "code",
       "id": "posofflinereadiness_getsignaldescription",
       "label": "getSignalDescription()",
@@ -219349,7 +219190,7 @@
       "source_location": "L221"
     },
     {
-      "community": 286,
+      "community": 285,
       "file_type": "code",
       "id": "posofflinereadiness_getsignalstatus",
       "label": "getSignalStatus()",
@@ -219358,7 +219199,7 @@
       "source_location": "L201"
     },
     {
-      "community": 286,
+      "community": 285,
       "file_type": "code",
       "id": "posofflinereadiness_getsummarydescription",
       "label": "getSummaryDescription()",
@@ -219367,7 +219208,7 @@
       "source_location": "L262"
     },
     {
-      "community": 286,
+      "community": 285,
       "file_type": "code",
       "id": "posofflinereadiness_getsummarytitle",
       "label": "getSummaryTitle()",
@@ -219376,7 +219217,7 @@
       "source_location": "L256"
     },
     {
-      "community": 286,
+      "community": 285,
       "file_type": "code",
       "id": "posofflinereadiness_isreadylike",
       "label": "isReadyLike()",
@@ -219385,7 +219226,7 @@
       "source_location": "L286"
     },
     {
-      "community": 287,
+      "community": 286,
       "file_type": "code",
       "id": "foundations_content_colorrolecard",
       "label": "ColorRoleCard()",
@@ -219394,7 +219235,7 @@
       "source_location": "L222"
     },
     {
-      "community": 287,
+      "community": 286,
       "file_type": "code",
       "id": "foundations_content_densitycard",
       "label": "DensityCard()",
@@ -219403,7 +219244,7 @@
       "source_location": "L283"
     },
     {
-      "community": 287,
+      "community": 286,
       "file_type": "code",
       "id": "foundations_content_detailviewrolecard",
       "label": "DetailViewRoleCard()",
@@ -219412,7 +219253,7 @@
       "source_location": "L363"
     },
     {
-      "community": 287,
+      "community": 286,
       "file_type": "code",
       "id": "foundations_content_hslvar",
       "label": "hslVar()",
@@ -219421,7 +219262,7 @@
       "source_location": "L214"
     },
     {
-      "community": 287,
+      "community": 286,
       "file_type": "code",
       "id": "foundations_content_motioncard",
       "label": "MotionCard()",
@@ -219430,7 +219271,7 @@
       "source_location": "L342"
     },
     {
-      "community": 287,
+      "community": 286,
       "file_type": "code",
       "id": "foundations_content_spacetokenrow",
       "label": "SpaceTokenRow()",
@@ -219439,7 +219280,7 @@
       "source_location": "L265"
     },
     {
-      "community": 287,
+      "community": 286,
       "file_type": "code",
       "id": "foundations_content_textvar",
       "label": "textVar()",
@@ -219448,7 +219289,7 @@
       "source_location": "L218"
     },
     {
-      "community": 287,
+      "community": 286,
       "file_type": "code",
       "id": "foundations_content_typespecimencard",
       "label": "TypeSpecimenCard()",
@@ -219457,13 +219298,94 @@
       "source_location": "L246"
     },
     {
-      "community": 287,
+      "community": 286,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_foundations_content_tsx",
       "label": "foundations-content.tsx",
       "norm_label": "foundations-content.tsx",
       "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 287,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 287,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 287,
+      "file_type": "code",
+      "id": "productutils_getpreferredsku",
+      "label": "getPreferredSku()",
+      "norm_label": "getpreferredsku()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 287,
+      "file_type": "code",
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 287,
+      "file_type": "code",
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 287,
+      "file_type": "code",
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 287,
+      "file_type": "code",
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L82"
+    },
+    {
+      "community": 287,
+      "file_type": "code",
+      "id": "productutils_sortskusbyavailabilitythenlength",
+      "label": "sortSkusByAvailabilityThenLength()",
+      "norm_label": "sortskusbyavailabilitythenlength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 287,
+      "file_type": "code",
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L59"
     },
     {
       "community": 288,
@@ -219630,335 +219552,326 @@
     {
       "community": 29,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registercartprojection_ts",
-      "label": "registerCartProjection.ts",
-      "norm_label": "registercartprojection.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
-      "source_location": "L1"
+      "id": "adjustments_applystockadjustmentbatchwithctx",
+      "label": "applyStockAdjustmentBatchWithCtx()",
+      "norm_label": "applystockadjustmentbatchwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L422"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "registercartprojection_addlocalavailabilityconsumption",
-      "label": "addLocalAvailabilityConsumption()",
-      "norm_label": "addlocalavailabilityconsumption()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
-      "source_location": "L562"
+      "id": "adjustments_assertdistinctstockadjustmentlineitems",
+      "label": "assertDistinctStockAdjustmentLineItems()",
+      "norm_label": "assertdistinctstockadjustmentlineitems()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L300"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "registercartprojection_addlocalavailabilitydeltaconsumption",
-      "label": "addLocalAvailabilityDeltaConsumption()",
-      "norm_label": "addlocalavailabilitydeltaconsumption()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
-      "source_location": "L630"
+      "id": "adjustments_assertnormalizedlineitem",
+      "label": "assertNormalizedLineItem()",
+      "norm_label": "assertnormalizedlineitem()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L374"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "registercartprojection_buildcatalogrepresentedpendingcheckoutitemids",
-      "label": "buildCatalogRepresentedPendingCheckoutItemIds()",
-      "norm_label": "buildcatalogrepresentedpendingcheckoutitemids()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
-      "source_location": "L79"
+      "id": "adjustments_buildinventorysnapshotrowsforproductskuswithctx",
+      "label": "buildInventorySnapshotRowsForProductSkusWithCtx()",
+      "norm_label": "buildinventorysnapshotrowsforproductskuswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L1073"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "registercartprojection_buildcatalogrepresentedpendingcheckoutlocaleventids",
-      "label": "buildCatalogRepresentedPendingCheckoutLocalEventIds()",
-      "norm_label": "buildcatalogrepresentedpendingcheckoutlocaleventids()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
-      "source_location": "L109"
+      "id": "adjustments_buildresolvedstockadjustmentstatus",
+      "label": "buildResolvedStockAdjustmentStatus()",
+      "norm_label": "buildresolvedstockadjustmentstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L767"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "registercartprojection_buildcatalogrepresentedpendingcheckoutproductsignatures",
-      "label": "buildCatalogRepresentedPendingCheckoutProductSignatures()",
-      "norm_label": "buildcatalogrepresentedpendingcheckoutproductsignatures()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
-      "source_location": "L175"
+      "id": "adjustments_buildstockadjustmentdecisioneventtype",
+      "label": "buildStockAdjustmentDecisionEventType()",
+      "norm_label": "buildstockadjustmentdecisioneventtype()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L757"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "registercartprojection_buildlocalavailabilityeventindex",
-      "label": "buildLocalAvailabilityEventIndex()",
-      "norm_label": "buildlocalavailabilityeventindex()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
-      "source_location": "L590"
+      "id": "adjustments_buildstockadjustmentoperationaleventmessage",
+      "label": "buildStockAdjustmentOperationalEventMessage()",
+      "norm_label": "buildstockadjustmentoperationaleventmessage()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L354"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "registercartprojection_buildlocalcartitempayload",
-      "label": "buildLocalCartItemPayload()",
-      "norm_label": "buildlocalcartitempayload()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
-      "source_location": "L34"
+      "id": "adjustments_buildstockadjustmentsourceid",
+      "label": "buildStockAdjustmentSourceId()",
+      "norm_label": "buildstockadjustmentsourceid()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L316"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "registercartprojection_buildlocalcartitempayloadfromcartitem",
-      "label": "buildLocalCartItemPayloadFromCartItem()",
-      "norm_label": "buildlocalcartitempayloadfromcartitem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
-      "source_location": "L231"
+      "id": "adjustments_buildstockadjustmenttitle",
+      "label": "buildStockAdjustmentTitle()",
+      "norm_label": "buildstockadjustmenttitle()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L320"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "registercartprojection_buildlocalpendingcheckoutdefinitioneventidsbyitemid",
-      "label": "buildLocalPendingCheckoutDefinitionEventIdsByItemId()",
-      "norm_label": "buildlocalpendingcheckoutdefinitioneventidsbyitemid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
+      "id": "adjustments_formatsignedquantity",
+      "label": "formatSignedQuantity()",
+      "norm_label": "formatsignedquantity()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L350"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "adjustments_getactorlabel",
+      "label": "getActorLabel()",
+      "norm_label": "getactorlabel()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L330"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "adjustments_getinventoryunitsummarywithctx",
+      "label": "getInventoryUnitSummaryWithCtx()",
+      "norm_label": "getinventoryunitsummarywithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L1012"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "adjustments_getstockadjustmentscopekey",
+      "label": "getStockAdjustmentScopeKey()",
+      "norm_label": "getstockadjustmentscopekey()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
       "source_location": "L136"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "registercartprojection_cartitemlineeventkey",
-      "label": "cartItemLineEventKey()",
-      "norm_label": "cartitemlineeventkey()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
-      "source_location": "L525"
+      "id": "adjustments_isonboardedtrustedproductforstockadjustment",
+      "label": "isOnboardedTrustedProductForStockAdjustment()",
+      "norm_label": "isonboardedtrustedproductforstockadjustment()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L176"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "registercartprojection_cartitemlinekey",
-      "label": "cartItemLineKey()",
-      "norm_label": "cartitemlinekey()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
-      "source_location": "L544"
+      "id": "adjustments_listinventorysnapshotforproductskuswithctx",
+      "label": "listInventorySnapshotForProductSkusWithCtx()",
+      "norm_label": "listinventorysnapshotforproductskuswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L982"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "registercartprojection_cartitemsfromlocalregistermodel",
-      "label": "cartItemsFromLocalRegisterModel()",
-      "norm_label": "cartitemsfromlocalregistermodel()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
-      "source_location": "L702"
+      "id": "adjustments_listinventorysnapshotwithctx",
+      "label": "listInventorySnapshotWithCtx()",
+      "norm_label": "listinventorysnapshotwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L957"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "registercartprojection_cartitemskuentry",
-      "label": "cartItemSkuEntry()",
-      "norm_label": "cartitemskuentry()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
-      "source_location": "L518"
+      "id": "adjustments_listproductskusforstockadjustmentscopewithctx",
+      "label": "listProductSkusForStockAdjustmentScopeWithCtx()",
+      "norm_label": "listproductskusforstockadjustmentscopewithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L243"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "registercartprojection_cartlinesourcekey",
-      "label": "cartLineSourceKey()",
-      "norm_label": "cartlinesourcekey()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
-      "source_location": "L199"
+      "id": "adjustments_mapsubmitstockadjustmentbatcherror",
+      "label": "mapSubmitStockAdjustmentBatchError()",
+      "norm_label": "mapsubmitstockadjustmentbatcherror()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L1668"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "registercartprojection_formatlocalpendingcheckoutsku",
-      "label": "formatLocalPendingCheckoutSku()",
-      "norm_label": "formatlocalpendingcheckoutsku()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
-      "source_location": "L466"
+      "id": "adjustments_pluralize",
+      "label": "pluralize()",
+      "norm_label": "pluralize()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L346"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "registercartprojection_getproductavailabilitystatus",
-      "label": "getProductAvailabilityStatus()",
-      "norm_label": "getproductavailabilitystatus()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
-      "source_location": "L266"
+      "id": "adjustments_readactivecheckoutreservedquantitiesforstockopssnapshot",
+      "label": "readActiveCheckoutReservedQuantitiesForStockOpsSnapshot()",
+      "norm_label": "readactivecheckoutreservedquantitiesforstockopssnapshot()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L905"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "registercartprojection_localavailabilityconsumptionfromreadmodel",
-      "label": "localAvailabilityConsumptionFromReadModel()",
-      "norm_label": "localavailabilityconsumptionfromreadmodel()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
-      "source_location": "L653"
+      "id": "adjustments_readactiveheldquantitiesforstockopssnapshot",
+      "label": "readActiveHeldQuantitiesForStockOpsSnapshot()",
+      "norm_label": "readactiveheldquantitiesforstockopssnapshot()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L873"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "registercartprojection_localpossessionidfromevent",
-      "label": "localPosSessionIdFromEvent()",
-      "norm_label": "localpossessionidfromevent()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
-      "source_location": "L575"
+      "id": "adjustments_readactivependingcheckoutskuidswithctx",
+      "label": "readActivePendingCheckoutSkuIdsWithCtx()",
+      "norm_label": "readactivependingcheckoutskuidswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L634"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "registercartprojection_maplocalcartitemtocartitem",
-      "label": "mapLocalCartItemToCartItem()",
-      "norm_label": "maplocalcartitemtocartitem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
-      "source_location": "L280"
+      "id": "adjustments_readactiveprovisionalimportskuidswithctx",
+      "label": "readActiveProvisionalImportSkuIdsWithCtx()",
+      "norm_label": "readactiveprovisionalimportskuidswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L541"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "registercartprojection_maplocalpendingcheckouteventstoproducts",
-      "label": "mapLocalPendingCheckoutEventsToProducts()",
-      "norm_label": "maplocalpendingcheckouteventstoproducts()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
-      "source_location": "L386"
+      "id": "adjustments_readcategorywithcache",
+      "label": "readCategoryWithCache()",
+      "norm_label": "readcategorywithcache()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L152"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "registercartprojection_mappendingcheckoutcartitemtoproduct",
-      "label": "mapPendingCheckoutCartItemToProduct()",
-      "norm_label": "mappendingcheckoutcartitemtoproduct()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
-      "source_location": "L356"
+      "id": "adjustments_readproductwithcache",
+      "label": "readProductWithCache()",
+      "norm_label": "readproductwithcache()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L140"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "registercartprojection_mapproducttooptimisticcartitem",
-      "label": "mapProductToOptimisticCartItem()",
-      "norm_label": "mapproducttooptimisticcartitem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
-      "source_location": "L10"
+      "id": "adjustments_readstockadjustmentblockedskustatuseswithctx",
+      "label": "readStockAdjustmentBlockedSkuStatusesWithCtx()",
+      "norm_label": "readstockadjustmentblockedskustatuseswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L709"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "registercartprojection_mergecartitemsbysku",
-      "label": "mergeCartItemsBySku()",
-      "norm_label": "mergecartitemsbysku()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
-      "source_location": "L788"
+      "id": "adjustments_readsubcategorywithcache",
+      "label": "readSubcategoryWithCache()",
+      "norm_label": "readsubcategorywithcache()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L164"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "registercartprojection_normalizependingcheckoutsearchtext",
-      "label": "normalizePendingCheckoutSearchText()",
-      "norm_label": "normalizependingcheckoutsearchtext()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
-      "source_location": "L305"
+      "id": "adjustments_requireinventorysnapshotforproductskusaccess",
+      "label": "requireInventorySnapshotForProductSkusAccess()",
+      "norm_label": "requireinventorysnapshotforproductskusaccess()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L1263"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "registercartprojection_numberfromrecord",
-      "label": "numberFromRecord()",
-      "norm_label": "numberfromrecord()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
-      "source_location": "L494"
+      "id": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
+      "label": "resolveStockAdjustmentApprovalDecisionWithCtx()",
+      "norm_label": "resolvestockadjustmentapprovaldecisionwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L773"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "registercartprojection_optimisticcartproductkeyfromcartitem",
-      "label": "optimisticCartProductKeyFromCartItem()",
-      "norm_label": "optimisticcartproductkeyfromcartitem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
-      "source_location": "L224"
+      "id": "adjustments_schedulecatalogsummarydirtymarker",
+      "label": "scheduleCatalogSummaryDirtyMarker()",
+      "norm_label": "schedulecatalogsummarydirtymarker()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L104"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "registercartprojection_pendingcheckoutaliasproductsignature",
-      "label": "pendingCheckoutAliasProductSignature()",
-      "norm_label": "pendingcheckoutaliasproductsignature()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
-      "source_location": "L158"
+      "id": "adjustments_shouldblockstockadjustmentforprovisionalimportrow",
+      "label": "shouldBlockStockAdjustmentForProvisionalImportRow()",
+      "norm_label": "shouldblockstockadjustmentforprovisionalimportrow()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L216"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "registercartprojection_pendingcheckoutcartitemmatchessearch",
-      "label": "pendingCheckoutCartItemMatchesSearch()",
-      "norm_label": "pendingcheckoutcartitemmatchessearch()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
-      "source_location": "L340"
+      "id": "adjustments_submitstockadjustmentbatchcommandwithctx",
+      "label": "submitStockAdjustmentBatchCommandWithCtx()",
+      "norm_label": "submitstockadjustmentbatchcommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L1726"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "registercartprojection_pendingcheckoutfieldsmatchsearch",
-      "label": "pendingCheckoutFieldsMatchSearch()",
-      "norm_label": "pendingcheckoutfieldsmatchsearch()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
-      "source_location": "L313"
+      "id": "adjustments_submitstockadjustmentbatchwithctx",
+      "label": "submitStockAdjustmentBatchWithCtx()",
+      "norm_label": "submitstockadjustmentbatchwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L1450"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "registercartprojection_productcartsourcekey",
-      "label": "productCartSourceKey()",
-      "norm_label": "productcartsourcekey()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
-      "source_location": "L62"
+      "id": "adjustments_temporarydeletestockadjustmentscopeskuswithctx",
+      "label": "temporaryDeleteStockAdjustmentScopeSkusWithCtx()",
+      "norm_label": "temporarydeletestockadjustmentscopeskuswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L1364"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "registercartprojection_recordfrompayload",
-      "label": "recordFromPayload()",
-      "norm_label": "recordfrompayload()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
-      "source_location": "L504"
+      "id": "adjustments_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L131"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "registercartprojection_recordornull",
-      "label": "recordOrNull()",
-      "norm_label": "recordornull()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
-      "source_location": "L478"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "registercartprojection_renderedcartlinesourcekey",
-      "label": "renderedCartLineSourceKey()",
-      "norm_label": "renderedcartlinesourcekey()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
-      "source_location": "L207"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "registercartprojection_stringfrompayload",
-      "label": "stringFromPayload()",
-      "norm_label": "stringfrompayload()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
-      "source_location": "L510"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "registercartprojection_stringfromrecord",
-      "label": "stringFromRecord()",
-      "norm_label": "stringfromrecord()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
-      "source_location": "L484"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "registercartprojection_totalsfromcartitems",
-      "label": "totalsFromCartItems()",
-      "norm_label": "totalsfromcartitems()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.ts",
-      "source_location": "L780"
+      "id": "packages_athena_webapp_convex_stockops_adjustments_ts",
+      "label": "adjustments.ts",
+      "norm_label": "adjustments.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L1"
     },
     {
       "community": 290,
@@ -221394,325 +221307,316 @@
     {
       "community": 30,
       "file_type": "code",
-      "id": "adjustments_applystockadjustmentbatchwithctx",
-      "label": "applyStockAdjustmentBatchWithCtx()",
-      "norm_label": "applystockadjustmentbatchwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "id": "dailyopeningview_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L1353"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "dailyopeningview_dailyopeningstatustitle",
+      "label": "DailyOpeningStatusTitle()",
+      "norm_label": "dailyopeningstatustitle()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L666"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "dailyopeningview_formatmetadatadisplayvalue",
+      "label": "formatMetadataDisplayValue()",
+      "norm_label": "formatmetadatadisplayvalue()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L504"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "dailyopeningview_formatmetadatavalue",
+      "label": "formatMetadataValue()",
+      "norm_label": "formatmetadatavalue()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L430"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "dailyopeningview_formatopeningitemtitle",
+      "label": "formatOpeningItemTitle()",
+      "norm_label": "formatopeningitemtitle()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L328"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "dailyopeningview_formatoperatingdate",
+      "label": "formatOperatingDate()",
+      "norm_label": "formatoperatingdate()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L272"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "dailyopeningview_formatoperatingdatewithweekday",
+      "label": "formatOperatingDateWithWeekday()",
+      "norm_label": "formatoperatingdatewithweekday()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L288"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "dailyopeningview_formatoperationalworktypelabel",
+      "label": "formatOperationalWorkTypeLabel()",
+      "norm_label": "formatoperationalworktypelabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L360"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "dailyopeningview_formattimestamp",
+      "label": "formatTimestamp()",
+      "norm_label": "formattimestamp()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L305"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "dailyopeningview_getacknowledgementkey",
+      "label": "getAcknowledgementKey()",
+      "norm_label": "getacknowledgementkey()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L407"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "dailyopeningview_getarraymetadatastringvalue",
+      "label": "getArrayMetadataStringValue()",
+      "norm_label": "getarraymetadatastringvalue()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L490"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "dailyopeningview_getdailyopeningapi",
+      "label": "getDailyOpeningApi()",
+      "norm_label": "getdailyopeningapi()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L262"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "dailyopeningview_getitemcontextlabel",
+      "label": "getItemContextLabel()",
+      "norm_label": "getitemcontextlabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
       "source_location": "L422"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "adjustments_assertdistinctstockadjustmentlineitems",
-      "label": "assertDistinctStockAdjustmentLineItems()",
-      "norm_label": "assertdistinctstockadjustmentlineitems()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L300"
+      "id": "dailyopeningview_getitemdescription",
+      "label": "getItemDescription()",
+      "norm_label": "getitemdescription()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L418"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "adjustments_assertnormalizedlineitem",
-      "label": "assertNormalizedLineItem()",
-      "norm_label": "assertnormalizedlineitem()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L374"
+      "id": "dailyopeningview_getitemid",
+      "label": "getItemId()",
+      "norm_label": "getitemid()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L399"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "adjustments_buildinventorysnapshotrowsforproductskuswithctx",
-      "label": "buildInventorySnapshotRowsForProductSkusWithCtx()",
-      "norm_label": "buildinventorysnapshotrowsforproductskuswithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L1073"
+      "id": "dailyopeningview_getmetadataentries",
+      "label": "getMetadataEntries()",
+      "norm_label": "getmetadataentries()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L564"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "adjustments_buildresolvedstockadjustmentstatus",
-      "label": "buildResolvedStockAdjustmentStatus()",
-      "norm_label": "buildresolvedstockadjustmentstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L767"
+      "id": "dailyopeningview_getmetadatalabel",
+      "label": "getMetadataLabel()",
+      "norm_label": "getmetadatalabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L443"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "adjustments_buildstockadjustmentdecisioneventtype",
-      "label": "buildStockAdjustmentDecisionEventType()",
-      "norm_label": "buildstockadjustmentdecisioneventtype()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L757"
+      "id": "dailyopeningview_getmetadatavalue",
+      "label": "getMetadataValue()",
+      "norm_label": "getmetadatavalue()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L465"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "adjustments_buildstockadjustmentoperationaleventmessage",
-      "label": "buildStockAdjustmentOperationalEventMessage()",
-      "norm_label": "buildstockadjustmentoperationaleventmessage()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L354"
+      "id": "dailyopeningview_getopeningautomationmessage",
+      "label": "getOpeningAutomationMessage()",
+      "norm_label": "getopeningautomationmessage()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L701"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "adjustments_buildstockadjustmentsourceid",
-      "label": "buildStockAdjustmentSourceId()",
-      "norm_label": "buildstockadjustmentsourceid()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L316"
+      "id": "dailyopeningview_getopeningreviewevidence",
+      "label": "getOpeningReviewEvidence()",
+      "norm_label": "getopeningreviewevidence()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L779"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "adjustments_buildstockadjustmenttitle",
-      "label": "buildStockAdjustmentTitle()",
-      "norm_label": "buildstockadjustmenttitle()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L320"
+      "id": "dailyopeningview_getopeningstartedbylabel",
+      "label": "getOpeningStartedByLabel()",
+      "norm_label": "getopeningstartedbylabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L787"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "adjustments_formatsignedquantity",
-      "label": "formatSignedQuantity()",
-      "norm_label": "formatsignedquantity()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L350"
+      "id": "dailyopeningview_getopeningstatus",
+      "label": "getOpeningStatus()",
+      "norm_label": "getopeningstatus()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L385"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "adjustments_getactorlabel",
-      "label": "getActorLabel()",
-      "norm_label": "getactorlabel()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L330"
+      "id": "dailyopeningview_getrequiredacknowledgementkeys",
+      "label": "getRequiredAcknowledgementKeys()",
+      "norm_label": "getrequiredacknowledgementkeys()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L411"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "adjustments_getinventoryunitsummarywithctx",
-      "label": "getInventoryUnitSummaryWithCtx()",
-      "norm_label": "getinventoryunitsummarywithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L1012"
+      "id": "dailyopeningview_getstatussignatureclassname",
+      "label": "getStatusSignatureClassName()",
+      "norm_label": "getstatussignatureclassname()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L626"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "adjustments_getstockadjustmentscopekey",
-      "label": "getStockAdjustmentScopeKey()",
-      "norm_label": "getstockadjustmentscopekey()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L136"
+      "id": "dailyopeningview_getstatussignatureiconclassname",
+      "label": "getStatusSignatureIconClassName()",
+      "norm_label": "getstatussignatureiconclassname()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L635"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "adjustments_isonboardedtrustedproductforstockadjustment",
-      "label": "isOnboardedTrustedProductForStockAdjustment()",
-      "norm_label": "isonboardedtrustedproductforstockadjustment()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L176"
+      "id": "dailyopeningview_getvisibleopeningautomationstatus",
+      "label": "getVisibleOpeningAutomationStatus()",
+      "norm_label": "getvisibleopeningautomationstatus()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L737"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "adjustments_listinventorysnapshotforproductskuswithctx",
-      "label": "listInventorySnapshotForProductSkusWithCtx()",
-      "norm_label": "listinventorysnapshotforproductskuswithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L982"
+      "id": "dailyopeningview_handlepagechange",
+      "label": "handlePageChange()",
+      "norm_label": "handlepagechange()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L826"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "adjustments_listinventorysnapshotwithctx",
-      "label": "listInventorySnapshotWithCtx()",
-      "norm_label": "listinventorysnapshotwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L957"
+      "id": "dailyopeningview_humanizemetadatalabel",
+      "label": "humanizeMetadataLabel()",
+      "norm_label": "humanizemetadatalabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L317"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "adjustments_listproductskusforstockadjustmentscopewithctx",
-      "label": "listProductSkusForStockAdjustmentScopeWithCtx()",
-      "norm_label": "listproductskusforstockadjustmentscopewithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L243"
+      "id": "dailyopeningview_isoperatorfacingopeningmetadata",
+      "label": "isOperatorFacingOpeningMetadata()",
+      "norm_label": "isoperatorfacingopeningmetadata()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L560"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "adjustments_mapsubmitstockadjustmentbatcherror",
-      "label": "mapSubmitStockAdjustmentBatchError()",
-      "norm_label": "mapsubmitstockadjustmentbatcherror()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L1668"
+      "id": "dailyopeningview_normalizecommandmessage",
+      "label": "normalizeCommandMessage()",
+      "norm_label": "normalizecommandmessage()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L606"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "adjustments_pluralize",
-      "label": "pluralize()",
-      "norm_label": "pluralize()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L346"
+      "id": "dailyopeningview_normalizemetadatalabel",
+      "label": "normalizeMetadataLabel()",
+      "norm_label": "normalizemetadatalabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L324"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "adjustments_readactivecheckoutreservedquantitiesforstockopssnapshot",
-      "label": "readActiveCheckoutReservedQuantitiesForStockOpsSnapshot()",
-      "norm_label": "readactivecheckoutreservedquantitiesforstockopssnapshot()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L905"
+      "id": "dailyopeningview_openingautomationstatuspanel",
+      "label": "OpeningAutomationStatusPanel()",
+      "norm_label": "openingautomationstatuspanel()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L754"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "adjustments_readactiveheldquantitiesforstockopssnapshot",
-      "label": "readActiveHeldQuantitiesForStockOpsSnapshot()",
-      "norm_label": "readactiveheldquantitiesforstockopssnapshot()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L873"
+      "id": "dailyopeningview_successcheckicon",
+      "label": "SuccessCheckIcon()",
+      "norm_label": "successcheckicon()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L644"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "adjustments_readactivependingcheckoutskuidswithctx",
-      "label": "readActivePendingCheckoutSkuIdsWithCtx()",
-      "norm_label": "readactivependingcheckoutskuidswithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L634"
+      "id": "dailyopeningview_toggleallacknowledgements",
+      "label": "toggleAllAcknowledgements()",
+      "norm_label": "toggleallacknowledgements()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L1434"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "adjustments_readactiveprovisionalimportskuidswithctx",
-      "label": "readActiveProvisionalImportSkuIdsWithCtx()",
-      "norm_label": "readactiveprovisionalimportskuidswithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L541"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "adjustments_readcategorywithcache",
-      "label": "readCategoryWithCache()",
-      "norm_label": "readcategorywithcache()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L152"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "adjustments_readproductwithcache",
-      "label": "readProductWithCache()",
-      "norm_label": "readproductwithcache()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L140"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "adjustments_readstockadjustmentblockedskustatuseswithctx",
-      "label": "readStockAdjustmentBlockedSkuStatusesWithCtx()",
-      "norm_label": "readstockadjustmentblockedskustatuseswithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L709"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "adjustments_readsubcategorywithcache",
-      "label": "readSubcategoryWithCache()",
-      "norm_label": "readsubcategorywithcache()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L164"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "adjustments_requireinventorysnapshotforproductskusaccess",
-      "label": "requireInventorySnapshotForProductSkusAccess()",
-      "norm_label": "requireinventorysnapshotforproductskusaccess()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L1263"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
-      "label": "resolveStockAdjustmentApprovalDecisionWithCtx()",
-      "norm_label": "resolvestockadjustmentapprovaldecisionwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L773"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "adjustments_schedulecatalogsummarydirtymarker",
-      "label": "scheduleCatalogSummaryDirtyMarker()",
-      "norm_label": "schedulecatalogsummarydirtymarker()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L104"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "adjustments_shouldblockstockadjustmentforprovisionalimportrow",
-      "label": "shouldBlockStockAdjustmentForProvisionalImportRow()",
-      "norm_label": "shouldblockstockadjustmentforprovisionalimportrow()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L216"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "adjustments_submitstockadjustmentbatchcommandwithctx",
-      "label": "submitStockAdjustmentBatchCommandWithCtx()",
-      "norm_label": "submitstockadjustmentbatchcommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L1726"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "adjustments_submitstockadjustmentbatchwithctx",
-      "label": "submitStockAdjustmentBatchWithCtx()",
-      "norm_label": "submitstockadjustmentbatchwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L1450"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "adjustments_temporarydeletestockadjustmentscopeskuswithctx",
-      "label": "temporaryDeleteStockAdjustmentScopeSkusWithCtx()",
-      "norm_label": "temporarydeletestockadjustmentscopeskuswithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L1364"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "adjustments_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L131"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_adjustments_ts",
-      "label": "adjustments.ts",
-      "norm_label": "adjustments.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "id": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
+      "label": "DailyOpeningView.tsx",
+      "norm_label": "dailyopeningview.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
       "source_location": "L1"
     },
     {
@@ -250599,6 +250503,42 @@
     {
       "community": 644,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_register_test_ts",
+      "label": "register.test.ts",
+      "norm_label": "register.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 644,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_public_register_test_ts",
+      "label": "register.test.ts",
+      "norm_label": "register.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 644,
+      "file_type": "code",
+      "id": "register_test_buildctx",
+      "label": "buildCtx()",
+      "norm_label": "buildctx()",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 644,
+      "file_type": "code",
+      "id": "register_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 645,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
       "label": "register.ts",
       "norm_label": "register.ts",
@@ -250606,7 +250546,7 @@
       "source_location": "L1"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "register_mapopendrawerusererror",
       "label": "mapOpenDrawerUserError()",
@@ -250615,7 +250555,7 @@
       "source_location": "L34"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "register_normalizeregisternumber",
       "label": "normalizeRegisterNumber()",
@@ -250624,7 +250564,7 @@
       "source_location": "L29"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "register_opendrawer",
       "label": "openDrawer()",
@@ -250633,7 +250573,7 @@
       "source_location": "L56"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "opendrawer_test_createdbgetmock",
       "label": "createDbGetMock()",
@@ -250642,7 +250582,7 @@
       "source_location": "L39"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "opendrawer_test_createdbmock",
       "label": "createDbMock()",
@@ -250651,7 +250591,7 @@
       "source_location": "L99"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "opendrawer_test_createdbquerymock",
       "label": "createDbQueryMock()",
@@ -250660,7 +250600,7 @@
       "source_location": "L74"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_opendrawer_test_ts",
       "label": "openDrawer.test.ts",
@@ -250669,7 +250609,7 @@
       "source_location": "L1"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "getregisterstate_buildregisterstate",
       "label": "buildRegisterState()",
@@ -250678,7 +250618,7 @@
       "source_location": "L21"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "getregisterstate_getactivesessionconflictforregisterstate",
       "label": "getActiveSessionConflictForRegisterState()",
@@ -250687,7 +250627,7 @@
       "source_location": "L42"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "getregisterstate_getregisterstate",
       "label": "getRegisterState()",
@@ -250696,7 +250636,7 @@
       "source_location": "L80"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
       "label": "getRegisterState.ts",
@@ -250705,7 +250645,7 @@
       "source_location": "L1"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_storepulse_test_ts",
       "label": "storePulse.test.ts",
@@ -250714,7 +250654,7 @@
       "source_location": "L1"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "storepulse_test_createdb",
       "label": "createDb()",
@@ -250723,7 +250663,7 @@
       "source_location": "L12"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "storepulse_test_item",
       "label": "item()",
@@ -250732,7 +250672,7 @@
       "source_location": "L127"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "storepulse_test_transaction",
       "label": "transaction()",
@@ -250741,7 +250681,7 @@
       "source_location": "L99"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_posregistersessionactivity_test_ts",
       "label": "posRegisterSessionActivity.test.ts",
@@ -250750,7 +250690,7 @@
       "source_location": "L1"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "posregistersessionactivity_test_buildactivity",
       "label": "buildActivity()",
@@ -250759,7 +250699,7 @@
       "source_location": "L457"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "posregistersessionactivity_test_buildreport",
       "label": "buildReport()",
@@ -250768,49 +250708,13 @@
       "source_location": "L436"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "posregistersessionactivity_test_createfakerepository",
       "label": "createFakeRepository()",
       "norm_label": "createfakerepository()",
       "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
       "source_location": "L476"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sync_registercatalogrevision_ts",
-      "label": "registerCatalogRevision.ts",
-      "norm_label": "registercatalogrevision.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerCatalogRevision.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "registercatalogrevision_advanceregistercatalogrevision",
-      "label": "advanceRegisterCatalogRevision()",
-      "norm_label": "advanceregistercatalogrevision()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerCatalogRevision.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "registercatalogrevision_readregistercatalogrevision",
-      "label": "readRegisterCatalogRevision()",
-      "norm_label": "readregistercatalogrevision()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerCatalogRevision.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "registercatalogrevision_readregistercatalogrevisionrow",
-      "label": "readRegisterCatalogRevisionRow()",
-      "norm_label": "readregistercatalogrevisionrow()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerCatalogRevision.ts",
-      "source_location": "L6"
     },
     {
       "community": 65,
@@ -251040,6 +250944,42 @@
     {
       "community": 650,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_sync_registercatalogrevision_ts",
+      "label": "registerCatalogRevision.ts",
+      "norm_label": "registercatalogrevision.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerCatalogRevision.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 650,
+      "file_type": "code",
+      "id": "registercatalogrevision_advanceregistercatalogrevision",
+      "label": "advanceRegisterCatalogRevision()",
+      "norm_label": "advanceregistercatalogrevision()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerCatalogRevision.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 650,
+      "file_type": "code",
+      "id": "registercatalogrevision_readregistercatalogrevision",
+      "label": "readRegisterCatalogRevision()",
+      "norm_label": "readregistercatalogrevision()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerCatalogRevision.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 650,
+      "file_type": "code",
+      "id": "registercatalogrevision_readregistercatalogrevisionrow",
+      "label": "readRegisterCatalogRevisionRow()",
+      "norm_label": "readregistercatalogrevisionrow()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerCatalogRevision.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 651,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_sequencegappolicy_ts",
       "label": "sequenceGapPolicy.ts",
       "norm_label": "sequencegappolicy.ts",
@@ -251047,7 +250987,7 @@
       "source_location": "L1"
     },
     {
-      "community": 650,
+      "community": 651,
       "file_type": "code",
       "id": "sequencegappolicy_decidesequencegapaction",
       "label": "decideSequenceGapAction()",
@@ -251056,7 +250996,7 @@
       "source_location": "L115"
     },
     {
-      "community": 650,
+      "community": 651,
       "file_type": "code",
       "id": "sequencegappolicy_issequencegapresolved",
       "label": "isSequenceGapResolved()",
@@ -251065,7 +251005,7 @@
       "source_location": "L219"
     },
     {
-      "community": 650,
+      "community": 651,
       "file_type": "code",
       "id": "sequencegappolicy_recordsequencegapobservation",
       "label": "recordSequenceGapObservation()",
@@ -251074,7 +251014,7 @@
       "source_location": "L190"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_staffproof_ts",
       "label": "staffProof.ts",
@@ -251083,7 +251023,7 @@
       "source_location": "L1"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "staffproof_createposlocalstaffprooftoken",
       "label": "createPosLocalStaffProofToken()",
@@ -251092,7 +251032,7 @@
       "source_location": "L10"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "staffproof_hashposlocalstaffprooftoken",
       "label": "hashPosLocalStaffProofToken()",
@@ -251101,7 +251041,7 @@
       "source_location": "L16"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "staffproof_tohex",
       "label": "toHex()",
@@ -251110,7 +251050,7 @@
       "source_location": "L4"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "cloudrepairpolicy_test_buildconflict",
       "label": "buildConflict()",
@@ -251119,7 +251059,7 @@
       "source_location": "L387"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "cloudrepairpolicy_test_buildevent",
       "label": "buildEvent()",
@@ -251128,7 +251068,7 @@
       "source_location": "L407"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "cloudrepairpolicy_test_createrepairprojectionrepository",
       "label": "createRepairProjectionRepository()",
@@ -251137,7 +251077,7 @@
       "source_location": "L282"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_cloudrepairpolicy_test_ts",
       "label": "cloudRepairPolicy.test.ts",
@@ -251146,7 +251086,7 @@
       "source_location": "L1"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_terminalcommandservice_test_ts",
       "label": "terminalCommandService.test.ts",
@@ -251155,7 +251095,7 @@
       "source_location": "L1"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildcommand",
       "label": "buildCommand()",
@@ -251164,7 +251104,7 @@
       "source_location": "L1731"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildrepository",
       "label": "buildRepository()",
@@ -251173,7 +251113,7 @@
       "source_location": "L1666"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildruntimestatus",
       "label": "buildRuntimeStatus()",
@@ -251182,7 +251122,7 @@
       "source_location": "L1755"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
       "label": "sessionCommandRepository.ts",
@@ -251191,7 +251131,7 @@
       "source_location": "L1"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "sessioncommandrepository_collectsessionitemsfrompages",
       "label": "collectSessionItemsFromPages()",
@@ -251200,7 +251140,7 @@
       "source_location": "L177"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "sessioncommandrepository_createsessioncommandrepository",
       "label": "createSessionCommandRepository()",
@@ -251209,49 +251149,13 @@
       "source_location": "L68"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "sessioncommandrepository_scansessionitembyskuinpages",
       "label": "scanSessionItemBySkuInPages()",
       "norm_label": "scansessionitembyskuinpages()",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
       "source_location": "L195"
-    },
-    {
-      "community": 655,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_register_test_ts",
-      "label": "register.test.ts",
-      "norm_label": "register.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 655,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_public_register_test_ts",
-      "label": "register.test.ts",
-      "norm_label": "register.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 655,
-      "file_type": "code",
-      "id": "register_test_buildctx",
-      "label": "buildCtx()",
-      "norm_label": "buildctx()",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 655,
-      "file_type": "code",
-      "id": "register_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L38"
     },
     {
       "community": 656,

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -100823,7 +100823,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_store_configuration_components_storehoursview_test_tsx",
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/StoreHoursView.test.tsx",
-      "source_location": "L227",
+      "source_location": "L229",
       "target": "storehoursview_test_changeanchorandsave",
       "weight": 1
     },
@@ -183259,7 +183259,7 @@
       "label": "changeAnchorAndSave()",
       "norm_label": "changeanchorandsave()",
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/StoreHoursView.test.tsx",
-      "source_location": "L227"
+      "source_location": "L229"
     },
     {
       "community": 1362,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2750
-- Graph nodes: 11385
-- Graph edges: 13960
+- Graph nodes: 11381
+- Graph edges: 13955
 - Communities: 2675
 
 ## Graph Hotspots

--- a/packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx
@@ -1150,9 +1150,12 @@ describe("DailyOpeningViewContent", () => {
     expect(
       within(openingReview).queryByText("Review inventory for Clogs"),
     ).not.toBeInTheDocument();
+    expect(
+      within(openingReview).getAllByRole("article")[0],
+    ).toHaveAttribute("data-density", "default");
   });
 
-  it("paginates automation review evidence at five items per page", async () => {
+  it("compacts and paginates long automation review evidence at ten items per page", async () => {
     const user = userEvent.setup();
     const reviewEvidence = Array.from({ length: 12 }, (_, index) => ({
       category: "operational_work_item",
@@ -1186,15 +1189,26 @@ describe("DailyOpeningViewContent", () => {
       .closest("section")!;
 
     expect(
-      within(openingReview).getByText("Showing 1-5 of 12"),
+      within(openingReview).getByText("Showing 1-10 of 12"),
     ).toBeInTheDocument();
-    expect(within(openingReview).getByText("Page 1 of 3")).toBeInTheDocument();
+    expect(within(openingReview).getByText("Page 1 of 2")).toBeInTheDocument();
     expect(
-      within(openingReview).getByText("Carry-forward review 5"),
+      within(openingReview).getByText("Carry-forward review 10"),
     ).toBeInTheDocument();
     expect(
-      within(openingReview).queryByText("Carry-forward review 6"),
+      within(openingReview).queryByText("Carry-forward review 11"),
     ).not.toBeInTheDocument();
+    expect(
+      within(openingReview).getAllByRole("article")[0],
+    ).toHaveAttribute("data-density", "compact");
+    expect(
+      within(openingReview).queryByText(
+        "Carry-forward work item 1 needs review.",
+      ),
+    ).not.toBeInTheDocument();
+    expect(
+      within(openingReview).getAllByRole("link", { name: "View open work" }),
+    ).toHaveLength(10);
 
     await user.click(
       within(openingReview).getByRole("button", {
@@ -1203,26 +1217,15 @@ describe("DailyOpeningViewContent", () => {
     );
 
     expect(
-      within(openingReview).getByText("Showing 6-10 of 12"),
-    ).toBeInTheDocument();
-    expect(within(openingReview).getByText("Page 2 of 3")).toBeInTheDocument();
-    expect(
-      within(openingReview).getByText("Carry-forward review 6"),
-    ).toBeInTheDocument();
-    expect(
-      within(openingReview).queryByText("Carry-forward review 5"),
-    ).not.toBeInTheDocument();
-
-    await user.click(
-      within(openingReview).getByRole("button", {
-        name: /go to last page/i,
-      }),
-    );
-
-    expect(
       within(openingReview).getByText("Showing 11-12 of 12"),
     ).toBeInTheDocument();
-    expect(within(openingReview).getByText("Page 3 of 3")).toBeInTheDocument();
+    expect(within(openingReview).getByText("Page 2 of 2")).toBeInTheDocument();
+    expect(
+      within(openingReview).getByText("Carry-forward review 11"),
+    ).toBeInTheDocument();
+    expect(
+      within(openingReview).queryByText("Carry-forward review 10"),
+    ).not.toBeInTheDocument();
     expect(
       within(openingReview).getByText("Carry-forward review 12"),
     ).toBeInTheDocument();

--- a/packages/athena-webapp/src/components/operations/DailyOpeningView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOpeningView.tsx
@@ -810,14 +810,18 @@ function OpeningAutomationReviewPanel({
   storeUrlSlug: string;
 }) {
   const [page, setPage] = useState(1);
+  const useCompactRows = items.length > OPENING_REVIEW_ITEMS_PER_PAGE;
+  const itemsPerPage = useCompactRows
+    ? COMPACT_OPENING_CARRY_FORWARD_ITEMS_PER_PAGE
+    : OPENING_REVIEW_ITEMS_PER_PAGE;
   const pageCount = Math.max(
-    Math.ceil(items.length / OPENING_REVIEW_ITEMS_PER_PAGE),
+    Math.ceil(items.length / itemsPerPage),
     1,
   );
   const clampedPage = Math.min(page, pageCount);
   const paginatedItems = items.slice(
-    (clampedPage - 1) * OPENING_REVIEW_ITEMS_PER_PAGE,
-    clampedPage * OPENING_REVIEW_ITEMS_PER_PAGE,
+    (clampedPage - 1) * itemsPerPage,
+    clampedPage * itemsPerPage,
   );
   const handlePageChange = (nextPage: number) => {
     setPage(Math.min(Math.max(nextPage, 1), pageCount));
@@ -852,10 +856,16 @@ function OpeningAutomationReviewPanel({
           {items.length} to review
         </Badge>
       </div>
-      <div className="mt-layout-md space-y-layout-xs">
+      <div
+        className={cn(
+          "mt-layout-md",
+          useCompactRows ? "space-y-0" : "space-y-layout-xs",
+        )}
+      >
         {paginatedItems.map((item) => (
           <OpeningItemCard
             currency={currency}
+            density={useCompactRows ? "compact" : "default"}
             item={item}
             key={getItemId(item)}
             orgUrlSlug={orgUrlSlug}
@@ -864,12 +874,12 @@ function OpeningAutomationReviewPanel({
           />
         ))}
       </div>
-      {items.length > OPENING_REVIEW_ITEMS_PER_PAGE ? (
+      {items.length > itemsPerPage ? (
         <ListPagination
           onPageChange={handlePageChange}
           page={clampedPage}
           pageCount={pageCount}
-          pageSize={OPENING_REVIEW_ITEMS_PER_PAGE}
+          pageSize={itemsPerPage}
           totalItems={items.length}
         />
       ) : null}

--- a/packages/athena-webapp/src/components/store-configuration/components/StoreHoursView.test.tsx
+++ b/packages/athena-webapp/src/components/store-configuration/components/StoreHoursView.test.tsx
@@ -190,6 +190,8 @@ describe("StoreHoursView", () => {
   });
 
   it("shows the active and pending reporting-cycle configuration", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-02T12:00:00.000Z"));
     mockedUseQuery.mockImplementation(((query: unknown) => {
       if (query === "listStoreScheduleVersions") {
         return [


### PR DESCRIPTION
## Summary

Long Opening Review carry-forward lists now use the same compact presentation as the Opening Handoff queue: connected rows, 10 items per page, and no repeated collapsed descriptions. Item metadata and **View open work** actions remain available, while lists of 5 or fewer items retain their existing presentation.

## Why

The completed Opening Review still rendered 5 full-height items per page, so a production list of 59 items required 12 pages and excessive scrolling. This keeps the review calm and scannable without changing its workflow or data.

The branch also freezes the clock in an existing pending-reporting-cycle test so its future-dated fixture remains deterministic after August 3, 2026.

## Validation

- `bun run test -- src/components/operations/DailyOpeningView.test.tsx` (27 passed)
- Focused Store Hours reporting-cycle fixture test (passed)
- Changed frontend lint and TypeScript (passed)
- `bun run pr:athena` (passed with reusable pre-push proof)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.6-000000)

https://linear.app/v26-labs/issue/V26-1153/compact-long-opening-review-carry-forward-lists
