### PR TITLE
fix(harness): point QA smoke at the login route

### DIFF
--- a/docs/solutions/harness/athena-qa-smoke-login-route-target-2026-08-03.md
+++ b/docs/solutions/harness/athena-qa-smoke-login-route-target-2026-08-03.md
@@ -1,0 +1,102 @@
+---
+title: Athena QA Smoke Must Target The Route That Owns Its Assertion
+date: 2026-08-03
+category: harness
+module: runtime-behavior
+problem_type: test_failure
+component: testing_framework
+symptoms:
+  - "Scheduled Athena QA Smoke workflow fails every 30 minutes while QA is healthy"
+  - "QA page did not render the Athena login email field. This may be a blank app shell, boot failure, or non-Athena access interstitial."
+  - "Harness report shows failure in the assertion phase with no page errors and no non-2xx same-origin responses"
+root_cause: missing_workflow_step
+resolution_type: test_fix
+severity: medium
+delivery_diff_fingerprint: 1f69f50fd946d2ef45805cb33a9be98a544035ec9e51119c5fb5cc7775034298
+tags:
+  - ci
+  - github-actions
+  - playwright
+  - qa
+  - smoke-test
+  - routing
+---
+
+# Athena QA Smoke Must Target The Route That Owns Its Assertion
+
+## Problem
+
+Every scheduled `Athena QA Smoke` run failed from 2026-07-28 onward while the QA
+deployment was completely healthy. The smoke navigated to the site root and
+asserted that `input#email[type='email']` mounts, but the root route had stopped
+serving the login form.
+
+## Symptoms
+
+- `Athena QA Smoke` red on every 30-minute schedule; last green run 2026-07-28.
+- Failure always in the `assertion` phase: "QA page did not render the Athena
+  login email field."
+- No page errors, no request failures, no 5xx same-origin responses — the only
+  diagnostic was the missing login field, so the report read like a blank app
+  shell.
+
+## What Didn't Work
+
+Reading the failure as an outage. The diagnostic message names a blank shell,
+boot failure, or access interstitial, and none of those applied. The page was
+rendering fine — it was rendering a *different, correct* page than the one the
+assertion described.
+
+## Solution
+
+Navigate the scenario at the route that actually owns the asserted DOM, resolved
+from the configured QA origin so the workflow's `ATHENA_QA_URL` stays the single
+knob:
+
+```ts
+export const ATHENA_QA_LOGIN_PATH = "/login";
+
+const qaBaseUrl = process.env.ATHENA_QA_URL ?? "https://athena-qa.wigclub.store/";
+const qaOrigin = new URL(qaBaseUrl).origin;
+const qaUrl = new URL(ATHENA_QA_LOGIN_PATH, qaBaseUrl).toString();
+```
+
+`qaOrigin` still drives same-origin response and request-failure filtering, so
+the network diagnostics are unchanged. Only the navigation target moved.
+
+## Why This Works
+
+`7c6cb892` changed `AppEntryDispatcher` so that an anonymous visitor with no
+prior-auth marker in `localStorage` is dispatched to `/landing` instead of
+`/login`:
+
+```ts
+navigate({ to: hasAuthenticatedBefore ? "/login" : "/landing" });
+```
+
+CI drives a fresh browser profile, so it is *always* the first-time-visitor
+branch and always landed on the public marketing page, which has no login form.
+A returning human on the same URL still saw the login screen, which is why the
+failure looked unreproducible by hand. Pointing the smoke at `/login` restores
+the invariant the assertion was written against: the app shell boots and mounts
+the login form.
+
+## Prevention
+
+- A browser smoke must navigate to the route that owns the DOM it asserts on.
+  Do not rely on a root route to redirect there — redirect targets are product
+  decisions that change without anyone thinking about the smoke.
+- Be suspicious of entry-point redirects keyed on `localStorage`, cookies, or
+  any other persisted client state: CI is permanently in the cold-start branch,
+  so a cold-start-only path becomes the *only* path CI ever exercises.
+- When a smoke fails identically on every scheduled run while the surface is
+  healthy by hand, suspect a stale assertion target before an outage. Check
+  whether the asserted route still renders what the assertion names.
+- The regression test in `scripts/harness-behavior-scenarios.test.ts` pins the
+  navigation target so this cannot silently drift back to the root.
+
+## Related Issues
+
+- `docs/solutions/harness/athena-qa-smoke-live-navigation-readiness-2026-06-01.md`
+  — the same scenario's earlier fix, which moved it off `networkidle` and made
+  the login-field assertion the readiness signal this note repairs.

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -18815,7 +18815,7 @@
       "relation": "calls",
       "source": "harness_behavior_scenarios_stripurlquery",
       "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L362",
+      "source_location": "L366",
       "target": "harness_behavior_scenarios_diagnoseathenaqalivesmoke",
       "weight": 1
     },
@@ -143843,7 +143843,7 @@
       "relation": "contains",
       "source": "scripts_harness_behavior_scenarios_ts",
       "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L322",
+      "source_location": "L326",
       "target": "harness_behavior_scenarios_diagnoseathenaqalivesmoke",
       "weight": 1
     },
@@ -143867,7 +143867,7 @@
       "relation": "contains",
       "source": "scripts_harness_behavior_scenarios_ts",
       "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L382",
+      "source_location": "L386",
       "target": "harness_behavior_scenarios_formatstorefrontbackenddiagnostic",
       "weight": 1
     },
@@ -207469,7 +207469,7 @@
       "label": "diagnoseAthenaQaLiveSmoke()",
       "norm_label": "diagnoseathenaqalivesmoke()",
       "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L322"
+      "source_location": "L326"
     },
     {
       "community": 221,
@@ -207487,7 +207487,7 @@
       "label": "formatStorefrontBackendDiagnostic()",
       "norm_label": "formatstorefrontbackenddiagnostic()",
       "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L382"
+      "source_location": "L386"
     },
     {
       "community": 221,

--- a/scripts/harness-behavior-scenarios.test.ts
+++ b/scripts/harness-behavior-scenarios.test.ts
@@ -314,6 +314,40 @@ describe("HARNESS_BEHAVIOR_SCENARIOS", () => {
     ).rejects.toThrow("QA page did not render the Athena login email field");
   });
 
+  it("boots the Athena QA smoke at the login route rather than the root landing page", async () => {
+    const page = {
+      on: () => {},
+      waitForSelector: async () => {},
+      textContent: async () => "athena",
+    };
+
+    const visitedUrls: string[] = [];
+    const previousQaUrl = process.env.ATHENA_QA_URL;
+    process.env.ATHENA_QA_URL = "https://athena-qa.example/";
+
+    try {
+      await ATHENA_QA_LIVE_SMOKE_SCENARIO.browser({
+        runPlaywrightFlow: async ({ url, steps }: any) => {
+          visitedUrls.push(url);
+          return {
+            stepResult: await steps({ page } as any),
+            consoleMessages: [],
+          };
+        },
+      } as any);
+    } finally {
+      if (previousQaUrl === undefined) {
+        delete process.env.ATHENA_QA_URL;
+      } else {
+        process.env.ATHENA_QA_URL = previousQaUrl;
+      }
+    }
+
+    // The root route sends anonymous first-time visitors to the marketing
+    // landing page, which never mounts the login form the smoke asserts on.
+    expect(visitedUrls).toEqual(["https://athena-qa.example/login"]);
+  });
+
   it("asserts the Valkey proxy scenario round-trip contract", async () => {
     const validBrowserResult = {
       rootText: "Valkey proxy running",

--- a/scripts/harness-behavior-scenarios.ts
+++ b/scripts/harness-behavior-scenarios.ts
@@ -319,6 +319,10 @@ function stripUrlQuery(url: string) {
   }
 }
 
+// Route that mounts the Athena login form. Kept next to the diagnostics so the
+// selector assertion and the navigation target stay in sync.
+export const ATHENA_QA_LOGIN_PATH = "/login";
+
 export function diagnoseAthenaQaLiveSmoke(input: {
   observedText: string;
   hasEmailField: boolean;
@@ -1296,8 +1300,13 @@ export const ATHENA_QA_LIVE_SMOKE_SCENARIO: HarnessBehaviorScenario<AthenaQaLive
     readiness: [],
     browser: async ({ runPlaywrightFlow }) => {
       const observations: AthenaQaLiveObservation[] = [];
-      const qaUrl = process.env.ATHENA_QA_URL ?? "https://athena-qa.wigclub.store/";
-      const qaOrigin = new URL(qaUrl).origin;
+      const qaBaseUrl =
+        process.env.ATHENA_QA_URL ?? "https://athena-qa.wigclub.store/";
+      const qaOrigin = new URL(qaBaseUrl).origin;
+      // The root route dispatches anonymous first-time visitors to the public
+      // marketing landing page, so it no longer mounts the login form. Boot the
+      // smoke straight at the login surface, which is the app shell we assert on.
+      const qaUrl = new URL(ATHENA_QA_LOGIN_PATH, qaBaseUrl).toString();
 
       const flowResult = await runPlaywrightFlow({
         url: qaUrl,


### PR DESCRIPTION
## Problem

Every scheduled `Athena QA Smoke` run has failed since 2026-07-28 while the QA deployment is completely healthy.

The smoke navigated to the site root and asserted `input#email[type='email']` mounts. `7c6cb892` changed `AppEntryDispatcher` so an anonymous visitor is routed by prior-auth state:

```ts
navigate({ to: hasAuthenticatedBefore ? "/login" : "/landing" });
```

CI drives a fresh browser profile, so it is *always* the first-time-visitor branch and always lands on the public marketing page, which has no login form. A human opening the same URL still sees the login screen (their `localStorage` marker is set), which is why the failure looked unreproducible by hand. Last green run was 2026-07-28 — exactly matching that commit.

## Fix

Navigate the scenario at the login route, resolved from `ATHENA_QA_URL` so that env var stays the single knob. `qaOrigin` still drives same-origin response and request-failure filtering, so network diagnostics are unchanged — only the navigation target moved.

## Verification

Against live QA, not just asserted:

- `/` → product-overview landing page, all 200s, no page errors
- `/login` → `input#email[type='email']` present
- Full scenario re-run against live QA with the fix: **passed** (4.3s, zero diagnostics)
- `bun test scripts/harness-behavior-scenarios.test.ts` → 12 pass
- `bun run pr:athena` → green, proof recorded

Added a regression test pinning the navigation target so it cannot silently drift back to the root, plus the solution note the delivery gate requires for harness changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)