### PR TITLE
feat(reports): size the SKU mix read from the days rail instead of its span

### DIFF
--- a/docs/reports/2026-08-04-sku-mix-measured-read-sizing-report.html
+++ b/docs/reports/2026-08-04-sku-mix-measured-read-sizing-report.html
@@ -1,0 +1,327 @@
+<!doctype html>
+<html lang="en" data-athena-landed-change-report="v1" data-athena-report-diff-fingerprint="c737a6d7b0f5dc71be442caf4e726ff10b0dcd40528a90a99ad324e74eff2b13" data-athena-report-base="origin/main" data-athena-report-head="feat/reports-sku-mix-measured-read-sizing">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>The cheap query sizes the expensive one: measured read routing for SKU mix</title>
+    <style>
+      :root {
+        --ink: #1f2933;
+        --muted: #596674;
+        --line: #d9e2ec;
+        --paper: #ffffff;
+        --soft: #f6f8fb;
+        --accent: #1d4ed8;
+        --accent-soft: #dbeafe;
+        --good: #166534;
+        --bad: #b91c1c;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--soft);
+        color: var(--ink);
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        line-height: 1.55;
+      }
+      main { max-width: 1120px; margin: 0 auto; padding: 48px 24px 72px; }
+      header { border-bottom: 1px solid var(--line); margin-bottom: 28px; padding-bottom: 28px; }
+      h1, h2, h3 { line-height: 1.18; letter-spacing: 0; }
+      h1 { font-size: 42px; max-width: 880px; margin: 0 0 16px; }
+      h2 { font-size: 28px; margin: 0 0 16px; }
+      h3 { font-size: 19px; margin: 22px 0 10px; }
+      p { margin: 0 0 14px; }
+      .lede { color: var(--muted); font-size: 18px; max-width: 880px; }
+      .meta { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 20px; }
+      .pill { border: 1px solid var(--line); border-radius: 999px; background: var(--paper); color: var(--muted); font-size: 13px; padding: 6px 10px; }
+      .panel { background: var(--paper); border: 1px solid var(--line); border-radius: 8px; margin: 18px 0; padding: 22px; }
+      code { background: #eef2f7; border: 1px solid #d8dee8; border-radius: 5px; padding: 1px 5px; }
+      pre { overflow: auto; background: #111827; color: #e5e7eb; border-radius: 8px; padding: 16px; }
+      pre code { background: transparent; border: 0; color: inherit; padding: 0; }
+      .table-scroll { overflow-x: auto; }
+      table { width: 100%; border-collapse: collapse; border: 1px solid var(--line); border-radius: 8px; overflow: hidden; }
+      th, td { border-bottom: 1px solid var(--line); padding: 11px 12px; text-align: left; vertical-align: top; }
+      th { background: #eef2f7; color: var(--muted); font-size: 13px; text-transform: uppercase; }
+      tr:last-child td { border-bottom: 0; }
+      .quiz-question { border-top: 1px solid var(--line); padding: 18px 0; }
+      .quiz-question:first-child { border-top: 0; }
+      fieldset { border: 0; margin: 0; padding: 0; }
+      legend { font-weight: 700; margin-bottom: 10px; }
+      label { display: block; border: 1px solid var(--line); border-radius: 8px; background: #fbfdff; margin: 8px 0; padding: 10px 12px; cursor: pointer; }
+      @media (hover: hover) and (pointer: fine) {
+        label:hover { border-color: #b6c5d8; }
+      }
+      button {
+        appearance: none;
+        border: 0;
+        border-radius: 8px;
+        background: var(--accent);
+        color: #ffffff;
+        cursor: pointer;
+        font-weight: 700;
+        padding: 11px 16px;
+        transition: transform 140ms cubic-bezier(0.23, 1, 0.32, 1);
+      }
+      button:active { transform: scale(0.97); }
+      button.secondary { background: #475569; }
+      .quiz-actions { display: flex; align-items: center; flex-wrap: wrap; gap: 12px; margin-top: 20px; }
+      #quizResult { font-weight: 700; }
+      .answer-detail { display: none; border-top: 1px dashed var(--line); color: var(--muted); margin-top: 10px; padding-top: 10px; }
+      .answer-detail.visible { display: block; }
+      .correct { border-color: #86efac !important; background: #f0fdf4 !important; }
+      .incorrect { border-color: #fecaca !important; background: #fef2f2 !important; }
+      .warn { background: #fffbeb; border-color: #fde68a; }
+      @media (prefers-reduced-motion: reduce) { button { transition-duration: 0ms; } }
+      @media (max-width: 820px) { h1 { font-size: 32px; } main { padding: 32px 16px 56px; } }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>The cheap query sizes the expensive one: measured read routing for SKU mix</h1>
+        <p class="lede">The SKU mix chart routed every selection longer than two days through admission control and a snapshot build &mdash; to fold, in production, a few hundred rows. The span rule was provable but calibrated to a worst case wigclub sits 23&times; below. This delivery publishes the fold&rsquo;s own row count onto the days rail, so the read that is already loaded can measure the read that is about to be issued.</p>
+        <div class="meta"><span class="pill">Delivery candidate</span><span class="pill">Branch feat/reports-sku-mix-measured-read-sizing</span><span class="pill">Base origin/main</span><span class="pill">737 focused reports tests green</span><span class="pill">Merge gate: pr:athena</span><span class="pill">Schema: one optional field</span><span class="pill">No fold-version bump</span><span class="pill">Backfill required</span></div>
+      </header>
+
+      <section class="panel"><h2>Executive Summary</h2>
+        <p>Multi-day SKU mix was moved onto the bounded resumable range-snapshot lifecycle in the previous delivery. Correct, but the routing predicate was a <em>proxy</em>: a selection qualified as cheap only by being at most two days long. That threshold was provable from the fold&rsquo;s 2,000-rows-per-operating-day ceiling &mdash; two days &times; 2,000 = 4,000 rows, under the reader&rsquo;s 5,000-row cap.</p>
+        <p><strong>Production sits nowhere near that ceiling.</strong> Wigclub&rsquo;s busiest day in seventeen months folds 88 SKU rows; the median day folds 30. The entire 184-day window reads 2,366 rows &mdash; inside the synchronous cap. The chart was buying admission control to fold a few hundred rows.</p>
+        <p><strong>The fold already knows the number.</strong> <code>foldDay</code> returns a <code>skuDays</code> map that <em>is</em> the day&rsquo;s row set, so <code>skuDays.size</code> equals the post-fold <code>reportSkuDay</code> count exactly. The sweeper now writes it onto the day document in the same mutation as those rows, and the days rail publishes it as <code>skuDayRowCount</code>.</p>
+        <p><strong>Routing became two tiers.</strong> The span rule survives as an unconditional floor that never depends on loaded data. Above it, <code>skuMixSyncRowProbe</code> sums the counts across the selection from rows the panel already holds and stays synchronous when the total clears a 4,000-row budget. Day, week, month and quarter selections now avoid admission entirely.</p>
+        <p><strong>What this does not fix.</strong> At wigclub&rsquo;s current run rate a fully operating 184-day window is roughly 6,214 rows &mdash; genuinely over the cap. The six-month window legitimately belongs on the async rail from around 2026-10-07. The win is everything narrower, which was never actually expensive.</p>
+      </section>
+
+      <section class="panel"><h2>Problem and Context</h2>
+        <p>The reported symptom was interaction latency: the mix chart felt unresponsive after it moved onto the heavy rail, while the days table loaded the same range quickly.</p>
+        <p><strong>The obvious fix does not work.</strong> <code>listDays</code> and the mix chart share a metric name, not a grain. <code>reportDay</code> holds one document per operating day with store-wide scalars &mdash; its <code>unitsSold</code> means &ldquo;the store sold 412 units that day&rdquo;. The pie slices <em>by SKU</em>, which exists only in <code>reportSkuDay</code>, one row per (day, SKU). For a 184-day window that is 184 documents versus up to 368,000 rows. Routing the chart at the days rail yields a single total with nothing to divide it into.</p>
+        <p><strong>The pre-aggregated rail is also not the answer.</strong> <code>reportPeriodSkuRollup</code> already stores per-SKU totals per period key, and trailing-six-month windows are month-aligned at the start. Measured against production it compresses only 1.0&times;&ndash;2.8&times; per month; across the window, 2,366 rows collapse to 1,082. Wigclub&rsquo;s catalogue is long-tail &mdash; 628 distinct SKUs over 2,366 SKU-days, so a SKU sells on about 3.8 days total &mdash; and month rollups only help when SKUs repeat across days. A hybrid whole-months-plus-partial-tail fold to save ~1,300 row reads was rejected as not worth the seam.</p>
+        <p><strong>The real defect was the question being asked.</strong> The predicate asked <em>how wide is this range</em> as a stand-in for <em>how much will this read cost</em>, because cost was not knowable without doing the read.</p>
+      </section>
+
+      <section class="panel"><h2>Mental Model</h2>
+        <p>Four ideas carry the change.</p>
+        <h3>1. A span ceiling is a proxy for cost</h3>
+        <p>Span, page count and item count are all stand-ins. If another query on screen already covers the same range, cost is knowable for free. The days rail is the right source not because it holds the data, but because it already covers the range. <strong>The cheap query sizes the expensive one.</strong></p>
+        <h3>2. Unknown is not zero &mdash; but a missing row is</h3>
+        <p>A day whose count is absent makes the whole range indeterminate, not &ldquo;the sum of the rest&rdquo;. But <code>reportDay</code> is <em>sparse</em>: wigclub has 108 day documents across 511 calendar days, and a day with no document had no activity and so no SKU rows. A missing <em>field</em> means unknown; a missing <em>row</em> legitimately means zero. Both are encoded, and callers must pass explicit coverage bounds so &ldquo;the reader never looked&rdquo; cannot masquerade as &ldquo;there was nothing there&rdquo;.</p>
+        <h3>3. A derived counter is only as trustworthy as its slowest writer</h3>
+        <p><code>reportDay</code> has two writers. The sweeper folds it; <code>ingest.ts</code> maintains it incrementally between folds, including inserting new <code>reportSkuDay</code> rows as facts arrive for the open day. A count written only by the fold goes stale-low all day, on exactly the day operators watch most.</p>
+        <h3>4. Trust predicates and performance predicates are different claims</h3>
+        <p>Both send a day through the same refold, which makes merging them tempting. But <code>certifiedFoldRevision</code> is the movement lane&rsquo;s <em>trust</em> boundary, while <code>skuDayRowCount</code> is the mix lane&rsquo;s <em>sizing</em> hint. A day missing the count is fully trustworthy.</p>
+      </section>
+
+      <section class="panel"><h2>Before and After</h2>
+        <div class="table-scroll">
+          <table>
+            <thead><tr><th>Selection</th><th>Before</th><th>After</th><th>Rows (wigclub today)</th></tr></thead>
+            <tbody>
+              <tr><td>1 day</td><td>synchronous</td><td>synchronous</td><td>~34</td></tr>
+              <tr><td>3 days</td><td><strong>admission + snapshot</strong></td><td>synchronous</td><td>~101</td></tr>
+              <tr><td>7 days</td><td><strong>admission + snapshot</strong></td><td>synchronous</td><td>~237</td></tr>
+              <tr><td>31 days</td><td><strong>admission + snapshot</strong></td><td>synchronous</td><td>~1,048</td></tr>
+              <tr><td>92 days</td><td>admission + snapshot</td><td>synchronous</td><td>~3,110</td></tr>
+              <tr><td>184 days</td><td>admission + snapshot</td><td>admission + snapshot</td><td>~6,214 at full rate</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p>The async lifecycle is unchanged and remains correct for the widest window. What changed is which selections are sent to it.</p>
+      </section>
+
+      <section class="panel"><h2>Key Files</h2>
+        <div class="table-scroll">
+          <table>
+            <thead><tr><th>File</th><th>Why it matters</th></tr></thead>
+            <tbody>
+              <tr><td><code>shared/reportsContract.ts</code></td><td>Adds <code>skuDayRowCount</code> to <code>ReportDayRow</code>, the <code>REPORT_SKU_MIX_SYNC_ROW_BUDGET</code> constant, and <code>skuMixSyncRowProbe</code> &mdash; the pure sizing function, with coverage bounds as required arguments.</td></tr>
+              <tr><td><code>convex/reports/sweeper.ts</code></td><td>Writes <code>skuDayRowCount: result.skuDays.size</code> into the day document in the same mutation that patches, inserts and deletes the SKU rows it counts.</td></tr>
+              <tr><td><code>convex/reports/ingest.ts</code></td><td>The second writer. SKU upserts moved <em>ahead of</em> the day write so this batch&rsquo;s inserts land in the same patch; a pre-U8 day deliberately stays uncounted rather than guessing from an unknown base.</td></tr>
+              <tr><td><code>convex/schemas/reports/derived.ts</code></td><td>Declares the field optional. Absent means unknown, never zero.</td></tr>
+              <tr><td><code>convex/reports/queries.ts</code></td><td>Passes the count through <code>toReportDayRow</code>, and moves <code>listRangeSkuMix</code> off the 92-day proxy cap onto the 184-day drill-down ceiling. The 5,000-row cap still fails closed and always was the real bound.</td></tr>
+              <tr><td><code>convex/reports/foldVersionRepair.ts</code></td><td>Adds <code>skuDayRowCountBackfillNeeded</code> as a predicate separate from <code>needsCertifiedRefold</code>, with its own counter; also fixes <code>missingRevisionCount</code>, which inferred its answer rather than testing it.</td></tr>
+              <tr><td><code>src/components/reports/ReportDaysPanel.tsx</code></td><td>Two-tier routing, sized from the <em>raw</em> <code>liveDays</code> result, and admission deferred until the routing verdict resolves.</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="panel"><h2>What Intentionally Did Not Change</h2>
+        <p><strong>No fold-version bump.</strong> The fold&rsquo;s output is unchanged, so refolding is not a correctness repair. A bump would have invalidated certified provenance for stores already cleared for the movement lane.</p>
+        <p><strong>The async lifecycle.</strong> <code>rangeSnapshotLifecycle.ts</code> and the mix snapshot path are untouched. So is the held-snapshot UI: the prior donut already stays on screen, dimmed and desaturated, while a new range builds &mdash; that behavior shipped previously and was left alone rather than rebuilt.</p>
+        <p><strong>The legacy movement reader.</strong> <code>listRangeSkuMovement</code> keeps <code>RANGE_SYNC_READER_MAX_SPAN_DAYS</code> at 92. It has no probe, so span remains its only proxy for cost.</p>
+        <p><strong>The span floor.</strong> Selections of at most two days route synchronously without consulting any loaded data, so a day click cannot regress because the days rail has not answered yet.</p>
+        <p><strong>Shared-demo behavior.</strong> Demo fixtures carry no counts, so the probe is indeterminate there and the span rule governs exactly as before.</p>
+      </section>
+
+      <section class="panel"><h2>Validation and Review Evidence</h2>
+        <p><strong>Focused suites:</strong> 737 tests green across <code>convex/reports</code> and <code>src/components/reports</code>. <code>tsc --noEmit</code> clean; <code>eslint</code> clean across all changed files.</p>
+        <p><strong>New coverage:</strong> probe unit tests for summation, sparse-day zeroing, out-of-range exclusion, indeterminacy on an uncounted day, and indeterminacy on insufficient coverage in both directions; a sweeper test asserting the published count equals the actual row count (compared against <code>skuDays.length</code>, not a literal) and drops to zero when a day sheds its last row; ingest tests for incremental exactness, zero-as-measurement, and absent-stays-absent; panel tests for both routing tiers and for deferred admission.</p>
+        <p><strong>Production data grounding:</strong> all three reporting tables were pulled in full from prod and reconciled locally. 1,130 of 1,130 month-SKU rollup pairs matched a local re-fold exactly; <code>reportDay.unitsSold</code> equalled the sum of its SKU rows on all 108 days; <code>factCount</code> was never below the SKU-row count on any day.</p>
+        <p><strong>Dev end-to-end:</strong> the backfill was marked and drained on dev wigclub &mdash; 73/73 days counted, zero marks remaining, and <strong>73/73 published counts equal the actual <code>reportSkuDay</code> row count</strong> (830 rows, 830 summed), with no SKU-day date lacking a day document.</p>
+        <div class="panel warn"><p><strong>Untested path.</strong> Refolds advance <code>certifiedFoldRevision</code>, which should invalidate range snapshots covering a refolded day via <code>sameRevisionVector</code>. The dev drain reported <code>rangesComputed: 0</code> throughout &mdash; there were no pending snapshots &mdash; so that cascade was not exercised. It will first run for real during the production backfill.</p>
+        <p><strong>Dev cron not firing.</strong> The dev deployment&rsquo;s 5-minute sweep cron did not tick; the drain was driven by invoking <code>reports/sweeper:sweep</code> directly (10 days per call, zero failures). Unrelated to this change, but it invalidates dev as a witness for any cron-driven behavior until fixed.</p></div>
+        <p><strong>Deployment status:</strong> <em>pending</em> at report time. Planned sequence: merge to <code>origin/main</code> &rarr; align local main &rarr; <code>scripts/deploy-vps.sh convex-athena-local</code> (<code>deploy_convex_prod</code> + <code>deploy_athena_local</code>) &rarr; production backfill for wigclub.</p>
+      </section>
+
+      <section class="panel"><h2>Operational Guidance</h2>
+        <p><strong>The backfill is required, not optional.</strong> Historical settled days never refold under normal traffic, so they never acquire the count on their own, and one uncounted day makes its whole range indeterminate. Without it the feature self-heals forward at one day per day &mdash; full six-month coverage in six months.</p>
+        <p><strong>Run it off-peak.</strong> Each refold advances <code>certifiedFoldRevision</code>, so completed Units moved and multi-day mix snapshots covering refolded days go <code>terminal_source_stale</code> and rebuild on next ensure. Self-healing, but visible to anyone with a wide sheet open.</p>
+        <p><strong>Command and drain rate:</strong> <code>markStaleFoldVersionDays</code> per store with <code>autoContinue</code>, then let the sweeper drain at <code>SWEEP_DIRTY_BATCH</code> (10 days) per 5-minute tick. Prod wigclub is 108 days &mdash; about 55 minutes, sharing the queue with real dirty days.</p>
+        <p><strong>Confirm with</strong> <code>countStaleFoldVersionDays</code>, whose <code>missingSkuDayRowCountCount</code> should reach zero. Note this is deliberately <em>not</em> on <code>countUncertifiedDays</code>, which remains the movement-readiness gate.</p>
+        <p><strong>Watch the budget over time.</strong> The 4,000-row budget is not permanent headroom. At wigclub&rsquo;s run rate the quarter view crosses it at roughly 2&times; volume and the month view at roughly 3&times;. Re-measure before assuming a range is still cheap.</p>
+      </section>
+
+      <section class="panel"><h2>Subagent Evidence</h2>
+        <p><strong>SubagentUnavailable</strong> &mdash; and the reason is a policy restriction rather than a platform limitation, so this is stated plainly rather than claimed as unavailability. The operating harness for this session instructed that agent dispatch not be used unless explicitly requested, and no such request was made. The session-context, delivered-diff and reviewer subagents this skill normally requires were therefore not run.</p>
+        <p><strong>This report is correspondingly less complete than standard.</strong> In particular it carries no independent review of its own claims or quiz quality, and no cross-session historical sweep for prior attempts at this problem.</p>
+        <p>What stands in for that evidence, all first-hand from the delivery session: full-table reconciliation against production data for the routing premises; a complete read of both <code>reportDay</code> writers before adding the derived counter; an end-to-end backfill on dev with row-level verification; and a self-review pass against stated intent that found and fixed three defects &mdash; the ingest staleness gap, admission firing before the probe resolved, and the probe reading the stable seam&rsquo;s previous-range rows instead of the raw subscription result.</p>
+      </section>
+
+      <section class="panel"><h2>Comprehension Quiz: Pass Required</h2>
+        <p>Ten questions, pass at 8/10.</p>
+        <form id="changeQuiz" data-threshold="8">
+
+          <div class="quiz-question" data-answer="2">
+            <fieldset><legend>1. Why can the days table&rsquo;s rail not simply supply the pie chart&rsquo;s data?</legend>
+              <label><input type="radio" name="q1" value="1" /> It is too slow at six-month spans.</label>
+              <label><input type="radio" name="q1" value="2" /> It stores store-wide daily scalars, not per-SKU rows, so it has no breakdown to divide a total into.</label>
+              <label><input type="radio" name="q1" value="3" /> Its rows are not certified for the mix lane.</label>
+              <label><input type="radio" name="q1" value="4" /> It is capped at 92 days.</label>
+            </fieldset>
+            <p class="answer-detail"><strong>Correct: B.</strong> <code>reportDay</code> holds one document per day with store-wide scalars. Per-SKU attribution exists only in <code>reportSkuDay</code>. The two share a metric name, not a grain.</p>
+          </div>
+
+          <div class="quiz-question" data-answer="3">
+            <fieldset><legend>2. The old two-day span threshold was described as &ldquo;provable&rdquo;. Provable from what?</legend>
+              <label><input type="radio" name="q2" value="1" /> Measured production percentiles.</label>
+              <label><input type="radio" name="q2" value="2" /> The 92-day synchronous reader cap.</label>
+              <label><input type="radio" name="q2" value="3" /> The fold&rsquo;s 2,000-rows-per-day ceiling: 2 &times; 2,000 = 4,000, under the 5,000-row reader cap.</label>
+              <label><input type="radio" name="q2" value="4" /> The 184-day drill-down ceiling.</label>
+            </fieldset>
+            <p class="answer-detail"><strong>Correct: C.</strong> It was a sound proof from a safety ceiling &mdash; but that ceiling sits about 23&times; above what production actually folds, which is why the rule was so conservative.</p>
+          </div>
+
+          <div class="quiz-question" data-answer="1">
+            <fieldset><legend>3. Why is <code>result.skuDays.size</code> an exact count rather than an estimate?</legend>
+              <label><input type="radio" name="q3" value="1" /> The map is the day&rsquo;s row set: every entry is patched or inserted, and every existing row absent from it is deleted.</label>
+              <label><input type="radio" name="q3" value="2" /> The fold recounts the table after writing.</label>
+              <label><input type="radio" name="q3" value="3" /> It is validated against <code>factCount</code>.</label>
+              <label><input type="radio" name="q3" value="4" /> A database trigger keeps it in sync.</label>
+            </fieldset>
+            <p class="answer-detail"><strong>Correct: A.</strong> And it is written in the same mutation as those rows, so the count cannot disagree with them at fold time.</p>
+          </div>
+
+          <div class="quiz-question" data-answer="4">
+            <fieldset><legend>4. A day in the selected range has no <code>reportDay</code> document at all. What does the probe do?</legend>
+              <label><input type="radio" name="q4" value="1" /> Returns <code>undefined</code> &mdash; the range is unprovable.</label>
+              <label><input type="radio" name="q4" value="2" /> Assumes the 2,000-row worst case for that day.</label>
+              <label><input type="radio" name="q4" value="3" /> Throws.</label>
+              <label><input type="radio" name="q4" value="4" /> Counts it as zero, because <code>reportDay</code> is sparse and no document means no activity.</label>
+            </fieldset>
+            <p class="answer-detail"><strong>Correct: D.</strong> A missing <em>row</em> means zero; a missing <em>field</em> means unknown. Conflating them would make the cheapest ranges &mdash; quiet ones &mdash; unprovable.</p>
+          </div>
+
+          <div class="quiz-question" data-answer="2">
+            <fieldset><legend>5. Why does the probe take explicit coverage bounds instead of inferring coverage from the rows it was given?</legend>
+              <label><input type="radio" name="q5" value="1" /> To support multiple stores in one call.</label>
+              <label><input type="radio" name="q5" value="2" /> Because rows are sparse, so their presence cannot prove the reader looked at the range &mdash; a range past the loaded window would otherwise sum to a confident understatement.</label>
+              <label><input type="radio" name="q5" value="3" /> To let the caller override the budget.</label>
+              <label><input type="radio" name="q5" value="4" /> To keep the function pure.</label>
+            </fieldset>
+            <p class="answer-detail"><strong>Correct: B.</strong> With a sparse table, &ldquo;no rows here&rdquo; and &ldquo;I never looked here&rdquo; are indistinguishable without separate coverage evidence.</p>
+          </div>
+
+          <div class="quiz-question" data-answer="3">
+            <fieldset><legend>6. Why is the sync budget 4,000 when the reader&rsquo;s cap is 5,000?</legend>
+              <label><input type="radio" name="q6" value="1" /> 4,000 is the fold&rsquo;s per-day ceiling.</label>
+              <label><input type="radio" name="q6" value="2" /> To leave room for the top-5 identity lookups.</label>
+              <label><input type="radio" name="q6" value="3" /> The probe sizes rows folded before the read happens; the gap absorbs a concurrent fold rather than letting the reader&rsquo;s fail-closed throw reach the operator.</label>
+              <label><input type="radio" name="q6" value="4" /> It matches the rollup row cap.</label>
+            </fieldset>
+            <p class="answer-detail"><strong>Correct: C.</strong> Sizing and reading are separated in time, so the budget deliberately under-commits.</p>
+          </div>
+
+          <div class="quiz-question" data-answer="1">
+            <fieldset><legend>7. What made <code>ingest.ts</code> a necessary part of this change?</legend>
+              <label><input type="radio" name="q7" value="1" /> It is a second writer that inserts <code>reportSkuDay</code> rows between folds, so a fold-only count would go stale-low on the open day.</label>
+              <label><input type="radio" name="q7" value="2" /> It owns the dirty-mark queue.</label>
+              <label><input type="radio" name="q7" value="3" /> It validates the schema.</label>
+              <label><input type="radio" name="q7" value="4" /> It computes the rollups.</label>
+            </fieldset>
+            <p class="answer-detail"><strong>Correct: A.</strong> Hence the rule: when a derived counter has more than one writer, every writer must maintain it in the same transaction as the rows it counts.</p>
+          </div>
+
+          <div class="quiz-question" data-answer="2">
+            <fieldset><legend>8. Ingest sees a new fact for a pre-backfill day that carries no count. What does it write?</legend>
+              <label><input type="radio" name="q8" value="1" /> The number of rows it just inserted.</label>
+              <label><input type="radio" name="q8" value="2" /> Nothing &mdash; the field stays absent, because base-plus-inserts on an unknown base would be a guess presented as a measurement.</label>
+              <label><input type="radio" name="q8" value="3" /> Zero, to initialize it.</label>
+              <label><input type="radio" name="q8" value="4" /> A full recount of the day&rsquo;s rows.</label>
+            </fieldset>
+            <p class="answer-detail"><strong>Correct: B.</strong> The day stays unprovable until its backfill refold supplies the real value.</p>
+          </div>
+
+          <div class="quiz-question" data-answer="4">
+            <fieldset><legend>9. Why is <code>skuDayRowCountBackfillNeeded</code> kept separate from <code>needsCertifiedRefold</code>?</legend>
+              <label><input type="radio" name="q9" value="1" /> They mark different dirty reasons.</label>
+              <label><input type="radio" name="q9" value="2" /> Only one is allowed to trigger a refold.</label>
+              <label><input type="radio" name="q9" value="3" /> They run on different schedules.</label>
+              <label><input type="radio" name="q9" value="4" /> Certification is the movement lane&rsquo;s trust boundary while the count is the mix lane&rsquo;s sizing hint &mdash; merging them would make a performance shortfall read as a movement-readiness failure.</label>
+            </fieldset>
+            <p class="answer-detail"><strong>Correct: D.</strong> A day missing the count is fully trustworthy. <code>countUncertifiedDays</code> must keep answering only the trust question.</p>
+          </div>
+
+          <div class="quiz-question" data-answer="3">
+            <fieldset><legend>10. What is the main operational side effect of running the backfill?</legend>
+              <label><input type="radio" name="q10" value="1" /> Day totals are briefly wrong.</label>
+              <label><input type="radio" name="q10" value="2" /> The mix chart is unavailable during the drain.</label>
+              <label><input type="radio" name="q10" value="3" /> Refolds advance <code>certifiedFoldRevision</code>, so range snapshots covering refolded days go stale and rebuild on next ensure.</label>
+              <label><input type="radio" name="q10" value="4" /> The fold version is bumped for every store.</label>
+            </fieldset>
+            <p class="answer-detail"><strong>Correct: C.</strong> Self-healing but visible, which is why it should run off-peak. There is deliberately no fold-version bump.</p>
+          </div>
+
+          <div class="quiz-actions">
+            <button type="button" id="gradeQuiz">Grade quiz</button>
+            <button type="button" class="secondary" id="resetQuiz">Reset</button>
+            <span id="quizResult" aria-live="polite"></span>
+          </div>
+        </form>
+      </section>
+
+    </main>
+    <script>
+      const questions = Array.from(document.querySelectorAll(".quiz-question"));
+      const result = document.getElementById("quizResult");
+      const form = document.getElementById("changeQuiz");
+      const threshold = Number(form.dataset.threshold || 0);
+      function clearGrades() {
+        questions.forEach((question) => {
+          question.classList.remove("correct", "incorrect");
+          question.querySelector(".answer-detail").classList.remove("visible");
+        });
+        result.textContent = "";
+        result.style.color = "";
+      }
+      document.getElementById("gradeQuiz").addEventListener("click", () => {
+        clearGrades();
+        let score = 0;
+        questions.forEach((question, index) => {
+          const selected = document.querySelector(`input[name="q${index + 1}"]:checked`);
+          const isCorrect = selected && Number(selected.value) === Number(question.dataset.answer);
+          if (isCorrect) score += 1;
+          question.classList.add(isCorrect ? "correct" : "incorrect");
+          question.querySelector(".answer-detail").classList.add("visible");
+        });
+        const passed = score >= threshold;
+        result.textContent = passed
+          ? `Passed: ${score}/${questions.length}.`
+          : `Not passed: ${score}/${questions.length}. Review the report and try again.`;
+        result.style.color = passed ? "var(--good)" : "var(--bad)";
+      });
+      document.getElementById("resetQuiz").addEventListener("click", () => {
+        form.reset();
+        clearGrades();
+      });
+    </script>
+  </body>
+</html>

--- a/docs/solutions/architecture-patterns/athena-measured-read-sizing-beats-proxy-span-routing-2026-08-04.md
+++ b/docs/solutions/architecture-patterns/athena-measured-read-sizing-beats-proxy-span-routing-2026-08-04.md
@@ -1,0 +1,245 @@
+---
+title: A Span Ceiling Is a Proxy for Cost, and a Rail That Already Loads the Range Can Measure the Cost Instead
+date: 2026-08-04
+category: architecture-patterns
+module: Athena Reports / SKU Mix Routing and Day Fold
+problem_type: architecture_pattern
+component: convex_backend
+resolution_type: code_fix
+severity: high
+applies_when:
+  - "A read is routed to expensive machinery by a cheap proxy (span, page count, item count) rather than by its actual cost"
+  - "A worst-case bound used for routing is orders of magnitude above what production tenants actually produce"
+  - "Another already-loaded query covers the same range and could size the expensive read for free"
+  - "A derived counter is written by more than one path (a batch fold and an incremental ingest) and must not drift"
+  - "An optional field is added to a table whose historical rows are never revisited by normal traffic"
+  - "A backfill refold would advance a provenance counter that other snapshots depend on"
+related_components:
+  - "reports-sku-mix"
+  - "reports-days-rail"
+  - "reports-sweeper-fold-authority"
+  - "reports-ingest-incremental"
+  - "reports-range-result-lifecycle"
+  - "reports-fold-version-repair"
+tags:
+  - measured-vs-proxy-routing
+  - read-sizing
+  - admission-control
+  - dual-writer-invariant
+  - optional-field-backfill
+  - sparse-tables
+  - unknown-is-not-zero
+  - provenance-invalidation
+delivery_diff_fingerprint: c737a6d7b0f5dc71be442caf4e726ff10b0dcd40528a90a99ad324e74eff2b13
+---
+
+# A Span Ceiling Is a Proxy for Cost, and a Rail That Already Loads the Range Can Measure the Cost Instead
+
+## Problem
+
+The Reports SKU-mix pie chart was moved onto the bounded resumable
+range-snapshot lifecycle that powers the Units moved sheet. Correct, but slow
+to interact with: any selection longer than two days paid an `ensureMixRange`
+admission, a `retryAfterMs` poll loop, and a scheduled snapshot build before
+the first slice rendered.
+
+The two-day threshold was not arbitrary. It was *provable*: the fold bounds
+`reportSkuDay` at 2,000 rows per operating day, so a two-day span reads at most
+4,000 rows, strictly under the synchronous reader's 5,000-row cap. Everything
+wider went async because nothing could prove it was cheap.
+
+The obvious-looking fix — "the days table loads the same range fast, use its
+rail" — does not work, and the reason is worth stating precisely.
+
+**`listDays` and the mix chart share a metric name, not a grain.** `reportDay`
+holds one document per operating day with store-wide scalars; its `unitsSold`
+means "the store sold 412 units that day". The pie slices *by SKU*, which only
+exists in `reportSkuDay` — one row per (day, SKU). For a 184-day window that is
+184 documents versus up to 368,000 rows. Routing the chart at the days rail
+would yield a single total with nothing to divide it into.
+
+**The pre-aggregated rail is also not the answer, and production says why.**
+`reportPeriodSkuRollup` already stores per-SKU totals per `d:`/`w:`/`m:` period
+key, and the trailing-six-month window is calendar-month aligned at its start.
+Measured against production, month rollups compress only 1.0x–2.8x — across the
+whole window, 2,366 rows collapse to 1,082. Wigclub's catalogue is long-tail
+(628 distinct SKUs over 2,366 SKU-days, so a SKU sells on ~3.8 days total), and
+pre-aggregating by month only helps when SKUs *repeat* across days. A hybrid
+whole-months-plus-partial-tail fold to save ~1,300 row reads is not worth the
+seam.
+
+## Root Cause
+
+The routing predicate answered the wrong question. It asked *how wide is this
+range* as a stand-in for *how much will this read cost*, because cost was not
+knowable without doing the read.
+
+The proxy was calibrated to a worst case production sits far below. Wigclub's
+busiest day in seventeen months folds **88** SKU rows against the 2,000-row
+bound — roughly 23x below — with a median of 30. The entire 184-day window
+reads 2,366 rows, comfortably inside the synchronous reader's own cap. The
+chart was buying admission control to fold a few hundred rows.
+
+## Solution
+
+**The fold already knows the number; publish it.** `foldDay` returns a
+`skuDays` map that *is* the day's row set — every entry patched or inserted,
+every existing row absent from it deleted. So `result.skuDays.size` equals the
+post-fold `reportSkuDay` count exactly, and the sweeper writes it onto the day
+document in the same mutation that writes those rows.
+
+No `REPORTS_FOLD_VERSION` bump. The fold's output is unchanged; refolding is
+not a correctness repair, and bumping would have invalidated certified
+provenance for stores already cleared for the movement lane.
+
+**Route in two tiers.** The span rule survives as an unconditional floor that
+never depends on loaded data, so a day click cannot regress because the days
+rail has not answered yet. Above it, `skuMixSyncRowProbe` sums `skuDayRowCount`
+across the selection from rows the panel already holds and routes synchronously
+when the total clears `REPORT_SKU_MIX_SYNC_ROW_BUDGET`.
+
+The days rail is the right source not because it holds the data, but because it
+already covers the range for free. **The cheap query sizes the expensive one.**
+
+### Four decisions that carry the design
+
+**Unknown is not zero.** A day whose `skuDayRowCount` is absent makes the whole
+range indeterminate — not "the sum of the rest". The probe returns `undefined`
+and routing falls back to the span rule, so the worst case of an unproven probe
+is exactly the prior behavior, never a read the reader might refuse.
+
+**Absent rows, however, *are* zero.** `reportDay` is sparse: wigclub has 108
+day documents across 511 calendar days. A day with no document had no activity
+and therefore no SKU rows. Treating those gaps as unknown would make the
+cheapest ranges unprovable. This is why coverage bounds are separate required
+arguments — they prove the reader *looked* at the range, which row presence
+alone cannot.
+
+**The budget sits below the cap, not at it.** `REPORT_SKU_MIX_SYNC_ROW_BUDGET`
+is 4,000 against a 5,000-row reader cap. The probe sizes rows folded a moment
+before the read happens; a concurrent fold can add rows in between. The gap
+absorbs that drift instead of letting the reader's fail-closed throw surface to
+an operator as "choose a shorter range".
+
+**Span ceilings are per-caller, and only the proxy moves.** `listRangeSkuMix`
+moved from the 92-day `RANGE_SYNC_READER_MAX_SPAN_DAYS` to the 184-day
+drill-down ceiling, because span is no longer how it proves cost. The
+5,000-row cap still fails closed and always was the real bound. The legacy
+movement reader keeps 92 — it has no probe, so span remains its only proxy.
+
+## The dual-writer invariant
+
+The trap: `reportDay` has **two** writers. The sweeper folds it, and
+`ingest.ts` maintains it incrementally between folds — including inserting new
+`reportSkuDay` rows as facts arrive for the open day. A count written only by
+the fold goes stale-low all day on exactly the day operators watch most.
+
+Ingest's SKU upserts were moved *ahead of* the day write so the count lands in
+the same patch, with three cases:
+
+- **new day** — this batch's inserts are its only rows;
+- **counted day** — base plus inserts (ingest patches existing rows and never
+  deletes; only the fold removes rows);
+- **pre-U8 day** — stays absent. The base is unknown, so base-plus-inserts
+  would be a guess presented as a measurement.
+
+Rule: *when a derived counter has more than one writer, every writer must
+maintain it in the same transaction as the rows it counts, or the counter is
+only trustworthy at the moment the slowest writer ran.*
+
+## Backfill and its blast radius
+
+Historical settled days never refold under normal traffic, so they never
+acquire the count on their own. Without a backfill the probe is permanently
+indeterminate for any range touching them — the feature self-heals forward at
+one day per day, reaching full six-month coverage in six months.
+
+`skuDayRowCountBackfillNeeded` is deliberately **separate** from
+`needsCertifiedRefold` and reported as its own counter. Certification is the
+movement lane's *trust* boundary; this is the mix lane's *sizing* hint. A day
+missing the count is fully trustworthy. Merging them would make
+`countUncertifiedDays` report a movement-readiness failure for a performance
+shortfall.
+
+This also exposed a latent bug: `missingRevisionCount` inferred "missing
+revision" from *stale AND current fold version*, which after U8 also matches a
+certified day that only wants the count. It now tests the revision directly.
+
+**The cost of the backfill is not the refold.** Each refold advances
+`certifiedFoldRevision`, which is the movement trust boundary. The changed
+revision fails `sameRevisionVector`, so every completed Units moved and
+multi-day mix snapshot covering a refolded day goes `terminal_source_stale` and
+rebuilds on next ensure. Self-healing, but visible — run it off-peak.
+
+## Verification
+
+Dev wigclub, 73 days: all marked, drained, and reconciled — **73/73 published
+counts equal the actual `reportSkuDay` row count**, 830 rows total against 830
+summed, no SKU-day date lacking a day document. The `min 0` day matters: zero
+stored as a measurement, not a gap.
+
+Post-backfill the probe routes every dev window synchronously (184 days = 830
+rows). Dev is small — median 9 rows/day — so this validates the mechanism, not
+the budget.
+
+Worth recording: the dev deployment's 5-minute sweep cron was not firing, so
+the drain had to be driven by hand. `reports/sweeper:sweep` invoked directly
+folded 10 days per call with zero failures. Any dev verification of
+cron-driven behavior should confirm the cron actually ticks first.
+
+## What this does not fix
+
+At wigclub's current run rate (55.3 facts, 33.8 SKU rows per active day, open
+every day since ~2026-05-12) a fully operating 184-day window is ~6,214 SKU
+rows — genuinely over the 5,000 cap. The full six-month window legitimately
+belongs on the async rail from roughly 2026-10-07 onward.
+
+The probe's win is everything narrower: day, week, month and quarter
+selections stay synchronous through realistic growth, where previously anything
+over two days did not. That is the ambient-interaction complaint, and it is the
+part that was never actually expensive.
+
+## Prevention
+
+**Before routing on a proxy, ask what the proxy stands in for and whether
+something already loaded can measure it.** Span, page count, and item count are
+all stand-ins for cost. If another query on screen already covers the same
+range, the cost is usually knowable for free. Reach for the proxy only when
+nothing can measure.
+
+**Check a worst-case bound against production before building on it.** The
+2,000-rows-per-day fold ceiling is real and correctly enforced, but production
+sits 23x below it. A routing rule derived from a safety ceiling will be wrong
+by that same factor. Pull the real distribution — median, p95, max — before
+deciding a range is expensive.
+
+**When adding a derived counter, enumerate every writer of the table first.**
+`grep` for `insert("<table>"` and `patch("<table>"` across the backend. Here
+that surfaced `ingest.ts` maintaining `reportSkuDay` incrementally between
+folds — invisible from the fold path, and the difference between a counter
+that is exact and one that silently drifts low all day.
+
+**Keep an optional field's absence meaning "unknown", and make callers prove
+coverage separately.** Defaulting absence to zero converts a gap into a
+confident wrong answer. On a sparse table the distinction is subtle: a missing
+*row* legitimately means zero, while a missing *field* means unknown. Encode
+both, and require explicit coverage bounds so "the reader never looked" cannot
+masquerade as "there was nothing there".
+
+**Separate trust predicates from performance predicates even when they share a
+repair path.** Both send a day through the same refold, so merging them is
+tempting. But they answer different questions, and a merged predicate makes a
+missing performance hint read as a trust failure on the rollout gate.
+
+**Before backfilling, trace what the refold invalidates.** A refold that
+advances a provenance counter cascades into every snapshot whose revision
+vector includes that day. Follow the counter to its consumers and schedule
+accordingly.
+
+## Related
+
+- [[athena-span-routed-ambient-aggregation-and-kind-generic-range-snapshots-2026-08-04]] —
+  established the span-routing rule this note supersedes for the mix lane.
+  Its ambient-vs-on-demand reasoning still holds; only the cost predicate changed.
+- [[athena-certified-fold-provenance-and-bounded-resumable-range-snapshots-2026-08-03]] —
+  the `certifiedFoldRevision` provenance the backfill perturbs.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 11538 nodes · 14170 edges · 2684 communities detected
+- 11545 nodes · 14178 edges · 2684 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2914,20 +2914,20 @@ Cohesion: 0.2
 Nodes (28): buildActiveCycleCountDraftsSubmissionKey(), buildCycleCountDraftCreatedMessage(), buildCycleCountDraftSavedMessage(), buildCycleCountDraftSubmissionKey(), buildCycleCountDraftSubmittedMessage(), createCycleCountDraftWithCtx(), discardCycleCountDraftCommandWithCtx(), ensureCycleCountDraftCommandWithCtx() (+20 more)
 
 ### Community 48 - "Community 48"
+Cohesion: 0.09
+Nodes (15): addWeekMetrics(), computeMixRequestKey(), computeMovementRequestKey(), dayPeriodKey(), deriveMovementRequestLifecycle(), inclusiveOperatingDaySpan(), isValidOperatingDateLabel(), mixRequestKeyIdentity() (+7 more)
+
+### Community 49 - "Community 49"
 Cohesion: 0.07
 Nodes (0):
 
-### Community 49 - "Community 49"
+### Community 50 - "Community 50"
 Cohesion: 0.14
 Nodes (23): buildDocumentationStatus(), buildEmptyHistoryMetric(), buildGraphifyStatus(), buildInferentialSummaryNote(), buildSummary(), collectHarnessScorecard(), countMissingSnippets(), createFileSystem() (+15 more)
 
-### Community 50 - "Community 50"
+### Community 51 - "Community 51"
 Cohesion: 0.16
 Nodes (25): asArray(), asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), assignOrDelete(), asString() (+17 more)
-
-### Community 51 - "Community 51"
-Cohesion: 0.1
-Nodes (15): addWeekMetrics(), computeMixRequestKey(), computeMovementRequestKey(), dayPeriodKey(), deriveMovementRequestLifecycle(), inclusiveOperatingDaySpan(), isValidOperatingDateLabel(), mixRequestKeyIdentity() (+7 more)
 
 ### Community 52 - "Community 52"
 Cohesion: 0.18
@@ -3690,124 +3690,124 @@ Cohesion: 0.27
 Nodes (5): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository(), dedupeRecoveryConflictsById(), listTerminalRecoveryConflictsForRepair(), listTerminalRecoveryConflictSources()
 
 ### Community 242 - "Community 242"
-Cohesion: 0.36
-Nodes (9): aggregateSkuDays(), computeRange(), computeRequestKey(), inclusiveDaySpan(), isValidOperatingDate(), requestRangeCore(), sumDays(), utcMillisForLabel() (+1 more)
-
-### Community 243 - "Community 243"
 Cohesion: 0.2
 Nodes (0):
 
+### Community 243 - "Community 243"
+Cohesion: 0.36
+Nodes (9): aggregateSkuDays(), computeRange(), computeRequestKey(), inclusiveDaySpan(), isValidOperatingDate(), requestRangeCore(), sumDays(), utcMillisForLabel() (+1 more)
+
 ### Community 244 - "Community 244"
+Cohesion: 0.2
+Nodes (0):
+
+### Community 245 - "Community 245"
 Cohesion: 0.31
 Nodes (6): classifySharedDemoPublicFunction(), denySharedDemoAction(), isSharedDemoOperationCapabilityAllowed(), requireSharedDemoCapability(), requireSharedDemoOrderFulfillmentUpdate(), requireSharedDemoRegisterSessionSyncReview()
 
-### Community 245 - "Community 245"
+### Community 246 - "Community 246"
 Cohesion: 0.36
 Nodes (9): bindSharedDemoRegisterBaselineWithCtx(), browserSessionNote(), buildSharedDemoRegisterCashBaseline(), buildSharedDemoRegisterNarrative(), buildSharedDemoStoreSchedule(), ensureSharedDemoStoreScheduleWithCtx(), planSharedDemoRegisterAllocation(), rollSharedDemoSeededRegisterWithCtx() (+1 more)
-
-### Community 246 - "Community 246"
-Cohesion: 0.29
-Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
 
 ### Community 247 - "Community 247"
 Cohesion: 0.29
 Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
 
 ### Community 248 - "Community 248"
+Cohesion: 0.29
+Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
+
+### Community 249 - "Community 249"
 Cohesion: 0.27
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 249 - "Community 249"
+### Community 250 - "Community 250"
 Cohesion: 0.33
 Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
 
-### Community 250 - "Community 250"
+### Community 251 - "Community 251"
 Cohesion: 0.29
 Nodes (6): handleAddService(), handleAttachBarcodeSubmit(), handleCardClick(), handleCardKeyDown(), handleClearSearch(), handleQuickAddSubmit()
 
-### Community 251 - "Community 251"
+### Community 252 - "Community 252"
 Cohesion: 0.44
 Nodes (7): addOperatingDays(), dateRangeForItemsPeriod(), dateRangeForOverviewWindow(), isoWeekStart(), operatingDateToUtc(), tableRangeIncludingSelection(), utcToOperatingDate()
 
-### Community 252 - "Community 252"
+### Community 253 - "Community 253"
 Cohesion: 0.24
 Nodes (3): mergeProductDataWithActiveProductRefresh(), stripSkus(), valuesMatch()
 
-### Community 253 - "Community 253"
+### Community 254 - "Community 254"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 254 - "Community 254"
+### Community 255 - "Community 255"
 Cohesion: 0.36
 Nodes (8): collectUpdateStaticAssetUrls(), extractLinkHrefUrls(), extractScriptSrcUrls(), isStaticShellLinkTag(), maybeAddShellAssetUrl(), readTagAttribute(), stageUpdateStaticAssets(), waitForActiveServiceWorker()
 
-### Community 255 - "Community 255"
+### Community 256 - "Community 256"
 Cohesion: 0.27
 Nodes (3): createRemoteAssistTransportClient(), getRemoteAssistTransportClientFactory(), LazyLiveKitRemoteAssistClient
 
-### Community 256 - "Community 256"
+### Community 257 - "Community 257"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 257 - "Community 257"
+### Community 258 - "Community 258"
 Cohesion: 0.22
 Nodes (3): build(), forward(), ResizeObserverStub
 
-### Community 258 - "Community 258"
+### Community 259 - "Community 259"
 Cohesion: 0.38
 Nodes (9): awardPointsForGuestOrders(), awardPointsForPastOrder(), getBaseUrl(), getEligiblePastOrders(), getOrderRewardPoints(), getPointHistory(), getRewardTiers(), getUserPoints() (+1 more)
 
-### Community 259 - "Community 259"
+### Community 260 - "Community 260"
 Cohesion: 0.31
 Nodes (7): architectureSolutionNote(), createFixtureRepo(), gitEnv(), nonFoundationalArchitectureSolutionNote(), runGit(), solutionNote(), write()
 
-### Community 260 - "Community 260"
+### Community 261 - "Community 261"
 Cohesion: 0.38
 Nodes (9): assertFrontendDependencyParity(), checkFrontendDependencyParity(), collectDependencyDeclarations(), collectFrontendDependencyFailures(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall() (+1 more)
 
-### Community 261 - "Community 261"
+### Community 262 - "Community 262"
 Cohesion: 0.4
 Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalizeGraphJsonContents(), resolveGraphifyPython(), runGraphifyRebuild(), sortJsonArray(), sortJsonValue()
 
-### Community 262 - "Community 262"
+### Community 263 - "Community 263"
 Cohesion: 0.33
 Nodes (9): buildPartialDeliveryRunBaseline(), countBy(), createDeliveryRunLedger(), readDeliveryRunBaseline(), readDeliveryRunLedger(), readJsonOrNull(), summarizeDeliveryRunBaseline(), writeDeliveryRunLedger() (+1 more)
 
-### Community 263 - "Community 263"
+### Community 264 - "Community 264"
 Cohesion: 0.22
 Nodes (0):
-
-### Community 264 - "Community 264"
-Cohesion: 0.28
-Nodes (4): authoritativeDeficitPosition(), deficitLotSeed(), ledgeredDeficitLotSeed(), ledgeredDeficitPosition()
 
 ### Community 265 - "Community 265"
 Cohesion: 0.28
-Nodes (3): deliveryDedupeKey(), joinKeyComponents(), normalizeRecipientEmail()
+Nodes (4): authoritativeDeficitPosition(), deficitLotSeed(), ledgeredDeficitLotSeed(), ledgeredDeficitPosition()
 
 ### Community 266 - "Community 266"
+Cohesion: 0.28
+Nodes (3): deliveryDedupeKey(), joinKeyComponents(), normalizeRecipientEmail()
+
+### Community 267 - "Community 267"
 Cohesion: 0.33
 Nodes (6): createNormalUserReadOperationAdapter(), createPublicReadOperationAdapter(), isAdmitted(), resolveReadOperationAdmission(), sharedDemoReadDenialError(), sharedDemoReadDenied()
 
-### Community 267 - "Community 267"
+### Community 268 - "Community 268"
 Cohesion: 0.39
 Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
-### Community 268 - "Community 268"
+### Community 269 - "Community 269"
 Cohesion: 0.25
 Nodes (2): formatOperatingDate(), formatRegisterCloseoutVarianceAlertOperatingDate()
 
-### Community 269 - "Community 269"
+### Community 270 - "Community 270"
 Cohesion: 0.39
 Nodes (7): findActivePendingCheckoutLookupAliasByCode(), firstEvidenceTime(), normalizePendingCheckoutLookupCode(), resolvePendingCheckoutSku(), resolvePendingCheckoutSkuFromItem(), retirePendingCheckoutLookupAliasForItem(), upsertPendingCheckoutLookupAlias()
 
-### Community 270 - "Community 270"
+### Community 271 - "Community 271"
 Cohesion: 0.47
 Nodes (8): getTrustedCatalogPrice(), isDraftAllowedInTrustedCatalog(), isPendingCheckoutLookupAliasVisible(), isSuppressedByActiveLegacyImportProvisionalRow(), isTrustedCatalogResult(), lookupByBarcode(), mapSkuToCatalogResult(), searchProducts()
-
-### Community 271 - "Community 271"
-Cohesion: 0.22
-Nodes (0):
 
 ### Community 272 - "Community 272"
 Cohesion: 0.22
@@ -3818,592 +3818,592 @@ Cohesion: 0.22
 Nodes (0):
 
 ### Community 274 - "Community 274"
+Cohesion: 0.22
+Nodes (0):
+
+### Community 275 - "Community 275"
 Cohesion: 0.39
 Nodes (6): buildLookupRefs(), buildTraceEvent(), buildTraceRecord(), recordServiceCaseTraceBestEffort(), resolveOccurredAt(), safeTraceWrite()
 
-### Community 275 - "Community 275"
+### Community 276 - "Community 276"
 Cohesion: 0.5
 Nodes (7): getNonEmptyString(), getOperationalEventJourney(), getOperationalEventStatus(), getOperationalEventStep(), isFailureStatus(), isOperationalEventDoc(), normalizeEvent()
 
-### Community 276 - "Community 276"
+### Community 277 - "Community 277"
 Cohesion: 0.25
 Nodes (2): getNextExpenseReportFilterSearch(), getNextExpenseReportPageSearch()
 
-### Community 277 - "Community 277"
+### Community 278 - "Community 278"
 Cohesion: 0.25
 Nodes (2): handleKeyDown(), isDebugShortcut()
 
-### Community 278 - "Community 278"
+### Community 279 - "Community 279"
 Cohesion: 0.28
 Nodes (4): cn(), formatCatalogMetric(), handleClearFilters(), handleQueryChange()
 
-### Community 279 - "Community 279"
+### Community 280 - "Community 280"
+Cohesion: 0.25
+Nodes (2): daysWithSkuRowCounts(), isoDateOffset()
+
+### Community 281 - "Community 281"
 Cohesion: 0.42
 Nodes (7): buildCompletedSaleItems(), buildDemoTransactionNumber(), buildReadyItems(), buildSummary(), createSharedDemoDailyCloseFixture(), getOperatingDateTimestamp(), shiftOperatingDate()
 
-### Community 280 - "Community 280"
+### Community 282 - "Community 282"
 Cohesion: 0.25
 Nodes (2): buildUsername(), normalizeNameSegment()
 
-### Community 281 - "Community 281"
+### Community 283 - "Community 283"
 Cohesion: 0.39
 Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
 
-### Community 282 - "Community 282"
+### Community 284 - "Community 284"
 Cohesion: 0.25
 Nodes (2): isValidMessageBlocker(), isValidPriority()
 
-### Community 283 - "Community 283"
+### Community 285 - "Community 285"
 Cohesion: 0.44
 Nodes (1): Logger
 
-### Community 284 - "Community 284"
+### Community 286 - "Community 286"
 Cohesion: 0.36
 Nodes (7): assertValidPosCartLine(), calculatePosCartLineSubtotal(), calculatePosCartTotals(), calculatePosItemTotal(), getPosEffectivePrice(), isPosServiceCartLine(), roundPosAmount()
 
-### Community 285 - "Community 285"
+### Community 287 - "Community 287"
 Cohesion: 0.36
 Nodes (7): browserLocks(), clearCurrentPosLocalStorageEngine(), createCurrentPosLocalStorageEngineStore(), maintenanceResult(), maintenanceUnavailableResult(), openCurrentPosLocalStorageEngine(), runCurrentPosLocalStorageEngineOperation()
 
-### Community 286 - "Community 286"
+### Community 288 - "Community 288"
 Cohesion: 0.25
 Nodes (2): canClearExactCloudClosedDrawer(), hasCommandIdentity()
 
-### Community 287 - "Community 287"
+### Community 289 - "Community 289"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 288 - "Community 288"
+### Community 290 - "Community 290"
 Cohesion: 0.28
 Nodes (4): comparePendingEvents(), getPendingEventUploadSequence(), selectNextOrderedBatch(), selectOrderedBatches()
 
-### Community 289 - "Community 289"
+### Community 291 - "Community 291"
 Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
-### Community 290 - "Community 290"
-Cohesion: 0.42
-Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
-
-### Community 291 - "Community 291"
-Cohesion: 0.36
-Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
-
 ### Community 292 - "Community 292"
-Cohesion: 0.22
-Nodes (0):
-
-### Community 293 - "Community 293"
-Cohesion: 0.31
-Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
-
-### Community 294 - "Community 294"
 Cohesion: 0.31
 Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
+### Community 293 - "Community 293"
+Cohesion: 0.42
+Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
+
+### Community 294 - "Community 294"
+Cohesion: 0.36
+Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
+
 ### Community 295 - "Community 295"
+Cohesion: 0.22
+Nodes (0):
+
+### Community 296 - "Community 296"
 Cohesion: 0.39
 Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
 
-### Community 296 - "Community 296"
+### Community 297 - "Community 297"
+Cohesion: 0.31
+Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+
+### Community 298 - "Community 298"
 Cohesion: 0.22
 Nodes (2): ClusterRedis, StandaloneRedis
 
-### Community 297 - "Community 297"
+### Community 299 - "Community 299"
 Cohesion: 0.42
 Nodes (8): assertCoverageToolchainParity(), checkCoverageToolchainParity(), collectCoverageToolchainFailures(), declaredVersion(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall()
 
-### Community 298 - "Community 298"
+### Community 300 - "Community 300"
 Cohesion: 0.46
 Nodes (7): deleteDirectoryInR2(), deleteFileInR2(), getR2(), listItemsInR2Directory(), readEnvValue(), resolveR2ConfigFromEnv(), uploadFileToR2()
 
-### Community 299 - "Community 299"
-Cohesion: 0.25
-Nodes (0):
-
-### Community 300 - "Community 300"
-Cohesion: 0.25
-Nodes (0):
-
 ### Community 301 - "Community 301"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 302 - "Community 302"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 303 - "Community 303"
 Cohesion: 0.32
 Nodes (4): createProductsQueryCtx(), createSkuMutationCtx(), pendingCheckoutEvidence(), pendingCheckoutItem()
 
-### Community 302 - "Community 302"
+### Community 304 - "Community 304"
 Cohesion: 0.39
 Nodes (5): convertCloseoutRecords(), convertPayments(), migratePosAmountTableWithCtx(), pesewasPatchForRow(), upsertMigrationRun()
 
-### Community 303 - "Community 303"
+### Community 305 - "Community 305"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 304 - "Community 304"
+### Community 306 - "Community 306"
 Cohesion: 0.5
 Nodes (6): addSubscriptionCommandWithCtx(), mapSubscriptionCommandError(), removeSubscriptionCommandWithCtx(), requireOrganizationFullAdminWithCtx(), requireOwnedSubscriptionRowWithCtx(), setSubscriptionEnabledCommandWithCtx()
 
-### Community 305 - "Community 305"
+### Community 307 - "Community 307"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 306 - "Community 306"
+### Community 308 - "Community 308"
 Cohesion: 0.36
 Nodes (4): buildApprovalRequestPendingData(), metadataNumber(), metadataString(), resolveApprovalRequestIdentifier()
 
-### Community 307 - "Community 307"
+### Community 309 - "Community 309"
 Cohesion: 0.36
 Nodes (4): hasCompletedWeeklyObservedAtVerification(), hasCompletedWeeklyReportingCycleAnchorVerification(), isWeeklyReportingEnabledForStore(), isWeeklyReportingEnabledForStoreDoc()
 
-### Community 308 - "Community 308"
+### Community 310 - "Community 310"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
-
-### Community 309 - "Community 309"
-Cohesion: 0.25
-Nodes (0):
-
-### Community 310 - "Community 310"
-Cohesion: 0.25
-Nodes (0):
 
 ### Community 311 - "Community 311"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 312 - "Community 312"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 313 - "Community 313"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 314 - "Community 314"
 Cohesion: 0.36
 Nodes (4): buildCtx(), buildStaffProfile(), buildStore(), buildTerminal()
 
-### Community 313 - "Community 313"
+### Community 315 - "Community 315"
 Cohesion: 0.36
 Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
 
-### Community 314 - "Community 314"
-Cohesion: 0.25
-Nodes (0):
+### Community 316 - "Community 316"
+Cohesion: 0.39
+Nodes (5): boundedLimit(), countStaleFoldVersionDaysWithCtx(), countUncertifiedDaysWithCtx(), dayPage(), markStaleFoldVersionDaysWithCtx()
 
-### Community 315 - "Community 315"
+### Community 317 - "Community 317"
 Cohesion: 0.29
 Nodes (2): payment(), saleFact()
 
-### Community 316 - "Community 316"
+### Community 318 - "Community 318"
 Cohesion: 0.5
 Nodes (7): addMetric(), applyToOpenDay(), factDeltas(), findExistingFact(), markDirty(), recordFacts(), toFactDoc()
 
-### Community 317 - "Community 317"
+### Community 319 - "Community 319"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 318 - "Community 318"
+### Community 320 - "Community 320"
 Cohesion: 0.29
 Nodes (2): measurePublicProjectionRead(), percentile95()
 
-### Community 319 - "Community 319"
+### Community 321 - "Community 321"
 Cohesion: 0.39
 Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 320 - "Community 320"
+### Community 322 - "Community 322"
 Cohesion: 0.5
 Nodes (7): assertDefaultWorkflowTraceAccess(), assertWorkflowTraceAccess(), getRegisterSessionTraceIdentity(), getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx(), requireAdminWorkflowTraceAccess(), requireFullAdminOrManagerElevationTraceAccess()
 
-### Community 321 - "Community 321"
+### Community 323 - "Community 323"
 Cohesion: 0.25
 Nodes (1): DataTableRowActions()
 
-### Community 322 - "Community 322"
+### Community 324 - "Community 324"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 323 - "Community 323"
+### Community 325 - "Community 325"
 Cohesion: 0.43
 Nodes (7): clearAthenaAuthSyncHandoff(), failAthenaAuthSyncHandoff(), getAthenaAuthSyncHandoffStatus(), normalizeAuthSyncRedirect(), parseHandoff(), readRawHandoff(), startAthenaAuthSyncHandoff()
 
-### Community 324 - "Community 324"
+### Community 326 - "Community 326"
 Cohesion: 0.5
 Nodes (6): apply(), beginPan(), distance(), onEnd(), onMove(), onStart()
 
-### Community 325 - "Community 325"
+### Community 327 - "Community 327"
 Cohesion: 0.32
 Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
 
-### Community 326 - "Community 326"
+### Community 328 - "Community 328"
 Cohesion: 0.25
 Nodes (1): ResizeObserverStub
 
-### Community 327 - "Community 327"
-Cohesion: 0.25
-Nodes (0):
-
-### Community 328 - "Community 328"
-Cohesion: 0.25
-Nodes (0):
-
 ### Community 329 - "Community 329"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 330 - "Community 330"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 331 - "Community 331"
 Cohesion: 0.46
 Nodes (6): claimRuntimeHostForTerminal(), createRuntimeHostOwnerId(), getRemoteAssistRuntimeState(), getRuntimeHostClaimStorage(), PosRemoteAssistRuntimeHost(), releaseRuntimeHostClaim()
 
-### Community 330 - "Community 330"
+### Community 332 - "Community 332"
 Cohesion: 0.29
 Nodes (2): buildStatusCopy(), ReportSkuMixChart()
 
-### Community 331 - "Community 331"
+### Community 333 - "Community 333"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 332 - "Community 332"
+### Community 334 - "Community 334"
 Cohesion: 0.43
 Nodes (5): getSessionStorage(), getSharedDemoSessionOrderStoragePrefix(), readSharedDemoSessionOrderPatch(), readSharedDemoSessionOrderPatches(), writeSharedDemoSessionOrderPatch()
 
-### Community 333 - "Community 333"
+### Community 335 - "Community 335"
 Cohesion: 0.39
 Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
-### Community 334 - "Community 334"
+### Community 336 - "Community 336"
 Cohesion: 0.39
 Nodes (4): createOptimisticExpenseItemId(), expenseCartItemSourceKey(), expenseLineMatchesProduct(), expenseLineSourceKey()
 
-### Community 335 - "Community 335"
+### Community 337 - "Community 337"
 Cohesion: 0.39
 Nodes (5): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState(), isServerConfirmedLocalResolution(), isServerConvergedSyncEvent()
 
-### Community 336 - "Community 336"
+### Community 338 - "Community 338"
 Cohesion: 0.29
 Nodes (2): createStore(), renderRuntime()
 
-### Community 337 - "Community 337"
+### Community 339 - "Community 339"
 Cohesion: 0.29
 Nodes (2): hasRegisterOperatorRole(), validateRestoredCashierPresence()
 
-### Community 338 - "Community 338"
+### Community 340 - "Community 340"
 Cohesion: 0.46
 Nodes (6): isLocalDevAppShellDisabled(), readCachedPosAppShellReadiness(), readPosAppShellReadiness(), resolveRegisterPath(), waitForActiveServiceWorker(), warmPosAppShellReadiness()
 
-### Community 339 - "Community 339"
+### Community 341 - "Community 341"
 Cohesion: 0.46
 Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
 
-### Community 340 - "Community 340"
+### Community 342 - "Community 342"
 Cohesion: 0.43
 Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
-
-### Community 341 - "Community 341"
-Cohesion: 0.25
-Nodes (0):
-
-### Community 342 - "Community 342"
-Cohesion: 0.39
-Nodes (5): createPackage(), installFixtureToolchain(), linkWorkspacePackage(), writeFixtureManifests(), writeJson()
 
 ### Community 343 - "Community 343"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 344 - "Community 344"
+Cohesion: 0.39
+Nodes (5): createPackage(), installFixtureToolchain(), linkWorkspacePackage(), writeFixtureManifests(), writeJson()
+
+### Community 345 - "Community 345"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 346 - "Community 346"
 Cohesion: 0.38
 Nodes (3): createAuthorizedRegisterDepositCtx(), createProjectedInventoryReviewQueryCtx(), createQueryCtx()
 
-### Community 345 - "Community 345"
+### Community 347 - "Community 347"
 Cohesion: 0.48
 Nodes (5): containsSensitiveText(), invalidPayloadMessage(), isPublicContextValue(), validatePayloadValue(), validateRegisteredContextEventPayload()
 
-### Community 346 - "Community 346"
+### Community 348 - "Community 348"
 Cohesion: 0.52
 Nodes (5): getWhatsAppReceiptConfig(), getWhatsAppWebhookAppSecret(), getWhatsAppWebhookVerifyToken(), optionalEnv(), requiredEnv()
 
-### Community 347 - "Community 347"
+### Community 349 - "Community 349"
 Cohesion: 0.33
 Nodes (2): capitalize(), compactComparison()
 
-### Community 348 - "Community 348"
+### Community 350 - "Community 350"
 Cohesion: 0.57
 Nodes (5): createExpenseTransactionFromSessionHandler(), expenseItemHasTrustedAvailabilityHold(), expenseItemUsesTrustedInventory(), expenseTransactionError(), voidExpenseTransactionHandler()
 
-### Community 349 - "Community 349"
+### Community 351 - "Community 351"
 Cohesion: 0.57
 Nodes (6): createWalkthroughDedupeHmac(), getActiveWalkthroughHmacKey(), getWalkthroughHmacSecret(), getWalkthroughHmacVerificationKeys(), matchesWalkthroughTombstone(), priorKeyring()
 
-### Community 350 - "Community 350"
+### Community 352 - "Community 352"
 Cohesion: 0.52
 Nodes (6): backfillAthenaUserNormalizedEmailBatchWithCtx(), boundedLimit(), candidateForUserWithCtx(), normalizedIdentityFingerprint(), recordIdentityConflictWithCtx(), toHex()
 
-### Community 351 - "Community 351"
+### Community 353 - "Community 353"
 Cohesion: 0.52
 Nodes (6): backfillReportFactObservedAtWithCtx(), boundedLimit(), factPage(), storeFactPage(), verifyReportFactObservedAtWithCtx(), verifyStoreReportFactObservedAtWithCtx()
 
-### Community 352 - "Community 352"
+### Community 354 - "Community 354"
 Cohesion: 0.52
 Nodes (6): backfillReportingCycleStartWithCtx(), boundedLimit(), schedulePage(), storeSchedulePage(), verifyReportingCycleStartWithCtx(), verifyStoreReportingCycleStartWithCtx()
 
-### Community 353 - "Community 353"
+### Community 355 - "Community 355"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 354 - "Community 354"
+### Community 356 - "Community 356"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 355 - "Community 355"
+### Community 357 - "Community 357"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
-### Community 356 - "Community 356"
+### Community 358 - "Community 358"
 Cohesion: 0.38
 Nodes (4): buildRegisterSessionAuthorityPatch(), initialRegisterSessionAuthorityRevision(), insertRegisterSessionWithAuthority(), patchRegisterSessionWithAuthority()
 
-### Community 357 - "Community 357"
+### Community 359 - "Community 359"
 Cohesion: 0.43
 Nodes (4): asBoolean(), asNumber(), asRecord(), getCashControlsConfig()
 
-### Community 358 - "Community 358"
+### Community 360 - "Community 360"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 359 - "Community 359"
+### Community 361 - "Community 361"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 360 - "Community 360"
+### Community 362 - "Community 362"
 Cohesion: 0.52
 Nodes (6): classifyProvisionalImportLineage(), findMixedTrustedAndProvisionalSkuId(), isFinalizationClosed(), isTrustedInventorySaleItem(), saleInventoryLineKey(), shouldRecordProvisionalImportSaleEvidence()
 
-### Community 361 - "Community 361"
+### Community 363 - "Community 363"
 Cohesion: 0.52
 Nodes (6): advanceRegisterMappingAuthority(), buildNextRegisterMappingAuthority(), createPosLocalSyncMappingWithAuthority(), markRegisterMappingAuthorityAmbiguous(), markRegisterMappingAuthorityMapped(), tombstoneRegisterMappingAuthority()
 
-### Community 362 - "Community 362"
+### Community 364 - "Community 364"
 Cohesion: 0.48
 Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
 
-### Community 363 - "Community 363"
+### Community 365 - "Community 365"
 Cohesion: 0.52
 Nodes (5): getBlockingRegisterSessionIdFromConflict(), isRegisterSessionConflict(), resolveScopedRegisterSession(), resolveTerminalRegisterConflict(), resolveTerminalRegisterSessionConflict()
 
-### Community 364 - "Community 364"
+### Community 366 - "Community 366"
 Cohesion: 0.52
 Nodes (6): blocked(), buildRecoveryAttemptId(), getOrganizationMemberForAccount(), recordRecoveryEvent(), validatePosAppAccount(), validateTerminalAppSessionRecoveryWithCtx()
 
-### Community 365 - "Community 365"
+### Community 367 - "Community 367"
 Cohesion: 0.33
 Nodes (2): findReusableRemoteAssistSession(), startRemoteAssistSession()
 
-### Community 366 - "Community 366"
-Cohesion: 0.48
-Nodes (5): boundedLimit(), countStaleFoldVersionDaysWithCtx(), countUncertifiedDaysWithCtx(), dayPage(), markStaleFoldVersionDaysWithCtx()
-
-### Community 367 - "Community 367"
+### Community 368 - "Community 368"
 Cohesion: 0.57
 Nodes (6): isIncludedDate(), parseDate(), resolveWeeklyPeriod(), scheduleForDate(), shiftDate(), weekday()
 
-### Community 368 - "Community 368"
+### Community 369 - "Community 369"
 Cohesion: 0.43
 Nodes (5): buildPosServiceCatalogRow(), buildPosServiceCheckoutReadiness(), buildServiceCatalogItem(), normalizeServiceCatalogNameKey(), suggestedDepositAmount()
 
-### Community 369 - "Community 369"
+### Community 370 - "Community 370"
 Cohesion: 0.48
 Nodes (5): bestEffortRecordPurchaseOrderReceivingTraceWithCtx(), bestEffortRecordPurchaseOrderStatusTraceWithCtx(), compactDetails(), ensurePurchaseOrderTraceWithCtx(), getPurchaseOrderTraceStatusAt()
 
-### Community 370 - "Community 370"
+### Community 371 - "Community 371"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 371 - "Community 371"
+### Community 372 - "Community 372"
 Cohesion: 0.33
 Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
 
-### Community 372 - "Community 372"
+### Community 373 - "Community 373"
 Cohesion: 0.38
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 373 - "Community 373"
+### Community 374 - "Community 374"
 Cohesion: 0.57
 Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
 
-### Community 374 - "Community 374"
+### Community 375 - "Community 375"
 Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
-### Community 375 - "Community 375"
+### Community 376 - "Community 376"
 Cohesion: 0.52
 Nodes (6): buildContextEventEnvelope(), buildContextEventIdempotencyKey(), compactContextPayload(), compactContextValue(), hashStableValue(), stableContextStringify()
 
-### Community 376 - "Community 376"
+### Community 377 - "Community 377"
 Cohesion: 0.57
 Nodes (6): buildInventoryImportReviewPayload(), getInventoryImportReviewPayloadChunkByteLength(), getUtf8ByteLength(), isHighSurrogate(), splitInventoryImportReviewRawContent(), splitInventoryImportReviewRowDecisions()
 
-### Community 377 - "Community 377"
+### Community 378 - "Community 378"
 Cohesion: 0.33
 Nodes (2): sharedDemoPickupOrderAmount(), sharedDemoProductBySku()
 
-### Community 378 - "Community 378"
+### Community 379 - "Community 379"
 Cohesion: 0.33
 Nodes (2): calculateCycleCountQuantityDelta(), resolveStockAdjustmentQuantityDelta()
-
-### Community 379 - "Community 379"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 380 - "Community 380"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 381 - "Community 381"
-Cohesion: 0.33
-Nodes (2): handlePinChange(), normalizeOtpCode()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 382 - "Community 382"
 Cohesion: 0.33
-Nodes (2): getReviewOverlayElement(), getReviewOverlaySection()
+Nodes (2): handlePinChange(), normalizeOtpCode()
 
 ### Community 383 - "Community 383"
-Cohesion: 0.29
-Nodes (0):
+Cohesion: 0.33
+Nodes (2): getReviewOverlayElement(), getReviewOverlaySection()
 
 ### Community 384 - "Community 384"
 Cohesion: 0.29
-Nodes (1): ResizeObserverStub
+Nodes (0):
 
 ### Community 385 - "Community 385"
-Cohesion: 0.33
-Nodes (2): formatCartAttributeParts(), normalizeCartAttribute()
+Cohesion: 0.29
+Nodes (1): ResizeObserverStub
 
 ### Community 386 - "Community 386"
 Cohesion: 0.33
-Nodes (2): handleKeypadPress(), setAmountFromTouch()
+Nodes (2): formatCartAttributeParts(), normalizeCartAttribute()
 
 ### Community 387 - "Community 387"
-Cohesion: 0.29
-Nodes (0):
+Cohesion: 0.33
+Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
 ### Community 388 - "Community 388"
 Cohesion: 0.29
-Nodes (1): ResizeObserverStub
+Nodes (0):
 
 ### Community 389 - "Community 389"
 Cohesion: 0.29
 Nodes (1): ResizeObserverStub
 
 ### Community 390 - "Community 390"
+Cohesion: 0.29
+Nodes (1): ResizeObserverStub
+
+### Community 391 - "Community 391"
 Cohesion: 0.33
 Nodes (2): isSelectedDay(), selectDay()
 
-### Community 391 - "Community 391"
+### Community 392 - "Community 392"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 392 - "Community 392"
+### Community 393 - "Community 393"
 Cohesion: 0.33
 Nodes (2): handleReset(), handleSubmit()
 
-### Community 393 - "Community 393"
+### Community 394 - "Community 394"
 Cohesion: 0.57
 Nodes (6): createSharedDemoCatalogSearchResults(), searchableValues(), sharedDemoCatalogSearchProductId(), sharedDemoCatalogSearchSkuId(), subcategoryFor(), toResult()
 
-### Community 394 - "Community 394"
+### Community 395 - "Community 395"
 Cohesion: 0.43
 Nodes (4): getLocalDateFromOperatingDate(), getLocalOperatingDate(), getLocalOperatingDateRange(), getLocalOperatingDateRangeFromSearch()
 
-### Community 395 - "Community 395"
+### Community 396 - "Community 396"
 Cohesion: 0.52
 Nodes (5): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), normalizeNonCashOverpayment(), roundPosAmount()
 
-### Community 396 - "Community 396"
+### Community 397 - "Community 397"
 Cohesion: 0.52
 Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
 
-### Community 397 - "Community 397"
+### Community 398 - "Community 398"
 Cohesion: 0.33
 Nodes (2): buildRuntimeSyncDebug(), getReviewDiagnosticsEvents()
 
-### Community 398 - "Community 398"
+### Community 399 - "Community 399"
 Cohesion: 0.38
 Nodes (3): getRegisterLifecycleAuthorityRolloutPolicy(), isRolloutMode(), resolveRegisterLifecycleAuthorityRolloutPolicy()
 
-### Community 399 - "Community 399"
+### Community 400 - "Community 400"
 Cohesion: 0.52
 Nodes (6): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isDuplicateLocalIdReviewItem(), isDuplicatePosSessionSaleReviewItem(), isRegisterCloseoutReviewItem(), normalizeStatus()
-
-### Community 400 - "Community 400"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 401 - "Community 401"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 402 - "Community 402"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 403 - "Community 403"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
-### Community 403 - "Community 403"
+### Community 404 - "Community 404"
 Cohesion: 0.48
 Nodes (6): collectDeliverableDiffFingerprint(), gitEnv(), isDeliverableFingerprintPath(), normalizeRepoPath(), runGit(), sortUniquePaths()
 
-### Community 404 - "Community 404"
+### Community 405 - "Community 405"
 Cohesion: 0.43
 Nodes (4): createPackage(), installFixturePackages(), writeFixtureManifests(), writeJson()
 
-### Community 405 - "Community 405"
+### Community 406 - "Community 406"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 406 - "Community 406"
+### Community 407 - "Community 407"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 407 - "Community 407"
+### Community 408 - "Community 408"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 408 - "Community 408"
+### Community 409 - "Community 409"
 Cohesion: 0.43
 Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
 
-### Community 409 - "Community 409"
+### Community 410 - "Community 410"
 Cohesion: 0.53
 Nodes (4): bestEffortRecordScheduledRunEvidence(), buildScheduledRunKey(), recordScheduledRunEvidenceWithCtx(), resolveScheduledWindow()
 
-### Community 410 - "Community 410"
+### Community 411 - "Community 411"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 411 - "Community 411"
+### Community 412 - "Community 412"
 Cohesion: 0.47
 Nodes (3): canonical(), isValidBody(), text()
 
-### Community 412 - "Community 412"
+### Community 413 - "Community 413"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 413 - "Community 413"
-Cohesion: 0.4
-Nodes (2): createMutationCtx(), seedTrustedConversionData()
 
 ### Community 414 - "Community 414"
 Cohesion: 0.4
-Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
+Nodes (2): createMutationCtx(), seedTrustedConversionData()
 
 ### Community 415 - "Community 415"
+Cohesion: 0.4
+Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
+
+### Community 416 - "Community 416"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 416 - "Community 416"
+### Community 417 - "Community 417"
 Cohesion: 0.6
 Nodes (5): backfillStoreCurrencyCaseWithCtx(), boundedLimit(), needsNormalization(), storePage(), verifyStoreCurrencyCaseWithCtx()
 
-### Community 417 - "Community 417"
+### Community 418 - "Community 418"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 418 - "Community 418"
+### Community 419 - "Community 419"
 Cohesion: 0.47
 Nodes (4): buildDailyCloseApprovalSubject(), buildDailyCloseCarryForwardApprovalRequirement(), buildDailyCloseCarryForwardApprovalSubject(), buildDailyCloseCompletionApprovalRequirement()
 
-### Community 419 - "Community 419"
+### Community 420 - "Community 420"
 Cohesion: 0.6
 Nodes (5): buildOnlineOrderOperationalEventMessage(), buildOperationalEventMessage(), buildStockAdjustmentOperationalEventMessage(), formatOnlineOrderLabel(), formatStockAdjustmentSubjectDetail()
-
-### Community 420 - "Community 420"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 421 - "Community 421"
 Cohesion: 0.33
@@ -4418,156 +4418,156 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 424 - "Community 424"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 425 - "Community 425"
 Cohesion: 0.4
 Nodes (2): scheduleRegisterCloseoutNotifications(), wasVarianceNotifiedBeforeRail()
 
-### Community 425 - "Community 425"
+### Community 426 - "Community 426"
 Cohesion: 0.6
 Nodes (4): cleanEventText(), cleanOptionalEventText(), sanitizeClientEventMetadata(), truncate()
 
-### Community 426 - "Community 426"
+### Community 427 - "Community 427"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 427 - "Community 427"
+### Community 428 - "Community 428"
 Cohesion: 0.47
 Nodes (3): foldDay(), revenueContribution(), zeroDayMetrics()
 
-### Community 428 - "Community 428"
+### Community 429 - "Community 429"
 Cohesion: 0.6
 Nodes (5): configuredTimezone(), isValidTimezone(), localDateLabel(), resolveOperatingDate(), resolveStoreTimezone()
 
-### Community 429 - "Community 429"
+### Community 430 - "Community 430"
 Cohesion: 0.4
 Nodes (2): at(), seedFullDay()
 
-### Community 430 - "Community 430"
+### Community 431 - "Community 431"
 Cohesion: 0.4
 Nodes (2): at(), seedVerifiableDay()
 
-### Community 431 - "Community 431"
+### Community 432 - "Community 432"
 Cohesion: 0.47
 Nodes (3): projectFrozenWeeklyInventoryAttention(), projectLiveWeeklyInventoryAttention(), summarizeWeeklyInventoryAttention()
 
-### Community 432 - "Community 432"
+### Community 433 - "Community 433"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 433 - "Community 433"
+### Community 434 - "Community 434"
 Cohesion: 0.6
 Nodes (5): getSharedDemoActorWithCtx(), requireReadySharedDemoStoreCapabilityIfApplicable(), requireSharedDemoActorWithCtx(), requireSharedDemoCapabilityIfApplicable(), requireSharedDemoStoreCapabilityIfApplicable()
 
-### Community 434 - "Community 434"
+### Community 435 - "Community 435"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 435 - "Community 435"
+### Community 436 - "Community 436"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 436 - "Community 436"
+### Community 437 - "Community 437"
 Cohesion: 0.53
 Nodes (4): buildOnlineOrderReportedReturns(), buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 437 - "Community 437"
+### Community 438 - "Community 438"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 438 - "Community 438"
+### Community 439 - "Community 439"
 Cohesion: 0.4
 Nodes (2): localDate(), resolveStoreTimeAuthority()
 
-### Community 439 - "Community 439"
+### Community 440 - "Community 440"
 Cohesion: 0.53
 Nodes (4): buildPurchaseOrderTraceSeed(), compactDetails(), formatPurchaseOrderLabel(), normalizeLookup()
 
-### Community 440 - "Community 440"
+### Community 441 - "Community 441"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 441 - "Community 441"
+### Community 442 - "Community 442"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 442 - "Community 442"
+### Community 443 - "Community 443"
 Cohesion: 0.4
 Nodes (2): compareHomepageRankedItems(), getHomepageSortRank()
 
-### Community 443 - "Community 443"
+### Community 444 - "Community 444"
 Cohesion: 0.47
 Nodes (3): canUploadPosLocalSyncLocalEventType(), getPosLocalSyncEventContractForLocalEventType(), getPosLocalSyncEventTypeForLocalEventType()
 
-### Community 444 - "Community 444"
+### Community 445 - "Community 445"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 445 - "Community 445"
+### Community 446 - "Community 446"
 Cohesion: 0.47
 Nodes (4): assertObjectKeysAreMinimized(), assertWorkflowTraceDetailsAreMinimized(), createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 446 - "Community 446"
+### Community 447 - "Community 447"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 447 - "Community 447"
+### Community 448 - "Community 448"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 448 - "Community 448"
+### Community 449 - "Community 449"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
-
-### Community 449 - "Community 449"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 450 - "Community 450"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 451 - "Community 451"
-Cohesion: 0.4
-Nodes (2): moveBestSeller(), saveOrder()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 452 - "Community 452"
 Cohesion: 0.4
-Nodes (2): moveFeaturedItem(), saveOrder()
+Nodes (2): moveBestSeller(), saveOrder()
 
 ### Community 453 - "Community 453"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): moveFeaturedItem(), saveOrder()
 
 ### Community 454 - "Community 454"
-Cohesion: 0.47
-Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
-
-### Community 455 - "Community 455"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 455 - "Community 455"
+Cohesion: 0.47
+Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
 
 ### Community 456 - "Community 456"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 457 - "Community 457"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 458 - "Community 458"
 Cohesion: 0.4
 Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
-### Community 458 - "Community 458"
+### Community 459 - "Community 459"
 Cohesion: 0.47
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
 
-### Community 459 - "Community 459"
+### Community 460 - "Community 460"
 Cohesion: 0.47
 Nodes (3): formatNextOpeningLabel(), formatStoreHoursTimeLabel(), formatStoreLocalDateLabel()
 
-### Community 460 - "Community 460"
+### Community 461 - "Community 461"
 Cohesion: 0.4
 Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
-
-### Community 461 - "Community 461"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 462 - "Community 462"
 Cohesion: 0.33
@@ -4602,108 +4602,108 @@ Cohesion: 0.4
 Nodes (2): isValidRecipientEmail(), normalizeRecipientEmailInput()
 
 ### Community 470 - "Community 470"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 471 - "Community 471"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 472 - "Community 472"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 473 - "Community 473"
 Cohesion: 0.73
 Nodes (5): canAccessCashControlsSurface(), canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
+
+### Community 473 - "Community 473"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 474 - "Community 474"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 475 - "Community 475"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 476 - "Community 476"
 Cohesion: 0.4
 Nodes (2): deriveRegisterLifecycleAuthorityCandidates(), mappingCandidate()
 
-### Community 477 - "Community 477"
+### Community 476 - "Community 476"
 Cohesion: 0.4
 Nodes (2): buildRecoveryCommandStore(), storeFactory()
+
+### Community 477 - "Community 477"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 478 - "Community 478"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 479 - "Community 479"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 480 - "Community 480"
 Cohesion: 0.47
 Nodes (3): buildAdminSkuSearchOption(), compactJoin(), presentationText()
 
-### Community 481 - "Community 481"
+### Community 480 - "Community 480"
 Cohesion: 0.53
 Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
 
-### Community 482 - "Community 482"
+### Community 481 - "Community 481"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 483 - "Community 483"
+### Community 482 - "Community 482"
 Cohesion: 0.33
 Nodes (1): MemoryCache
 
-### Community 484 - "Community 484"
+### Community 483 - "Community 483"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 485 - "Community 485"
+### Community 484 - "Community 484"
 Cohesion: 0.47
 Nodes (3): completePendingAuthSync(), navigationTargetForRedirect(), sleep()
+
+### Community 485 - "Community 485"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 486 - "Community 486"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 487 - "Community 487"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 488 - "Community 488"
 Cohesion: 0.6
 Nodes (5): useDailyCloseFixture(), useDailyOpeningFixture(), useDailyOperationsFixture(), usePosHubFixture(), useWorkspaceFixture()
 
-### Community 489 - "Community 489"
+### Community 488 - "Community 488"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 490 - "Community 490"
+### Community 489 - "Community 489"
 Cohesion: 0.47
 Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
-### Community 491 - "Community 491"
+### Community 490 - "Community 490"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 491 - "Community 491"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 492 - "Community 492"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 493 - "Community 493"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 494 - "Community 494"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 495 - "Community 495"
+### Community 494 - "Community 494"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 495 - "Community 495"
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 496 - "Community 496"
 Cohesion: 0.53

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -16979,7 +16979,7 @@
       "relation": "calls",
       "source": "foldversionrepair_daypage",
       "source_file": "packages/athena-webapp/convex/reports/foldVersionRepair.ts",
-      "source_location": "L213",
+      "source_location": "L244",
       "target": "foldversionrepair_countstalefoldversiondayswithctx",
       "weight": 1
     },
@@ -16991,7 +16991,7 @@
       "relation": "calls",
       "source": "foldversionrepair_daypage",
       "source_file": "packages/athena-webapp/convex/reports/foldVersionRepair.ts",
-      "source_location": "L238",
+      "source_location": "L275",
       "target": "foldversionrepair_countuncertifieddayswithctx",
       "weight": 1
     },
@@ -17003,7 +17003,7 @@
       "relation": "calls",
       "source": "foldversionrepair_boundedlimit",
       "source_file": "packages/athena-webapp/convex/reports/foldVersionRepair.ts",
-      "source_location": "L102",
+      "source_location": "L122",
       "target": "foldversionrepair_daypage",
       "weight": 1
     },
@@ -17015,7 +17015,7 @@
       "relation": "calls",
       "source": "foldversionrepair_daypage",
       "source_file": "packages/athena-webapp/convex/reports/foldVersionRepair.ts",
-      "source_location": "L111",
+      "source_location": "L131",
       "target": "foldversionrepair_markstalefoldversiondayswithctx",
       "weight": 1
     },
@@ -17027,7 +17027,7 @@
       "relation": "calls",
       "source": "foldversionrepair_test_day",
       "source_file": "packages/athena-webapp/convex/reports/foldVersionRepair.test.ts",
-      "source_location": "L157",
+      "source_location": "L164",
       "target": "foldversionrepair_test_certifiedday",
       "weight": 1
     },
@@ -23999,7 +23999,7 @@
       "relation": "calls",
       "source": "ingest_markdirty",
       "source_file": "packages/athena-webapp/convex/reports/ingest.ts",
-      "source_location": "L488",
+      "source_location": "L554",
       "target": "ingest_applytoopenday",
       "weight": 1
     },
@@ -24011,7 +24011,7 @@
       "relation": "calls",
       "source": "ingest_applytoopenday",
       "source_file": "packages/athena-webapp/convex/reports/ingest.ts",
-      "source_location": "L610",
+      "source_location": "L635",
       "target": "ingest_recordfacts",
       "weight": 1
     },
@@ -24023,7 +24023,7 @@
       "relation": "calls",
       "source": "ingest_findexistingfact",
       "source_file": "packages/athena-webapp/convex/reports/ingest.ts",
-      "source_location": "L576",
+      "source_location": "L601",
       "target": "ingest_recordfacts",
       "weight": 1
     },
@@ -24035,7 +24035,7 @@
       "relation": "calls",
       "source": "ingest_markdirty",
       "source_file": "packages/athena-webapp/convex/reports/ingest.ts",
-      "source_location": "L619",
+      "source_location": "L644",
       "target": "ingest_recordfacts",
       "weight": 1
     },
@@ -24047,7 +24047,7 @@
       "relation": "calls",
       "source": "ingest_tofactdoc",
       "source_file": "packages/athena-webapp/convex/reports/ingest.ts",
-      "source_location": "L600",
+      "source_location": "L625",
       "target": "ingest_recordfacts",
       "weight": 1
     },
@@ -69077,13 +69077,25 @@
     },
     {
       "_src": "packages_athena_webapp_convex_reports_contract_test_ts",
+      "_tgt": "contract_test_day",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_reports_contract_test_ts",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L1197",
+      "target": "contract_test_day",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_reports_contract_test_ts",
       "_tgt": "contract_test_fieldsof",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_contract_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L80",
+      "source_location": "L82",
       "target": "contract_test_fieldsof",
       "weight": 1
     },
@@ -69095,7 +69107,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_contract_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L859",
+      "source_location": "L861",
       "target": "contract_test_headerfor",
       "weight": 1
     },
@@ -69107,7 +69119,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_contract_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L1103",
+      "source_location": "L1105",
       "target": "contract_test_inclusivedays",
       "weight": 1
     },
@@ -69119,8 +69131,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_contract_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L489",
+      "source_location": "L491",
       "target": "contract_test_movementidentityargs",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_reports_contract_test_ts",
+      "_tgt": "contract_test_probe",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_reports_contract_test_ts",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L1201",
+      "target": "contract_test_probe",
       "weight": 1
     },
     {
@@ -69131,7 +69155,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_contract_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L448",
+      "source_location": "L450",
       "target": "contract_test_seedproductsku",
       "weight": 1
     },
@@ -69143,7 +69167,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_contract_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L429",
+      "source_location": "L431",
       "target": "contract_test_seedstore",
       "weight": 1
     },
@@ -69155,7 +69179,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_contract_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L86",
+      "source_location": "L88",
       "target": "contract_test_unionliterals",
       "weight": 1
     },
@@ -69467,7 +69491,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_foldversionrepair_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/foldVersionRepair.test.ts",
-      "source_location": "L153",
+      "source_location": "L159",
       "target": "foldversionrepair_test_certifiedday",
       "weight": 1
     },
@@ -69479,7 +69503,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_foldversionrepair_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/foldVersionRepair.test.ts",
-      "source_location": "L35",
+      "source_location": "L36",
       "target": "foldversionrepair_test_createctx",
       "weight": 1
     },
@@ -69491,7 +69515,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_foldversionrepair_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/foldVersionRepair.test.ts",
-      "source_location": "L137",
+      "source_location": "L138",
       "target": "foldversionrepair_test_day",
       "weight": 1
     },
@@ -69503,7 +69527,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_foldversionrepair_ts",
       "source_file": "packages/athena-webapp/convex/reports/foldVersionRepair.ts",
-      "source_location": "L79",
+      "source_location": "L99",
       "target": "foldversionrepair_boundedlimit",
       "weight": 1
     },
@@ -69515,7 +69539,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_foldversionrepair_ts",
       "source_file": "packages/athena-webapp/convex/reports/foldVersionRepair.ts",
-      "source_location": "L209",
+      "source_location": "L240",
       "target": "foldversionrepair_countstalefoldversiondayswithctx",
       "weight": 1
     },
@@ -69527,7 +69551,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_foldversionrepair_ts",
       "source_file": "packages/athena-webapp/convex/reports/foldVersionRepair.ts",
-      "source_location": "L234",
+      "source_location": "L271",
       "target": "foldversionrepair_countuncertifieddayswithctx",
       "weight": 1
     },
@@ -69539,7 +69563,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_foldversionrepair_ts",
       "source_file": "packages/athena-webapp/convex/reports/foldVersionRepair.ts",
-      "source_location": "L93",
+      "source_location": "L113",
       "target": "foldversionrepair_daypage",
       "weight": 1
     },
@@ -69551,7 +69575,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_foldversionrepair_ts",
       "source_file": "packages/athena-webapp/convex/reports/foldVersionRepair.ts",
-      "source_location": "L106",
+      "source_location": "L126",
       "target": "foldversionrepair_markstalefoldversiondayswithctx",
       "weight": 1
     },
@@ -69568,6 +69592,18 @@
       "weight": 1
     },
     {
+      "_src": "packages_athena_webapp_convex_reports_foldversionrepair_ts",
+      "_tgt": "foldversionrepair_skudayrowcountbackfillneeded",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_reports_foldversionrepair_ts",
+      "source_file": "packages/athena-webapp/convex/reports/foldVersionRepair.ts",
+      "source_location": "L90",
+      "target": "foldversionrepair_skudayrowcountbackfillneeded",
+      "weight": 1
+    },
+    {
       "_src": "packages_athena_webapp_convex_reports_ingest_test_ts",
       "_tgt": "ingest_test_brokenctx",
       "confidence": "EXTRACTED",
@@ -69575,7 +69611,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_ingest_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/ingest.test.ts",
-      "source_location": "L723",
+      "source_location": "L784",
       "target": "ingest_test_brokenctx",
       "weight": 1
     },
@@ -69719,7 +69755,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_ingest_ts",
       "source_file": "packages/athena-webapp/convex/reports/ingest.ts",
-      "source_location": "L539",
+      "source_location": "L564",
       "target": "ingest_recordfacts",
       "weight": 1
     },
@@ -69995,7 +70031,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L2586",
+      "source_location": "L2634",
       "target": "queries_test_readall",
       "weight": 1
     },
@@ -70007,7 +70043,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L1537",
+      "source_location": "L1585",
       "target": "queries_test_seedacceptedweek",
       "weight": 1
     },
@@ -70031,7 +70067,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L2552",
+      "source_location": "L2600",
       "target": "queries_test_seedmember",
       "weight": 1
     },
@@ -70043,7 +70079,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L1451",
+      "source_location": "L1499",
       "target": "queries_test_seedrange",
       "weight": 1
     },
@@ -70055,7 +70091,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L753",
+      "source_location": "L801",
       "target": "queries_test_seedreportday",
       "weight": 1
     },
@@ -70067,7 +70103,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L797",
+      "source_location": "L845",
       "target": "queries_test_seedrollup",
       "weight": 1
     },
@@ -70091,7 +70127,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L1141",
+      "source_location": "L1189",
       "target": "queries_test_seedskuday",
       "weight": 1
     },
@@ -70115,7 +70151,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L2574",
+      "source_location": "L2622",
       "target": "queries_test_signin",
       "weight": 1
     },
@@ -70127,7 +70163,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L2580",
+      "source_location": "L2628",
       "target": "queries_test_signout",
       "weight": 1
     },
@@ -70139,7 +70175,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L1316",
+      "source_location": "L1334",
       "target": "queries_cleanmetadatavalue",
       "weight": 1
     },
@@ -70151,7 +70187,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L114",
+      "source_location": "L117",
       "target": "queries_cyclestartdateforweeklyreportid",
       "weight": 1
     },
@@ -70163,7 +70199,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L997",
+      "source_location": "L1015",
       "target": "queries_decodecursor",
       "weight": 1
     },
@@ -70175,7 +70211,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L993",
+      "source_location": "L1011",
       "target": "queries_encodecursor",
       "weight": 1
     },
@@ -70187,7 +70223,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L244",
+      "source_location": "L247",
       "target": "queries_finalscheduleddate",
       "weight": 1
     },
@@ -70199,7 +70235,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L311",
+      "source_location": "L314",
       "target": "queries_hasweeklypostures",
       "weight": 1
     },
@@ -70211,7 +70247,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L415",
+      "source_location": "L418",
       "target": "queries_inclusivedayspan",
       "weight": 1
     },
@@ -70223,7 +70259,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L155",
+      "source_location": "L158",
       "target": "queries_inventoryattentionprojection",
       "weight": 1
     },
@@ -70235,7 +70271,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L1026",
+      "source_location": "L1044",
       "target": "queries_livepostransactioncount",
       "weight": 1
     },
@@ -70247,7 +70283,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L1376",
+      "source_location": "L1394",
       "target": "queries_precedingequalrange",
       "weight": 1
     },
@@ -70259,7 +70295,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L137",
+      "source_location": "L140",
       "target": "queries_priornetsaleschange",
       "weight": 1
     },
@@ -70271,7 +70307,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L1059",
+      "source_location": "L1077",
       "target": "queries_priorperioddaterange",
       "weight": 1
     },
@@ -70283,7 +70319,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L202",
+      "source_location": "L205",
       "target": "queries_priorperiodprojection",
       "weight": 1
     },
@@ -70295,7 +70331,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L425",
+      "source_location": "L428",
       "target": "queries_requirevaliddaterange",
       "weight": 1
     },
@@ -70307,7 +70343,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L89",
+      "source_location": "L92",
       "target": "queries_requireweeklyhistorypagination",
       "weight": 1
     },
@@ -70319,7 +70355,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L1325",
+      "source_location": "L1343",
       "target": "queries_resolveskuidentity",
       "weight": 1
     },
@@ -70331,7 +70367,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L1385",
+      "source_location": "L1403",
       "target": "queries_skurangetotals",
       "weight": 1
     },
@@ -70343,7 +70379,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L1623",
+      "source_location": "L1641",
       "target": "queries_sum",
       "weight": 1
     },
@@ -70355,7 +70391,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L353",
+      "source_location": "L356",
       "target": "queries_toacceptedweeklyprojection",
       "weight": 1
     },
@@ -70367,7 +70403,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L439",
+      "source_location": "L442",
       "target": "queries_toreportdayrow",
       "weight": 1
     },
@@ -70379,7 +70415,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L461",
+      "source_location": "L466",
       "target": "queries_toskuperiodrow",
       "weight": 1
     },
@@ -70391,7 +70427,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L317",
+      "source_location": "L320",
       "target": "queries_toweeklycurrentprojection",
       "weight": 1
     },
@@ -70403,7 +70439,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L1086",
+      "source_location": "L1104",
       "target": "queries_transactioncountsfordays",
       "weight": 1
     },
@@ -70415,7 +70451,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L170",
+      "source_location": "L173",
       "target": "queries_variancepostureprojection",
       "weight": 1
     },
@@ -70427,7 +70463,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L228",
+      "source_location": "L231",
       "target": "queries_weeklyamendmentprojection",
       "weight": 1
     },
@@ -70439,7 +70475,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L255",
+      "source_location": "L258",
       "target": "queries_weeklyownerroutes",
       "weight": 1
     },
@@ -70451,7 +70487,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L110",
+      "source_location": "L113",
       "target": "queries_weeklyreportid",
       "weight": 1
     },
@@ -70463,7 +70499,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L120",
+      "source_location": "L123",
       "target": "queries_weeklysummary",
       "weight": 1
     },
@@ -70475,7 +70511,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L1357",
+      "source_location": "L1375",
       "target": "queries_withskuidentity",
       "weight": 1
     },
@@ -71987,7 +72023,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L1485",
+      "source_location": "L1532",
       "target": "sweeper_test_insertmovementheader",
       "weight": 1
     },
@@ -72011,7 +72047,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L1110",
+      "source_location": "L1157",
       "target": "sweeper_test_insertweeklyclosefixture",
       "weight": 1
     },
@@ -72047,7 +72083,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L1482",
+      "source_location": "L1529",
       "target": "sweeper_test_movementconstants",
       "weight": 1
     },
@@ -72059,7 +72095,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L1184",
+      "source_location": "L1231",
       "target": "sweeper_test_readdocs",
       "weight": 1
     },
@@ -72095,7 +72131,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L1517",
+      "source_location": "L1564",
       "target": "sweeper_test_withfrozenscheduler",
       "weight": 1
     },
@@ -72107,7 +72143,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L467",
+      "source_location": "L472",
       "target": "sweeper_computependingranges",
       "weight": 1
     },
@@ -72131,7 +72167,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L505",
+      "source_location": "L510",
       "target": "sweeper_expirerangeresults",
       "weight": 1
     },
@@ -72143,7 +72179,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L450",
+      "source_location": "L455",
       "target": "sweeper_findopenoperatingdate",
       "weight": 1
     },
@@ -72179,7 +72215,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L414",
+      "source_location": "L419",
       "target": "sweeper_markdaydirty",
       "weight": 1
     },
@@ -72203,7 +72239,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L537",
+      "source_location": "L542",
       "target": "sweeper_rangesnapshotkindconfigs",
       "weight": 1
     },
@@ -72239,7 +72275,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L541",
+      "source_location": "L546",
       "target": "sweeper_sweepwithctx",
       "weight": 1
     },
@@ -81983,7 +82019,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_shared_reportscontract_ts",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1162",
+      "source_location": "L1232",
       "target": "reportscontract_admissiblemovementdayrevision",
       "weight": 1
     },
@@ -82007,7 +82043,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_shared_reportscontract_ts",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1358",
+      "source_location": "L1428",
       "target": "reportscontract_computemixrequestkey",
       "weight": 1
     },
@@ -82019,7 +82055,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_shared_reportscontract_ts",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1139",
+      "source_location": "L1209",
       "target": "reportscontract_computemovementrequestkey",
       "weight": 1
     },
@@ -82043,7 +82079,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_shared_reportscontract_ts",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1405",
+      "source_location": "L1475",
       "target": "reportscontract_derivemixrequestlifecycle",
       "weight": 1
     },
@@ -82055,7 +82091,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_shared_reportscontract_ts",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1269",
+      "source_location": "L1339",
       "target": "reportscontract_derivemovementrequestlifecycle",
       "weight": 1
     },
@@ -82091,7 +82127,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_shared_reportscontract_ts",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1054",
+      "source_location": "L1124",
       "target": "reportscontract_inclusiveoperatingdayspan",
       "weight": 1
     },
@@ -82115,7 +82151,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_shared_reportscontract_ts",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1042",
+      "source_location": "L1112",
       "target": "reportscontract_isvalidoperatingdatelabel",
       "weight": 1
     },
@@ -82127,7 +82163,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_shared_reportscontract_ts",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1343",
+      "source_location": "L1413",
       "target": "reportscontract_mixrequestkeyidentity",
       "weight": 1
     },
@@ -82139,7 +82175,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_shared_reportscontract_ts",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1373",
+      "source_location": "L1443",
       "target": "reportscontract_mixunitssoldsortkey",
       "weight": 1
     },
@@ -82163,7 +82199,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_shared_reportscontract_ts",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1205",
+      "source_location": "L1275",
       "target": "reportscontract_movementabsnetunitssortkey",
       "weight": 1
     },
@@ -82175,7 +82211,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_shared_reportscontract_ts",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1255",
+      "source_location": "L1325",
       "target": "reportscontract_movementpagecount",
       "weight": 1
     },
@@ -82187,7 +82223,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_shared_reportscontract_ts",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1119",
+      "source_location": "L1189",
       "target": "reportscontract_movementrequestkeyidentity",
       "weight": 1
     },
@@ -82199,7 +82235,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_shared_reportscontract_ts",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1184",
+      "source_location": "L1254",
       "target": "reportscontract_movementsourcerowmatchesrevision",
       "weight": 1
     },
@@ -82241,6 +82277,18 @@
     },
     {
       "_src": "packages_athena_webapp_shared_reportscontract_ts",
+      "_tgt": "reportscontract_skumixsyncrowprobe",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_shared_reportscontract_ts",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L1050",
+      "target": "reportscontract_skumixsyncrowprobe",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_shared_reportscontract_ts",
       "_tgt": "reportscontract_trailingsixmonthsstart",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
@@ -82271,7 +82319,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_shared_reportscontract_ts",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1069",
+      "source_location": "L1139",
       "target": "reportscontract_validatereportrangerequest",
       "weight": 1
     },
@@ -98195,8 +98243,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportdayspanel_test_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.test.tsx",
-      "source_location": "L1446",
+      "source_location": "L1596",
       "target": "reportdayspanel_test_constructor",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_reports_reportdayspanel_test_tsx",
+      "_tgt": "reportdayspanel_test_dayswithskurowcounts",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_reports_reportdayspanel_test_tsx",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.test.tsx",
+      "source_location": "L76",
+      "target": "reportdayspanel_test_dayswithskurowcounts",
       "weight": 1
     },
     {
@@ -98207,7 +98267,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportdayspanel_test_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.test.tsx",
-      "source_location": "L1718",
+      "source_location": "L1868",
       "target": "reportdayspanel_test_installmixqueries",
       "weight": 1
     },
@@ -98219,7 +98279,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportdayspanel_test_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.test.tsx",
-      "source_location": "L101",
+      "source_location": "L146",
       "target": "reportdayspanel_test_isodateoffset",
       "weight": 1
     },
@@ -98231,7 +98291,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportdayspanel_test_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.test.tsx",
-      "source_location": "L1734",
+      "source_location": "L1884",
       "target": "reportdayspanel_test_livemixreadercalls",
       "weight": 1
     },
@@ -98243,8 +98303,32 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportdayspanel_test_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.test.tsx",
-      "source_location": "L1703",
+      "source_location": "L1853",
       "target": "reportdayspanel_test_mixvisibleresult",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_reports_reportdayspanel_test_tsx",
+      "_tgt": "reportdayspanel_test_onlydaysread",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_reports_reportdayspanel_test_tsx",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.test.tsx",
+      "source_location": "L106",
+      "target": "reportdayspanel_test_onlydaysread",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_reports_reportdayspanel_test_tsx",
+      "_tgt": "reportdayspanel_test_syncmixcalls",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_reports_reportdayspanel_test_tsx",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.test.tsx",
+      "source_location": "L218",
+      "target": "reportdayspanel_test_syncmixcalls",
       "weight": 1
     },
     {
@@ -98255,7 +98339,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportdayspanel_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
-      "source_location": "L528",
+      "source_location": "L574",
       "target": "reportdayspanel_cn",
       "weight": 1
     },
@@ -98267,7 +98351,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportdayspanel_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
-      "source_location": "L367",
+      "source_location": "L413",
       "target": "reportdayspanel_handlemixretry",
       "weight": 1
     },
@@ -98279,7 +98363,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportdayspanel_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
-      "source_location": "L407",
+      "source_location": "L453",
       "target": "reportdayspanel_isinselectedrange",
       "weight": 1
     },
@@ -98291,7 +98375,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportdayspanel_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
-      "source_location": "L405",
+      "source_location": "L451",
       "target": "reportdayspanel_isselectedday",
       "weight": 1
     },
@@ -98303,7 +98387,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportdayspanel_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
-      "source_location": "L53",
+      "source_location": "L55",
       "target": "reportdayspanel_pagecontainingdate",
       "weight": 1
     },
@@ -98315,7 +98399,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportdayspanel_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
-      "source_location": "L409",
+      "source_location": "L455",
       "target": "reportdayspanel_selectday",
       "weight": 1
     },
@@ -135755,7 +135839,7 @@
       "relation": "calls",
       "source": "queries_inclusivedayspan",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L1377",
+      "source_location": "L1395",
       "target": "queries_precedingequalrange",
       "weight": 1
     },
@@ -135767,7 +135851,7 @@
       "relation": "calls",
       "source": "queries_priornetsaleschange",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L219",
+      "source_location": "L222",
       "target": "queries_priorperiodprojection",
       "weight": 1
     },
@@ -135779,7 +135863,7 @@
       "relation": "calls",
       "source": "queries_weeklysummary",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L215",
+      "source_location": "L218",
       "target": "queries_priorperiodprojection",
       "weight": 1
     },
@@ -135791,7 +135875,7 @@
       "relation": "calls",
       "source": "queries_inclusivedayspan",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L433",
+      "source_location": "L436",
       "target": "queries_requirevaliddaterange",
       "weight": 1
     },
@@ -135803,7 +135887,7 @@
       "relation": "calls",
       "source": "queries_cleanmetadatavalue",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L1335",
+      "source_location": "L1353",
       "target": "queries_resolveskuidentity",
       "weight": 1
     },
@@ -135815,7 +135899,7 @@
       "relation": "calls",
       "source": "queries_skurangetotals",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L1396",
+      "source_location": "L1414",
       "target": "queries_sum",
       "weight": 1
     },
@@ -135827,7 +135911,7 @@
       "relation": "calls",
       "source": "queries_inventoryattentionprojection",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L397",
+      "source_location": "L400",
       "target": "queries_toacceptedweeklyprojection",
       "weight": 1
     },
@@ -135839,7 +135923,7 @@
       "relation": "calls",
       "source": "queries_priorperiodprojection",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L403",
+      "source_location": "L406",
       "target": "queries_toacceptedweeklyprojection",
       "weight": 1
     },
@@ -135851,7 +135935,7 @@
       "relation": "calls",
       "source": "queries_variancepostureprojection",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L404",
+      "source_location": "L407",
       "target": "queries_toacceptedweeklyprojection",
       "weight": 1
     },
@@ -135863,7 +135947,7 @@
       "relation": "calls",
       "source": "queries_weeklyamendmentprojection",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L401",
+      "source_location": "L404",
       "target": "queries_toacceptedweeklyprojection",
       "weight": 1
     },
@@ -135875,7 +135959,7 @@
       "relation": "calls",
       "source": "queries_weeklyownerroutes",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L405",
+      "source_location": "L408",
       "target": "queries_toacceptedweeklyprojection",
       "weight": 1
     },
@@ -135887,7 +135971,7 @@
       "relation": "calls",
       "source": "queries_weeklyreportid",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L379",
+      "source_location": "L382",
       "target": "queries_toacceptedweeklyprojection",
       "weight": 1
     },
@@ -135899,7 +135983,7 @@
       "relation": "calls",
       "source": "queries_weeklysummary",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L364",
+      "source_location": "L367",
       "target": "queries_toacceptedweeklyprojection",
       "weight": 1
     },
@@ -135911,7 +135995,7 @@
       "relation": "calls",
       "source": "queries_inventoryattentionprojection",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L337",
+      "source_location": "L340",
       "target": "queries_toweeklycurrentprojection",
       "weight": 1
     },
@@ -135923,7 +136007,7 @@
       "relation": "calls",
       "source": "queries_priorperiodprojection",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L342",
+      "source_location": "L345",
       "target": "queries_toweeklycurrentprojection",
       "weight": 1
     },
@@ -135935,7 +136019,7 @@
       "relation": "calls",
       "source": "queries_variancepostureprojection",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L343",
+      "source_location": "L346",
       "target": "queries_toweeklycurrentprojection",
       "weight": 1
     },
@@ -135947,7 +136031,7 @@
       "relation": "calls",
       "source": "queries_weeklyamendmentprojection",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L340",
+      "source_location": "L343",
       "target": "queries_toweeklycurrentprojection",
       "weight": 1
     },
@@ -135959,7 +136043,7 @@
       "relation": "calls",
       "source": "queries_weeklyownerroutes",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L344",
+      "source_location": "L347",
       "target": "queries_toweeklycurrentprojection",
       "weight": 1
     },
@@ -135971,7 +136055,7 @@
       "relation": "calls",
       "source": "queries_weeklysummary",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L328",
+      "source_location": "L331",
       "target": "queries_toweeklycurrentprojection",
       "weight": 1
     },
@@ -135983,7 +136067,7 @@
       "relation": "calls",
       "source": "queries_weeklysummary",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L233",
+      "source_location": "L236",
       "target": "queries_weeklyamendmentprojection",
       "weight": 1
     },
@@ -135995,7 +136079,7 @@
       "relation": "calls",
       "source": "queries_finalscheduleddate",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L261",
+      "source_location": "L264",
       "target": "queries_weeklyownerroutes",
       "weight": 1
     },
@@ -140639,8 +140723,20 @@
       "relation": "calls",
       "source": "reportdayspanel_isselectedday",
       "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
-      "source_location": "L411",
+      "source_location": "L457",
       "target": "reportdayspanel_selectday",
+      "weight": 1
+    },
+    {
+      "_src": "reportdayspanel_test_dayswithskurowcounts",
+      "_tgt": "reportdayspanel_test_isodateoffset",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "reportdayspanel_test_dayswithskurowcounts",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.test.tsx",
+      "source_location": "L82",
+      "target": "reportdayspanel_test_isodateoffset",
       "weight": 1
     },
     {
@@ -140867,7 +140963,7 @@
       "relation": "calls",
       "source": "reportscontract_mixrequestkeyidentity",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1363",
+      "source_location": "L1433",
       "target": "reportscontract_computemixrequestkey",
       "weight": 1
     },
@@ -140879,7 +140975,7 @@
       "relation": "calls",
       "source": "reportscontract_movementrequestkeyidentity",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1144",
+      "source_location": "L1214",
       "target": "reportscontract_computemovementrequestkey",
       "weight": 1
     },
@@ -140891,7 +140987,7 @@
       "relation": "calls",
       "source": "reportscontract_movementpagecount",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1288",
+      "source_location": "L1358",
       "target": "reportscontract_derivemovementrequestlifecycle",
       "weight": 1
     },
@@ -140939,7 +141035,7 @@
       "relation": "calls",
       "source": "reportscontract_inclusiveoperatingdayspan",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1084",
+      "source_location": "L1154",
       "target": "reportscontract_validatereportrangerequest",
       "weight": 1
     },
@@ -140951,7 +141047,7 @@
       "relation": "calls",
       "source": "reportscontract_isvalidoperatingdatelabel",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1074",
+      "source_location": "L1144",
       "target": "reportscontract_validatereportrangerequest",
       "weight": 1
     },
@@ -160019,7 +160115,7 @@
       "relation": "calls",
       "source": "sweeper_computependingranges",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L632",
+      "source_location": "L637",
       "target": "sweeper_sweepwithctx",
       "weight": 1
     },
@@ -160031,7 +160127,7 @@
       "relation": "calls",
       "source": "sweeper_expirerangeresults",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L683",
+      "source_location": "L688",
       "target": "sweeper_sweepwithctx",
       "weight": 1
     },
@@ -160043,7 +160139,7 @@
       "relation": "calls",
       "source": "sweeper_foldandreplaceday",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L598",
+      "source_location": "L603",
       "target": "sweeper_sweepwithctx",
       "weight": 1
     },
@@ -160055,7 +160151,7 @@
       "relation": "calls",
       "source": "sweeper_markdaydirty",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L620",
+      "source_location": "L625",
       "target": "sweeper_sweepwithctx",
       "weight": 1
     },
@@ -160067,7 +160163,7 @@
       "relation": "calls",
       "source": "sweeper_rangesnapshotkindconfigs",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L691",
+      "source_location": "L696",
       "target": "sweeper_sweepwithctx",
       "weight": 1
     },
@@ -160079,7 +160175,7 @@
       "relation": "calls",
       "source": "sweeper_readstoreallowlist",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L543",
+      "source_location": "L548",
       "target": "sweeper_sweepwithctx",
       "weight": 1
     },
@@ -183193,7 +183289,7 @@
       "label": "computePendingRanges()",
       "norm_label": "computependingranges()",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L467"
+      "source_location": "L472"
     },
     {
       "community": 129,
@@ -183220,7 +183316,7 @@
       "label": "expireRangeResults()",
       "norm_label": "expirerangeresults()",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L505"
+      "source_location": "L510"
     },
     {
       "community": 129,
@@ -183229,7 +183325,7 @@
       "label": "findOpenOperatingDate()",
       "norm_label": "findopenoperatingdate()",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L450"
+      "source_location": "L455"
     },
     {
       "community": 129,
@@ -183256,7 +183352,7 @@
       "label": "markDayDirty()",
       "norm_label": "markdaydirty()",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L414"
+      "source_location": "L419"
     },
     {
       "community": 129,
@@ -183274,7 +183370,7 @@
       "label": "rangeSnapshotKindConfigs()",
       "norm_label": "rangesnapshotkindconfigs()",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L537"
+      "source_location": "L542"
     },
     {
       "community": 129,
@@ -183301,7 +183397,7 @@
       "label": "sweepWithCtx()",
       "norm_label": "sweepwithctx()",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L541"
+      "source_location": "L546"
     },
     {
       "community": 129,
@@ -189520,7 +189616,7 @@
       "label": "readAll()",
       "norm_label": "readall()",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L2586"
+      "source_location": "L2634"
     },
     {
       "community": 146,
@@ -189529,7 +189625,7 @@
       "label": "seedAcceptedWeek()",
       "norm_label": "seedacceptedweek()",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L1537"
+      "source_location": "L1585"
     },
     {
       "community": 146,
@@ -189547,7 +189643,7 @@
       "label": "seedMember()",
       "norm_label": "seedmember()",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L2552"
+      "source_location": "L2600"
     },
     {
       "community": 146,
@@ -189556,7 +189652,7 @@
       "label": "seedRange()",
       "norm_label": "seedrange()",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L1451"
+      "source_location": "L1499"
     },
     {
       "community": 146,
@@ -189565,7 +189661,7 @@
       "label": "seedReportDay()",
       "norm_label": "seedreportday()",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L753"
+      "source_location": "L801"
     },
     {
       "community": 146,
@@ -189574,7 +189670,7 @@
       "label": "seedRollup()",
       "norm_label": "seedrollup()",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L797"
+      "source_location": "L845"
     },
     {
       "community": 146,
@@ -189592,7 +189688,7 @@
       "label": "seedSkuDay()",
       "norm_label": "seedskuday()",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L1141"
+      "source_location": "L1189"
     },
     {
       "community": 146,
@@ -189610,7 +189706,7 @@
       "label": "signIn()",
       "norm_label": "signin()",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L2574"
+      "source_location": "L2622"
     },
     {
       "community": 146,
@@ -189619,7 +189715,7 @@
       "label": "signOut()",
       "norm_label": "signout()",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L2580"
+      "source_location": "L2628"
     },
     {
       "community": 1460,
@@ -200212,7 +200308,7 @@
       "label": "insertMovementHeader()",
       "norm_label": "insertmovementheader()",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L1485"
+      "source_location": "L1532"
     },
     {
       "community": 180,
@@ -200230,7 +200326,7 @@
       "label": "insertWeeklyCloseFixture()",
       "norm_label": "insertweeklyclosefixture()",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L1110"
+      "source_location": "L1157"
     },
     {
       "community": 180,
@@ -200257,7 +200353,7 @@
       "label": "movementConstants()",
       "norm_label": "movementconstants()",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L1482"
+      "source_location": "L1529"
     },
     {
       "community": 180,
@@ -200266,7 +200362,7 @@
       "label": "readDocs()",
       "norm_label": "readdocs()",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L1184"
+      "source_location": "L1231"
     },
     {
       "community": 180,
@@ -200293,7 +200389,7 @@
       "label": "withFrozenScheduler()",
       "norm_label": "withfrozenscheduler()",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L1517"
+      "source_location": "L1564"
     },
     {
       "community": 1800,
@@ -215085,91 +215181,91 @@
     {
       "community": 242,
       "file_type": "code",
-      "id": "customrange_aggregateskudays",
-      "label": "aggregateSkuDays()",
-      "norm_label": "aggregateskudays()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L217"
+      "id": "contract_test_day",
+      "label": "day()",
+      "norm_label": "day()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L1197"
     },
     {
       "community": 242,
       "file_type": "code",
-      "id": "customrange_computerange",
-      "label": "computeRange()",
-      "norm_label": "computerange()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L253"
+      "id": "contract_test_fieldsof",
+      "label": "fieldsOf()",
+      "norm_label": "fieldsof()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L82"
     },
     {
       "community": 242,
       "file_type": "code",
-      "id": "customrange_computerequestkey",
-      "label": "computeRequestKey()",
-      "norm_label": "computerequestkey()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L84"
+      "id": "contract_test_headerfor",
+      "label": "headerFor()",
+      "norm_label": "headerfor()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L861"
     },
     {
       "community": 242,
       "file_type": "code",
-      "id": "customrange_inclusivedayspan",
-      "label": "inclusiveDaySpan()",
-      "norm_label": "inclusivedayspan()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L52"
+      "id": "contract_test_inclusivedays",
+      "label": "inclusiveDays()",
+      "norm_label": "inclusivedays()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L1105"
     },
     {
       "community": 242,
       "file_type": "code",
-      "id": "customrange_isvalidoperatingdate",
-      "label": "isValidOperatingDate()",
-      "norm_label": "isvalidoperatingdate()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L35"
+      "id": "contract_test_movementidentityargs",
+      "label": "movementIdentityArgs()",
+      "norm_label": "movementidentityargs()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L491"
     },
     {
       "community": 242,
       "file_type": "code",
-      "id": "customrange_requestrangecore",
-      "label": "requestRangeCore()",
-      "norm_label": "requestrangecore()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L112"
+      "id": "contract_test_probe",
+      "label": "probe()",
+      "norm_label": "probe()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L1201"
     },
     {
       "community": 242,
       "file_type": "code",
-      "id": "customrange_sumdays",
-      "label": "sumDays()",
-      "norm_label": "sumdays()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L189"
+      "id": "contract_test_seedproductsku",
+      "label": "seedProductSku()",
+      "norm_label": "seedproductsku()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L450"
     },
     {
       "community": 242,
       "file_type": "code",
-      "id": "customrange_utcmillisforlabel",
-      "label": "utcMillisForLabel()",
-      "norm_label": "utcmillisforlabel()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L46"
+      "id": "contract_test_seedstore",
+      "label": "seedStore()",
+      "norm_label": "seedstore()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L431"
     },
     {
       "community": 242,
       "file_type": "code",
-      "id": "customrange_validaterangeargs",
-      "label": "validateRangeArgs()",
-      "norm_label": "validaterangeargs()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L58"
+      "id": "contract_test_unionliterals",
+      "label": "unionLiterals()",
+      "norm_label": "unionliterals()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L88"
     },
     {
       "community": 242,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_customrange_ts",
-      "label": "customRange.ts",
-      "norm_label": "customrange.ts",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "id": "packages_athena_webapp_convex_reports_contract_test_ts",
+      "label": "contract.test.ts",
+      "norm_label": "contract.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
       "source_location": "L1"
     },
     {
@@ -215265,92 +215361,92 @@
     {
       "community": 243,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_rangesnapshotlifecycle_test_ts",
-      "label": "rangeSnapshotLifecycle.test.ts",
-      "norm_label": "rangesnapshotlifecycle.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "id": "customrange_aggregateskudays",
+      "label": "aggregateSkuDays()",
+      "norm_label": "aggregateskudays()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L217"
+    },
+    {
+      "community": 243,
+      "file_type": "code",
+      "id": "customrange_computerange",
+      "label": "computeRange()",
+      "norm_label": "computerange()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L253"
+    },
+    {
+      "community": 243,
+      "file_type": "code",
+      "id": "customrange_computerequestkey",
+      "label": "computeRequestKey()",
+      "norm_label": "computerequestkey()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 243,
+      "file_type": "code",
+      "id": "customrange_inclusivedayspan",
+      "label": "inclusiveDaySpan()",
+      "norm_label": "inclusivedayspan()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 243,
+      "file_type": "code",
+      "id": "customrange_isvalidoperatingdate",
+      "label": "isValidOperatingDate()",
+      "norm_label": "isvalidoperatingdate()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 243,
+      "file_type": "code",
+      "id": "customrange_requestrangecore",
+      "label": "requestRangeCore()",
+      "norm_label": "requestrangecore()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L112"
+    },
+    {
+      "community": 243,
+      "file_type": "code",
+      "id": "customrange_sumdays",
+      "label": "sumDays()",
+      "norm_label": "sumdays()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L189"
+    },
+    {
+      "community": 243,
+      "file_type": "code",
+      "id": "customrange_utcmillisforlabel",
+      "label": "utcMillisForLabel()",
+      "norm_label": "utcmillisforlabel()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 243,
+      "file_type": "code",
+      "id": "customrange_validaterangeargs",
+      "label": "validateRangeArgs()",
+      "norm_label": "validaterangeargs()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 243,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_reports_customrange_ts",
+      "label": "customRange.ts",
+      "norm_label": "customrange.ts",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 243,
-      "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_allow",
-      "label": "allow()",
-      "norm_label": "allow()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L53"
-    },
-    {
-      "community": 243,
-      "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_certifyday",
-      "label": "certifyDay()",
-      "norm_label": "certifyday()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L109"
-    },
-    {
-      "community": 243,
-      "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_consume",
-      "label": "consume()",
-      "norm_label": "consume()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L296"
-    },
-    {
-      "community": 243,
-      "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_drive",
-      "label": "drive()",
-      "norm_label": "drive()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L247"
-    },
-    {
-      "community": 243,
-      "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_ensuresynthetic",
-      "label": "ensureSynthetic()",
-      "norm_label": "ensuresynthetic()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L208"
-    },
-    {
-      "community": 243,
-      "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_headerbykey",
-      "label": "headerByKey()",
-      "norm_label": "headerbykey()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L230"
-    },
-    {
-      "community": 243,
-      "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_insertkindedheader",
-      "label": "insertKindedHeader()",
-      "norm_label": "insertkindedheader()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L612"
-    },
-    {
-      "community": 243,
-      "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_seedstore",
-      "label": "seedStore()",
-      "norm_label": "seedstore()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 243,
-      "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_synthetickind",
-      "label": "syntheticKind()",
-      "norm_label": "synthetickind()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L150"
     },
     {
       "community": 2430,
@@ -215445,92 +215541,92 @@
     {
       "community": 244,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_shareddemo_policy_ts",
-      "label": "policy.ts",
-      "norm_label": "policy.ts",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/policy.ts",
+      "id": "packages_athena_webapp_convex_reports_rangesnapshotlifecycle_test_ts",
+      "label": "rangeSnapshotLifecycle.test.ts",
+      "norm_label": "rangesnapshotlifecycle.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
       "source_location": "L1"
     },
     {
       "community": 244,
       "file_type": "code",
-      "id": "policy_classifyshareddemoexternalgateway",
-      "label": "classifySharedDemoExternalGateway()",
-      "norm_label": "classifyshareddemoexternalgateway()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/policy.ts",
-      "source_location": "L275"
+      "id": "rangesnapshotlifecycle_test_allow",
+      "label": "allow()",
+      "norm_label": "allow()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L53"
     },
     {
       "community": 244,
       "file_type": "code",
-      "id": "policy_classifyshareddemopublicfunction",
-      "label": "classifySharedDemoPublicFunction()",
-      "norm_label": "classifyshareddemopublicfunction()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/policy.ts",
-      "source_location": "L259"
+      "id": "rangesnapshotlifecycle_test_certifyday",
+      "label": "certifyDay()",
+      "norm_label": "certifyday()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L109"
     },
     {
       "community": 244,
       "file_type": "code",
-      "id": "policy_decideshareddemoeffect",
-      "label": "decideSharedDemoEffect()",
-      "norm_label": "decideshareddemoeffect()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/policy.ts",
-      "source_location": "L319"
+      "id": "rangesnapshotlifecycle_test_consume",
+      "label": "consume()",
+      "norm_label": "consume()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L296"
     },
     {
       "community": 244,
       "file_type": "code",
-      "id": "policy_denyshareddemoaction",
-      "label": "denySharedDemoAction()",
-      "norm_label": "denyshareddemoaction()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/policy.ts",
-      "source_location": "L17"
+      "id": "rangesnapshotlifecycle_test_drive",
+      "label": "drive()",
+      "norm_label": "drive()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L247"
     },
     {
       "community": 244,
       "file_type": "code",
-      "id": "policy_isshareddemooperationcapabilityallowed",
-      "label": "isSharedDemoOperationCapabilityAllowed()",
-      "norm_label": "isshareddemooperationcapabilityallowed()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/policy.ts",
-      "source_location": "L58"
+      "id": "rangesnapshotlifecycle_test_ensuresynthetic",
+      "label": "ensureSynthetic()",
+      "norm_label": "ensuresynthetic()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L208"
     },
     {
       "community": 244,
       "file_type": "code",
-      "id": "policy_requireshareddemocapability",
-      "label": "requireSharedDemoCapability()",
-      "norm_label": "requireshareddemocapability()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/policy.ts",
-      "source_location": "L312"
+      "id": "rangesnapshotlifecycle_test_headerbykey",
+      "label": "headerByKey()",
+      "norm_label": "headerbykey()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L230"
     },
     {
       "community": 244,
       "file_type": "code",
-      "id": "policy_requireshareddemoorderfulfillmentupdate",
-      "label": "requireSharedDemoOrderFulfillmentUpdate()",
-      "norm_label": "requireshareddemoorderfulfillmentupdate()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/policy.ts",
-      "source_location": "L77"
+      "id": "rangesnapshotlifecycle_test_insertkindedheader",
+      "label": "insertKindedHeader()",
+      "norm_label": "insertkindedheader()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L612"
     },
     {
       "community": 244,
       "file_type": "code",
-      "id": "policy_requireshareddemoregistersessionsyncreview",
-      "label": "requireSharedDemoRegisterSessionSyncReview()",
-      "norm_label": "requireshareddemoregistersessionsyncreview()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/policy.ts",
-      "source_location": "L97"
+      "id": "rangesnapshotlifecycle_test_seedstore",
+      "label": "seedStore()",
+      "norm_label": "seedstore()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L73"
     },
     {
       "community": 244,
       "file_type": "code",
-      "id": "policy_validateshareddemocoverage",
-      "label": "validateSharedDemoCoverage()",
-      "norm_label": "validateshareddemocoverage()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/policy.ts",
-      "source_location": "L337"
+      "id": "rangesnapshotlifecycle_test_synthetickind",
+      "label": "syntheticKind()",
+      "norm_label": "synthetickind()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L150"
     },
     {
       "community": 2440,
@@ -215625,92 +215721,92 @@
     {
       "community": 245,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_shareddemo_registerbaseline_ts",
-      "label": "registerBaseline.ts",
-      "norm_label": "registerbaseline.ts",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/registerBaseline.ts",
+      "id": "packages_athena_webapp_convex_shareddemo_policy_ts",
+      "label": "policy.ts",
+      "norm_label": "policy.ts",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/policy.ts",
       "source_location": "L1"
     },
     {
       "community": 245,
       "file_type": "code",
-      "id": "registerbaseline_bindshareddemoregisterbaselinewithctx",
-      "label": "bindSharedDemoRegisterBaselineWithCtx()",
-      "norm_label": "bindshareddemoregisterbaselinewithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/registerBaseline.ts",
-      "source_location": "L185"
+      "id": "policy_classifyshareddemoexternalgateway",
+      "label": "classifySharedDemoExternalGateway()",
+      "norm_label": "classifyshareddemoexternalgateway()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/policy.ts",
+      "source_location": "L275"
     },
     {
       "community": 245,
       "file_type": "code",
-      "id": "registerbaseline_browsersessionnote",
-      "label": "browserSessionNote()",
-      "norm_label": "browsersessionnote()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/registerBaseline.ts",
-      "source_location": "L61"
+      "id": "policy_classifyshareddemopublicfunction",
+      "label": "classifySharedDemoPublicFunction()",
+      "norm_label": "classifyshareddemopublicfunction()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/policy.ts",
+      "source_location": "L259"
     },
     {
       "community": 245,
       "file_type": "code",
-      "id": "registerbaseline_buildshareddemoregistercashbaseline",
-      "label": "buildSharedDemoRegisterCashBaseline()",
-      "norm_label": "buildshareddemoregistercashbaseline()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/registerBaseline.ts",
-      "source_location": "L54"
+      "id": "policy_decideshareddemoeffect",
+      "label": "decideSharedDemoEffect()",
+      "norm_label": "decideshareddemoeffect()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/policy.ts",
+      "source_location": "L319"
     },
     {
       "community": 245,
       "file_type": "code",
-      "id": "registerbaseline_buildshareddemoregisternarrative",
-      "label": "buildSharedDemoRegisterNarrative()",
-      "norm_label": "buildshareddemoregisternarrative()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/registerBaseline.ts",
-      "source_location": "L65"
+      "id": "policy_denyshareddemoaction",
+      "label": "denySharedDemoAction()",
+      "norm_label": "denyshareddemoaction()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/policy.ts",
+      "source_location": "L17"
     },
     {
       "community": 245,
       "file_type": "code",
-      "id": "registerbaseline_buildshareddemostoreschedule",
-      "label": "buildSharedDemoStoreSchedule()",
-      "norm_label": "buildshareddemostoreschedule()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/registerBaseline.ts",
-      "source_location": "L126"
+      "id": "policy_isshareddemooperationcapabilityallowed",
+      "label": "isSharedDemoOperationCapabilityAllowed()",
+      "norm_label": "isshareddemooperationcapabilityallowed()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/policy.ts",
+      "source_location": "L58"
     },
     {
       "community": 245,
       "file_type": "code",
-      "id": "registerbaseline_ensureshareddemostoreschedulewithctx",
-      "label": "ensureSharedDemoStoreScheduleWithCtx()",
-      "norm_label": "ensureshareddemostoreschedulewithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/registerBaseline.ts",
-      "source_location": "L154"
+      "id": "policy_requireshareddemocapability",
+      "label": "requireSharedDemoCapability()",
+      "norm_label": "requireshareddemocapability()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/policy.ts",
+      "source_location": "L312"
     },
     {
       "community": 245,
       "file_type": "code",
-      "id": "registerbaseline_planshareddemoregisterallocation",
-      "label": "planSharedDemoRegisterAllocation()",
-      "norm_label": "planshareddemoregisterallocation()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/registerBaseline.ts",
-      "source_location": "L48"
+      "id": "policy_requireshareddemoorderfulfillmentupdate",
+      "label": "requireSharedDemoOrderFulfillmentUpdate()",
+      "norm_label": "requireshareddemoorderfulfillmentupdate()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/policy.ts",
+      "source_location": "L77"
     },
     {
       "community": 245,
       "file_type": "code",
-      "id": "registerbaseline_rollshareddemoseededregisterwithctx",
-      "label": "rollSharedDemoSeededRegisterWithCtx()",
-      "norm_label": "rollshareddemoseededregisterwithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/registerBaseline.ts",
-      "source_location": "L99"
+      "id": "policy_requireshareddemoregistersessionsyncreview",
+      "label": "requireSharedDemoRegisterSessionSyncReview()",
+      "norm_label": "requireshareddemoregistersessionsyncreview()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/policy.ts",
+      "source_location": "L97"
     },
     {
       "community": 245,
       "file_type": "code",
-      "id": "registerbaseline_shareddemoseededregisteropenedat",
-      "label": "sharedDemoSeededRegisterOpenedAt()",
-      "norm_label": "shareddemoseededregisteropenedat()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/registerBaseline.ts",
-      "source_location": "L36"
+      "id": "policy_validateshareddemocoverage",
+      "label": "validateSharedDemoCoverage()",
+      "norm_label": "validateshareddemocoverage()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/policy.ts",
+      "source_location": "L337"
     },
     {
       "community": 2450,
@@ -215805,92 +215901,92 @@
     {
       "community": 246,
       "file_type": "code",
-      "id": "heroheaderimageuploader_editmodebuttons",
-      "label": "EditModeButtons()",
-      "norm_label": "editmodebuttons()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
-      "source_location": "L179"
-    },
-    {
-      "community": 246,
-      "file_type": "code",
-      "id": "heroheaderimageuploader_handleeditclick",
-      "label": "handleEditClick()",
-      "norm_label": "handleeditclick()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
-      "source_location": "L108"
-    },
-    {
-      "community": 246,
-      "file_type": "code",
-      "id": "heroheaderimageuploader_handlefileselect",
-      "label": "handleFileSelect()",
-      "norm_label": "handlefileselect()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
-      "source_location": "L113"
-    },
-    {
-      "community": 246,
-      "file_type": "code",
-      "id": "heroheaderimageuploader_handlerevert",
-      "label": "handleRevert()",
-      "norm_label": "handlerevert()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
-      "source_location": "L163"
-    },
-    {
-      "community": 246,
-      "file_type": "code",
-      "id": "heroheaderimageuploader_handleupload",
-      "label": "handleUpload()",
-      "norm_label": "handleupload()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
-      "source_location": "L127"
-    },
-    {
-      "community": 246,
-      "file_type": "code",
-      "id": "heroheaderimageuploader_reseteditstate",
-      "label": "resetEditState()",
-      "norm_label": "reseteditstate()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
-      "source_location": "L95"
-    },
-    {
-      "community": 246,
-      "file_type": "code",
-      "id": "heroheaderimageuploader_uploadimage",
-      "label": "uploadImage()",
-      "norm_label": "uploadimage()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
-      "source_location": "L67"
-    },
-    {
-      "community": 246,
-      "file_type": "code",
-      "id": "heroheaderimageuploader_validatefile",
-      "label": "validateFile()",
-      "norm_label": "validatefile()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 246,
-      "file_type": "code",
-      "id": "heroheaderimageuploader_viewmodebutton",
-      "label": "ViewModeButton()",
-      "norm_label": "viewmodebutton()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
-      "source_location": "L205"
-    },
-    {
-      "community": 246,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_heroheaderimageuploader_tsx",
-      "label": "HeroHeaderImageUploader.tsx",
-      "norm_label": "heroheaderimageuploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
+      "id": "packages_athena_webapp_convex_shareddemo_registerbaseline_ts",
+      "label": "registerBaseline.ts",
+      "norm_label": "registerbaseline.ts",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/registerBaseline.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 246,
+      "file_type": "code",
+      "id": "registerbaseline_bindshareddemoregisterbaselinewithctx",
+      "label": "bindSharedDemoRegisterBaselineWithCtx()",
+      "norm_label": "bindshareddemoregisterbaselinewithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/registerBaseline.ts",
+      "source_location": "L185"
+    },
+    {
+      "community": 246,
+      "file_type": "code",
+      "id": "registerbaseline_browsersessionnote",
+      "label": "browserSessionNote()",
+      "norm_label": "browsersessionnote()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/registerBaseline.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 246,
+      "file_type": "code",
+      "id": "registerbaseline_buildshareddemoregistercashbaseline",
+      "label": "buildSharedDemoRegisterCashBaseline()",
+      "norm_label": "buildshareddemoregistercashbaseline()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/registerBaseline.ts",
+      "source_location": "L54"
+    },
+    {
+      "community": 246,
+      "file_type": "code",
+      "id": "registerbaseline_buildshareddemoregisternarrative",
+      "label": "buildSharedDemoRegisterNarrative()",
+      "norm_label": "buildshareddemoregisternarrative()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/registerBaseline.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 246,
+      "file_type": "code",
+      "id": "registerbaseline_buildshareddemostoreschedule",
+      "label": "buildSharedDemoStoreSchedule()",
+      "norm_label": "buildshareddemostoreschedule()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/registerBaseline.ts",
+      "source_location": "L126"
+    },
+    {
+      "community": 246,
+      "file_type": "code",
+      "id": "registerbaseline_ensureshareddemostoreschedulewithctx",
+      "label": "ensureSharedDemoStoreScheduleWithCtx()",
+      "norm_label": "ensureshareddemostoreschedulewithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/registerBaseline.ts",
+      "source_location": "L154"
+    },
+    {
+      "community": 246,
+      "file_type": "code",
+      "id": "registerbaseline_planshareddemoregisterallocation",
+      "label": "planSharedDemoRegisterAllocation()",
+      "norm_label": "planshareddemoregisterallocation()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/registerBaseline.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 246,
+      "file_type": "code",
+      "id": "registerbaseline_rollshareddemoseededregisterwithctx",
+      "label": "rollSharedDemoSeededRegisterWithCtx()",
+      "norm_label": "rollshareddemoseededregisterwithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/registerBaseline.ts",
+      "source_location": "L99"
+    },
+    {
+      "community": 246,
+      "file_type": "code",
+      "id": "registerbaseline_shareddemoseededregisteropenedat",
+      "label": "sharedDemoSeededRegisterOpenedAt()",
+      "norm_label": "shareddemoseededregisteropenedat()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/registerBaseline.ts",
+      "source_location": "L36"
     },
     {
       "community": 2460,
@@ -215985,92 +216081,92 @@
     {
       "community": 247,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_shoplookimageuploader_tsx",
-      "label": "ShopLookImageUploader.tsx",
-      "norm_label": "shoplookimageuploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "shoplookimageuploader_editmodebuttons",
+      "id": "heroheaderimageuploader_editmodebuttons",
       "label": "EditModeButtons()",
       "norm_label": "editmodebuttons()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
-      "source_location": "L173"
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
+      "source_location": "L179"
     },
     {
       "community": 247,
       "file_type": "code",
-      "id": "shoplookimageuploader_handleeditclick",
+      "id": "heroheaderimageuploader_handleeditclick",
       "label": "handleEditClick()",
       "norm_label": "handleeditclick()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
-      "source_location": "L115"
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
+      "source_location": "L108"
     },
     {
       "community": 247,
       "file_type": "code",
-      "id": "shoplookimageuploader_handlefileselect",
+      "id": "heroheaderimageuploader_handlefileselect",
       "label": "handleFileSelect()",
       "norm_label": "handlefileselect()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
-      "source_location": "L120"
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
+      "source_location": "L113"
     },
     {
       "community": 247,
       "file_type": "code",
-      "id": "shoplookimageuploader_handlerevert",
+      "id": "heroheaderimageuploader_handlerevert",
       "label": "handleRevert()",
       "norm_label": "handlerevert()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
-      "source_location": "L157"
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
+      "source_location": "L163"
     },
     {
       "community": 247,
       "file_type": "code",
-      "id": "shoplookimageuploader_handleupload",
+      "id": "heroheaderimageuploader_handleupload",
       "label": "handleUpload()",
       "norm_label": "handleupload()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
-      "source_location": "L134"
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
+      "source_location": "L127"
     },
     {
       "community": 247,
       "file_type": "code",
-      "id": "shoplookimageuploader_reseteditstate",
+      "id": "heroheaderimageuploader_reseteditstate",
       "label": "resetEditState()",
       "norm_label": "reseteditstate()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
-      "source_location": "L102"
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
+      "source_location": "L95"
     },
     {
       "community": 247,
       "file_type": "code",
-      "id": "shoplookimageuploader_uploadimage",
+      "id": "heroheaderimageuploader_uploadimage",
       "label": "uploadImage()",
       "norm_label": "uploadimage()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
-      "source_location": "L74"
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
+      "source_location": "L67"
     },
     {
       "community": 247,
       "file_type": "code",
-      "id": "shoplookimageuploader_validatefile",
+      "id": "heroheaderimageuploader_validatefile",
       "label": "validateFile()",
       "norm_label": "validatefile()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
-      "source_location": "L57"
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
+      "source_location": "L50"
     },
     {
       "community": 247,
       "file_type": "code",
-      "id": "shoplookimageuploader_viewmodebutton",
+      "id": "heroheaderimageuploader_viewmodebutton",
       "label": "ViewModeButton()",
       "norm_label": "viewmodebutton()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
-      "source_location": "L199"
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
+      "source_location": "L205"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_heroheaderimageuploader_tsx",
+      "label": "HeroHeaderImageUploader.tsx",
+      "norm_label": "heroheaderimageuploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
+      "source_location": "L1"
     },
     {
       "community": 2470,
@@ -216165,92 +216261,92 @@
     {
       "community": 248,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_skuactivitytimeline_tsx",
-      "label": "SkuActivityTimeline.tsx",
-      "norm_label": "skuactivitytimeline.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/SkuActivityTimeline.tsx",
+      "id": "packages_athena_webapp_src_components_homepage_shoplookimageuploader_tsx",
+      "label": "ShopLookImageUploader.tsx",
+      "norm_label": "shoplookimageuploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
       "source_location": "L1"
     },
     {
       "community": 248,
       "file_type": "code",
-      "id": "skuactivitytimeline_formatbackendlabel",
-      "label": "formatBackendLabel()",
-      "norm_label": "formatbackendlabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/SkuActivityTimeline.tsx",
-      "source_location": "L111"
+      "id": "shoplookimageuploader_editmodebuttons",
+      "label": "EditModeButtons()",
+      "norm_label": "editmodebuttons()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
+      "source_location": "L173"
     },
     {
       "community": 248,
       "file_type": "code",
-      "id": "skuactivitytimeline_formatinventorynumber",
-      "label": "formatInventoryNumber()",
-      "norm_label": "formatinventorynumber()",
-      "source_file": "packages/athena-webapp/src/components/operations/SkuActivityTimeline.tsx",
-      "source_location": "L99"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "skuactivitytimeline_formatquantity",
-      "label": "formatQuantity()",
-      "norm_label": "formatquantity()",
-      "source_file": "packages/athena-webapp/src/components/operations/SkuActivityTimeline.tsx",
-      "source_location": "L107"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "skuactivitytimeline_getactivitytitle",
-      "label": "getActivityTitle()",
-      "norm_label": "getactivitytitle()",
-      "source_file": "packages/athena-webapp/src/components/operations/SkuActivityTimeline.tsx",
-      "source_location": "L126"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "skuactivitytimeline_getdiagnostictitle",
-      "label": "getDiagnosticTitle()",
-      "norm_label": "getdiagnostictitle()",
-      "source_file": "packages/athena-webapp/src/components/operations/SkuActivityTimeline.tsx",
-      "source_location": "L177"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "skuactivitytimeline_getdiagnostictone",
-      "label": "getDiagnosticTone()",
-      "norm_label": "getdiagnostictone()",
-      "source_file": "packages/athena-webapp/src/components/operations/SkuActivityTimeline.tsx",
-      "source_location": "L187"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "skuactivitytimeline_getreservationtitle",
-      "label": "getReservationTitle()",
-      "norm_label": "getreservationtitle()",
-      "source_file": "packages/athena-webapp/src/components/operations/SkuActivityTimeline.tsx",
+      "id": "shoplookimageuploader_handleeditclick",
+      "label": "handleEditClick()",
+      "norm_label": "handleeditclick()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
       "source_location": "L115"
     },
     {
       "community": 248,
       "file_type": "code",
-      "id": "skuactivitytimeline_getstatustone",
-      "label": "getStatusTone()",
-      "norm_label": "getstatustone()",
-      "source_file": "packages/athena-webapp/src/components/operations/SkuActivityTimeline.tsx",
-      "source_location": "L198"
+      "id": "shoplookimageuploader_handlefileselect",
+      "label": "handleFileSelect()",
+      "norm_label": "handlefileselect()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
+      "source_location": "L120"
     },
     {
       "community": 248,
       "file_type": "code",
-      "id": "skuactivitytimeline_pluralize",
-      "label": "pluralize()",
-      "norm_label": "pluralize()",
-      "source_file": "packages/athena-webapp/src/components/operations/SkuActivityTimeline.tsx",
-      "source_location": "L103"
+      "id": "shoplookimageuploader_handlerevert",
+      "label": "handleRevert()",
+      "norm_label": "handlerevert()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
+      "source_location": "L157"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "shoplookimageuploader_handleupload",
+      "label": "handleUpload()",
+      "norm_label": "handleupload()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
+      "source_location": "L134"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "shoplookimageuploader_reseteditstate",
+      "label": "resetEditState()",
+      "norm_label": "reseteditstate()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
+      "source_location": "L102"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "shoplookimageuploader_uploadimage",
+      "label": "uploadImage()",
+      "norm_label": "uploadimage()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
+      "source_location": "L74"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "shoplookimageuploader_validatefile",
+      "label": "validateFile()",
+      "norm_label": "validatefile()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
+      "source_location": "L57"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "shoplookimageuploader_viewmodebutton",
+      "label": "ViewModeButton()",
+      "norm_label": "viewmodebutton()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
+      "source_location": "L199"
     },
     {
       "community": 2480,
@@ -216345,92 +216441,92 @@
     {
       "community": 249,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_refundutils_ts",
-      "label": "refundUtils.ts",
-      "norm_label": "refundutils.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "id": "packages_athena_webapp_src_components_operations_skuactivitytimeline_tsx",
+      "label": "SkuActivityTimeline.tsx",
+      "norm_label": "skuactivitytimeline.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/SkuActivityTimeline.tsx",
       "source_location": "L1"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "refundutils_calculaterefundamount",
-      "label": "calculateRefundAmount()",
-      "norm_label": "calculaterefundamount()",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
-      "source_location": "L128"
+      "id": "skuactivitytimeline_formatbackendlabel",
+      "label": "formatBackendLabel()",
+      "norm_label": "formatbackendlabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/SkuActivityTimeline.tsx",
+      "source_location": "L111"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "refundutils_canusepartialrefund",
-      "label": "canUsePartialRefund()",
-      "norm_label": "canusepartialrefund()",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
-      "source_location": "L120"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "refundutils_getamountrefunded",
-      "label": "getAmountRefunded()",
-      "norm_label": "getamountrefunded()",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "id": "skuactivitytimeline_formatinventorynumber",
+      "label": "formatInventoryNumber()",
+      "norm_label": "formatinventorynumber()",
+      "source_file": "packages/athena-webapp/src/components/operations/SkuActivityTimeline.tsx",
       "source_location": "L99"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "refundutils_getavailableitems",
-      "label": "getAvailableItems()",
-      "norm_label": "getavailableitems()",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "refundutils_getitemstorefund",
-      "label": "getItemsToRefund()",
-      "norm_label": "getitemstorefund()",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
-      "source_location": "L176"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "refundutils_getnetamount",
-      "label": "getNetAmount()",
-      "norm_label": "getnetamount()",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "id": "skuactivitytimeline_formatquantity",
+      "label": "formatQuantity()",
+      "norm_label": "formatquantity()",
+      "source_file": "packages/athena-webapp/src/components/operations/SkuActivityTimeline.tsx",
       "source_location": "L107"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "refundutils_refundreducer",
-      "label": "refundReducer()",
-      "norm_label": "refundreducer()",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
-      "source_location": "L31"
+      "id": "skuactivitytimeline_getactivitytitle",
+      "label": "getActivityTitle()",
+      "norm_label": "getactivitytitle()",
+      "source_file": "packages/athena-webapp/src/components/operations/SkuActivityTimeline.tsx",
+      "source_location": "L126"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "refundutils_shouldshowreturntostock",
-      "label": "shouldShowReturnToStock()",
-      "norm_label": "shouldshowreturntostock()",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
-      "source_location": "L257"
+      "id": "skuactivitytimeline_getdiagnostictitle",
+      "label": "getDiagnosticTitle()",
+      "norm_label": "getdiagnostictitle()",
+      "source_file": "packages/athena-webapp/src/components/operations/SkuActivityTimeline.tsx",
+      "source_location": "L177"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "refundutils_validaterefund",
-      "label": "validateRefund()",
-      "norm_label": "validaterefund()",
-      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
-      "source_location": "L201"
+      "id": "skuactivitytimeline_getdiagnostictone",
+      "label": "getDiagnosticTone()",
+      "norm_label": "getdiagnostictone()",
+      "source_file": "packages/athena-webapp/src/components/operations/SkuActivityTimeline.tsx",
+      "source_location": "L187"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "skuactivitytimeline_getreservationtitle",
+      "label": "getReservationTitle()",
+      "norm_label": "getreservationtitle()",
+      "source_file": "packages/athena-webapp/src/components/operations/SkuActivityTimeline.tsx",
+      "source_location": "L115"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "skuactivitytimeline_getstatustone",
+      "label": "getStatusTone()",
+      "norm_label": "getstatustone()",
+      "source_file": "packages/athena-webapp/src/components/operations/SkuActivityTimeline.tsx",
+      "source_location": "L198"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "skuactivitytimeline_pluralize",
+      "label": "pluralize()",
+      "norm_label": "pluralize()",
+      "source_file": "packages/athena-webapp/src/components/operations/SkuActivityTimeline.tsx",
+      "source_location": "L103"
     },
     {
       "community": 2490,
@@ -216867,92 +216963,92 @@
     {
       "community": 250,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
-      "label": "ProductEntry.tsx",
-      "norm_label": "productentry.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
+      "id": "packages_athena_webapp_src_components_orders_refundutils_ts",
+      "label": "refundUtils.ts",
+      "norm_label": "refundutils.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L1"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "productentry_handleaddservice",
-      "label": "handleAddService()",
-      "norm_label": "handleaddservice()",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L152"
+      "id": "refundutils_calculaterefundamount",
+      "label": "calculateRefundAmount()",
+      "norm_label": "calculaterefundamount()",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "source_location": "L128"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "productentry_handleamountchange",
-      "label": "handleAmountChange()",
-      "norm_label": "handleamountchange()",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L145"
+      "id": "refundutils_canusepartialrefund",
+      "label": "canUsePartialRefund()",
+      "norm_label": "canusepartialrefund()",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "source_location": "L120"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "productentry_handleattachbarcodesubmit",
-      "label": "handleAttachBarcodeSubmit()",
-      "norm_label": "handleattachbarcodesubmit()",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L689"
+      "id": "refundutils_getamountrefunded",
+      "label": "getAmountRefunded()",
+      "norm_label": "getamountrefunded()",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "source_location": "L99"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "productentry_handlecardclick",
-      "label": "handleCardClick()",
-      "norm_label": "handlecardclick()",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L215"
+      "id": "refundutils_getavailableitems",
+      "label": "getAvailableItems()",
+      "norm_label": "getavailableitems()",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "source_location": "L115"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "productentry_handlecardkeydown",
-      "label": "handleCardKeyDown()",
-      "norm_label": "handlecardkeydown()",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L221"
+      "id": "refundutils_getitemstorefund",
+      "label": "getItemsToRefund()",
+      "norm_label": "getitemstorefund()",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "source_location": "L176"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "productentry_handleclearsearch",
-      "label": "handleClearSearch()",
-      "norm_label": "handleclearsearch()",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L357"
+      "id": "refundutils_getnetamount",
+      "label": "getNetAmount()",
+      "norm_label": "getnetamount()",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "source_location": "L107"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "productentry_handlequickaddopenchange",
-      "label": "handleQuickAddOpenChange()",
-      "norm_label": "handlequickaddopenchange()",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L594"
+      "id": "refundutils_refundreducer",
+      "label": "refundReducer()",
+      "norm_label": "refundreducer()",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "source_location": "L31"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "productentry_handlequickaddsubmit",
-      "label": "handleQuickAddSubmit()",
-      "norm_label": "handlequickaddsubmit()",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L602"
+      "id": "refundutils_shouldshowreturntostock",
+      "label": "shouldShowReturnToStock()",
+      "norm_label": "shouldshowreturntostock()",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "source_location": "L257"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "productentry_servicesearchresultisincart",
-      "label": "serviceSearchResultIsInCart()",
-      "norm_label": "servicesearchresultisincart()",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
-      "source_location": "L106"
+      "id": "refundutils_validaterefund",
+      "label": "validateRefund()",
+      "norm_label": "validaterefund()",
+      "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
+      "source_location": "L201"
     },
     {
       "community": 2500,
@@ -217047,92 +217143,92 @@
     {
       "community": 251,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reports_reportperiodkeys_ts",
-      "label": "reportPeriodKeys.ts",
-      "norm_label": "reportperiodkeys.ts",
-      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
+      "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
+      "label": "ProductEntry.tsx",
+      "norm_label": "productentry.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
       "source_location": "L1"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "reportperiodkeys_addoperatingdays",
-      "label": "addOperatingDays()",
-      "norm_label": "addoperatingdays()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
-      "source_location": "L74"
+      "id": "productentry_handleaddservice",
+      "label": "handleAddService()",
+      "norm_label": "handleaddservice()",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
+      "source_location": "L152"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "reportperiodkeys_daterangeforitemsperiod",
-      "label": "dateRangeForItemsPeriod()",
-      "norm_label": "daterangeforitemsperiod()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
+      "id": "productentry_handleamountchange",
+      "label": "handleAmountChange()",
+      "norm_label": "handleamountchange()",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
       "source_location": "L145"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "reportperiodkeys_daterangeforoverviewwindow",
-      "label": "dateRangeForOverviewWindow()",
-      "norm_label": "daterangeforoverviewwindow()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
-      "source_location": "L118"
+      "id": "productentry_handleattachbarcodesubmit",
+      "label": "handleAttachBarcodeSubmit()",
+      "norm_label": "handleattachbarcodesubmit()",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
+      "source_location": "L689"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "reportperiodkeys_isoweekstart",
-      "label": "isoWeekStart()",
-      "norm_label": "isoweekstart()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
-      "source_location": "L112"
+      "id": "productentry_handlecardclick",
+      "label": "handleCardClick()",
+      "norm_label": "handlecardclick()",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
+      "source_location": "L215"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "reportperiodkeys_operatingdatetoutc",
-      "label": "operatingDateToUtc()",
-      "norm_label": "operatingdatetoutc()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
-      "source_location": "L66"
+      "id": "productentry_handlecardkeydown",
+      "label": "handleCardKeyDown()",
+      "norm_label": "handlecardkeydown()",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
+      "source_location": "L221"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "reportperiodkeys_periodkeyforselection",
-      "label": "periodKeyForSelection()",
-      "norm_label": "periodkeyforselection()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
-      "source_location": "L169"
+      "id": "productentry_handleclearsearch",
+      "label": "handleClearSearch()",
+      "norm_label": "handleclearsearch()",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
+      "source_location": "L357"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "reportperiodkeys_tablerangeincludingselection",
-      "label": "tableRangeIncludingSelection()",
-      "norm_label": "tablerangeincludingselection()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
-      "source_location": "L86"
+      "id": "productentry_handlequickaddopenchange",
+      "label": "handleQuickAddOpenChange()",
+      "norm_label": "handlequickaddopenchange()",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
+      "source_location": "L594"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "reportperiodkeys_todayoperatingdateguess",
-      "label": "todayOperatingDateGuess()",
-      "norm_label": "todayoperatingdateguess()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
-      "source_location": "L184"
+      "id": "productentry_handlequickaddsubmit",
+      "label": "handleQuickAddSubmit()",
+      "norm_label": "handlequickaddsubmit()",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
+      "source_location": "L602"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "reportperiodkeys_utctooperatingdate",
-      "label": "utcToOperatingDate()",
-      "norm_label": "utctooperatingdate()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
-      "source_location": "L70"
+      "id": "productentry_servicesearchresultisincart",
+      "label": "serviceSearchResultIsInCart()",
+      "norm_label": "servicesearchresultisincart()",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
+      "source_location": "L106"
     },
     {
       "community": 2510,
@@ -217227,92 +217323,92 @@
     {
       "community": 252,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_contexts_productcontext_tsx",
-      "label": "ProductContext.tsx",
-      "norm_label": "productcontext.tsx",
-      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
+      "id": "packages_athena_webapp_src_components_reports_reportperiodkeys_ts",
+      "label": "reportPeriodKeys.ts",
+      "norm_label": "reportperiodkeys.ts",
+      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
       "source_location": "L1"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "productcontext_convertskutovariant",
-      "label": "convertSkuToVariant()",
-      "norm_label": "convertskutovariant()",
-      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
-      "source_location": "L87"
+      "id": "reportperiodkeys_addoperatingdays",
+      "label": "addOperatingDays()",
+      "norm_label": "addoperatingdays()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
+      "source_location": "L74"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "productcontext_mergeproductdatawithactiveproductrefresh",
-      "label": "mergeProductDataWithActiveProductRefresh()",
-      "norm_label": "mergeproductdatawithactiveproductrefresh()",
-      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
-      "source_location": "L114"
-    },
-    {
-      "community": 252,
-      "file_type": "code",
-      "id": "productcontext_mergeproductvariantswithactiveproductrefresh",
-      "label": "mergeProductVariantsWithActiveProductRefresh()",
-      "norm_label": "mergeproductvariantswithactiveproductrefresh()",
-      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
+      "id": "reportperiodkeys_daterangeforitemsperiod",
+      "label": "dateRangeForItemsPeriod()",
+      "norm_label": "daterangeforitemsperiod()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
       "source_location": "L145"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "productcontext_mergetrustedinventoryfinalizationintoproduct",
-      "label": "mergeTrustedInventoryFinalizationIntoProduct()",
-      "norm_label": "mergetrustedinventoryfinalizationintoproduct()",
-      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
-      "source_location": "L219"
+      "id": "reportperiodkeys_daterangeforoverviewwindow",
+      "label": "dateRangeForOverviewWindow()",
+      "norm_label": "daterangeforoverviewwindow()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
+      "source_location": "L118"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "productcontext_mergetrustedinventoryfinalizationintovariants",
-      "label": "mergeTrustedInventoryFinalizationIntoVariants()",
-      "norm_label": "mergetrustedinventoryfinalizationintovariants()",
-      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
-      "source_location": "L199"
+      "id": "reportperiodkeys_isoweekstart",
+      "label": "isoWeekStart()",
+      "norm_label": "isoweekstart()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
+      "source_location": "L112"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "productcontext_productprovider",
-      "label": "ProductProvider()",
-      "norm_label": "productprovider()",
-      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
-      "source_location": "L237"
+      "id": "reportperiodkeys_operatingdatetoutc",
+      "label": "operatingDateToUtc()",
+      "norm_label": "operatingdatetoutc()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
+      "source_location": "L66"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "productcontext_stripskus",
-      "label": "stripSkus()",
-      "norm_label": "stripskus()",
-      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
-      "source_location": "L80"
+      "id": "reportperiodkeys_periodkeyforselection",
+      "label": "periodKeyForSelection()",
+      "norm_label": "periodkeyforselection()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
+      "source_location": "L169"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "productcontext_useproduct",
-      "label": "useProduct()",
-      "norm_label": "useproduct()",
-      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
-      "source_location": "L552"
+      "id": "reportperiodkeys_tablerangeincludingselection",
+      "label": "tableRangeIncludingSelection()",
+      "norm_label": "tablerangeincludingselection()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
+      "source_location": "L86"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "productcontext_valuesmatch",
-      "label": "valuesMatch()",
-      "norm_label": "valuesmatch()",
-      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
-      "source_location": "L76"
+      "id": "reportperiodkeys_todayoperatingdateguess",
+      "label": "todayOperatingDateGuess()",
+      "norm_label": "todayoperatingdateguess()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
+      "source_location": "L184"
+    },
+    {
+      "community": 252,
+      "file_type": "code",
+      "id": "reportperiodkeys_utctooperatingdate",
+      "label": "utcToOperatingDate()",
+      "norm_label": "utctooperatingdate()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
+      "source_location": "L70"
     },
     {
       "community": 2520,
@@ -217407,92 +217503,92 @@
     {
       "community": 253,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
-      "label": "usePOSProducts.ts",
-      "norm_label": "useposproducts.ts",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "id": "packages_athena_webapp_src_contexts_productcontext_tsx",
+      "label": "ProductContext.tsx",
+      "norm_label": "productcontext.tsx",
+      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
       "source_location": "L1"
     },
     {
       "community": 253,
       "file_type": "code",
-      "id": "useposproducts_useposbarcodesearch",
-      "label": "usePOSBarcodeSearch()",
-      "norm_label": "useposbarcodesearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L21"
+      "id": "productcontext_convertskutovariant",
+      "label": "convertSkuToVariant()",
+      "norm_label": "convertskutovariant()",
+      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
+      "source_location": "L87"
     },
     {
       "community": 253,
       "file_type": "code",
-      "id": "useposproducts_usepospendingcheckoutitemforsale",
-      "label": "usePOSPendingCheckoutItemForSale()",
-      "norm_label": "usepospendingcheckoutitemforsale()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L46"
+      "id": "productcontext_mergeproductdatawithactiveproductrefresh",
+      "label": "mergeProductDataWithActiveProductRefresh()",
+      "norm_label": "mergeproductdatawithactiveproductrefresh()",
+      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
+      "source_location": "L114"
     },
     {
       "community": 253,
       "file_type": "code",
-      "id": "useposproducts_usepospendingcheckoutitemsforreview",
-      "label": "usePOSPendingCheckoutItemsForReview()",
-      "norm_label": "usepospendingcheckoutitemsforreview()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L49"
+      "id": "productcontext_mergeproductvariantswithactiveproductrefresh",
+      "label": "mergeProductVariantsWithActiveProductRefresh()",
+      "norm_label": "mergeproductvariantswithactiveproductrefresh()",
+      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
+      "source_location": "L145"
     },
     {
       "community": 253,
       "file_type": "code",
-      "id": "useposproducts_useposproductidsearch",
-      "label": "usePOSProductIdSearch()",
-      "norm_label": "useposproductidsearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L28"
+      "id": "productcontext_mergetrustedinventoryfinalizationintoproduct",
+      "label": "mergeTrustedInventoryFinalizationIntoProduct()",
+      "norm_label": "mergetrustedinventoryfinalizationintoproduct()",
+      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
+      "source_location": "L219"
     },
     {
       "community": 253,
       "file_type": "code",
-      "id": "useposproducts_useposproductsearch",
-      "label": "usePOSProductSearch()",
-      "norm_label": "useposproductsearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L14"
+      "id": "productcontext_mergetrustedinventoryfinalizationintovariants",
+      "label": "mergeTrustedInventoryFinalizationIntoVariants()",
+      "norm_label": "mergetrustedinventoryfinalizationintovariants()",
+      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
+      "source_location": "L199"
     },
     {
       "community": 253,
       "file_type": "code",
-      "id": "useposproducts_useposquickaddproductsku",
-      "label": "usePOSQuickAddProductSku()",
-      "norm_label": "useposquickaddproductsku()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L44"
+      "id": "productcontext_productprovider",
+      "label": "ProductProvider()",
+      "norm_label": "productprovider()",
+      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
+      "source_location": "L237"
     },
     {
       "community": 253,
       "file_type": "code",
-      "id": "useposproducts_useposregistercatalog",
-      "label": "usePOSRegisterCatalog()",
-      "norm_label": "useposregistercatalog()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L35"
+      "id": "productcontext_stripskus",
+      "label": "stripSkus()",
+      "norm_label": "stripskus()",
+      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
+      "source_location": "L80"
     },
     {
       "community": 253,
       "file_type": "code",
-      "id": "useposproducts_useposresolvependingcheckoutitemreview",
-      "label": "usePOSResolvePendingCheckoutItemReview()",
-      "norm_label": "useposresolvependingcheckoutitemreview()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L53"
+      "id": "productcontext_useproduct",
+      "label": "useProduct()",
+      "norm_label": "useproduct()",
+      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
+      "source_location": "L552"
     },
     {
       "community": 253,
       "file_type": "code",
-      "id": "useposproducts_usepostransactioncomplete",
-      "label": "usePOSTransactionComplete()",
-      "norm_label": "usepostransactioncomplete()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L42"
+      "id": "productcontext_valuesmatch",
+      "label": "valuesMatch()",
+      "norm_label": "valuesmatch()",
+      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
+      "source_location": "L76"
     },
     {
       "community": 2530,
@@ -217587,92 +217683,92 @@
     {
       "community": 254,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_app_update_updateassetstaging_ts",
-      "label": "updateAssetStaging.ts",
-      "norm_label": "updateassetstaging.ts",
-      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
+      "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
+      "label": "usePOSProducts.ts",
+      "norm_label": "useposproducts.ts",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L1"
     },
     {
       "community": 254,
       "file_type": "code",
-      "id": "updateassetstaging_collectupdatestaticasseturls",
-      "label": "collectUpdateStaticAssetUrls()",
-      "norm_label": "collectupdatestaticasseturls()",
-      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
-      "source_location": "L201"
+      "id": "useposproducts_useposbarcodesearch",
+      "label": "usePOSBarcodeSearch()",
+      "norm_label": "useposbarcodesearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L21"
     },
     {
       "community": 254,
       "file_type": "code",
-      "id": "updateassetstaging_extractlinkhrefurls",
-      "label": "extractLinkHrefUrls()",
-      "norm_label": "extractlinkhrefurls()",
-      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
-      "source_location": "L226"
+      "id": "useposproducts_usepospendingcheckoutitemforsale",
+      "label": "usePOSPendingCheckoutItemForSale()",
+      "norm_label": "usepospendingcheckoutitemforsale()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L46"
     },
     {
       "community": 254,
       "file_type": "code",
-      "id": "updateassetstaging_extractscriptsrcurls",
-      "label": "extractScriptSrcUrls()",
-      "norm_label": "extractscriptsrcurls()",
-      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
-      "source_location": "L219"
+      "id": "useposproducts_usepospendingcheckoutitemsforreview",
+      "label": "usePOSPendingCheckoutItemsForReview()",
+      "norm_label": "usepospendingcheckoutitemsforreview()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L49"
     },
     {
       "community": 254,
       "file_type": "code",
-      "id": "updateassetstaging_isstaticshelllinktag",
-      "label": "isStaticShellLinkTag()",
-      "norm_label": "isstaticshelllinktag()",
-      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
-      "source_location": "L239"
+      "id": "useposproducts_useposproductidsearch",
+      "label": "usePOSProductIdSearch()",
+      "norm_label": "useposproductidsearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L28"
     },
     {
       "community": 254,
       "file_type": "code",
-      "id": "updateassetstaging_maybeaddshellasseturl",
-      "label": "maybeAddShellAssetUrl()",
-      "norm_label": "maybeaddshellasseturl()",
-      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
-      "source_location": "L254"
+      "id": "useposproducts_useposproductsearch",
+      "label": "usePOSProductSearch()",
+      "norm_label": "useposproductsearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L14"
     },
     {
       "community": 254,
       "file_type": "code",
-      "id": "updateassetstaging_readtagattribute",
-      "label": "readTagAttribute()",
-      "norm_label": "readtagattribute()",
-      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
-      "source_location": "L249"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "updateassetstaging_stageupdatestaticassets",
-      "label": "stageUpdateStaticAssets()",
-      "norm_label": "stageupdatestaticassets()",
-      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
+      "id": "useposproducts_useposquickaddproductsku",
+      "label": "usePOSQuickAddProductSku()",
+      "norm_label": "useposquickaddproductsku()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L44"
     },
     {
       "community": 254,
       "file_type": "code",
-      "id": "updateassetstaging_toserviceworkerresult",
-      "label": "toServiceWorkerResult()",
-      "norm_label": "toserviceworkerresult()",
-      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
-      "source_location": "L289"
+      "id": "useposproducts_useposregistercatalog",
+      "label": "usePOSRegisterCatalog()",
+      "norm_label": "useposregistercatalog()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L35"
     },
     {
       "community": 254,
       "file_type": "code",
-      "id": "updateassetstaging_waitforactiveserviceworker",
-      "label": "waitForActiveServiceWorker()",
-      "norm_label": "waitforactiveserviceworker()",
-      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
-      "source_location": "L268"
+      "id": "useposproducts_useposresolvependingcheckoutitemreview",
+      "label": "usePOSResolvePendingCheckoutItemReview()",
+      "norm_label": "useposresolvependingcheckoutitemreview()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "useposproducts_usepostransactioncomplete",
+      "label": "usePOSTransactionComplete()",
+      "norm_label": "usepostransactioncomplete()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L42"
     },
     {
       "community": 2540,
@@ -217767,92 +217863,92 @@
     {
       "community": 255,
       "file_type": "code",
-      "id": "createremoteassisttransportclient_createremoteassisttransportclient",
-      "label": "createRemoteAssistTransportClient()",
-      "norm_label": "createremoteassisttransportclient()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "createremoteassisttransportclient_getremoteassisttransportclientfactory",
-      "label": "getRemoteAssistTransportClientFactory()",
-      "norm_label": "getremoteassisttransportclientfactory()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "createremoteassisttransportclient_lazylivekitremoteassistclient",
-      "label": "LazyLiveKitRemoteAssistClient",
-      "norm_label": "lazylivekitremoteassistclient",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "createremoteassisttransportclient_lazylivekitremoteassistclient_connect",
-      "label": ".connect()",
-      "norm_label": ".connect()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "createremoteassisttransportclient_lazylivekitremoteassistclient_disconnect",
-      "label": ".disconnect()",
-      "norm_label": ".disconnect()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "createremoteassisttransportclient_lazylivekitremoteassistclient_loadclient",
-      "label": ".loadClient()",
-      "norm_label": ".loadclient()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "createremoteassisttransportclient_lazylivekitremoteassistclient_publish",
-      "label": ".publish()",
-      "norm_label": ".publish()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
-      "source_location": "L53"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "createremoteassisttransportclient_lazylivekitremoteassistclient_subscribe",
-      "label": ".subscribe()",
-      "norm_label": ".subscribe()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "createremoteassisttransportclient_lazylivekitremoteassistclient_subscribetoconnectionstate",
-      "label": ".subscribeToConnectionState()",
-      "norm_label": ".subscribetoconnectionstate()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
-      "source_location": "L64"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_remote_assist_transport_createremoteassisttransportclient_ts",
-      "label": "createRemoteAssistTransportClient.ts",
-      "norm_label": "createremoteassisttransportclient.ts",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
+      "id": "packages_athena_webapp_src_lib_app_update_updateassetstaging_ts",
+      "label": "updateAssetStaging.ts",
+      "norm_label": "updateassetstaging.ts",
+      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "updateassetstaging_collectupdatestaticasseturls",
+      "label": "collectUpdateStaticAssetUrls()",
+      "norm_label": "collectupdatestaticasseturls()",
+      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
+      "source_location": "L201"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "updateassetstaging_extractlinkhrefurls",
+      "label": "extractLinkHrefUrls()",
+      "norm_label": "extractlinkhrefurls()",
+      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
+      "source_location": "L226"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "updateassetstaging_extractscriptsrcurls",
+      "label": "extractScriptSrcUrls()",
+      "norm_label": "extractscriptsrcurls()",
+      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
+      "source_location": "L219"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "updateassetstaging_isstaticshelllinktag",
+      "label": "isStaticShellLinkTag()",
+      "norm_label": "isstaticshelllinktag()",
+      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
+      "source_location": "L239"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "updateassetstaging_maybeaddshellasseturl",
+      "label": "maybeAddShellAssetUrl()",
+      "norm_label": "maybeaddshellasseturl()",
+      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
+      "source_location": "L254"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "updateassetstaging_readtagattribute",
+      "label": "readTagAttribute()",
+      "norm_label": "readtagattribute()",
+      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
+      "source_location": "L249"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "updateassetstaging_stageupdatestaticassets",
+      "label": "stageUpdateStaticAssets()",
+      "norm_label": "stageupdatestaticassets()",
+      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
+      "source_location": "L44"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "updateassetstaging_toserviceworkerresult",
+      "label": "toServiceWorkerResult()",
+      "norm_label": "toserviceworkerresult()",
+      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
+      "source_location": "L289"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "updateassetstaging_waitforactiveserviceworker",
+      "label": "waitForActiveServiceWorker()",
+      "norm_label": "waitforactiveserviceworker()",
+      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
+      "source_location": "L268"
     },
     {
       "community": 2550,
@@ -217947,92 +218043,92 @@
     {
       "community": 256,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_tests_pos_simple_test_ts",
-      "label": "simple.test.ts",
-      "norm_label": "simple.test.ts",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L1"
+      "id": "createremoteassisttransportclient_createremoteassisttransportclient",
+      "label": "createRemoteAssistTransportClient()",
+      "norm_label": "createremoteassisttransportclient()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
+      "source_location": "L15"
     },
     {
       "community": 256,
       "file_type": "code",
-      "id": "simple_test_addtocart",
-      "label": "addToCart()",
-      "norm_label": "addtocart()",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L249"
+      "id": "createremoteassisttransportclient_getremoteassisttransportclientfactory",
+      "label": "getRemoteAssistTransportClientFactory()",
+      "norm_label": "getremoteassisttransportclientfactory()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
+      "source_location": "L21"
     },
     {
       "community": 256,
       "file_type": "code",
-      "id": "simple_test_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L173"
+      "id": "createremoteassisttransportclient_lazylivekitremoteassistclient",
+      "label": "LazyLiveKitRemoteAssistClient",
+      "norm_label": "lazylivekitremoteassistclient",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
+      "source_location": "L27"
     },
     {
       "community": 256,
       "file_type": "code",
-      "id": "simple_test_formatpaymentmethod",
-      "label": "formatPaymentMethod()",
-      "norm_label": "formatpaymentmethod()",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L201"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "simple_test_formatreceiptdate",
-      "label": "formatReceiptDate()",
-      "norm_label": "formatreceiptdate()",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L225"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "simple_test_generatetransactionnumber",
-      "label": "generateTransactionNumber()",
-      "norm_label": "generatetransactionnumber()",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "id": "createremoteassisttransportclient_lazylivekitremoteassistclient_connect",
+      "label": ".connect()",
+      "norm_label": ".connect()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
       "source_location": "L38"
     },
     {
       "community": 256,
       "file_type": "code",
-      "id": "simple_test_removefromcart",
-      "label": "removeFromCart()",
-      "norm_label": "removefromcart()",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L288"
+      "id": "createremoteassisttransportclient_lazylivekitremoteassistclient_disconnect",
+      "label": ".disconnect()",
+      "norm_label": ".disconnect()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
+      "source_location": "L48"
     },
     {
       "community": 256,
       "file_type": "code",
-      "id": "simple_test_updatequantity",
-      "label": "updateQuantity()",
-      "norm_label": "updatequantity()",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L311"
+      "id": "createremoteassisttransportclient_lazylivekitremoteassistclient_loadclient",
+      "label": ".loadClient()",
+      "norm_label": ".loadclient()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
+      "source_location": "L73"
     },
     {
       "community": 256,
       "file_type": "code",
-      "id": "simple_test_validateinventory",
-      "label": "validateInventory()",
-      "norm_label": "validateinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L77"
+      "id": "createremoteassisttransportclient_lazylivekitremoteassistclient_publish",
+      "label": ".publish()",
+      "norm_label": ".publish()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
+      "source_location": "L53"
     },
     {
       "community": 256,
       "file_type": "code",
-      "id": "simple_test_validateinventorywithaggregation",
-      "label": "validateInventoryWithAggregation()",
-      "norm_label": "validateinventorywithaggregation()",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L130"
+      "id": "createremoteassisttransportclient_lazylivekitremoteassistclient_subscribe",
+      "label": ".subscribe()",
+      "norm_label": ".subscribe()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "createremoteassisttransportclient_lazylivekitremoteassistclient_subscribetoconnectionstate",
+      "label": ".subscribeToConnectionState()",
+      "norm_label": ".subscribetoconnectionstate()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
+      "source_location": "L64"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_remote_assist_transport_createremoteassisttransportclient_ts",
+      "label": "createRemoteAssistTransportClient.ts",
+      "norm_label": "createremoteassisttransportclient.ts",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
+      "source_location": "L1"
     },
     {
       "community": 2560,
@@ -218127,92 +218223,92 @@
     {
       "community": 257,
       "file_type": "code",
-      "id": "packages_athena_webapp_vitest_setup_ts",
-      "label": "vitest.setup.ts",
-      "norm_label": "vitest.setup.ts",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "id": "packages_athena_webapp_src_tests_pos_simple_test_ts",
+      "label": "simple.test.ts",
+      "norm_label": "simple.test.ts",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L1"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "vitest_setup_build",
-      "label": "build()",
-      "norm_label": "build()",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L60"
+      "id": "simple_test_addtocart",
+      "label": "addToCart()",
+      "norm_label": "addtocart()",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L249"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "vitest_setup_forward",
-      "label": "forward()",
-      "norm_label": "forward()",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L74"
+      "id": "simple_test_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L173"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "vitest_setup_pointercapturestub",
-      "label": "pointerCaptureStub()",
-      "norm_label": "pointercapturestub()",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L125"
+      "id": "simple_test_formatpaymentmethod",
+      "label": "formatPaymentMethod()",
+      "norm_label": "formatpaymentmethod()",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L201"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "vitest_setup_pointerreleasestub",
-      "label": "pointerReleaseStub()",
-      "norm_label": "pointerreleasestub()",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L126"
+      "id": "simple_test_formatreceiptdate",
+      "label": "formatReceiptDate()",
+      "norm_label": "formatreceiptdate()",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L225"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "vitest_setup_resizeobserverstub",
-      "label": "ResizeObserverStub",
-      "norm_label": "resizeobserverstub",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L100"
+      "id": "simple_test_generatetransactionnumber",
+      "label": "generateTransactionNumber()",
+      "norm_label": "generatetransactionnumber()",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L38"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "vitest_setup_resizeobserverstub_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L101"
+      "id": "simple_test_removefromcart",
+      "label": "removeFromCart()",
+      "norm_label": "removefromcart()",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L288"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "vitest_setup_resizeobserverstub_disconnect",
-      "label": ".disconnect()",
-      "norm_label": ".disconnect()",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L119"
+      "id": "simple_test_updatequantity",
+      "label": "updateQuantity()",
+      "norm_label": "updatequantity()",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L311"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "vitest_setup_resizeobserverstub_observe",
-      "label": ".observe()",
-      "norm_label": ".observe()",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L102"
+      "id": "simple_test_validateinventory",
+      "label": "validateInventory()",
+      "norm_label": "validateinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L77"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "vitest_setup_resizeobserverstub_unobserve",
-      "label": ".unobserve()",
-      "norm_label": ".unobserve()",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L118"
+      "id": "simple_test_validateinventorywithaggregation",
+      "label": "validateInventoryWithAggregation()",
+      "norm_label": "validateinventorywithaggregation()",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L130"
     },
     {
       "community": 2570,
@@ -218307,92 +218403,92 @@
     {
       "community": 258,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_rewards_ts",
-      "label": "rewards.ts",
-      "norm_label": "rewards.ts",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "id": "packages_athena_webapp_vitest_setup_ts",
+      "label": "vitest.setup.ts",
+      "norm_label": "vitest.setup.ts",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
       "source_location": "L1"
     },
     {
       "community": 258,
       "file_type": "code",
-      "id": "rewards_awardpointsforguestorders",
-      "label": "awardPointsForGuestOrders()",
-      "norm_label": "awardpointsforguestorders()",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L198"
+      "id": "vitest_setup_build",
+      "label": "build()",
+      "norm_label": "build()",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L60"
     },
     {
       "community": 258,
       "file_type": "code",
-      "id": "rewards_awardpointsforpastorder",
-      "label": "awardPointsForPastOrder()",
-      "norm_label": "awardpointsforpastorder()",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L151"
+      "id": "vitest_setup_forward",
+      "label": "forward()",
+      "norm_label": "forward()",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L74"
     },
     {
       "community": 258,
       "file_type": "code",
-      "id": "rewards_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L3"
+      "id": "vitest_setup_pointercapturestub",
+      "label": "pointerCaptureStub()",
+      "norm_label": "pointercapturestub()",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L125"
     },
     {
       "community": 258,
       "file_type": "code",
-      "id": "rewards_geteligiblepastorders",
-      "label": "getEligiblePastOrders()",
-      "norm_label": "geteligiblepastorders()",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L129"
+      "id": "vitest_setup_pointerreleasestub",
+      "label": "pointerReleaseStub()",
+      "norm_label": "pointerreleasestub()",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L126"
     },
     {
       "community": 258,
       "file_type": "code",
-      "id": "rewards_getorderrewardpoints",
-      "label": "getOrderRewardPoints()",
-      "norm_label": "getorderrewardpoints()",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L175"
+      "id": "vitest_setup_resizeobserverstub",
+      "label": "ResizeObserverStub",
+      "norm_label": "resizeobserverstub",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L100"
     },
     {
       "community": 258,
       "file_type": "code",
-      "id": "rewards_getpointhistory",
-      "label": "getPointHistory()",
-      "norm_label": "getpointhistory()",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L71"
+      "id": "vitest_setup_resizeobserverstub_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L101"
     },
     {
       "community": 258,
       "file_type": "code",
-      "id": "rewards_getrewardtiers",
-      "label": "getRewardTiers()",
-      "norm_label": "getrewardtiers()",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L90"
+      "id": "vitest_setup_resizeobserverstub_disconnect",
+      "label": ".disconnect()",
+      "norm_label": ".disconnect()",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L119"
     },
     {
       "community": 258,
       "file_type": "code",
-      "id": "rewards_getuserpoints",
-      "label": "getUserPoints()",
-      "norm_label": "getuserpoints()",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L54"
+      "id": "vitest_setup_resizeobserverstub_observe",
+      "label": ".observe()",
+      "norm_label": ".observe()",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L102"
     },
     {
       "community": 258,
       "file_type": "code",
-      "id": "rewards_redeemrewardpoints",
-      "label": "redeemRewardPoints()",
-      "norm_label": "redeemrewardpoints()",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L107"
+      "id": "vitest_setup_resizeobserverstub_unobserve",
+      "label": ".unobserve()",
+      "norm_label": ".unobserve()",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L118"
     },
     {
       "community": 2580,
@@ -218487,92 +218583,92 @@
     {
       "community": 259,
       "file_type": "code",
-      "id": "compound_solution_check_test_architecturesolutionnote",
-      "label": "architectureSolutionNote()",
-      "norm_label": "architecturesolutionnote()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L115"
+      "id": "packages_storefront_webapp_src_api_rewards_ts",
+      "label": "rewards.ts",
+      "norm_label": "rewards.ts",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L1"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "compound_solution_check_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L20"
+      "id": "rewards_awardpointsforguestorders",
+      "label": "awardPointsForGuestOrders()",
+      "norm_label": "awardpointsforguestorders()",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L198"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "compound_solution_check_test_extracttemplateblock",
-      "label": "extractTemplateBlock()",
-      "norm_label": "extracttemplateblock()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L131"
+      "id": "rewards_awardpointsforpastorder",
+      "label": "awardPointsForPastOrder()",
+      "norm_label": "awardpointsforpastorder()",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L151"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "compound_solution_check_test_gitenv",
-      "label": "gitEnv()",
-      "norm_label": "gitenv()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L55"
+      "id": "rewards_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L3"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "compound_solution_check_test_linechanges",
-      "label": "lineChanges()",
-      "norm_label": "linechanges()",
-      "source_file": "scripts/compound-solution-check.test.ts",
+      "id": "rewards_geteligiblepastorders",
+      "label": "getEligiblePastOrders()",
+      "norm_label": "geteligiblepastorders()",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L129"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "rewards_getorderrewardpoints",
+      "label": "getOrderRewardPoints()",
+      "norm_label": "getorderrewardpoints()",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L175"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "rewards_getpointhistory",
+      "label": "getPointHistory()",
+      "norm_label": "getpointhistory()",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L71"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "compound_solution_check_test_nonfoundationalarchitecturesolutionnote",
-      "label": "nonFoundationalArchitectureSolutionNote()",
-      "norm_label": "nonfoundationalarchitecturesolutionnote()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L123"
+      "id": "rewards_getrewardtiers",
+      "label": "getRewardTiers()",
+      "norm_label": "getrewardtiers()",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L90"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "compound_solution_check_test_rungit",
-      "label": "runGit()",
-      "norm_label": "rungit()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L40"
+      "id": "rewards_getuserpoints",
+      "label": "getUserPoints()",
+      "norm_label": "getuserpoints()",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L54"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "compound_solution_check_test_solutionnote",
-      "label": "solutionNote()",
-      "norm_label": "solutionnote()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L80"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "compound_solution_check_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L34"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "scripts_compound_solution_check_test_ts",
-      "label": "compound-solution-check.test.ts",
-      "norm_label": "compound-solution-check.test.ts",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L1"
+      "id": "rewards_redeemrewardpoints",
+      "label": "redeemRewardPoints()",
+      "norm_label": "redeemrewardpoints()",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L107"
     },
     {
       "community": 2590,
@@ -219000,91 +219096,91 @@
     {
       "community": 260,
       "file_type": "code",
-      "id": "frontend_dependency_parity_assertfrontenddependencyparity",
-      "label": "assertFrontendDependencyParity()",
-      "norm_label": "assertfrontenddependencyparity()",
-      "source_file": "scripts/frontend-dependency-parity.ts",
-      "source_location": "L207"
+      "id": "compound_solution_check_test_architecturesolutionnote",
+      "label": "architectureSolutionNote()",
+      "norm_label": "architecturesolutionnote()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L115"
     },
     {
       "community": 260,
       "file_type": "code",
-      "id": "frontend_dependency_parity_checkfrontenddependencyparity",
-      "label": "checkFrontendDependencyParity()",
-      "norm_label": "checkfrontenddependencyparity()",
-      "source_file": "scripts/frontend-dependency-parity.ts",
-      "source_location": "L179"
+      "id": "compound_solution_check_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L20"
     },
     {
       "community": 260,
       "file_type": "code",
-      "id": "frontend_dependency_parity_collectdependencydeclarations",
-      "label": "collectDependencyDeclarations()",
-      "norm_label": "collectdependencydeclarations()",
-      "source_file": "scripts/frontend-dependency-parity.ts",
-      "source_location": "L53"
+      "id": "compound_solution_check_test_extracttemplateblock",
+      "label": "extractTemplateBlock()",
+      "norm_label": "extracttemplateblock()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L131"
     },
     {
       "community": 260,
       "file_type": "code",
-      "id": "frontend_dependency_parity_collectfrontenddependencyfailures",
-      "label": "collectFrontendDependencyFailures()",
-      "norm_label": "collectfrontenddependencyfailures()",
-      "source_file": "scripts/frontend-dependency-parity.ts",
+      "id": "compound_solution_check_test_gitenv",
+      "label": "gitEnv()",
+      "norm_label": "gitenv()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "compound_solution_check_test_linechanges",
+      "label": "lineChanges()",
+      "norm_label": "linechanges()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "compound_solution_check_test_nonfoundationalarchitecturesolutionnote",
+      "label": "nonFoundationalArchitectureSolutionNote()",
+      "norm_label": "nonfoundationalarchitecturesolutionnote()",
+      "source_file": "scripts/compound-solution-check.test.ts",
       "source_location": "L123"
     },
     {
       "community": 260,
       "file_type": "code",
-      "id": "frontend_dependency_parity_formatfailuremessage",
-      "label": "formatFailureMessage()",
-      "norm_label": "formatfailuremessage()",
-      "source_file": "scripts/frontend-dependency-parity.ts",
-      "source_location": "L185"
+      "id": "compound_solution_check_test_rungit",
+      "label": "runGit()",
+      "norm_label": "rungit()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L40"
     },
     {
       "community": 260,
       "file_type": "code",
-      "id": "frontend_dependency_parity_installedversion",
-      "label": "installedVersion()",
-      "norm_label": "installedversion()",
-      "source_file": "scripts/frontend-dependency-parity.ts",
-      "source_location": "L77"
+      "id": "compound_solution_check_test_solutionnote",
+      "label": "solutionNote()",
+      "norm_label": "solutionnote()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L80"
     },
     {
       "community": 260,
       "file_type": "code",
-      "id": "frontend_dependency_parity_readmanifest",
-      "label": "readManifest()",
-      "norm_label": "readmanifest()",
-      "source_file": "scripts/frontend-dependency-parity.ts",
-      "source_location": "L41"
+      "id": "compound_solution_check_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L34"
     },
     {
       "community": 260,
       "file_type": "code",
-      "id": "frontend_dependency_parity_runfrozeninstall",
-      "label": "runFrozenInstall()",
-      "norm_label": "runfrozeninstall()",
-      "source_file": "scripts/frontend-dependency-parity.ts",
-      "source_location": "L191"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "frontend_dependency_parity_satisfiesdeclaredversion",
-      "label": "satisfiesDeclaredVersion()",
-      "norm_label": "satisfiesdeclaredversion()",
-      "source_file": "scripts/frontend-dependency-parity.ts",
-      "source_location": "L111"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "scripts_frontend_dependency_parity_ts",
-      "label": "frontend-dependency-parity.ts",
-      "norm_label": "frontend-dependency-parity.ts",
-      "source_file": "scripts/frontend-dependency-parity.ts",
+      "id": "scripts_compound_solution_check_test_ts",
+      "label": "compound-solution-check.test.ts",
+      "norm_label": "compound-solution-check.test.ts",
+      "source_file": "scripts/compound-solution-check.test.ts",
       "source_location": "L1"
     },
     {
@@ -219180,91 +219276,91 @@
     {
       "community": 261,
       "file_type": "code",
-      "id": "graphify_rebuild_comparedeterministically",
-      "label": "compareDeterministically()",
-      "norm_label": "comparedeterministically()",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L134"
+      "id": "frontend_dependency_parity_assertfrontenddependencyparity",
+      "label": "assertFrontendDependencyParity()",
+      "norm_label": "assertfrontenddependencyparity()",
+      "source_file": "scripts/frontend-dependency-parity.ts",
+      "source_location": "L207"
     },
     {
       "community": 261,
       "file_type": "code",
-      "id": "graphify_rebuild_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L94"
+      "id": "frontend_dependency_parity_checkfrontenddependencyparity",
+      "label": "checkFrontendDependencyParity()",
+      "norm_label": "checkfrontenddependencyparity()",
+      "source_file": "scripts/frontend-dependency-parity.ts",
+      "source_location": "L179"
     },
     {
       "community": 261,
       "file_type": "code",
-      "id": "graphify_rebuild_isjsonobject",
-      "label": "isJsonObject()",
-      "norm_label": "isjsonobject()",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L130"
+      "id": "frontend_dependency_parity_collectdependencydeclarations",
+      "label": "collectDependencyDeclarations()",
+      "norm_label": "collectdependencydeclarations()",
+      "source_file": "scripts/frontend-dependency-parity.ts",
+      "source_location": "L53"
     },
     {
       "community": 261,
       "file_type": "code",
-      "id": "graphify_rebuild_normalizegraphjsonartifact",
-      "label": "normalizeGraphJsonArtifact()",
-      "norm_label": "normalizegraphjsonartifact()",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L184"
+      "id": "frontend_dependency_parity_collectfrontenddependencyfailures",
+      "label": "collectFrontendDependencyFailures()",
+      "norm_label": "collectfrontenddependencyfailures()",
+      "source_file": "scripts/frontend-dependency-parity.ts",
+      "source_location": "L123"
     },
     {
       "community": 261,
       "file_type": "code",
-      "id": "graphify_rebuild_normalizegraphjsoncontents",
-      "label": "normalizeGraphJsonContents()",
-      "norm_label": "normalizegraphjsoncontents()",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L168"
+      "id": "frontend_dependency_parity_formatfailuremessage",
+      "label": "formatFailureMessage()",
+      "norm_label": "formatfailuremessage()",
+      "source_file": "scripts/frontend-dependency-parity.ts",
+      "source_location": "L185"
     },
     {
       "community": 261,
       "file_type": "code",
-      "id": "graphify_rebuild_resolvegraphifypython",
-      "label": "resolveGraphifyPython()",
-      "norm_label": "resolvegraphifypython()",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L103"
+      "id": "frontend_dependency_parity_installedversion",
+      "label": "installedVersion()",
+      "norm_label": "installedversion()",
+      "source_file": "scripts/frontend-dependency-parity.ts",
+      "source_location": "L77"
     },
     {
       "community": 261,
       "file_type": "code",
-      "id": "graphify_rebuild_rungraphifyrebuild",
-      "label": "runGraphifyRebuild()",
-      "norm_label": "rungraphifyrebuild()",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L194"
+      "id": "frontend_dependency_parity_readmanifest",
+      "label": "readManifest()",
+      "norm_label": "readmanifest()",
+      "source_file": "scripts/frontend-dependency-parity.ts",
+      "source_location": "L41"
     },
     {
       "community": 261,
       "file_type": "code",
-      "id": "graphify_rebuild_sortjsonarray",
-      "label": "sortJsonArray()",
-      "norm_label": "sortjsonarray()",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L162"
+      "id": "frontend_dependency_parity_runfrozeninstall",
+      "label": "runFrozenInstall()",
+      "norm_label": "runfrozeninstall()",
+      "source_file": "scripts/frontend-dependency-parity.ts",
+      "source_location": "L191"
     },
     {
       "community": 261,
       "file_type": "code",
-      "id": "graphify_rebuild_sortjsonvalue",
-      "label": "sortJsonValue()",
-      "norm_label": "sortjsonvalue()",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L146"
+      "id": "frontend_dependency_parity_satisfiesdeclaredversion",
+      "label": "satisfiesDeclaredVersion()",
+      "norm_label": "satisfiesdeclaredversion()",
+      "source_file": "scripts/frontend-dependency-parity.ts",
+      "source_location": "L111"
     },
     {
       "community": 261,
       "file_type": "code",
-      "id": "scripts_graphify_rebuild_ts",
-      "label": "graphify-rebuild.ts",
-      "norm_label": "graphify-rebuild.ts",
-      "source_file": "scripts/graphify-rebuild.ts",
+      "id": "scripts_frontend_dependency_parity_ts",
+      "label": "frontend-dependency-parity.ts",
+      "norm_label": "frontend-dependency-parity.ts",
+      "source_file": "scripts/frontend-dependency-parity.ts",
       "source_location": "L1"
     },
     {
@@ -219360,91 +219456,91 @@
     {
       "community": 262,
       "file_type": "code",
-      "id": "harness_delivery_run_ledger_buildpartialdeliveryrunbaseline",
-      "label": "buildPartialDeliveryRunBaseline()",
-      "norm_label": "buildpartialdeliveryrunbaseline()",
-      "source_file": "scripts/harness-delivery-run-ledger.ts",
-      "source_location": "L251"
+      "id": "graphify_rebuild_comparedeterministically",
+      "label": "compareDeterministically()",
+      "norm_label": "comparedeterministically()",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L134"
     },
     {
       "community": 262,
       "file_type": "code",
-      "id": "harness_delivery_run_ledger_countby",
-      "label": "countBy()",
-      "norm_label": "countby()",
-      "source_file": "scripts/harness-delivery-run-ledger.ts",
-      "source_location": "L95"
+      "id": "graphify_rebuild_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L94"
     },
     {
       "community": 262,
       "file_type": "code",
-      "id": "harness_delivery_run_ledger_createdeliveryrunledger",
-      "label": "createDeliveryRunLedger()",
-      "norm_label": "createdeliveryrunledger()",
-      "source_file": "scripts/harness-delivery-run-ledger.ts",
-      "source_location": "L109"
+      "id": "graphify_rebuild_isjsonobject",
+      "label": "isJsonObject()",
+      "norm_label": "isjsonobject()",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L130"
     },
     {
       "community": 262,
       "file_type": "code",
-      "id": "harness_delivery_run_ledger_readdeliveryrunbaseline",
-      "label": "readDeliveryRunBaseline()",
-      "norm_label": "readdeliveryrunbaseline()",
-      "source_file": "scripts/harness-delivery-run-ledger.ts",
-      "source_location": "L244"
+      "id": "graphify_rebuild_normalizegraphjsonartifact",
+      "label": "normalizeGraphJsonArtifact()",
+      "norm_label": "normalizegraphjsonartifact()",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L184"
     },
     {
       "community": 262,
       "file_type": "code",
-      "id": "harness_delivery_run_ledger_readdeliveryrunledger",
-      "label": "readDeliveryRunLedger()",
-      "norm_label": "readdeliveryrunledger()",
-      "source_file": "scripts/harness-delivery-run-ledger.ts",
-      "source_location": "L237"
+      "id": "graphify_rebuild_normalizegraphjsoncontents",
+      "label": "normalizeGraphJsonContents()",
+      "norm_label": "normalizegraphjsoncontents()",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L168"
     },
     {
       "community": 262,
       "file_type": "code",
-      "id": "harness_delivery_run_ledger_readjsonornull",
-      "label": "readJsonOrNull()",
-      "norm_label": "readjsonornull()",
-      "source_file": "scripts/harness-delivery-run-ledger.ts",
-      "source_location": "L191"
+      "id": "graphify_rebuild_resolvegraphifypython",
+      "label": "resolveGraphifyPython()",
+      "norm_label": "resolvegraphifypython()",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L103"
     },
     {
       "community": 262,
       "file_type": "code",
-      "id": "harness_delivery_run_ledger_summarizedeliveryrunbaseline",
-      "label": "summarizeDeliveryRunBaseline()",
-      "norm_label": "summarizedeliveryrunbaseline()",
-      "source_file": "scripts/harness-delivery-run-ledger.ts",
-      "source_location": "L207"
+      "id": "graphify_rebuild_rungraphifyrebuild",
+      "label": "runGraphifyRebuild()",
+      "norm_label": "rungraphifyrebuild()",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L194"
     },
     {
       "community": 262,
       "file_type": "code",
-      "id": "harness_delivery_run_ledger_writedeliveryrunledger",
-      "label": "writeDeliveryRunLedger()",
-      "norm_label": "writedeliveryrunledger()",
-      "source_file": "scripts/harness-delivery-run-ledger.ts",
-      "source_location": "L164"
+      "id": "graphify_rebuild_sortjsonarray",
+      "label": "sortJsonArray()",
+      "norm_label": "sortjsonarray()",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L162"
     },
     {
       "community": 262,
       "file_type": "code",
-      "id": "harness_delivery_run_ledger_writejson",
-      "label": "writeJson()",
-      "norm_label": "writejson()",
-      "source_file": "scripts/harness-delivery-run-ledger.ts",
-      "source_location": "L158"
+      "id": "graphify_rebuild_sortjsonvalue",
+      "label": "sortJsonValue()",
+      "norm_label": "sortjsonvalue()",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L146"
     },
     {
       "community": 262,
       "file_type": "code",
-      "id": "scripts_harness_delivery_run_ledger_ts",
-      "label": "harness-delivery-run-ledger.ts",
-      "norm_label": "harness-delivery-run-ledger.ts",
-      "source_file": "scripts/harness-delivery-run-ledger.ts",
+      "id": "scripts_graphify_rebuild_ts",
+      "label": "graphify-rebuild.ts",
+      "norm_label": "graphify-rebuild.ts",
+      "source_file": "scripts/graphify-rebuild.ts",
       "source_location": "L1"
     },
     {
@@ -219540,83 +219636,92 @@
     {
       "community": 263,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_storeschedule_test_ts",
-      "label": "storeSchedule.test.ts",
-      "norm_label": "storeschedule.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
+      "id": "harness_delivery_run_ledger_buildpartialdeliveryrunbaseline",
+      "label": "buildPartialDeliveryRunBaseline()",
+      "norm_label": "buildpartialdeliveryrunbaseline()",
+      "source_file": "scripts/harness-delivery-run-ledger.ts",
+      "source_location": "L251"
+    },
+    {
+      "community": 263,
+      "file_type": "code",
+      "id": "harness_delivery_run_ledger_countby",
+      "label": "countBy()",
+      "norm_label": "countby()",
+      "source_file": "scripts/harness-delivery-run-ledger.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 263,
+      "file_type": "code",
+      "id": "harness_delivery_run_ledger_createdeliveryrunledger",
+      "label": "createDeliveryRunLedger()",
+      "norm_label": "createdeliveryrunledger()",
+      "source_file": "scripts/harness-delivery-run-ledger.ts",
+      "source_location": "L109"
+    },
+    {
+      "community": 263,
+      "file_type": "code",
+      "id": "harness_delivery_run_ledger_readdeliveryrunbaseline",
+      "label": "readDeliveryRunBaseline()",
+      "norm_label": "readdeliveryrunbaseline()",
+      "source_file": "scripts/harness-delivery-run-ledger.ts",
+      "source_location": "L244"
+    },
+    {
+      "community": 263,
+      "file_type": "code",
+      "id": "harness_delivery_run_ledger_readdeliveryrunledger",
+      "label": "readDeliveryRunLedger()",
+      "norm_label": "readdeliveryrunledger()",
+      "source_file": "scripts/harness-delivery-run-ledger.ts",
+      "source_location": "L237"
+    },
+    {
+      "community": 263,
+      "file_type": "code",
+      "id": "harness_delivery_run_ledger_readjsonornull",
+      "label": "readJsonOrNull()",
+      "norm_label": "readjsonornull()",
+      "source_file": "scripts/harness-delivery-run-ledger.ts",
+      "source_location": "L191"
+    },
+    {
+      "community": 263,
+      "file_type": "code",
+      "id": "harness_delivery_run_ledger_summarizedeliveryrunbaseline",
+      "label": "summarizeDeliveryRunBaseline()",
+      "norm_label": "summarizedeliveryrunbaseline()",
+      "source_file": "scripts/harness-delivery-run-ledger.ts",
+      "source_location": "L207"
+    },
+    {
+      "community": 263,
+      "file_type": "code",
+      "id": "harness_delivery_run_ledger_writedeliveryrunledger",
+      "label": "writeDeliveryRunLedger()",
+      "norm_label": "writedeliveryrunledger()",
+      "source_file": "scripts/harness-delivery-run-ledger.ts",
+      "source_location": "L164"
+    },
+    {
+      "community": 263,
+      "file_type": "code",
+      "id": "harness_delivery_run_ledger_writejson",
+      "label": "writeJson()",
+      "norm_label": "writejson()",
+      "source_file": "scripts/harness-delivery-run-ledger.ts",
+      "source_location": "L158"
+    },
+    {
+      "community": 263,
+      "file_type": "code",
+      "id": "scripts_harness_delivery_run_ledger_ts",
+      "label": "harness-delivery-run-ledger.ts",
+      "norm_label": "harness-delivery-run-ledger.ts",
+      "source_file": "scripts/harness-delivery-run-ledger.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 263,
-      "file_type": "code",
-      "id": "storeschedule_test_baseschedule",
-      "label": "baseSchedule()",
-      "norm_label": "baseschedule()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 263,
-      "file_type": "code",
-      "id": "storeschedule_test_createbackfillctx",
-      "label": "createBackfillCtx()",
-      "norm_label": "createbackfillctx()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
-      "source_location": "L963"
-    },
-    {
-      "community": 263,
-      "file_type": "code",
-      "id": "storeschedule_test_insertversion",
-      "label": "insertVersion()",
-      "norm_label": "insertversion()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
-      "source_location": "L616"
-    },
-    {
-      "community": 263,
-      "file_type": "code",
-      "id": "storeschedule_test_listversions",
-      "label": "listVersions()",
-      "norm_label": "listversions()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
-      "source_location": "L658"
-    },
-    {
-      "community": 263,
-      "file_type": "code",
-      "id": "storeschedule_test_policy",
-      "label": "policy()",
-      "norm_label": "policy()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
-      "source_location": "L945"
-    },
-    {
-      "community": 263,
-      "file_type": "code",
-      "id": "storeschedule_test_readprojectfile",
-      "label": "readProjectFile()",
-      "norm_label": "readprojectfile()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 263,
-      "file_type": "code",
-      "id": "storeschedule_test_resolveat",
-      "label": "resolveAt()",
-      "norm_label": "resolveat()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
-      "source_location": "L649"
-    },
-    {
-      "community": 263,
-      "file_type": "code",
-      "id": "storeschedule_test_seedstore",
-      "label": "seedStore()",
-      "norm_label": "seedstore()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
-      "source_location": "L595"
     },
     {
       "community": 2630,
@@ -219711,83 +219816,83 @@
     {
       "community": 264,
       "file_type": "code",
-      "id": "effects_test_activedeficitledgerseed",
-      "label": "activeDeficitLedgerSeed()",
-      "norm_label": "activedeficitledgerseed()",
-      "source_file": "packages/athena-webapp/convex/inventoryLedger/effects.test.ts",
-      "source_location": "L165"
-    },
-    {
-      "community": 264,
-      "file_type": "code",
-      "id": "effects_test_authoritativedeficitposition",
-      "label": "authoritativeDeficitPosition()",
-      "norm_label": "authoritativedeficitposition()",
-      "source_file": "packages/athena-webapp/convex/inventoryLedger/effects.test.ts",
-      "source_location": "L121"
-    },
-    {
-      "community": 264,
-      "file_type": "code",
-      "id": "effects_test_baseargs",
-      "label": "baseArgs()",
-      "norm_label": "baseargs()",
-      "source_file": "packages/athena-webapp/convex/inventoryLedger/effects.test.ts",
-      "source_location": "L199"
-    },
-    {
-      "community": 264,
-      "file_type": "code",
-      "id": "effects_test_createeffectctx",
-      "label": "createEffectCtx()",
-      "norm_label": "createeffectctx()",
-      "source_file": "packages/athena-webapp/convex/inventoryLedger/effects.test.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 264,
-      "file_type": "code",
-      "id": "effects_test_deficitlotseed",
-      "label": "deficitLotSeed()",
-      "norm_label": "deficitlotseed()",
-      "source_file": "packages/athena-webapp/convex/inventoryLedger/effects.test.ts",
-      "source_location": "L140"
-    },
-    {
-      "community": 264,
-      "file_type": "code",
-      "id": "effects_test_ledgereddeficitlotseed",
-      "label": "ledgeredDeficitLotSeed()",
-      "norm_label": "ledgereddeficitlotseed()",
-      "source_file": "packages/athena-webapp/convex/inventoryLedger/effects.test.ts",
-      "source_location": "L183"
-    },
-    {
-      "community": 264,
-      "file_type": "code",
-      "id": "effects_test_ledgereddeficitposition",
-      "label": "ledgeredDeficitPosition()",
-      "norm_label": "ledgereddeficitposition()",
-      "source_file": "packages/athena-webapp/convex/inventoryLedger/effects.test.ts",
-      "source_location": "L192"
-    },
-    {
-      "community": 264,
-      "file_type": "code",
-      "id": "effects_test_productskuseed",
-      "label": "productSkuSeed()",
-      "norm_label": "productskuseed()",
-      "source_file": "packages/athena-webapp/convex/inventoryLedger/effects.test.ts",
-      "source_location": "L232"
-    },
-    {
-      "community": 264,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventoryledger_effects_test_ts",
-      "label": "effects.test.ts",
-      "norm_label": "effects.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventoryLedger/effects.test.ts",
+      "id": "packages_athena_webapp_convex_inventory_storeschedule_test_ts",
+      "label": "storeSchedule.test.ts",
+      "norm_label": "storeschedule.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 264,
+      "file_type": "code",
+      "id": "storeschedule_test_baseschedule",
+      "label": "baseSchedule()",
+      "norm_label": "baseschedule()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 264,
+      "file_type": "code",
+      "id": "storeschedule_test_createbackfillctx",
+      "label": "createBackfillCtx()",
+      "norm_label": "createbackfillctx()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
+      "source_location": "L963"
+    },
+    {
+      "community": 264,
+      "file_type": "code",
+      "id": "storeschedule_test_insertversion",
+      "label": "insertVersion()",
+      "norm_label": "insertversion()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
+      "source_location": "L616"
+    },
+    {
+      "community": 264,
+      "file_type": "code",
+      "id": "storeschedule_test_listversions",
+      "label": "listVersions()",
+      "norm_label": "listversions()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
+      "source_location": "L658"
+    },
+    {
+      "community": 264,
+      "file_type": "code",
+      "id": "storeschedule_test_policy",
+      "label": "policy()",
+      "norm_label": "policy()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
+      "source_location": "L945"
+    },
+    {
+      "community": 264,
+      "file_type": "code",
+      "id": "storeschedule_test_readprojectfile",
+      "label": "readProjectFile()",
+      "norm_label": "readprojectfile()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 264,
+      "file_type": "code",
+      "id": "storeschedule_test_resolveat",
+      "label": "resolveAt()",
+      "norm_label": "resolveat()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
+      "source_location": "L649"
+    },
+    {
+      "community": 264,
+      "file_type": "code",
+      "id": "storeschedule_test_seedstore",
+      "label": "seedStore()",
+      "norm_label": "seedstore()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
+      "source_location": "L595"
     },
     {
       "community": 2640,
@@ -219882,82 +219987,82 @@
     {
       "community": 265,
       "file_type": "code",
-      "id": "deliverypolicy_classifydeliveryresult",
-      "label": "classifyDeliveryResult()",
-      "norm_label": "classifydeliveryresult()",
-      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.ts",
-      "source_location": "L87"
+      "id": "effects_test_activedeficitledgerseed",
+      "label": "activeDeficitLedgerSeed()",
+      "norm_label": "activedeficitledgerseed()",
+      "source_file": "packages/athena-webapp/convex/inventoryLedger/effects.test.ts",
+      "source_location": "L165"
     },
     {
       "community": 265,
       "file_type": "code",
-      "id": "deliverypolicy_computedeliveryleasems",
-      "label": "computeDeliveryLeaseMs()",
-      "norm_label": "computedeliveryleasems()",
-      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.ts",
-      "source_location": "L59"
+      "id": "effects_test_authoritativedeficitposition",
+      "label": "authoritativeDeficitPosition()",
+      "norm_label": "authoritativedeficitposition()",
+      "source_file": "packages/athena-webapp/convex/inventoryLedger/effects.test.ts",
+      "source_location": "L121"
     },
     {
       "community": 265,
       "file_type": "code",
-      "id": "deliverypolicy_deliverydedupekey",
-      "label": "deliveryDedupeKey()",
-      "norm_label": "deliverydedupekey()",
-      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.ts",
-      "source_location": "L128"
+      "id": "effects_test_baseargs",
+      "label": "baseArgs()",
+      "norm_label": "baseargs()",
+      "source_file": "packages/athena-webapp/convex/inventoryLedger/effects.test.ts",
+      "source_location": "L199"
     },
     {
       "community": 265,
       "file_type": "code",
-      "id": "deliverypolicy_encodekeycomponent",
-      "label": "encodeKeyComponent()",
-      "norm_label": "encodekeycomponent()",
-      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.ts",
-      "source_location": "L120"
+      "id": "effects_test_createeffectctx",
+      "label": "createEffectCtx()",
+      "norm_label": "createeffectctx()",
+      "source_file": "packages/athena-webapp/convex/inventoryLedger/effects.test.ts",
+      "source_location": "L30"
     },
     {
       "community": 265,
       "file_type": "code",
-      "id": "deliverypolicy_joinkeycomponents",
-      "label": "joinKeyComponents()",
-      "norm_label": "joinkeycomponents()",
-      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.ts",
-      "source_location": "L124"
+      "id": "effects_test_deficitlotseed",
+      "label": "deficitLotSeed()",
+      "norm_label": "deficitlotseed()",
+      "source_file": "packages/athena-webapp/convex/inventoryLedger/effects.test.ts",
+      "source_location": "L140"
     },
     {
       "community": 265,
       "file_type": "code",
-      "id": "deliverypolicy_nextbackoffms",
-      "label": "nextBackoffMs()",
-      "norm_label": "nextbackoffms()",
-      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.ts",
-      "source_location": "L82"
+      "id": "effects_test_ledgereddeficitlotseed",
+      "label": "ledgeredDeficitLotSeed()",
+      "norm_label": "ledgereddeficitlotseed()",
+      "source_file": "packages/athena-webapp/convex/inventoryLedger/effects.test.ts",
+      "source_location": "L183"
     },
     {
       "community": 265,
       "file_type": "code",
-      "id": "deliverypolicy_nextdispatchdelayms",
-      "label": "nextDispatchDelayMs()",
-      "norm_label": "nextdispatchdelayms()",
-      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.ts",
-      "source_location": "L49"
+      "id": "effects_test_ledgereddeficitposition",
+      "label": "ledgeredDeficitPosition()",
+      "norm_label": "ledgereddeficitposition()",
+      "source_file": "packages/athena-webapp/convex/inventoryLedger/effects.test.ts",
+      "source_location": "L192"
     },
     {
       "community": 265,
       "file_type": "code",
-      "id": "deliverypolicy_normalizerecipientemail",
-      "label": "normalizeRecipientEmail()",
-      "norm_label": "normalizerecipientemail()",
-      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.ts",
-      "source_location": "L112"
+      "id": "effects_test_productskuseed",
+      "label": "productSkuSeed()",
+      "norm_label": "productskuseed()",
+      "source_file": "packages/athena-webapp/convex/inventoryLedger/effects.test.ts",
+      "source_location": "L232"
     },
     {
       "community": 265,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_notifications_deliverypolicy_ts",
-      "label": "deliveryPolicy.ts",
-      "norm_label": "deliverypolicy.ts",
-      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.ts",
+      "id": "packages_athena_webapp_convex_inventoryledger_effects_test_ts",
+      "label": "effects.test.ts",
+      "norm_label": "effects.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventoryLedger/effects.test.ts",
       "source_location": "L1"
     },
     {
@@ -220053,83 +220158,83 @@
     {
       "community": 266,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operationadmission_readadapters_ts",
-      "label": "readAdapters.ts",
-      "norm_label": "readadapters.ts",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.ts",
+      "id": "deliverypolicy_classifydeliveryresult",
+      "label": "classifyDeliveryResult()",
+      "norm_label": "classifydeliveryresult()",
+      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 266,
+      "file_type": "code",
+      "id": "deliverypolicy_computedeliveryleasems",
+      "label": "computeDeliveryLeaseMs()",
+      "norm_label": "computedeliveryleasems()",
+      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 266,
+      "file_type": "code",
+      "id": "deliverypolicy_deliverydedupekey",
+      "label": "deliveryDedupeKey()",
+      "norm_label": "deliverydedupekey()",
+      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 266,
+      "file_type": "code",
+      "id": "deliverypolicy_encodekeycomponent",
+      "label": "encodeKeyComponent()",
+      "norm_label": "encodekeycomponent()",
+      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.ts",
+      "source_location": "L120"
+    },
+    {
+      "community": 266,
+      "file_type": "code",
+      "id": "deliverypolicy_joinkeycomponents",
+      "label": "joinKeyComponents()",
+      "norm_label": "joinkeycomponents()",
+      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.ts",
+      "source_location": "L124"
+    },
+    {
+      "community": 266,
+      "file_type": "code",
+      "id": "deliverypolicy_nextbackoffms",
+      "label": "nextBackoffMs()",
+      "norm_label": "nextbackoffms()",
+      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.ts",
+      "source_location": "L82"
+    },
+    {
+      "community": 266,
+      "file_type": "code",
+      "id": "deliverypolicy_nextdispatchdelayms",
+      "label": "nextDispatchDelayMs()",
+      "norm_label": "nextdispatchdelayms()",
+      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 266,
+      "file_type": "code",
+      "id": "deliverypolicy_normalizerecipientemail",
+      "label": "normalizeRecipientEmail()",
+      "norm_label": "normalizerecipientemail()",
+      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.ts",
+      "source_location": "L112"
+    },
+    {
+      "community": 266,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_notifications_deliverypolicy_ts",
+      "label": "deliveryPolicy.ts",
+      "norm_label": "deliverypolicy.ts",
+      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 266,
-      "file_type": "code",
-      "id": "readadapters_createnormaluserreadoperationadapter",
-      "label": "createNormalUserReadOperationAdapter()",
-      "norm_label": "createnormaluserreadoperationadapter()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 266,
-      "file_type": "code",
-      "id": "readadapters_createpublicreadoperationadapter",
-      "label": "createPublicReadOperationAdapter()",
-      "norm_label": "createpublicreadoperationadapter()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 266,
-      "file_type": "code",
-      "id": "readadapters_createshareddemoreadoperationadapter",
-      "label": "createSharedDemoReadOperationAdapter()",
-      "norm_label": "createshareddemoreadoperationadapter()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 266,
-      "file_type": "code",
-      "id": "readadapters_isadmitted",
-      "label": "isAdmitted()",
-      "norm_label": "isadmitted()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.ts",
-      "source_location": "L177"
-    },
-    {
-      "community": 266,
-      "file_type": "code",
-      "id": "readadapters_isrecognizedshareddemoactorerror",
-      "label": "isRecognizedSharedDemoActorError()",
-      "norm_label": "isrecognizedshareddemoactorerror()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.ts",
-      "source_location": "L183"
-    },
-    {
-      "community": 266,
-      "file_type": "code",
-      "id": "readadapters_resolvereadoperationadmission",
-      "label": "resolveReadOperationAdmission()",
-      "norm_label": "resolvereadoperationadmission()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.ts",
-      "source_location": "L118"
-    },
-    {
-      "community": 266,
-      "file_type": "code",
-      "id": "readadapters_shareddemoreaddenialerror",
-      "label": "sharedDemoReadDenialError()",
-      "norm_label": "shareddemoreaddenialerror()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.ts",
-      "source_location": "L202"
-    },
-    {
-      "community": 266,
-      "file_type": "code",
-      "id": "readadapters_shareddemoreaddenied",
-      "label": "sharedDemoReadDenied()",
-      "norm_label": "shareddemoreaddenied()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.ts",
-      "source_location": "L191"
     },
     {
       "community": 2660,
@@ -220224,83 +220329,83 @@
     {
       "community": 267,
       "file_type": "code",
-      "id": "managerelevations_assertactiveterminal",
-      "label": "assertActiveTerminal()",
-      "norm_label": "assertactiveterminal()",
-      "source_file": "packages/athena-webapp/convex/operations/managerElevations.ts",
+      "id": "packages_athena_webapp_convex_operationadmission_readadapters_ts",
+      "label": "readAdapters.ts",
+      "norm_label": "readadapters.ts",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 267,
+      "file_type": "code",
+      "id": "readadapters_createnormaluserreadoperationadapter",
+      "label": "createNormalUserReadOperationAdapter()",
+      "norm_label": "createnormaluserreadoperationadapter()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 267,
+      "file_type": "code",
+      "id": "readadapters_createpublicreadoperationadapter",
+      "label": "createPublicReadOperationAdapter()",
+      "norm_label": "createpublicreadoperationadapter()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.ts",
       "source_location": "L45"
     },
     {
       "community": 267,
       "file_type": "code",
-      "id": "managerelevations_endmanagerelevationwithctx",
-      "label": "endManagerElevationWithCtx()",
-      "norm_label": "endmanagerelevationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/managerElevations.ts",
-      "source_location": "L286"
+      "id": "readadapters_createshareddemoreadoperationadapter",
+      "label": "createSharedDemoReadOperationAdapter()",
+      "norm_label": "createshareddemoreadoperationadapter()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.ts",
+      "source_location": "L67"
     },
     {
       "community": 267,
       "file_type": "code",
-      "id": "managerelevations_getactivemanagerelevationbyidwithctx",
-      "label": "getActiveManagerElevationByIdWithCtx()",
-      "norm_label": "getactivemanagerelevationbyidwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/managerElevations.ts",
-      "source_location": "L165"
+      "id": "readadapters_isadmitted",
+      "label": "isAdmitted()",
+      "norm_label": "isadmitted()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.ts",
+      "source_location": "L177"
     },
     {
       "community": 267,
       "file_type": "code",
-      "id": "managerelevations_getactivemanagerelevationwithctx",
-      "label": "getActiveManagerElevationWithCtx()",
-      "norm_label": "getactivemanagerelevationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/managerElevations.ts",
-      "source_location": "L145"
+      "id": "readadapters_isrecognizedshareddemoactorerror",
+      "label": "isRecognizedSharedDemoActorError()",
+      "norm_label": "isrecognizedshareddemoactorerror()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.ts",
+      "source_location": "L183"
     },
     {
       "community": 267,
       "file_type": "code",
-      "id": "managerelevations_getcandidateelevations",
-      "label": "getCandidateElevations()",
-      "norm_label": "getcandidateelevations()",
-      "source_file": "packages/athena-webapp/convex/operations/managerElevations.ts",
-      "source_location": "L68"
+      "id": "readadapters_resolvereadoperationadmission",
+      "label": "resolveReadOperationAdmission()",
+      "norm_label": "resolvereadoperationadmission()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.ts",
+      "source_location": "L118"
     },
     {
       "community": 267,
       "file_type": "code",
-      "id": "managerelevations_getstaffdisplayname",
-      "label": "getStaffDisplayName()",
-      "norm_label": "getstaffdisplayname()",
-      "source_file": "packages/athena-webapp/convex/operations/managerElevations.ts",
-      "source_location": "L37"
+      "id": "readadapters_shareddemoreaddenialerror",
+      "label": "sharedDemoReadDenialError()",
+      "norm_label": "shareddemoreaddenialerror()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.ts",
+      "source_location": "L202"
     },
     {
       "community": 267,
       "file_type": "code",
-      "id": "managerelevations_startmanagerelevationwithctx",
-      "label": "startManagerElevationWithCtx()",
-      "norm_label": "startmanagerelevationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/managerElevations.ts",
-      "source_location": "L188"
-    },
-    {
-      "community": 267,
-      "file_type": "code",
-      "id": "managerelevations_toactiveelevation",
-      "label": "toActiveElevation()",
-      "norm_label": "toactiveelevation()",
-      "source_file": "packages/athena-webapp/convex/operations/managerElevations.ts",
-      "source_location": "L87"
-    },
-    {
-      "community": 267,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_managerelevations_ts",
-      "label": "managerElevations.ts",
-      "norm_label": "managerelevations.ts",
-      "source_file": "packages/athena-webapp/convex/operations/managerElevations.ts",
-      "source_location": "L1"
+      "id": "readadapters_shareddemoreaddenied",
+      "label": "sharedDemoReadDenied()",
+      "norm_label": "shareddemoreaddenied()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.ts",
+      "source_location": "L191"
     },
     {
       "community": 2670,
@@ -220395,83 +220500,83 @@
     {
       "community": 268,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_registercloseoutvarianceemail_ts",
-      "label": "registerCloseoutVarianceEmail.ts",
-      "norm_label": "registercloseoutvarianceemail.ts",
-      "source_file": "packages/athena-webapp/convex/operations/registerCloseoutVarianceEmail.ts",
+      "id": "managerelevations_assertactiveterminal",
+      "label": "assertActiveTerminal()",
+      "norm_label": "assertactiveterminal()",
+      "source_file": "packages/athena-webapp/convex/operations/managerElevations.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 268,
+      "file_type": "code",
+      "id": "managerelevations_endmanagerelevationwithctx",
+      "label": "endManagerElevationWithCtx()",
+      "norm_label": "endmanagerelevationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/managerElevations.ts",
+      "source_location": "L286"
+    },
+    {
+      "community": 268,
+      "file_type": "code",
+      "id": "managerelevations_getactivemanagerelevationbyidwithctx",
+      "label": "getActiveManagerElevationByIdWithCtx()",
+      "norm_label": "getactivemanagerelevationbyidwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/managerElevations.ts",
+      "source_location": "L165"
+    },
+    {
+      "community": 268,
+      "file_type": "code",
+      "id": "managerelevations_getactivemanagerelevationwithctx",
+      "label": "getActiveManagerElevationWithCtx()",
+      "norm_label": "getactivemanagerelevationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/managerElevations.ts",
+      "source_location": "L145"
+    },
+    {
+      "community": 268,
+      "file_type": "code",
+      "id": "managerelevations_getcandidateelevations",
+      "label": "getCandidateElevations()",
+      "norm_label": "getcandidateelevations()",
+      "source_file": "packages/athena-webapp/convex/operations/managerElevations.ts",
+      "source_location": "L68"
+    },
+    {
+      "community": 268,
+      "file_type": "code",
+      "id": "managerelevations_getstaffdisplayname",
+      "label": "getStaffDisplayName()",
+      "norm_label": "getstaffdisplayname()",
+      "source_file": "packages/athena-webapp/convex/operations/managerElevations.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 268,
+      "file_type": "code",
+      "id": "managerelevations_startmanagerelevationwithctx",
+      "label": "startManagerElevationWithCtx()",
+      "norm_label": "startmanagerelevationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/managerElevations.ts",
+      "source_location": "L188"
+    },
+    {
+      "community": 268,
+      "file_type": "code",
+      "id": "managerelevations_toactiveelevation",
+      "label": "toActiveElevation()",
+      "norm_label": "toactiveelevation()",
+      "source_file": "packages/athena-webapp/convex/operations/managerElevations.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 268,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_managerelevations_ts",
+      "label": "managerElevations.ts",
+      "norm_label": "managerelevations.ts",
+      "source_file": "packages/athena-webapp/convex/operations/managerElevations.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 268,
-      "file_type": "code",
-      "id": "registercloseoutvarianceemail_amountfrommetadata",
-      "label": "amountFromMetadata()",
-      "norm_label": "amountfrommetadata()",
-      "source_file": "packages/athena-webapp/convex/operations/registerCloseoutVarianceEmail.ts",
-      "source_location": "L244"
-    },
-    {
-      "community": 268,
-      "file_type": "code",
-      "id": "registercloseoutvarianceemail_buildregisterreviewurl",
-      "label": "buildRegisterReviewUrl()",
-      "norm_label": "buildregisterreviewurl()",
-      "source_file": "packages/athena-webapp/convex/operations/registerCloseoutVarianceEmail.ts",
-      "source_location": "L295"
-    },
-    {
-      "community": 268,
-      "file_type": "code",
-      "id": "registercloseoutvarianceemail_formatoperatingdate",
-      "label": "formatOperatingDate()",
-      "norm_label": "formatoperatingdate()",
-      "source_file": "packages/athena-webapp/convex/operations/registerCloseoutVarianceEmail.ts",
-      "source_location": "L282"
-    },
-    {
-      "community": 268,
-      "file_type": "code",
-      "id": "registercloseoutvarianceemail_formatregistercloseoutvariancealertoperatingdate",
-      "label": "formatRegisterCloseoutVarianceAlertOperatingDate()",
-      "norm_label": "formatregistercloseoutvariancealertoperatingdate()",
-      "source_file": "packages/athena-webapp/convex/operations/registerCloseoutVarianceEmail.ts",
-      "source_location": "L207"
-    },
-    {
-      "community": 268,
-      "file_type": "code",
-      "id": "registercloseoutvarianceemail_formatregistercloseoutvariancealertreason",
-      "label": "formatRegisterCloseoutVarianceAlertReason()",
-      "norm_label": "formatregistercloseoutvariancealertreason()",
-      "source_file": "packages/athena-webapp/convex/operations/registerCloseoutVarianceEmail.ts",
-      "source_location": "L196"
-    },
-    {
-      "community": 268,
-      "file_type": "code",
-      "id": "registercloseoutvarianceemail_formatregisterlabel",
-      "label": "formatRegisterLabel()",
-      "norm_label": "formatregisterlabel()",
-      "source_file": "packages/athena-webapp/convex/operations/registerCloseoutVarianceEmail.ts",
-      "source_location": "L252"
-    },
-    {
-      "community": 268,
-      "file_type": "code",
-      "id": "registercloseoutvarianceemail_formatsubmittedat",
-      "label": "formatSubmittedAt()",
-      "norm_label": "formatsubmittedat()",
-      "source_file": "packages/athena-webapp/convex/operations/registerCloseoutVarianceEmail.ts",
-      "source_location": "L268"
-    },
-    {
-      "community": 268,
-      "file_type": "code",
-      "id": "registercloseoutvarianceemail_readcloseoutvariancemetadata",
-      "label": "readCloseoutVarianceMetadata()",
-      "norm_label": "readcloseoutvariancemetadata()",
-      "source_file": "packages/athena-webapp/convex/operations/registerCloseoutVarianceEmail.ts",
-      "source_location": "L219"
     },
     {
       "community": 2680,
@@ -220512,83 +220617,83 @@
     {
       "community": 269,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_pendingcheckoutskuresolution_ts",
-      "label": "pendingCheckoutSkuResolution.ts",
-      "norm_label": "pendingcheckoutskuresolution.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/pendingCheckoutSkuResolution.ts",
+      "id": "packages_athena_webapp_convex_operations_registercloseoutvarianceemail_ts",
+      "label": "registerCloseoutVarianceEmail.ts",
+      "norm_label": "registercloseoutvarianceemail.ts",
+      "source_file": "packages/athena-webapp/convex/operations/registerCloseoutVarianceEmail.ts",
       "source_location": "L1"
     },
     {
       "community": 269,
       "file_type": "code",
-      "id": "pendingcheckoutskuresolution_findactivependingcheckoutlookupaliasbycode",
-      "label": "findActivePendingCheckoutLookupAliasByCode()",
-      "norm_label": "findactivependingcheckoutlookupaliasbycode()",
-      "source_file": "packages/athena-webapp/convex/pos/application/pendingCheckoutSkuResolution.ts",
-      "source_location": "L193"
+      "id": "registercloseoutvarianceemail_amountfrommetadata",
+      "label": "amountFromMetadata()",
+      "norm_label": "amountfrommetadata()",
+      "source_file": "packages/athena-webapp/convex/operations/registerCloseoutVarianceEmail.ts",
+      "source_location": "L244"
     },
     {
       "community": 269,
       "file_type": "code",
-      "id": "pendingcheckoutskuresolution_firstevidencetime",
-      "label": "firstEvidenceTime()",
-      "norm_label": "firstevidencetime()",
-      "source_file": "packages/athena-webapp/convex/pos/application/pendingCheckoutSkuResolution.ts",
-      "source_location": "L49"
+      "id": "registercloseoutvarianceemail_buildregisterreviewurl",
+      "label": "buildRegisterReviewUrl()",
+      "norm_label": "buildregisterreviewurl()",
+      "source_file": "packages/athena-webapp/convex/operations/registerCloseoutVarianceEmail.ts",
+      "source_location": "L295"
     },
     {
       "community": 269,
       "file_type": "code",
-      "id": "pendingcheckoutskuresolution_haspendingcheckouttransactionattribution",
-      "label": "hasPendingCheckoutTransactionAttribution()",
-      "norm_label": "haspendingcheckouttransactionattribution()",
-      "source_file": "packages/athena-webapp/convex/pos/application/pendingCheckoutSkuResolution.ts",
-      "source_location": "L53"
+      "id": "registercloseoutvarianceemail_formatoperatingdate",
+      "label": "formatOperatingDate()",
+      "norm_label": "formatoperatingdate()",
+      "source_file": "packages/athena-webapp/convex/operations/registerCloseoutVarianceEmail.ts",
+      "source_location": "L282"
     },
     {
       "community": 269,
       "file_type": "code",
-      "id": "pendingcheckoutskuresolution_normalizependingcheckoutlookupcode",
-      "label": "normalizePendingCheckoutLookupCode()",
-      "norm_label": "normalizependingcheckoutlookupcode()",
-      "source_file": "packages/athena-webapp/convex/pos/application/pendingCheckoutSkuResolution.ts",
-      "source_location": "L44"
+      "id": "registercloseoutvarianceemail_formatregistercloseoutvariancealertoperatingdate",
+      "label": "formatRegisterCloseoutVarianceAlertOperatingDate()",
+      "norm_label": "formatregistercloseoutvariancealertoperatingdate()",
+      "source_file": "packages/athena-webapp/convex/operations/registerCloseoutVarianceEmail.ts",
+      "source_location": "L207"
     },
     {
       "community": 269,
       "file_type": "code",
-      "id": "pendingcheckoutskuresolution_resolvependingcheckoutsku",
-      "label": "resolvePendingCheckoutSku()",
-      "norm_label": "resolvependingcheckoutsku()",
-      "source_file": "packages/athena-webapp/convex/pos/application/pendingCheckoutSkuResolution.ts",
-      "source_location": "L67"
+      "id": "registercloseoutvarianceemail_formatregistercloseoutvariancealertreason",
+      "label": "formatRegisterCloseoutVarianceAlertReason()",
+      "norm_label": "formatregistercloseoutvariancealertreason()",
+      "source_file": "packages/athena-webapp/convex/operations/registerCloseoutVarianceEmail.ts",
+      "source_location": "L196"
     },
     {
       "community": 269,
       "file_type": "code",
-      "id": "pendingcheckoutskuresolution_resolvependingcheckoutskufromitem",
-      "label": "resolvePendingCheckoutSkuFromItem()",
-      "norm_label": "resolvependingcheckoutskufromitem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/pendingCheckoutSkuResolution.ts",
-      "source_location": "L93"
+      "id": "registercloseoutvarianceemail_formatregisterlabel",
+      "label": "formatRegisterLabel()",
+      "norm_label": "formatregisterlabel()",
+      "source_file": "packages/athena-webapp/convex/operations/registerCloseoutVarianceEmail.ts",
+      "source_location": "L252"
     },
     {
       "community": 269,
       "file_type": "code",
-      "id": "pendingcheckoutskuresolution_retirependingcheckoutlookupaliasforitem",
-      "label": "retirePendingCheckoutLookupAliasForItem()",
-      "norm_label": "retirependingcheckoutlookupaliasforitem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/pendingCheckoutSkuResolution.ts",
-      "source_location": "L271"
+      "id": "registercloseoutvarianceemail_formatsubmittedat",
+      "label": "formatSubmittedAt()",
+      "norm_label": "formatsubmittedat()",
+      "source_file": "packages/athena-webapp/convex/operations/registerCloseoutVarianceEmail.ts",
+      "source_location": "L268"
     },
     {
       "community": 269,
       "file_type": "code",
-      "id": "pendingcheckoutskuresolution_upsertpendingcheckoutlookupalias",
-      "label": "upsertPendingCheckoutLookupAlias()",
-      "norm_label": "upsertpendingcheckoutlookupalias()",
-      "source_file": "packages/athena-webapp/convex/pos/application/pendingCheckoutSkuResolution.ts",
-      "source_location": "L218"
+      "id": "registercloseoutvarianceemail_readcloseoutvariancemetadata",
+      "label": "readCloseoutVarianceMetadata()",
+      "norm_label": "readcloseoutvariancemetadata()",
+      "source_file": "packages/athena-webapp/convex/operations/registerCloseoutVarianceEmail.ts",
+      "source_location": "L219"
     },
     {
       "community": 27,
@@ -220926,6 +221031,87 @@
     {
       "community": 270,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_pendingcheckoutskuresolution_ts",
+      "label": "pendingCheckoutSkuResolution.ts",
+      "norm_label": "pendingcheckoutskuresolution.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/pendingCheckoutSkuResolution.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "pendingcheckoutskuresolution_findactivependingcheckoutlookupaliasbycode",
+      "label": "findActivePendingCheckoutLookupAliasByCode()",
+      "norm_label": "findactivependingcheckoutlookupaliasbycode()",
+      "source_file": "packages/athena-webapp/convex/pos/application/pendingCheckoutSkuResolution.ts",
+      "source_location": "L193"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "pendingcheckoutskuresolution_firstevidencetime",
+      "label": "firstEvidenceTime()",
+      "norm_label": "firstevidencetime()",
+      "source_file": "packages/athena-webapp/convex/pos/application/pendingCheckoutSkuResolution.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "pendingcheckoutskuresolution_haspendingcheckouttransactionattribution",
+      "label": "hasPendingCheckoutTransactionAttribution()",
+      "norm_label": "haspendingcheckouttransactionattribution()",
+      "source_file": "packages/athena-webapp/convex/pos/application/pendingCheckoutSkuResolution.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "pendingcheckoutskuresolution_normalizependingcheckoutlookupcode",
+      "label": "normalizePendingCheckoutLookupCode()",
+      "norm_label": "normalizependingcheckoutlookupcode()",
+      "source_file": "packages/athena-webapp/convex/pos/application/pendingCheckoutSkuResolution.ts",
+      "source_location": "L44"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "pendingcheckoutskuresolution_resolvependingcheckoutsku",
+      "label": "resolvePendingCheckoutSku()",
+      "norm_label": "resolvependingcheckoutsku()",
+      "source_file": "packages/athena-webapp/convex/pos/application/pendingCheckoutSkuResolution.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "pendingcheckoutskuresolution_resolvependingcheckoutskufromitem",
+      "label": "resolvePendingCheckoutSkuFromItem()",
+      "norm_label": "resolvependingcheckoutskufromitem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/pendingCheckoutSkuResolution.ts",
+      "source_location": "L93"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "pendingcheckoutskuresolution_retirependingcheckoutlookupaliasforitem",
+      "label": "retirePendingCheckoutLookupAliasForItem()",
+      "norm_label": "retirependingcheckoutlookupaliasforitem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/pendingCheckoutSkuResolution.ts",
+      "source_location": "L271"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "pendingcheckoutskuresolution_upsertpendingcheckoutlookupalias",
+      "label": "upsertPendingCheckoutLookupAlias()",
+      "norm_label": "upsertpendingcheckoutlookupalias()",
+      "source_file": "packages/athena-webapp/convex/pos/application/pendingCheckoutSkuResolution.ts",
+      "source_location": "L218"
+    },
+    {
+      "community": 271,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_searchcatalog_ts",
       "label": "searchCatalog.ts",
       "norm_label": "searchcatalog.ts",
@@ -220933,7 +221119,7 @@
       "source_location": "L1"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "searchcatalog_gettrustedcatalogprice",
       "label": "getTrustedCatalogPrice()",
@@ -220942,7 +221128,7 @@
       "source_location": "L69"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "searchcatalog_isdraftallowedintrustedcatalog",
       "label": "isDraftAllowedInTrustedCatalog()",
@@ -220951,7 +221137,7 @@
       "source_location": "L45"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "searchcatalog_ispendingcheckoutlookupaliasvisible",
       "label": "isPendingCheckoutLookupAliasVisible()",
@@ -220960,7 +221146,7 @@
       "source_location": "L96"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "searchcatalog_issuppressedbyactivelegacyimportprovisionalrow",
       "label": "isSuppressedByActiveLegacyImportProvisionalRow()",
@@ -220969,7 +221155,7 @@
       "source_location": "L73"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "searchcatalog_istrustedcatalogresult",
       "label": "isTrustedCatalogResult()",
@@ -220978,7 +221164,7 @@
       "source_location": "L51"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "searchcatalog_lookupbybarcode",
       "label": "lookupByBarcode()",
@@ -220987,7 +221173,7 @@
       "source_location": "L317"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "searchcatalog_mapskutocatalogresult",
       "label": "mapSkuToCatalogResult()",
@@ -220996,7 +221182,7 @@
       "source_location": "L137"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "searchcatalog_searchproducts",
       "label": "searchProducts()",
@@ -221005,7 +221191,7 @@
       "source_location": "L189"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "collectterminaloperationalfacts_test_buildquery",
       "label": "buildQuery()",
@@ -221014,7 +221200,7 @@
       "source_location": "L328"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "collectterminaloperationalfacts_test_buildqueryctx",
       "label": "buildQueryCtx()",
@@ -221023,7 +221209,7 @@
       "source_location": "L157"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "collectterminaloperationalfacts_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -221032,7 +221218,7 @@
       "source_location": "L236"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "collectterminaloperationalfacts_test_buildruntimestatus",
       "label": "buildRuntimeStatus()",
@@ -221041,7 +221227,7 @@
       "source_location": "L194"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "collectterminaloperationalfacts_test_buildsyncconflict",
       "label": "buildSyncConflict()",
@@ -221050,7 +221236,7 @@
       "source_location": "L278"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "collectterminaloperationalfacts_test_buildsyncevent",
       "label": "buildSyncEvent()",
@@ -221059,7 +221245,7 @@
       "source_location": "L255"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "collectterminaloperationalfacts_test_buildterminal",
       "label": "buildTerminal()",
@@ -221068,7 +221254,7 @@
       "source_location": "L174"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "collectterminaloperationalfacts_test_emptysyncevidence",
       "label": "emptySyncEvidence()",
@@ -221077,7 +221263,7 @@
       "source_location": "L299"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminaloperationalstate_collectterminaloperationalfacts_test_ts",
       "label": "collectTerminalOperationalFacts.test.ts",
@@ -221086,7 +221272,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_terminalrepository_test_ts",
       "label": "terminalRepository.test.ts",
@@ -221095,7 +221281,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "terminalrepository_test_buildctx",
       "label": "buildCtx()",
@@ -221104,7 +221290,7 @@
       "source_location": "L1386"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "terminalrepository_test_buildoperationalworkitem",
       "label": "buildOperationalWorkItem()",
@@ -221113,7 +221299,7 @@
       "source_location": "L1569"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "terminalrepository_test_buildquery",
       "label": "buildQuery()",
@@ -221122,7 +221308,7 @@
       "source_location": "L1418"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "terminalrepository_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -221131,7 +221317,7 @@
       "source_location": "L1493"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "terminalrepository_test_buildruntimestatus",
       "label": "buildRuntimeStatus()",
@@ -221140,7 +221326,7 @@
       "source_location": "L1462"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "terminalrepository_test_buildsyncconflict",
       "label": "buildSyncConflict()",
@@ -221149,7 +221335,7 @@
       "source_location": "L1549"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "terminalrepository_test_buildsyncevent",
       "label": "buildSyncEvent()",
@@ -221158,7 +221344,7 @@
       "source_location": "L1511"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "terminalrepository_test_buildsyncmapping",
       "label": "buildSyncMapping()",
@@ -221167,7 +221353,7 @@
       "source_location": "L1530"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_reseedtestsupport_ts",
       "label": "reseedTestSupport.ts",
@@ -221176,7 +221362,7 @@
       "source_location": "L1"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "reseedtestsupport_seeddailyclose",
       "label": "seedDailyClose()",
@@ -221185,7 +221371,7 @@
       "source_location": "L385"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "reseedtestsupport_seedonlineorder",
       "label": "seedOnlineOrder()",
@@ -221194,7 +221380,7 @@
       "source_location": "L205"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "reseedtestsupport_seedpaymentallocation",
       "label": "seedPaymentAllocation()",
@@ -221203,7 +221389,7 @@
       "source_location": "L299"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "reseedtestsupport_seedposcorrection",
       "label": "seedPosCorrection()",
@@ -221212,7 +221398,7 @@
       "source_location": "L150"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "reseedtestsupport_seedpossale",
       "label": "seedPosSale()",
@@ -221221,7 +221407,7 @@
       "source_location": "L97"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "reseedtestsupport_seedreceivingbatch",
       "label": "seedReceivingBatch()",
@@ -221230,7 +221416,7 @@
       "source_location": "L419"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "reseedtestsupport_seedservicecase",
       "label": "seedServiceCase()",
@@ -221239,7 +221425,7 @@
       "source_location": "L327"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "reseedtestsupport_seedstore",
       "label": "seedStore()",
@@ -221248,7 +221434,7 @@
       "source_location": "L29"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_servicecasetracing_ts",
       "label": "serviceCaseTracing.ts",
@@ -221257,7 +221443,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "servicecasetracing_buildactorrefs",
       "label": "buildActorRefs()",
@@ -221266,7 +221452,7 @@
       "source_location": "L99"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "servicecasetracing_buildeventkey",
       "label": "buildEventKey()",
@@ -221275,7 +221461,7 @@
       "source_location": "L171"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "servicecasetracing_buildlookuprefs",
       "label": "buildLookupRefs()",
@@ -221284,7 +221470,7 @@
       "source_location": "L112"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "servicecasetracing_buildtraceevent",
       "label": "buildTraceEvent()",
@@ -221293,7 +221479,7 @@
       "source_location": "L212"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "servicecasetracing_buildtracerecord",
       "label": "buildTraceRecord()",
@@ -221302,7 +221488,7 @@
       "source_location": "L137"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "servicecasetracing_recordservicecasetracebesteffort",
       "label": "recordServiceCaseTraceBestEffort()",
@@ -221311,7 +221497,7 @@
       "source_location": "L385"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "servicecasetracing_resolveoccurredat",
       "label": "resolveOccurredAt()",
@@ -221320,7 +221506,7 @@
       "source_location": "L80"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "servicecasetracing_safetracewrite",
       "label": "safeTraceWrite()",
@@ -221329,7 +221515,7 @@
       "source_location": "L74"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "customerobservabilitytimelinedata_buildcustomerobservabilitytimeline",
       "label": "buildCustomerObservabilityTimeline()",
@@ -221338,7 +221524,7 @@
       "source_location": "L206"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "customerobservabilitytimelinedata_getnonemptystring",
       "label": "getNonEmptyString()",
@@ -221347,7 +221533,7 @@
       "source_location": "L84"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "customerobservabilitytimelinedata_getoperationaleventjourney",
       "label": "getOperationalEventJourney()",
@@ -221356,7 +221542,7 @@
       "source_location": "L98"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "customerobservabilitytimelinedata_getoperationaleventstatus",
       "label": "getOperationalEventStatus()",
@@ -221365,7 +221551,7 @@
       "source_location": "L116"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "customerobservabilitytimelinedata_getoperationaleventstep",
       "label": "getOperationalEventStep()",
@@ -221374,7 +221560,7 @@
       "source_location": "L102"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "customerobservabilitytimelinedata_isfailurestatus",
       "label": "isFailureStatus()",
@@ -221383,7 +221569,7 @@
       "source_location": "L88"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "customerobservabilitytimelinedata_isoperationaleventdoc",
       "label": "isOperationalEventDoc()",
@@ -221392,7 +221578,7 @@
       "source_location": "L92"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "customerobservabilitytimelinedata_normalizeevent",
       "label": "normalizeEvent()",
@@ -221401,7 +221587,7 @@
       "source_location": "L130"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimelinedata_ts",
       "label": "customerObservabilityTimelineData.ts",
@@ -221410,7 +221596,7 @@
       "source_location": "L1"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "expensereportsview_expensereportmobilecard",
       "label": "ExpenseReportMobileCard()",
@@ -221419,7 +221605,7 @@
       "source_location": "L101"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "expensereportsview_getexpensereporttimefilter",
       "label": "getExpenseReportTimeFilter()",
@@ -221428,7 +221614,7 @@
       "source_location": "L53"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "expensereportsview_getnextexpensereportfiltersearch",
       "label": "getNextExpenseReportFilterSearch()",
@@ -221437,7 +221623,7 @@
       "source_location": "L91"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "expensereportsview_getnextexpensereportpagesearch",
       "label": "getNextExpenseReportPageSearch()",
@@ -221446,7 +221632,7 @@
       "source_location": "L75"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "expensereportsview_getpageindexfromsearch",
       "label": "getPageIndexFromSearch()",
@@ -221455,7 +221641,7 @@
       "source_location": "L47"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "expensereportsview_getstartofoperatingdate",
       "label": "getStartOfOperatingDate()",
@@ -221464,7 +221650,7 @@
       "source_location": "L29"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "expensereportsview_isonoperatingdate",
       "label": "isOnOperatingDate()",
@@ -221473,7 +221659,7 @@
       "source_location": "L37"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "expensereportsview_istoday",
       "label": "isToday()",
@@ -221482,7 +221668,7 @@
       "source_location": "L23"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
       "label": "ExpenseReportsView.tsx",
@@ -221491,7 +221677,7 @@
       "source_location": "L1"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
       "label": "POSRegisterView.tsx",
@@ -221500,7 +221686,7 @@
       "source_location": "L1"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "posregisterview_cn",
       "label": "cn()",
@@ -221509,7 +221695,7 @@
       "source_location": "L578"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "posregisterview_handlecmdk",
       "label": "handleCmdK()",
@@ -221518,7 +221704,7 @@
       "source_location": "L2146"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "posregisterview_handlekeydown",
       "label": "handleKeyDown()",
@@ -221527,7 +221713,7 @@
       "source_location": "L835"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "posregisterview_handleretry",
       "label": "handleRetry()",
@@ -221536,7 +221722,7 @@
       "source_location": "L1653"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "posregisterview_if",
       "label": "if()",
@@ -221545,7 +221731,7 @@
       "source_location": "L781"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "posregisterview_isdebugshortcut",
       "label": "isDebugShortcut()",
@@ -221554,7 +221740,7 @@
       "source_location": "L830"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "posregisterview_switch",
       "label": "switch()",
@@ -221563,7 +221749,7 @@
       "source_location": "L659"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "posregisterview_usecollapsesidebarforposflow",
       "label": "useCollapseSidebarForPosFlow()",
@@ -221572,7 +221758,7 @@
       "source_location": "L77"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_tsx",
       "label": "Products.tsx",
@@ -221581,7 +221767,7 @@
       "source_location": "L1"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "products_cn",
       "label": "cn()",
@@ -221590,7 +221776,7 @@
       "source_location": "L467"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "products_formatcatalogmetric",
       "label": "formatCatalogMetric()",
@@ -221599,7 +221785,7 @@
       "source_location": "L131"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "products_getproductsearchpageindex",
       "label": "getProductSearchPageIndex()",
@@ -221608,7 +221794,7 @@
       "source_location": "L42"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "products_handleclearfilters",
       "label": "handleClearFilters()",
@@ -221617,7 +221803,7 @@
       "source_location": "L261"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "products_handleopenquickadd",
       "label": "handleOpenQuickAdd()",
@@ -221626,7 +221812,7 @@
       "source_location": "L231"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "products_handlequerychange",
       "label": "handleQueryChange()",
@@ -221635,7 +221821,7 @@
       "source_location": "L241"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "products_handlequickaddsubmit",
       "label": "handleQuickAddSubmit()",
@@ -221644,94 +221830,13 @@
       "source_location": "L191"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "products_handlesearchpageindexchange",
       "label": "handleSearchPageIndexChange()",
       "norm_label": "handlesearchpageindexchange()",
       "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
       "source_location": "L265"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_shared_demo_shareddemodailyclosefixture_ts",
-      "label": "sharedDemoDailyCloseFixture.ts",
-      "norm_label": "shareddemodailyclosefixture.ts",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoDailyCloseFixture.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "shareddemodailyclosefixture_buildcompletedsaleitems",
-      "label": "buildCompletedSaleItems()",
-      "norm_label": "buildcompletedsaleitems()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoDailyCloseFixture.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "shareddemodailyclosefixture_builddemotransactionnumber",
-      "label": "buildDemoTransactionNumber()",
-      "norm_label": "builddemotransactionnumber()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoDailyCloseFixture.ts",
-      "source_location": "L50"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "shareddemodailyclosefixture_buildreadyitems",
-      "label": "buildReadyItems()",
-      "norm_label": "buildreadyitems()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoDailyCloseFixture.ts",
-      "source_location": "L104"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "shareddemodailyclosefixture_buildsummary",
-      "label": "buildSummary()",
-      "norm_label": "buildsummary()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoDailyCloseFixture.ts",
-      "source_location": "L169"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "shareddemodailyclosefixture_createshareddemodailyclosefixture",
-      "label": "createSharedDemoDailyCloseFixture()",
-      "norm_label": "createshareddemodailyclosefixture()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoDailyCloseFixture.ts",
-      "source_location": "L199"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "shareddemodailyclosefixture_formatpaymentmethod",
-      "label": "formatPaymentMethod()",
-      "norm_label": "formatpaymentmethod()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoDailyCloseFixture.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "shareddemodailyclosefixture_getoperatingdatetimestamp",
-      "label": "getOperatingDateTimestamp()",
-      "norm_label": "getoperatingdatetimestamp()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoDailyCloseFixture.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "shareddemodailyclosefixture_shiftoperatingdate",
-      "label": "shiftOperatingDate()",
-      "norm_label": "shiftoperatingdate()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoDailyCloseFixture.ts",
-      "source_location": "L28"
     },
     {
       "community": 28,
@@ -222069,6 +222174,168 @@
     {
       "community": 280,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_reports_reportdayspanel_test_tsx",
+      "label": "ReportDaysPanel.test.tsx",
+      "norm_label": "reportdayspanel.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "reportdayspanel_test_constructor",
+      "label": "constructor()",
+      "norm_label": "constructor()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.test.tsx",
+      "source_location": "L1196"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "reportdayspanel_test_dayswithskurowcounts",
+      "label": "daysWithSkuRowCounts()",
+      "norm_label": "dayswithskurowcounts()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.test.tsx",
+      "source_location": "L76"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "reportdayspanel_test_installmixqueries",
+      "label": "installMixQueries()",
+      "norm_label": "installmixqueries()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.test.tsx",
+      "source_location": "L1868"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "reportdayspanel_test_isodateoffset",
+      "label": "isoDateOffset()",
+      "norm_label": "isodateoffset()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.test.tsx",
+      "source_location": "L146"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "reportdayspanel_test_livemixreadercalls",
+      "label": "liveMixReaderCalls()",
+      "norm_label": "livemixreadercalls()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.test.tsx",
+      "source_location": "L1884"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "reportdayspanel_test_mixvisibleresult",
+      "label": "mixVisibleResult()",
+      "norm_label": "mixvisibleresult()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.test.tsx",
+      "source_location": "L1853"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "reportdayspanel_test_onlydaysread",
+      "label": "onlyDaysRead()",
+      "norm_label": "onlydaysread()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.test.tsx",
+      "source_location": "L106"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "reportdayspanel_test_syncmixcalls",
+      "label": "syncMixCalls()",
+      "norm_label": "syncmixcalls()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.test.tsx",
+      "source_location": "L218"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_shared_demo_shareddemodailyclosefixture_ts",
+      "label": "sharedDemoDailyCloseFixture.ts",
+      "norm_label": "shareddemodailyclosefixture.ts",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoDailyCloseFixture.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
+      "id": "shareddemodailyclosefixture_buildcompletedsaleitems",
+      "label": "buildCompletedSaleItems()",
+      "norm_label": "buildcompletedsaleitems()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoDailyCloseFixture.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
+      "id": "shareddemodailyclosefixture_builddemotransactionnumber",
+      "label": "buildDemoTransactionNumber()",
+      "norm_label": "builddemotransactionnumber()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoDailyCloseFixture.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
+      "id": "shareddemodailyclosefixture_buildreadyitems",
+      "label": "buildReadyItems()",
+      "norm_label": "buildreadyitems()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoDailyCloseFixture.ts",
+      "source_location": "L104"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
+      "id": "shareddemodailyclosefixture_buildsummary",
+      "label": "buildSummary()",
+      "norm_label": "buildsummary()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoDailyCloseFixture.ts",
+      "source_location": "L169"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
+      "id": "shareddemodailyclosefixture_createshareddemodailyclosefixture",
+      "label": "createSharedDemoDailyCloseFixture()",
+      "norm_label": "createshareddemodailyclosefixture()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoDailyCloseFixture.ts",
+      "source_location": "L199"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
+      "id": "shareddemodailyclosefixture_formatpaymentmethod",
+      "label": "formatPaymentMethod()",
+      "norm_label": "formatpaymentmethod()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoDailyCloseFixture.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
+      "id": "shareddemodailyclosefixture_getoperatingdatetimestamp",
+      "label": "getOperatingDateTimestamp()",
+      "norm_label": "getoperatingdatetimestamp()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoDailyCloseFixture.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
+      "id": "shareddemodailyclosefixture_shiftoperatingdate",
+      "label": "shiftOperatingDate()",
+      "norm_label": "shiftoperatingdate()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoDailyCloseFixture.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 282,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_staffmanagement_tsx",
       "label": "StaffManagement.tsx",
       "norm_label": "staffmanagement.tsx",
@@ -222076,7 +222343,7 @@
       "source_location": "L1"
     },
     {
-      "community": 280,
+      "community": 282,
       "file_type": "code",
       "id": "staffmanagement_buildusername",
       "label": "buildUsername()",
@@ -222085,7 +222352,7 @@
       "source_location": "L95"
     },
     {
-      "community": 280,
+      "community": 282,
       "file_type": "code",
       "id": "staffmanagement_credentialstatusbadge",
       "label": "CredentialStatusBadge()",
@@ -222094,7 +222361,7 @@
       "source_location": "L133"
     },
     {
-      "community": 280,
+      "community": 282,
       "file_type": "code",
       "id": "staffmanagement_formatrolelabel",
       "label": "formatRoleLabel()",
@@ -222103,7 +222370,7 @@
       "source_location": "L122"
     },
     {
-      "community": 280,
+      "community": 282,
       "file_type": "code",
       "id": "staffmanagement_handledeactivate",
       "label": "handleDeactivate()",
@@ -222112,7 +222379,7 @@
       "source_location": "L790"
     },
     {
-      "community": 280,
+      "community": 282,
       "file_type": "code",
       "id": "staffmanagement_handlepinkeydown",
       "label": "handlePinKeyDown()",
@@ -222121,7 +222388,7 @@
       "source_location": "L626"
     },
     {
-      "community": 280,
+      "community": 282,
       "file_type": "code",
       "id": "staffmanagement_handlesubmit",
       "label": "handleSubmit()",
@@ -222130,7 +222397,7 @@
       "source_location": "L644"
     },
     {
-      "community": 280,
+      "community": 282,
       "file_type": "code",
       "id": "staffmanagement_normalizenamesegment",
       "label": "normalizeNameSegment()",
@@ -222139,7 +222406,7 @@
       "source_location": "L87"
     },
     {
-      "community": 280,
+      "community": 282,
       "file_type": "code",
       "id": "staffmanagement_staffprovisionform",
       "label": "StaffProvisionForm()",
@@ -222148,7 +222415,7 @@
       "source_location": "L170"
     },
     {
-      "community": 281,
+      "community": 283,
       "file_type": "code",
       "id": "fulfillmentview_handledeliveryrestrictiontoggle",
       "label": "handleDeliveryRestrictionToggle()",
@@ -222157,7 +222424,7 @@
       "source_location": "L155"
     },
     {
-      "community": 281,
+      "community": 283,
       "file_type": "code",
       "id": "fulfillmentview_handlepickuprestrictiontoggle",
       "label": "handlePickupRestrictionToggle()",
@@ -222166,7 +222433,7 @@
       "source_location": "L116"
     },
     {
-      "community": 281,
+      "community": 283,
       "file_type": "code",
       "id": "fulfillmentview_handlesavedeliveryrestriction",
       "label": "handleSaveDeliveryRestriction()",
@@ -222175,7 +222442,7 @@
       "source_location": "L203"
     },
     {
-      "community": 281,
+      "community": 283,
       "file_type": "code",
       "id": "fulfillmentview_handlesavepickuprestriction",
       "label": "handleSavePickupRestriction()",
@@ -222184,7 +222451,7 @@
       "source_location": "L194"
     },
     {
-      "community": 281,
+      "community": 283,
       "file_type": "code",
       "id": "fulfillmentview_savedeliveryrestriction",
       "label": "saveDeliveryRestriction()",
@@ -222193,7 +222460,7 @@
       "source_location": "L101"
     },
     {
-      "community": 281,
+      "community": 283,
       "file_type": "code",
       "id": "fulfillmentview_saveenabledeliverychanges",
       "label": "saveEnableDeliveryChanges()",
@@ -222202,7 +222469,7 @@
       "source_location": "L63"
     },
     {
-      "community": 281,
+      "community": 283,
       "file_type": "code",
       "id": "fulfillmentview_saveenablestorepickupchanges",
       "label": "saveEnableStorePickupChanges()",
@@ -222211,7 +222478,7 @@
       "source_location": "L40"
     },
     {
-      "community": 281,
+      "community": 283,
       "file_type": "code",
       "id": "fulfillmentview_savepickuprestriction",
       "label": "savePickupRestriction()",
@@ -222220,7 +222487,7 @@
       "source_location": "L86"
     },
     {
-      "community": 281,
+      "community": 283,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_fulfillmentview_tsx",
       "label": "FulfillmentView.tsx",
@@ -222229,7 +222496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 282,
+      "community": 284,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_update_updatecoordinator_ts",
       "label": "updateCoordinator.ts",
@@ -222238,7 +222505,7 @@
       "source_location": "L1"
     },
     {
-      "community": 282,
+      "community": 284,
       "file_type": "code",
       "id": "updatecoordinator_areblockersequal",
       "label": "areBlockersEqual()",
@@ -222247,7 +222514,7 @@
       "source_location": "L484"
     },
     {
-      "community": 282,
+      "community": 284,
       "file_type": "code",
       "id": "updatecoordinator_compareblockers",
       "label": "compareBlockers()",
@@ -222256,7 +222523,7 @@
       "source_location": "L496"
     },
     {
-      "community": 282,
+      "community": 284,
       "file_type": "code",
       "id": "updatecoordinator_createtabid",
       "label": "createTabId()",
@@ -222265,7 +222532,7 @@
       "source_location": "L507"
     },
     {
-      "community": 282,
+      "community": 284,
       "file_type": "code",
       "id": "updatecoordinator_createupdatecoordinatorstore",
       "label": "createUpdateCoordinatorStore()",
@@ -222274,7 +222541,7 @@
       "source_location": "L108"
     },
     {
-      "community": 282,
+      "community": 284,
       "file_type": "code",
       "id": "updatecoordinator_isvalidmessageblocker",
       "label": "isValidMessageBlocker()",
@@ -222283,7 +222550,7 @@
       "source_location": "L448"
     },
     {
-      "community": 282,
+      "community": 284,
       "file_type": "code",
       "id": "updatecoordinator_isvalidpriority",
       "label": "isValidPriority()",
@@ -222292,7 +222559,7 @@
       "source_location": "L474"
     },
     {
-      "community": 282,
+      "community": 284,
       "file_type": "code",
       "id": "updatecoordinator_isvalidupdateapplyblockerinput",
       "label": "isValidUpdateApplyBlockerInput()",
@@ -222301,7 +222568,7 @@
       "source_location": "L468"
     },
     {
-      "community": 282,
+      "community": 284,
       "file_type": "code",
       "id": "updatecoordinator_isvalidupdatecoordinatormessage",
       "label": "isValidUpdateCoordinatorMessage()",
@@ -222310,7 +222577,7 @@
       "source_location": "L428"
     },
     {
-      "community": 283,
+      "community": 285,
       "file_type": "code",
       "id": "logger_logger",
       "label": "Logger",
@@ -222319,7 +222586,7 @@
       "source_location": "L12"
     },
     {
-      "community": 283,
+      "community": 285,
       "file_type": "code",
       "id": "logger_logger_constructor",
       "label": ".constructor()",
@@ -222328,7 +222595,7 @@
       "source_location": "L15"
     },
     {
-      "community": 283,
+      "community": 285,
       "file_type": "code",
       "id": "logger_logger_debug",
       "label": ".debug()",
@@ -222337,7 +222604,7 @@
       "source_location": "L45"
     },
     {
-      "community": 283,
+      "community": 285,
       "file_type": "code",
       "id": "logger_logger_error",
       "label": ".error()",
@@ -222346,7 +222613,7 @@
       "source_location": "L63"
     },
     {
-      "community": 283,
+      "community": 285,
       "file_type": "code",
       "id": "logger_logger_formatmessage",
       "label": ".formatMessage()",
@@ -222355,7 +222622,7 @@
       "source_location": "L30"
     },
     {
-      "community": 283,
+      "community": 285,
       "file_type": "code",
       "id": "logger_logger_info",
       "label": ".info()",
@@ -222364,7 +222631,7 @@
       "source_location": "L51"
     },
     {
-      "community": 283,
+      "community": 285,
       "file_type": "code",
       "id": "logger_logger_shouldlog",
       "label": ".shouldLog()",
@@ -222373,7 +222640,7 @@
       "source_location": "L20"
     },
     {
-      "community": 283,
+      "community": 285,
       "file_type": "code",
       "id": "logger_logger_warn",
       "label": ".warn()",
@@ -222382,7 +222649,7 @@
       "source_location": "L57"
     },
     {
-      "community": 283,
+      "community": 285,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_logger_ts",
       "label": "logger.ts",
@@ -222391,7 +222658,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 286,
       "file_type": "code",
       "id": "cart_assertvalidposcartline",
       "label": "assertValidPosCartLine()",
@@ -222400,7 +222667,7 @@
       "source_location": "L65"
     },
     {
-      "community": 284,
+      "community": 286,
       "file_type": "code",
       "id": "cart_calculateposcartlinesubtotal",
       "label": "calculatePosCartLineSubtotal()",
@@ -222409,7 +222676,7 @@
       "source_location": "L39"
     },
     {
-      "community": 284,
+      "community": 286,
       "file_type": "code",
       "id": "cart_calculateposcarttotals",
       "label": "calculatePosCartTotals()",
@@ -222418,7 +222685,7 @@
       "source_location": "L8"
     },
     {
-      "community": 284,
+      "community": 286,
       "file_type": "code",
       "id": "cart_calculatepositemtotal",
       "label": "calculatePosItemTotal()",
@@ -222427,7 +222694,7 @@
       "source_location": "L35"
     },
     {
-      "community": 284,
+      "community": 286,
       "file_type": "code",
       "id": "cart_getposeffectiveprice",
       "label": "getPosEffectivePrice()",
@@ -222436,7 +222703,7 @@
       "source_location": "L49"
     },
     {
-      "community": 284,
+      "community": 286,
       "file_type": "code",
       "id": "cart_isposproductcartline",
       "label": "isPosProductCartLine()",
@@ -222445,7 +222712,7 @@
       "source_location": "L59"
     },
     {
-      "community": 284,
+      "community": 286,
       "file_type": "code",
       "id": "cart_isposservicecartline",
       "label": "isPosServiceCartLine()",
@@ -222454,7 +222721,7 @@
       "source_location": "L53"
     },
     {
-      "community": 284,
+      "community": 286,
       "file_type": "code",
       "id": "cart_roundposamount",
       "label": "roundPosAmount()",
@@ -222463,7 +222730,7 @@
       "source_location": "L83"
     },
     {
-      "community": 284,
+      "community": 286,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_cart_ts",
       "label": "cart.ts",
@@ -222472,7 +222739,7 @@
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 287,
       "file_type": "code",
       "id": "indexeddbposlocalstorageengine_browserlocks",
       "label": "browserLocks()",
@@ -222481,7 +222748,7 @@
       "source_location": "L112"
     },
     {
-      "community": 285,
+      "community": 287,
       "file_type": "code",
       "id": "indexeddbposlocalstorageengine_clearcurrentposlocalstorageengine",
       "label": "clearCurrentPosLocalStorageEngine()",
@@ -222490,7 +222757,7 @@
       "source_location": "L75"
     },
     {
-      "community": 285,
+      "community": 287,
       "file_type": "code",
       "id": "indexeddbposlocalstorageengine_createcurrentposlocalstorageenginestore",
       "label": "createCurrentPosLocalStorageEngineStore()",
@@ -222499,7 +222766,7 @@
       "source_location": "L25"
     },
     {
-      "community": 285,
+      "community": 287,
       "file_type": "code",
       "id": "indexeddbposlocalstorageengine_getcurrentposlocalstorageenginelifecyclehealth",
       "label": "getCurrentPosLocalStorageEngineLifecycleHealth()",
@@ -222508,7 +222775,7 @@
       "source_location": "L105"
     },
     {
-      "community": 285,
+      "community": 287,
       "file_type": "code",
       "id": "indexeddbposlocalstorageengine_maintenanceresult",
       "label": "maintenanceResult()",
@@ -222517,7 +222784,7 @@
       "source_location": "L117"
     },
     {
-      "community": 285,
+      "community": 287,
       "file_type": "code",
       "id": "indexeddbposlocalstorageengine_maintenanceunavailableresult",
       "label": "maintenanceUnavailableResult()",
@@ -222526,7 +222793,7 @@
       "source_location": "L127"
     },
     {
-      "community": 285,
+      "community": 287,
       "file_type": "code",
       "id": "indexeddbposlocalstorageengine_opencurrentposlocalstorageengine",
       "label": "openCurrentPosLocalStorageEngine()",
@@ -222535,7 +222802,7 @@
       "source_location": "L31"
     },
     {
-      "community": 285,
+      "community": 287,
       "file_type": "code",
       "id": "indexeddbposlocalstorageengine_runcurrentposlocalstorageengineoperation",
       "label": "runCurrentPosLocalStorageEngineOperation()",
@@ -222544,7 +222811,7 @@
       "source_location": "L49"
     },
     {
-      "community": 285,
+      "community": 287,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_indexeddbposlocalstorageengine_ts",
       "label": "indexedDbPosLocalStorageEngine.ts",
@@ -222553,7 +222820,7 @@
       "source_location": "L1"
     },
     {
-      "community": 286,
+      "community": 288,
       "file_type": "code",
       "id": "localcommandgateway_blockedsalemessage",
       "label": "blockedSaleMessage()",
@@ -222562,7 +222829,7 @@
       "source_location": "L1058"
     },
     {
-      "community": 286,
+      "community": 288,
       "file_type": "code",
       "id": "localcommandgateway_canclearexactcloudcloseddrawer",
       "label": "canClearExactCloudClosedDrawer()",
@@ -222571,7 +222838,7 @@
       "source_location": "L1032"
     },
     {
-      "community": 286,
+      "community": 288,
       "file_type": "code",
       "id": "localcommandgateway_createlocalcommandgateway",
       "label": "createLocalCommandGateway()",
@@ -222580,7 +222847,7 @@
       "source_location": "L107"
     },
     {
-      "community": 286,
+      "community": 288,
       "file_type": "code",
       "id": "localcommandgateway_hascommandidentity",
       "label": "hasCommandIdentity()",
@@ -222589,7 +222856,7 @@
       "source_location": "L1086"
     },
     {
-      "community": 286,
+      "community": 288,
       "file_type": "code",
       "id": "localcommandgateway_haslocalsaleactivity",
       "label": "hasLocalSaleActivity()",
@@ -222598,7 +222865,7 @@
       "source_location": "L1011"
     },
     {
-      "community": 286,
+      "community": 288,
       "file_type": "code",
       "id": "localcommandgateway_isopenlocalregistersessionstatus",
       "label": "isOpenLocalRegisterSessionStatus()",
@@ -222607,7 +222874,7 @@
       "source_location": "L1046"
     },
     {
-      "community": 286,
+      "community": 288,
       "file_type": "code",
       "id": "localcommandgateway_resolvestaffprooftoken",
       "label": "resolveStaffProofToken()",
@@ -222616,7 +222883,7 @@
       "source_location": "L1002"
     },
     {
-      "community": 286,
+      "community": 288,
       "file_type": "code",
       "id": "localcommandgateway_tolocalusererror",
       "label": "toLocalUserError()",
@@ -222625,7 +222892,7 @@
       "source_location": "L1050"
     },
     {
-      "community": 286,
+      "community": 288,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localcommandgateway_ts",
       "label": "localCommandGateway.ts",
@@ -222634,7 +222901,7 @@
       "source_location": "L1"
     },
     {
-      "community": 287,
+      "community": 289,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstore_test_ts",
       "label": "posLocalStore.test.ts",
@@ -222643,7 +222910,7 @@
       "source_location": "L1"
     },
     {
-      "community": 287,
+      "community": 289,
       "file_type": "code",
       "id": "poslocalstore_test_buildauthorityrecord",
       "label": "buildAuthorityRecord()",
@@ -222652,7 +222919,7 @@
       "source_location": "L20"
     },
     {
-      "community": 287,
+      "community": 289,
       "file_type": "code",
       "id": "poslocalstore_test_buildavailabilityrow",
       "label": "buildAvailabilityRow()",
@@ -222661,7 +222928,7 @@
       "source_location": "L76"
     },
     {
-      "community": 287,
+      "community": 289,
       "file_type": "code",
       "id": "poslocalstore_test_buildcashierpresencerecord",
       "label": "buildCashierPresenceRecord()",
@@ -222670,7 +222937,7 @@
       "source_location": "L51"
     },
     {
-      "community": 287,
+      "community": 289,
       "file_type": "code",
       "id": "poslocalstore_test_buildcatalogrow",
       "label": "buildCatalogRow()",
@@ -222679,7 +222946,7 @@
       "source_location": "L88"
     },
     {
-      "community": 287,
+      "community": 289,
       "file_type": "code",
       "id": "poslocalstore_test_buildservicecatalogrow",
       "label": "buildServiceCatalogRow()",
@@ -222688,7 +222955,7 @@
       "source_location": "L111"
     },
     {
-      "community": 287,
+      "community": 289,
       "file_type": "code",
       "id": "poslocalstore_test_createcontrolledindexeddb",
       "label": "createControlledIndexedDb()",
@@ -222697,7 +222964,7 @@
       "source_location": "L4181"
     },
     {
-      "community": 287,
+      "community": 289,
       "file_type": "code",
       "id": "poslocalstore_test_createsuccessfulrequest",
       "label": "createSuccessfulRequest()",
@@ -222706,175 +222973,13 @@
       "source_location": "L4295"
     },
     {
-      "community": 287,
+      "community": 289,
       "file_type": "code",
       "id": "poslocalstore_test_installclearableindexeddbmock",
       "label": "installClearableIndexedDbMock()",
       "norm_label": "installclearableindexeddbmock()",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.test.ts",
       "source_location": "L138"
-    },
-    {
-      "community": 288,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_syncscheduler_ts",
-      "label": "syncScheduler.ts",
-      "norm_label": "syncscheduler.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 288,
-      "file_type": "code",
-      "id": "syncscheduler_comparependingevents",
-      "label": "comparePendingEvents()",
-      "norm_label": "comparependingevents()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.ts",
-      "source_location": "L371"
-    },
-    {
-      "community": 288,
-      "file_type": "code",
-      "id": "syncscheduler_createposlocalsyncscheduler",
-      "label": "createPosLocalSyncScheduler()",
-      "norm_label": "createposlocalsyncscheduler()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.ts",
-      "source_location": "L92"
-    },
-    {
-      "community": 288,
-      "file_type": "code",
-      "id": "syncscheduler_getcurrentbackoffdelay",
-      "label": "getCurrentBackoffDelay()",
-      "norm_label": "getcurrentbackoffdelay()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.ts",
-      "source_location": "L408"
-    },
-    {
-      "community": 288,
-      "file_type": "code",
-      "id": "syncscheduler_geterrormessage",
-      "label": "getErrorMessage()",
-      "norm_label": "geterrormessage()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.ts",
-      "source_location": "L416"
-    },
-    {
-      "community": 288,
-      "file_type": "code",
-      "id": "syncscheduler_getpendingeventcursorkey",
-      "label": "getPendingEventCursorKey()",
-      "norm_label": "getpendingeventcursorkey()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.ts",
-      "source_location": "L392"
-    },
-    {
-      "community": 288,
-      "file_type": "code",
-      "id": "syncscheduler_getpendingeventuploadsequence",
-      "label": "getPendingEventUploadSequence()",
-      "norm_label": "getpendingeventuploadsequence()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.ts",
-      "source_location": "L402"
-    },
-    {
-      "community": 288,
-      "file_type": "code",
-      "id": "syncscheduler_selectnextorderedbatch",
-      "label": "selectNextOrderedBatch()",
-      "norm_label": "selectnextorderedbatch()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.ts",
-      "source_location": "L331"
-    },
-    {
-      "community": 288,
-      "file_type": "code",
-      "id": "syncscheduler_selectorderedbatches",
-      "label": "selectOrderedBatches()",
-      "norm_label": "selectorderedbatches()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.ts",
-      "source_location": "L338"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_test_ts",
-      "label": "useExpenseRegisterViewModel.test.ts",
-      "norm_label": "useexpenseregisterviewmodel.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "useexpenseregisterviewmodel_test_buildexpensecartitem",
-      "label": "buildExpenseCartItem()",
-      "norm_label": "buildexpensecartitem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
-      "source_location": "L220"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "useexpenseregisterviewmodel_test_buildproduct",
-      "label": "buildProduct()",
-      "norm_label": "buildproduct()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
-      "source_location": "L241"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "useexpenseregisterviewmodel_test_buildregistercatalogavailabilityrow",
-      "label": "buildRegisterCatalogAvailabilityRow()",
-      "norm_label": "buildregistercatalogavailabilityrow()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
-      "source_location": "L208"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "useexpenseregisterviewmodel_test_buildregistercatalogrow",
-      "label": "buildRegisterCatalogRow()",
-      "norm_label": "buildregistercatalogrow()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
-      "source_location": "L185"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "useexpenseregisterviewmodel_test_bumplocalexpenseeventreplay",
-      "label": "bumpLocalExpenseEventReplay()",
-      "norm_label": "bumplocalexpenseeventreplay()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
-      "source_location": "L340"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "useexpenseregisterviewmodel_test_deferred",
-      "label": "deferred()",
-      "norm_label": "deferred()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
-      "source_location": "L259"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "useexpenseregisterviewmodel_test_enablelocalexpenseeventreplay",
-      "label": "enableLocalExpenseEventReplay()",
-      "norm_label": "enablelocalexpenseeventreplay()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
-      "source_location": "L336"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "useexpenseregisterviewmodel_test_seedactiveexpensecart",
-      "label": "seedActiveExpenseCart()",
-      "norm_label": "seedactiveexpensecart()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
-      "source_location": "L270"
     },
     {
       "community": 29,
@@ -223203,329 +223308,167 @@
     {
       "community": 290,
       "file_type": "code",
-      "id": "applyremoteassistcontrolintent_applyacceptedcontrolresult",
-      "label": "applyAcceptedControlResult()",
-      "norm_label": "applyacceptedcontrolresult()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L84"
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_syncscheduler_ts",
+      "label": "syncScheduler.ts",
+      "norm_label": "syncscheduler.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.ts",
+      "source_location": "L1"
     },
     {
       "community": 290,
       "file_type": "code",
-      "id": "applyremoteassistcontrolintent_applykeyevent",
-      "label": "applyKeyEvent()",
-      "norm_label": "applykeyevent()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L155"
+      "id": "syncscheduler_comparependingevents",
+      "label": "comparePendingEvents()",
+      "norm_label": "comparependingevents()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.ts",
+      "source_location": "L371"
     },
     {
       "community": 290,
       "file_type": "code",
-      "id": "applyremoteassistcontrolintent_applypointerevent",
-      "label": "applyPointerEvent()",
-      "norm_label": "applypointerevent()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L116"
+      "id": "syncscheduler_createposlocalsyncscheduler",
+      "label": "createPosLocalSyncScheduler()",
+      "norm_label": "createposlocalsyncscheduler()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.ts",
+      "source_location": "L92"
     },
     {
       "community": 290,
       "file_type": "code",
-      "id": "applyremoteassistcontrolintent_applyremoteassistcontrolintent",
-      "label": "applyRemoteAssistControlIntent()",
-      "norm_label": "applyremoteassistcontrolintent()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L17"
+      "id": "syncscheduler_getcurrentbackoffdelay",
+      "label": "getCurrentBackoffDelay()",
+      "norm_label": "getcurrentbackoffdelay()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.ts",
+      "source_location": "L408"
     },
     {
       "community": 290,
       "file_type": "code",
-      "id": "applyremoteassistcontrolintent_getrecentcontrolresult",
-      "label": "getRecentControlResult()",
-      "norm_label": "getrecentcontrolresult()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L95"
+      "id": "syncscheduler_geterrormessage",
+      "label": "getErrorMessage()",
+      "norm_label": "geterrormessage()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.ts",
+      "source_location": "L416"
     },
     {
       "community": 290,
       "file_type": "code",
-      "id": "applyremoteassistcontrolintent_getremoteassistcontroltarget",
-      "label": "getRemoteAssistControlTarget()",
-      "norm_label": "getremoteassistcontroltarget()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L145"
+      "id": "syncscheduler_getpendingeventcursorkey",
+      "label": "getPendingEventCursorKey()",
+      "norm_label": "getpendingeventcursorkey()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.ts",
+      "source_location": "L392"
     },
     {
       "community": 290,
       "file_type": "code",
-      "id": "applyremoteassistcontrolintent_prepareremoteassistcontrolintent",
-      "label": "prepareRemoteAssistControlIntent()",
-      "norm_label": "prepareremoteassistcontrolintent()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L27"
+      "id": "syncscheduler_getpendingeventuploadsequence",
+      "label": "getPendingEventUploadSequence()",
+      "norm_label": "getpendingeventuploadsequence()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.ts",
+      "source_location": "L402"
     },
     {
       "community": 290,
       "file_type": "code",
-      "id": "applyremoteassistcontrolintent_remembercontrolresult",
-      "label": "rememberControlResult()",
-      "norm_label": "remembercontrolresult()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L101"
+      "id": "syncscheduler_selectnextorderedbatch",
+      "label": "selectNextOrderedBatch()",
+      "norm_label": "selectnextorderedbatch()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.ts",
+      "source_location": "L331"
     },
     {
       "community": 290,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_remote_assist_runtime_applyremoteassistcontrolintent_ts",
-      "label": "applyRemoteAssistControlIntent.ts",
-      "norm_label": "applyremoteassistcontrolintent.ts",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "id": "syncscheduler_selectorderedbatches",
+      "label": "selectOrderedBatches()",
+      "norm_label": "selectorderedbatches()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.ts",
+      "source_location": "L338"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_test_ts",
+      "label": "useExpenseRegisterViewModel.test.ts",
+      "norm_label": "useexpenseregisterviewmodel.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
       "source_location": "L1"
     },
     {
       "community": 291,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_offline_posofflinereadiness_ts",
-      "label": "posOfflineReadiness.ts",
-      "norm_label": "posofflinereadiness.ts",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L1"
+      "id": "useexpenseregisterviewmodel_test_buildexpensecartitem",
+      "label": "buildExpenseCartItem()",
+      "norm_label": "buildexpensecartitem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
+      "source_location": "L220"
     },
     {
       "community": 291,
       "file_type": "code",
-      "id": "posofflinereadiness_buildposofflinereadinesssummary",
-      "label": "buildPosOfflineReadinessSummary()",
-      "norm_label": "buildposofflinereadinesssummary()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L152"
+      "id": "useexpenseregisterviewmodel_test_buildproduct",
+      "label": "buildProduct()",
+      "norm_label": "buildproduct()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
+      "source_location": "L241"
     },
     {
       "community": 291,
       "file_type": "code",
-      "id": "posofflinereadiness_buildsignal",
-      "label": "buildSignal()",
-      "norm_label": "buildsignal()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L178"
+      "id": "useexpenseregisterviewmodel_test_buildregistercatalogavailabilityrow",
+      "label": "buildRegisterCatalogAvailabilityRow()",
+      "norm_label": "buildregistercatalogavailabilityrow()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
+      "source_location": "L208"
     },
     {
       "community": 291,
       "file_type": "code",
-      "id": "posofflinereadiness_formatage",
-      "label": "formatAge()",
-      "norm_label": "formatage()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L290"
+      "id": "useexpenseregisterviewmodel_test_buildregistercatalogrow",
+      "label": "buildRegisterCatalogRow()",
+      "norm_label": "buildregistercatalogrow()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
+      "source_location": "L185"
     },
     {
       "community": 291,
       "file_type": "code",
-      "id": "posofflinereadiness_getsignaldescription",
-      "label": "getSignalDescription()",
-      "norm_label": "getsignaldescription()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L221"
+      "id": "useexpenseregisterviewmodel_test_bumplocalexpenseeventreplay",
+      "label": "bumpLocalExpenseEventReplay()",
+      "norm_label": "bumplocalexpenseeventreplay()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
+      "source_location": "L340"
     },
     {
       "community": 291,
       "file_type": "code",
-      "id": "posofflinereadiness_getsignalstatus",
-      "label": "getSignalStatus()",
-      "norm_label": "getsignalstatus()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L201"
+      "id": "useexpenseregisterviewmodel_test_deferred",
+      "label": "deferred()",
+      "norm_label": "deferred()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
+      "source_location": "L259"
     },
     {
       "community": 291,
       "file_type": "code",
-      "id": "posofflinereadiness_getsummarydescription",
-      "label": "getSummaryDescription()",
-      "norm_label": "getsummarydescription()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L262"
+      "id": "useexpenseregisterviewmodel_test_enablelocalexpenseeventreplay",
+      "label": "enableLocalExpenseEventReplay()",
+      "norm_label": "enablelocalexpenseeventreplay()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
+      "source_location": "L336"
     },
     {
       "community": 291,
       "file_type": "code",
-      "id": "posofflinereadiness_getsummarytitle",
-      "label": "getSummaryTitle()",
-      "norm_label": "getsummarytitle()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L256"
-    },
-    {
-      "community": 291,
-      "file_type": "code",
-      "id": "posofflinereadiness_isreadylike",
-      "label": "isReadyLike()",
-      "norm_label": "isreadylike()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L286"
+      "id": "useexpenseregisterviewmodel_test_seedactiveexpensecart",
+      "label": "seedActiveExpenseCart()",
+      "norm_label": "seedactiveexpensecart()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts",
+      "source_location": "L270"
     },
     {
       "community": 292,
-      "file_type": "code",
-      "id": "foundations_content_colorrolecard",
-      "label": "ColorRoleCard()",
-      "norm_label": "colorrolecard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L222"
-    },
-    {
-      "community": 292,
-      "file_type": "code",
-      "id": "foundations_content_densitycard",
-      "label": "DensityCard()",
-      "norm_label": "densitycard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L283"
-    },
-    {
-      "community": 292,
-      "file_type": "code",
-      "id": "foundations_content_detailviewrolecard",
-      "label": "DetailViewRoleCard()",
-      "norm_label": "detailviewrolecard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L363"
-    },
-    {
-      "community": 292,
-      "file_type": "code",
-      "id": "foundations_content_hslvar",
-      "label": "hslVar()",
-      "norm_label": "hslvar()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L214"
-    },
-    {
-      "community": 292,
-      "file_type": "code",
-      "id": "foundations_content_motioncard",
-      "label": "MotionCard()",
-      "norm_label": "motioncard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L342"
-    },
-    {
-      "community": 292,
-      "file_type": "code",
-      "id": "foundations_content_spacetokenrow",
-      "label": "SpaceTokenRow()",
-      "norm_label": "spacetokenrow()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L265"
-    },
-    {
-      "community": 292,
-      "file_type": "code",
-      "id": "foundations_content_textvar",
-      "label": "textVar()",
-      "norm_label": "textvar()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L218"
-    },
-    {
-      "community": 292,
-      "file_type": "code",
-      "id": "foundations_content_typespecimencard",
-      "label": "TypeSpecimenCard()",
-      "norm_label": "typespecimencard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L246"
-    },
-    {
-      "community": 292,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_tsx",
-      "label": "foundations-content.tsx",
-      "norm_label": "foundations-content.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 293,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_utils_versionchecker_ts",
-      "label": "versionChecker.ts",
-      "norm_label": "versionchecker.ts",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 293,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
-      "label": "versionChecker.ts",
-      "norm_label": "versionchecker.ts",
-      "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 293,
-      "file_type": "code",
-      "id": "versionchecker_buildidfromscripts",
-      "label": "buildIdFromScripts()",
-      "norm_label": "buildidfromscripts()",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
-      "source_location": "L192"
-    },
-    {
-      "community": 293,
-      "file_type": "code",
-      "id": "versionchecker_createversionchecker",
-      "label": "createVersionChecker()",
-      "norm_label": "createversionchecker()",
-      "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 293,
-      "file_type": "code",
-      "id": "versionchecker_getinitialdeploybuildid",
-      "label": "getInitialDeployBuildId()",
-      "norm_label": "getinitialdeploybuildid()",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
-      "source_location": "L135"
-    },
-    {
-      "community": 293,
-      "file_type": "code",
-      "id": "versionchecker_readdeploybuildid",
-      "label": "readDeployBuildId()",
-      "norm_label": "readdeploybuildid()",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
-      "source_location": "L141"
-    },
-    {
-      "community": 293,
-      "file_type": "code",
-      "id": "versionchecker_readdocumentscriptsources",
-      "label": "readDocumentScriptSources()",
-      "norm_label": "readdocumentscriptsources()",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
-      "source_location": "L174"
-    },
-    {
-      "community": 293,
-      "file_type": "code",
-      "id": "versionchecker_readentryhtmlscripts",
-      "label": "readEntryHtmlScripts()",
-      "norm_label": "readentryhtmlscripts()",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
-      "source_location": "L151"
-    },
-    {
-      "community": 293,
-      "file_type": "code",
-      "id": "versionchecker_readscriptsources",
-      "label": "readScriptSources()",
-      "norm_label": "readscriptsources()",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
-      "source_location": "L182"
-    },
-    {
-      "community": 294,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_productutils_ts",
       "label": "productUtils.ts",
@@ -223534,7 +223477,7 @@
       "source_location": "L1"
     },
     {
-      "community": 294,
+      "community": 292,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_productutils_ts",
       "label": "productUtils.ts",
@@ -223543,7 +223486,7 @@
       "source_location": "L1"
     },
     {
-      "community": 294,
+      "community": 292,
       "file_type": "code",
       "id": "productutils_getpreferredsku",
       "label": "getPreferredSku()",
@@ -223552,7 +223495,7 @@
       "source_location": "L78"
     },
     {
-      "community": 294,
+      "community": 292,
       "file_type": "code",
       "id": "productutils_getproductname",
       "label": "getProductName()",
@@ -223561,7 +223504,7 @@
       "source_location": "L18"
     },
     {
-      "community": 294,
+      "community": 292,
       "file_type": "code",
       "id": "productutils_haslowstock",
       "label": "hasLowStock()",
@@ -223570,7 +223513,7 @@
       "source_location": "L52"
     },
     {
-      "community": 294,
+      "community": 292,
       "file_type": "code",
       "id": "productutils_issoldout",
       "label": "isSoldOut()",
@@ -223579,7 +223522,7 @@
       "source_location": "L45"
     },
     {
-      "community": 294,
+      "community": 292,
       "file_type": "code",
       "id": "productutils_sortproduct",
       "label": "sortProduct()",
@@ -223588,7 +223531,7 @@
       "source_location": "L82"
     },
     {
-      "community": 294,
+      "community": 292,
       "file_type": "code",
       "id": "productutils_sortskusbyavailabilitythenlength",
       "label": "sortSkusByAvailabilityThenLength()",
@@ -223597,7 +223540,7 @@
       "source_location": "L63"
     },
     {
-      "community": 294,
+      "community": 292,
       "file_type": "code",
       "id": "productutils_sortskusbylength",
       "label": "sortSkusByLength()",
@@ -223606,7 +223549,250 @@
       "source_location": "L59"
     },
     {
+      "community": 293,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_applyacceptedcontrolresult",
+      "label": "applyAcceptedControlResult()",
+      "norm_label": "applyacceptedcontrolresult()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 293,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_applykeyevent",
+      "label": "applyKeyEvent()",
+      "norm_label": "applykeyevent()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L155"
+    },
+    {
+      "community": 293,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_applypointerevent",
+      "label": "applyPointerEvent()",
+      "norm_label": "applypointerevent()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L116"
+    },
+    {
+      "community": 293,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_applyremoteassistcontrolintent",
+      "label": "applyRemoteAssistControlIntent()",
+      "norm_label": "applyremoteassistcontrolintent()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 293,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_getrecentcontrolresult",
+      "label": "getRecentControlResult()",
+      "norm_label": "getrecentcontrolresult()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 293,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_getremoteassistcontroltarget",
+      "label": "getRemoteAssistControlTarget()",
+      "norm_label": "getremoteassistcontroltarget()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L145"
+    },
+    {
+      "community": 293,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_prepareremoteassistcontrolintent",
+      "label": "prepareRemoteAssistControlIntent()",
+      "norm_label": "prepareremoteassistcontrolintent()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 293,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_remembercontrolresult",
+      "label": "rememberControlResult()",
+      "norm_label": "remembercontrolresult()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 293,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_remote_assist_runtime_applyremoteassistcontrolintent_ts",
+      "label": "applyRemoteAssistControlIntent.ts",
+      "norm_label": "applyremoteassistcontrolintent.ts",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 294,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_offline_posofflinereadiness_ts",
+      "label": "posOfflineReadiness.ts",
+      "norm_label": "posofflinereadiness.ts",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 294,
+      "file_type": "code",
+      "id": "posofflinereadiness_buildposofflinereadinesssummary",
+      "label": "buildPosOfflineReadinessSummary()",
+      "norm_label": "buildposofflinereadinesssummary()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L152"
+    },
+    {
+      "community": 294,
+      "file_type": "code",
+      "id": "posofflinereadiness_buildsignal",
+      "label": "buildSignal()",
+      "norm_label": "buildsignal()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L178"
+    },
+    {
+      "community": 294,
+      "file_type": "code",
+      "id": "posofflinereadiness_formatage",
+      "label": "formatAge()",
+      "norm_label": "formatage()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L290"
+    },
+    {
+      "community": 294,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsignaldescription",
+      "label": "getSignalDescription()",
+      "norm_label": "getsignaldescription()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L221"
+    },
+    {
+      "community": 294,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsignalstatus",
+      "label": "getSignalStatus()",
+      "norm_label": "getsignalstatus()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L201"
+    },
+    {
+      "community": 294,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsummarydescription",
+      "label": "getSummaryDescription()",
+      "norm_label": "getsummarydescription()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L262"
+    },
+    {
+      "community": 294,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsummarytitle",
+      "label": "getSummaryTitle()",
+      "norm_label": "getsummarytitle()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L256"
+    },
+    {
+      "community": 294,
+      "file_type": "code",
+      "id": "posofflinereadiness_isreadylike",
+      "label": "isReadyLike()",
+      "norm_label": "isreadylike()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L286"
+    },
+    {
       "community": 295,
+      "file_type": "code",
+      "id": "foundations_content_colorrolecard",
+      "label": "ColorRoleCard()",
+      "norm_label": "colorrolecard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L222"
+    },
+    {
+      "community": 295,
+      "file_type": "code",
+      "id": "foundations_content_densitycard",
+      "label": "DensityCard()",
+      "norm_label": "densitycard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L283"
+    },
+    {
+      "community": 295,
+      "file_type": "code",
+      "id": "foundations_content_detailviewrolecard",
+      "label": "DetailViewRoleCard()",
+      "norm_label": "detailviewrolecard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L363"
+    },
+    {
+      "community": 295,
+      "file_type": "code",
+      "id": "foundations_content_hslvar",
+      "label": "hslVar()",
+      "norm_label": "hslvar()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L214"
+    },
+    {
+      "community": 295,
+      "file_type": "code",
+      "id": "foundations_content_motioncard",
+      "label": "MotionCard()",
+      "norm_label": "motioncard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L342"
+    },
+    {
+      "community": 295,
+      "file_type": "code",
+      "id": "foundations_content_spacetokenrow",
+      "label": "SpaceTokenRow()",
+      "norm_label": "spacetokenrow()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L265"
+    },
+    {
+      "community": 295,
+      "file_type": "code",
+      "id": "foundations_content_textvar",
+      "label": "textVar()",
+      "norm_label": "textvar()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L218"
+    },
+    {
+      "community": 295,
+      "file_type": "code",
+      "id": "foundations_content_typespecimencard",
+      "label": "TypeSpecimenCard()",
+      "norm_label": "typespecimencard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L246"
+    },
+    {
+      "community": 295,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_tsx",
+      "label": "foundations-content.tsx",
+      "norm_label": "foundations-content.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 296,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontobservability_ts",
       "label": "storefrontObservability.ts",
@@ -223615,7 +223801,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "storefrontobservability_createstorefrontobservabilitycontext",
       "label": "createStorefrontObservabilityContext()",
@@ -223624,7 +223810,7 @@
       "source_location": "L182"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "storefrontobservability_createstorefrontobservabilitypayload",
       "label": "createStorefrontObservabilityPayload()",
@@ -223633,7 +223819,7 @@
       "source_location": "L229"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
       "label": "getOrCreateStorefrontObservabilitySessionId()",
@@ -223642,7 +223828,7 @@
       "source_location": "L157"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "storefrontobservability_isbrowserautomationcontext",
       "label": "isBrowserAutomationContext()",
@@ -223651,7 +223837,7 @@
       "source_location": "L125"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "storefrontobservability_issyntheticmonitororigin",
       "label": "isSyntheticMonitorOrigin()",
@@ -223660,7 +223846,7 @@
       "source_location": "L121"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "storefrontobservability_resolvestorefrontanalyticsorigin",
       "label": "resolveStorefrontAnalyticsOrigin()",
@@ -223669,7 +223855,7 @@
       "source_location": "L135"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "storefrontobservability_resolveviewportbucket",
       "label": "resolveViewportBucket()",
@@ -223678,7 +223864,7 @@
       "source_location": "L211"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "storefrontobservability_trackstorefrontevent",
       "label": "trackStorefrontEvent()",
@@ -223687,7 +223873,88 @@
       "source_location": "L265"
     },
     {
-      "community": 296,
+      "community": 297,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_utils_versionchecker_ts",
+      "label": "versionChecker.ts",
+      "norm_label": "versionchecker.ts",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 297,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
+      "label": "versionChecker.ts",
+      "norm_label": "versionchecker.ts",
+      "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 297,
+      "file_type": "code",
+      "id": "versionchecker_buildidfromscripts",
+      "label": "buildIdFromScripts()",
+      "norm_label": "buildidfromscripts()",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
+      "source_location": "L192"
+    },
+    {
+      "community": 297,
+      "file_type": "code",
+      "id": "versionchecker_createversionchecker",
+      "label": "createVersionChecker()",
+      "norm_label": "createversionchecker()",
+      "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 297,
+      "file_type": "code",
+      "id": "versionchecker_getinitialdeploybuildid",
+      "label": "getInitialDeployBuildId()",
+      "norm_label": "getinitialdeploybuildid()",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 297,
+      "file_type": "code",
+      "id": "versionchecker_readdeploybuildid",
+      "label": "readDeployBuildId()",
+      "norm_label": "readdeploybuildid()",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
+      "source_location": "L141"
+    },
+    {
+      "community": 297,
+      "file_type": "code",
+      "id": "versionchecker_readdocumentscriptsources",
+      "label": "readDocumentScriptSources()",
+      "norm_label": "readdocumentscriptsources()",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
+      "source_location": "L174"
+    },
+    {
+      "community": 297,
+      "file_type": "code",
+      "id": "versionchecker_readentryhtmlscripts",
+      "label": "readEntryHtmlScripts()",
+      "norm_label": "readentryhtmlscripts()",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
+      "source_location": "L151"
+    },
+    {
+      "community": 297,
+      "file_type": "code",
+      "id": "versionchecker_readscriptsources",
+      "label": "readScriptSources()",
+      "norm_label": "readscriptsources()",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
+      "source_location": "L182"
+    },
+    {
+      "community": 298,
       "file_type": "code",
       "id": "app_test_clusterredis",
       "label": "ClusterRedis",
@@ -223696,7 +223963,7 @@
       "source_location": "L94"
     },
     {
-      "community": 296,
+      "community": 298,
       "file_type": "code",
       "id": "app_test_clusterredis_constructor",
       "label": ".constructor()",
@@ -223705,7 +223972,7 @@
       "source_location": "L95"
     },
     {
-      "community": 296,
+      "community": 298,
       "file_type": "code",
       "id": "app_test_createinmemoryredis",
       "label": "createInMemoryRedis()",
@@ -223714,7 +223981,7 @@
       "source_location": "L39"
     },
     {
-      "community": 296,
+      "community": 298,
       "file_type": "code",
       "id": "app_test_createresponserecorder",
       "label": "createResponseRecorder()",
@@ -223723,7 +223990,7 @@
       "source_location": "L12"
     },
     {
-      "community": 296,
+      "community": 298,
       "file_type": "code",
       "id": "app_test_createsilentlogger",
       "label": "createSilentLogger()",
@@ -223732,7 +223999,7 @@
       "source_location": "L31"
     },
     {
-      "community": 296,
+      "community": 298,
       "file_type": "code",
       "id": "app_test_log",
       "label": "log()",
@@ -223741,7 +224008,7 @@
       "source_location": "L297"
     },
     {
-      "community": 296,
+      "community": 298,
       "file_type": "code",
       "id": "app_test_standaloneredis",
       "label": "StandaloneRedis",
@@ -223750,7 +224017,7 @@
       "source_location": "L70"
     },
     {
-      "community": 296,
+      "community": 298,
       "file_type": "code",
       "id": "app_test_standaloneredis_constructor",
       "label": ".constructor()",
@@ -223759,7 +224026,7 @@
       "source_location": "L71"
     },
     {
-      "community": 296,
+      "community": 298,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_app_test_js",
       "label": "app.test.js",
@@ -223768,7 +224035,7 @@
       "source_location": "L1"
     },
     {
-      "community": 297,
+      "community": 299,
       "file_type": "code",
       "id": "coverage_toolchain_parity_assertcoveragetoolchainparity",
       "label": "assertCoverageToolchainParity()",
@@ -223777,7 +224044,7 @@
       "source_location": "L165"
     },
     {
-      "community": 297,
+      "community": 299,
       "file_type": "code",
       "id": "coverage_toolchain_parity_checkcoveragetoolchainparity",
       "label": "checkCoverageToolchainParity()",
@@ -223786,7 +224053,7 @@
       "source_location": "L137"
     },
     {
-      "community": 297,
+      "community": 299,
       "file_type": "code",
       "id": "coverage_toolchain_parity_collectcoveragetoolchainfailures",
       "label": "collectCoverageToolchainFailures()",
@@ -223795,7 +224062,7 @@
       "source_location": "L93"
     },
     {
-      "community": 297,
+      "community": 299,
       "file_type": "code",
       "id": "coverage_toolchain_parity_declaredversion",
       "label": "declaredVersion()",
@@ -223804,7 +224071,7 @@
       "source_location": "L51"
     },
     {
-      "community": 297,
+      "community": 299,
       "file_type": "code",
       "id": "coverage_toolchain_parity_formatfailuremessage",
       "label": "formatFailureMessage()",
@@ -223813,7 +224080,7 @@
       "source_location": "L143"
     },
     {
-      "community": 297,
+      "community": 299,
       "file_type": "code",
       "id": "coverage_toolchain_parity_installedversion",
       "label": "installedVersion()",
@@ -223822,7 +224089,7 @@
       "source_location": "L59"
     },
     {
-      "community": 297,
+      "community": 299,
       "file_type": "code",
       "id": "coverage_toolchain_parity_readmanifest",
       "label": "readManifest()",
@@ -223831,7 +224098,7 @@
       "source_location": "L47"
     },
     {
-      "community": 297,
+      "community": 299,
       "file_type": "code",
       "id": "coverage_toolchain_parity_runfrozeninstall",
       "label": "runFrozenInstall()",
@@ -223840,157 +224107,13 @@
       "source_location": "L149"
     },
     {
-      "community": 297,
+      "community": 299,
       "file_type": "code",
       "id": "scripts_coverage_toolchain_parity_ts",
       "label": "coverage-toolchain-parity.ts",
       "norm_label": "coverage-toolchain-parity.ts",
       "source_file": "scripts/coverage-toolchain-parity.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 298,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cloudflare_r2_ts",
-      "label": "r2.ts",
-      "norm_label": "r2.ts",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 298,
-      "file_type": "code",
-      "id": "r2_deletedirectoryinr2",
-      "label": "deleteDirectoryInR2()",
-      "norm_label": "deletedirectoryinr2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L140"
-    },
-    {
-      "community": 298,
-      "file_type": "code",
-      "id": "r2_deletefileinr2",
-      "label": "deleteFileInR2()",
-      "norm_label": "deletefileinr2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 298,
-      "file_type": "code",
-      "id": "r2_getr2",
-      "label": "getR2()",
-      "norm_label": "getr2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L69"
-    },
-    {
-      "community": 298,
-      "file_type": "code",
-      "id": "r2_listitemsinr2directory",
-      "label": "listItemsInR2Directory()",
-      "norm_label": "listitemsinr2directory()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L188"
-    },
-    {
-      "community": 298,
-      "file_type": "code",
-      "id": "r2_readenvvalue",
-      "label": "readEnvValue()",
-      "norm_label": "readenvvalue()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 298,
-      "file_type": "code",
-      "id": "r2_resolver2configfromenv",
-      "label": "resolveR2ConfigFromEnv()",
-      "norm_label": "resolver2configfromenv()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 298,
-      "file_type": "code",
-      "id": "r2_uploadfiletor2",
-      "label": "uploadFileToR2()",
-      "norm_label": "uploadfiletor2()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
-      "source_location": "L98"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_customermessaging_repository_ts",
-      "label": "repository.ts",
-      "norm_label": "repository.ts",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/repository.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "repository_createorreusereceiptsharetoken",
-      "label": "createOrReuseReceiptShareToken()",
-      "norm_label": "createorreusereceiptsharetoken()",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/repository.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "repository_createreceiptdeliveryattempt",
-      "label": "createReceiptDeliveryAttempt()",
-      "norm_label": "createreceiptdeliveryattempt()",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/repository.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "repository_listreceiptdeliveriesfortransaction",
-      "label": "listReceiptDeliveriesForTransaction()",
-      "norm_label": "listreceiptdeliveriesfortransaction()",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/repository.ts",
-      "source_location": "L171"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "repository_markreceiptdeliveryfailed",
-      "label": "markReceiptDeliveryFailed()",
-      "norm_label": "markreceiptdeliveryfailed()",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/repository.ts",
-      "source_location": "L118"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "repository_markreceiptdeliveryprovideraccepted",
-      "label": "markReceiptDeliveryProviderAccepted()",
-      "norm_label": "markreceiptdeliveryprovideraccepted()",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/repository.ts",
-      "source_location": "L100"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "repository_resolvereceiptsharetoken",
-      "label": "resolveReceiptShareToken()",
-      "norm_label": "resolvereceiptsharetoken()",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/repository.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "repository_updatedeliverybyprovidermessageid",
-      "label": "updateDeliveryByProviderMessageId()",
-      "norm_label": "updatedeliverybyprovidermessageid()",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/repository.ts",
-      "source_location": "L138"
     },
     {
       "community": 3,
@@ -225003,6 +225126,150 @@
     {
       "community": 300,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_cloudflare_r2_ts",
+      "label": "r2.ts",
+      "norm_label": "r2.ts",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "r2_deletedirectoryinr2",
+      "label": "deleteDirectoryInR2()",
+      "norm_label": "deletedirectoryinr2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L140"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "r2_deletefileinr2",
+      "label": "deleteFileInR2()",
+      "norm_label": "deletefileinr2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L116"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "r2_getr2",
+      "label": "getR2()",
+      "norm_label": "getr2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L69"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "r2_listitemsinr2directory",
+      "label": "listItemsInR2Directory()",
+      "norm_label": "listitemsinr2directory()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L188"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "r2_readenvvalue",
+      "label": "readEnvValue()",
+      "norm_label": "readenvvalue()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "r2_resolver2configfromenv",
+      "label": "resolveR2ConfigFromEnv()",
+      "norm_label": "resolver2configfromenv()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "r2_uploadfiletor2",
+      "label": "uploadFileToR2()",
+      "norm_label": "uploadfiletor2()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
+      "source_location": "L98"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_customermessaging_repository_ts",
+      "label": "repository.ts",
+      "norm_label": "repository.ts",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/repository.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "repository_createorreusereceiptsharetoken",
+      "label": "createOrReuseReceiptShareToken()",
+      "norm_label": "createorreusereceiptsharetoken()",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/repository.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "repository_createreceiptdeliveryattempt",
+      "label": "createReceiptDeliveryAttempt()",
+      "norm_label": "createreceiptdeliveryattempt()",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/repository.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "repository_listreceiptdeliveriesfortransaction",
+      "label": "listReceiptDeliveriesForTransaction()",
+      "norm_label": "listreceiptdeliveriesfortransaction()",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/repository.ts",
+      "source_location": "L171"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "repository_markreceiptdeliveryfailed",
+      "label": "markReceiptDeliveryFailed()",
+      "norm_label": "markreceiptdeliveryfailed()",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/repository.ts",
+      "source_location": "L118"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "repository_markreceiptdeliveryprovideraccepted",
+      "label": "markReceiptDeliveryProviderAccepted()",
+      "norm_label": "markreceiptdeliveryprovideraccepted()",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/repository.ts",
+      "source_location": "L100"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "repository_resolvereceiptsharetoken",
+      "label": "resolveReceiptShareToken()",
+      "norm_label": "resolvereceiptsharetoken()",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/repository.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "repository_updatedeliverybyprovidermessageid",
+      "label": "updateDeliveryByProviderMessageId()",
+      "norm_label": "updatedeliverybyprovidermessageid()",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/repository.ts",
+      "source_location": "L138"
+    },
+    {
+      "community": 302,
+      "file_type": "code",
       "id": "inventoryimportcostoverlayorchestration_test_constructionanchor",
       "label": "constructionAnchor()",
       "norm_label": "constructionanchor()",
@@ -225010,7 +225277,7 @@
       "source_location": "L34"
     },
     {
-      "community": 300,
+      "community": 302,
       "file_type": "code",
       "id": "inventoryimportcostoverlayorchestration_test_constructionsource",
       "label": "constructionSource()",
@@ -225019,7 +225286,7 @@
       "source_location": "L52"
     },
     {
-      "community": 300,
+      "community": 302,
       "file_type": "code",
       "id": "inventoryimportcostoverlayorchestration_test_createconstructionharness",
       "label": "createConstructionHarness()",
@@ -225028,7 +225295,7 @@
       "source_location": "L62"
     },
     {
-      "community": 300,
+      "community": 302,
       "file_type": "code",
       "id": "inventoryimportcostoverlayorchestration_test_createmutationharness",
       "label": "createMutationHarness()",
@@ -225037,7 +225304,7 @@
       "source_location": "L231"
     },
     {
-      "community": 300,
+      "community": 302,
       "file_type": "code",
       "id": "inventoryimportcostoverlayorchestration_test_gethandler",
       "label": "getHandler()",
@@ -225046,7 +225313,7 @@
       "source_location": "L23"
     },
     {
-      "community": 300,
+      "community": 302,
       "file_type": "code",
       "id": "inventoryimportcostoverlayorchestration_test_orchestrationrun",
       "label": "orchestrationRun()",
@@ -225055,7 +225322,7 @@
       "source_location": "L338"
     },
     {
-      "community": 300,
+      "community": 302,
       "file_type": "code",
       "id": "inventoryimportcostoverlayorchestration_test_preparedrow",
       "label": "preparedRow()",
@@ -225064,7 +225331,7 @@
       "source_location": "L316"
     },
     {
-      "community": 300,
+      "community": 302,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_inventoryimportcostoverlayorchestration_test_ts",
       "label": "inventoryImportCostOverlayOrchestration.test.ts",
@@ -225073,7 +225340,7 @@
       "source_location": "L1"
     },
     {
-      "community": 301,
+      "community": 303,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_products_sku_test_ts",
       "label": "products.sku.test.ts",
@@ -225082,7 +225349,7 @@
       "source_location": "L1"
     },
     {
-      "community": 301,
+      "community": 303,
       "file_type": "code",
       "id": "products_sku_test_createproductsqueryctx",
       "label": "createProductsQueryCtx()",
@@ -225091,7 +225358,7 @@
       "source_location": "L305"
     },
     {
-      "community": 301,
+      "community": 303,
       "file_type": "code",
       "id": "products_sku_test_createskumutationctx",
       "label": "createSkuMutationCtx()",
@@ -225100,7 +225367,7 @@
       "source_location": "L161"
     },
     {
-      "community": 301,
+      "community": 303,
       "file_type": "code",
       "id": "products_sku_test_gethandler",
       "label": "getHandler()",
@@ -225109,7 +225376,7 @@
       "source_location": "L91"
     },
     {
-      "community": 301,
+      "community": 303,
       "file_type": "code",
       "id": "products_sku_test_gettestscheduler",
       "label": "getTestScheduler()",
@@ -225118,7 +225385,7 @@
       "source_location": "L95"
     },
     {
-      "community": 301,
+      "community": 303,
       "file_type": "code",
       "id": "products_sku_test_pendingcheckoutevidence",
       "label": "pendingCheckoutEvidence()",
@@ -225127,7 +225394,7 @@
       "source_location": "L101"
     },
     {
-      "community": 301,
+      "community": 303,
       "file_type": "code",
       "id": "products_sku_test_pendingcheckoutitem",
       "label": "pendingCheckoutItem()",
@@ -225136,7 +225403,7 @@
       "source_location": "L113"
     },
     {
-      "community": 301,
+      "community": 303,
       "file_type": "code",
       "id": "products_sku_test_pendingcheckoutreviewworkitem",
       "label": "pendingCheckoutReviewWorkItem()",
@@ -225145,7 +225412,7 @@
       "source_location": "L139"
     },
     {
-      "community": 302,
+      "community": 304,
       "file_type": "code",
       "id": "migrateposamountstopesewas_convertcloseoutrecords",
       "label": "convertCloseoutRecords()",
@@ -225154,7 +225421,7 @@
       "source_location": "L48"
     },
     {
-      "community": 302,
+      "community": 304,
       "file_type": "code",
       "id": "migrateposamountstopesewas_convertpayments",
       "label": "convertPayments()",
@@ -225163,7 +225430,7 @@
       "source_location": "L38"
     },
     {
-      "community": 302,
+      "community": 304,
       "file_type": "code",
       "id": "migrateposamountstopesewas_migrateposamounttablewithctx",
       "label": "migratePosAmountTableWithCtx()",
@@ -225172,7 +225439,7 @@
       "source_location": "L150"
     },
     {
-      "community": 302,
+      "community": 304,
       "file_type": "code",
       "id": "migrateposamountstopesewas_pesewaspatchforrow",
       "label": "pesewasPatchForRow()",
@@ -225181,7 +225448,7 @@
       "source_location": "L73"
     },
     {
-      "community": 302,
+      "community": 304,
       "file_type": "code",
       "id": "migrateposamountstopesewas_posamountmigrationstatuswithctx",
       "label": "posAmountMigrationStatusWithCtx()",
@@ -225190,7 +225457,7 @@
       "source_location": "L196"
     },
     {
-      "community": 302,
+      "community": 304,
       "file_type": "code",
       "id": "migrateposamountstopesewas_topesewasoptional",
       "label": "toPesewasOptional()",
@@ -225199,7 +225466,7 @@
       "source_location": "L34"
     },
     {
-      "community": 302,
+      "community": 304,
       "file_type": "code",
       "id": "migrateposamountstopesewas_upsertmigrationrun",
       "label": "upsertMigrationRun()",
@@ -225208,7 +225475,7 @@
       "source_location": "L112"
     },
     {
-      "community": 302,
+      "community": 304,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_migrateposamountstopesewas_ts",
       "label": "migratePosAmountsToPesewas.ts",
@@ -225217,7 +225484,7 @@
       "source_location": "L1"
     },
     {
-      "community": 303,
+      "community": 305,
       "file_type": "code",
       "id": "config_buildmtncollectionscallbackurl",
       "label": "buildMtnCollectionsCallbackUrl()",
@@ -225226,7 +225493,7 @@
       "source_location": "L135"
     },
     {
-      "community": 303,
+      "community": 305,
       "file_type": "code",
       "id": "config_buildmtncollectionslookupprefixes",
       "label": "buildMtnCollectionsLookupPrefixes()",
@@ -225235,7 +225502,7 @@
       "source_location": "L43"
     },
     {
-      "community": 303,
+      "community": 305,
       "file_type": "code",
       "id": "config_istargetenvironment",
       "label": "isTargetEnvironment()",
@@ -225244,7 +225511,7 @@
       "source_location": "L67"
     },
     {
-      "community": 303,
+      "community": 305,
       "file_type": "code",
       "id": "config_readscopedvalue",
       "label": "readScopedValue()",
@@ -225253,7 +225520,7 @@
       "source_location": "L56"
     },
     {
-      "community": 303,
+      "community": 305,
       "file_type": "code",
       "id": "config_resolveconfigforprefix",
       "label": "resolveConfigForPrefix()",
@@ -225262,7 +225529,7 @@
       "source_location": "L73"
     },
     {
-      "community": 303,
+      "community": 305,
       "file_type": "code",
       "id": "config_resolvemtncollectionsconfigfromenv",
       "label": "resolveMtnCollectionsConfigFromEnv()",
@@ -225271,7 +225538,7 @@
       "source_location": "L108"
     },
     {
-      "community": 303,
+      "community": 305,
       "file_type": "code",
       "id": "config_toenvsegment",
       "label": "toEnvSegment()",
@@ -225280,7 +225547,7 @@
       "source_location": "L29"
     },
     {
-      "community": 303,
+      "community": 305,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_config_ts",
       "label": "config.ts",
@@ -225289,7 +225556,7 @@
       "source_location": "L1"
     },
     {
-      "community": 304,
+      "community": 306,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_notifications_subscriptions_ts",
       "label": "subscriptions.ts",
@@ -225298,7 +225565,7 @@
       "source_location": "L1"
     },
     {
-      "community": 304,
+      "community": 306,
       "file_type": "code",
       "id": "subscriptions_addsubscriptioncommandwithctx",
       "label": "addSubscriptionCommandWithCtx()",
@@ -225307,7 +225574,7 @@
       "source_location": "L300"
     },
     {
-      "community": 304,
+      "community": 306,
       "file_type": "code",
       "id": "subscriptions_mapsubscriptioncommanderror",
       "label": "mapSubscriptionCommandError()",
@@ -225316,7 +225583,7 @@
       "source_location": "L267"
     },
     {
-      "community": 304,
+      "community": 306,
       "file_type": "code",
       "id": "subscriptions_memberdisplayname",
       "label": "memberDisplayName()",
@@ -225325,7 +225592,7 @@
       "source_location": "L199"
     },
     {
-      "community": 304,
+      "community": 306,
       "file_type": "code",
       "id": "subscriptions_removesubscriptioncommandwithctx",
       "label": "removeSubscriptionCommandWithCtx()",
@@ -225334,7 +225601,7 @@
       "source_location": "L444"
     },
     {
-      "community": 304,
+      "community": 306,
       "file_type": "code",
       "id": "subscriptions_requireorganizationfulladminwithctx",
       "label": "requireOrganizationFullAdminWithCtx()",
@@ -225343,7 +225610,7 @@
       "source_location": "L78"
     },
     {
-      "community": 304,
+      "community": 306,
       "file_type": "code",
       "id": "subscriptions_requireownedsubscriptionrowwithctx",
       "label": "requireOwnedSubscriptionRowWithCtx()",
@@ -225352,7 +225619,7 @@
       "source_location": "L391"
     },
     {
-      "community": 304,
+      "community": 306,
       "file_type": "code",
       "id": "subscriptions_setsubscriptionenabledcommandwithctx",
       "label": "setSubscriptionEnabledCommandWithCtx()",
@@ -225361,7 +225628,7 @@
       "source_location": "L409"
     },
     {
-      "community": 305,
+      "community": 307,
       "file_type": "code",
       "id": "approvalauditevents_recordapprovalauditeventwithctx",
       "label": "recordApprovalAuditEventWithCtx()",
@@ -225370,7 +225637,7 @@
       "source_location": "L30"
     },
     {
-      "community": 305,
+      "community": 307,
       "file_type": "code",
       "id": "approvalauditevents_recordapprovaldecisionrecordedauditeventwithctx",
       "label": "recordApprovalDecisionRecordedAuditEventWithCtx()",
@@ -225379,7 +225646,7 @@
       "source_location": "L107"
     },
     {
-      "community": 305,
+      "community": 307,
       "file_type": "code",
       "id": "approvalauditevents_recordapprovalproofconsumedauditeventwithctx",
       "label": "recordApprovalProofConsumedAuditEventWithCtx()",
@@ -225388,7 +225655,7 @@
       "source_location": "L87"
     },
     {
-      "community": 305,
+      "community": 307,
       "file_type": "code",
       "id": "approvalauditevents_recordapprovalrequiredauditeventwithctx",
       "label": "recordApprovalRequiredAuditEventWithCtx()",
@@ -225397,7 +225664,7 @@
       "source_location": "L67"
     },
     {
-      "community": 305,
+      "community": 307,
       "file_type": "code",
       "id": "approvalauditevents_recordapprovedcommandappliedauditeventwithctx",
       "label": "recordApprovedCommandAppliedAuditEventWithCtx()",
@@ -225406,7 +225673,7 @@
       "source_location": "L117"
     },
     {
-      "community": 305,
+      "community": 307,
       "file_type": "code",
       "id": "approvalauditevents_recordasyncapprovalrequestcreatedauditeventwithctx",
       "label": "recordAsyncApprovalRequestCreatedAuditEventWithCtx()",
@@ -225415,7 +225682,7 @@
       "source_location": "L97"
     },
     {
-      "community": 305,
+      "community": 307,
       "file_type": "code",
       "id": "approvalauditevents_recordmanagerapprovalgrantedauditeventwithctx",
       "label": "recordManagerApprovalGrantedAuditEventWithCtx()",
@@ -225424,7 +225691,7 @@
       "source_location": "L77"
     },
     {
-      "community": 305,
+      "community": 307,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalauditevents_ts",
       "label": "approvalAuditEvents.ts",
@@ -225433,7 +225700,7 @@
       "source_location": "L1"
     },
     {
-      "community": 306,
+      "community": 308,
       "file_type": "code",
       "id": "approvalrequestemail_buildapprovalrequestpendingdata",
       "label": "buildApprovalRequestPendingData()",
@@ -225442,7 +225709,7 @@
       "source_location": "L109"
     },
     {
-      "community": 306,
+      "community": 308,
       "file_type": "code",
       "id": "approvalrequestemail_buildapprovalsqueueurl",
       "label": "buildApprovalsQueueUrl()",
@@ -225451,7 +225718,7 @@
       "source_location": "L219"
     },
     {
-      "community": 306,
+      "community": 308,
       "file_type": "code",
       "id": "approvalrequestemail_formatcreatedat",
       "label": "formatCreatedAt()",
@@ -225460,7 +225727,7 @@
       "source_location": "L204"
     },
     {
-      "community": 306,
+      "community": 308,
       "file_type": "code",
       "id": "approvalrequestemail_metadatanumber",
       "label": "metadataNumber()",
@@ -225469,7 +225736,7 @@
       "source_location": "L235"
     },
     {
-      "community": 306,
+      "community": 308,
       "file_type": "code",
       "id": "approvalrequestemail_metadatastring",
       "label": "metadataString()",
@@ -225478,7 +225745,7 @@
       "source_location": "L227"
     },
     {
-      "community": 306,
+      "community": 308,
       "file_type": "code",
       "id": "approvalrequestemail_resolveapprovalrequestidentifier",
       "label": "resolveApprovalRequestIdentifier()",
@@ -225487,7 +225754,7 @@
       "source_location": "L169"
     },
     {
-      "community": 306,
+      "community": 308,
       "file_type": "code",
       "id": "approvalrequestemail_resolverequestername",
       "label": "resolveRequesterName()",
@@ -225496,7 +225763,7 @@
       "source_location": "L186"
     },
     {
-      "community": 306,
+      "community": 308,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequestemail_ts",
       "label": "approvalRequestEmail.ts",
@@ -225505,7 +225772,7 @@
       "source_location": "L1"
     },
     {
-      "community": 307,
+      "community": 309,
       "file_type": "code",
       "id": "capabilitycatalog_classifyathenapublicwrite",
       "label": "classifyAthenaPublicWrite()",
@@ -225514,7 +225781,7 @@
       "source_location": "L300"
     },
     {
-      "community": 307,
+      "community": 309,
       "file_type": "code",
       "id": "capabilitycatalog_hascompletedweeklyobservedatverification",
       "label": "hasCompletedWeeklyObservedAtVerification()",
@@ -225523,7 +225790,7 @@
       "source_location": "L64"
     },
     {
-      "community": 307,
+      "community": 309,
       "file_type": "code",
       "id": "capabilitycatalog_hascompletedweeklyreportingcycleanchorverification",
       "label": "hasCompletedWeeklyReportingCycleAnchorVerification()",
@@ -225532,7 +225799,7 @@
       "source_location": "L82"
     },
     {
-      "community": 307,
+      "community": 309,
       "file_type": "code",
       "id": "capabilitycatalog_isclosewithinweeklyacceptancefloor",
       "label": "isCloseWithinWeeklyAcceptanceFloor()",
@@ -225541,7 +225808,7 @@
       "source_location": "L99"
     },
     {
-      "community": 307,
+      "community": 309,
       "file_type": "code",
       "id": "capabilitycatalog_isshareddemocapabilityallowed",
       "label": "isSharedDemoCapabilityAllowed()",
@@ -225550,7 +225817,7 @@
       "source_location": "L321"
     },
     {
-      "community": 307,
+      "community": 309,
       "file_type": "code",
       "id": "capabilitycatalog_isweeklyreportingenabledforstore",
       "label": "isWeeklyReportingEnabledForStore()",
@@ -225559,7 +225826,7 @@
       "source_location": "L117"
     },
     {
-      "community": 307,
+      "community": 309,
       "file_type": "code",
       "id": "capabilitycatalog_isweeklyreportingenabledforstoredoc",
       "label": "isWeeklyReportingEnabledForStoreDoc()",
@@ -225568,156 +225835,12 @@
       "source_location": "L136"
     },
     {
-      "community": 307,
+      "community": 309,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_platform_capabilitycatalog_ts",
       "label": "capabilityCatalog.ts",
       "norm_label": "capabilitycatalog.ts",
       "source_file": "packages/athena-webapp/convex/platform/capabilityCatalog.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 308,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
-      "label": "posSessionTracing.ts",
-      "norm_label": "possessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 308,
-      "file_type": "code",
-      "id": "possessiontracing_buildpossessiontraceevent",
-      "label": "buildPosSessionTraceEvent()",
-      "norm_label": "buildpossessiontraceevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L226"
-    },
-    {
-      "community": 308,
-      "file_type": "code",
-      "id": "possessiontracing_buildpossessiontracerecord",
-      "label": "buildPosSessionTraceRecord()",
-      "norm_label": "buildpossessiontracerecord()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L142"
-    },
-    {
-      "community": 308,
-      "file_type": "code",
-      "id": "possessiontracing_buildtracesummary",
-      "label": "buildTraceSummary()",
-      "norm_label": "buildtracesummary()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L105"
-    },
-    {
-      "community": 308,
-      "file_type": "code",
-      "id": "possessiontracing_createpossessiontracerecorder",
-      "label": "createPosSessionTraceRecorder()",
-      "norm_label": "createpossessiontracerecorder()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L559"
-    },
-    {
-      "community": 308,
-      "file_type": "code",
-      "id": "possessiontracing_formatpaymentmethod",
-      "label": "formatPaymentMethod()",
-      "norm_label": "formatpaymentmethod()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L218"
-    },
-    {
-      "community": 308,
-      "file_type": "code",
-      "id": "possessiontracing_recordpossessiontracebesteffort",
-      "label": "recordPosSessionTraceBestEffort()",
-      "norm_label": "recordpossessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L532"
-    },
-    {
-      "community": 308,
-      "file_type": "code",
-      "id": "possessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
-      "source_location": "L524"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_builditem",
-      "label": "buildItem()",
-      "norm_label": "builditem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L1083"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L1077"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_buildsession",
-      "label": "buildSession()",
-      "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L1073"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_createcommandservice",
-      "label": "createCommandService()",
-      "norm_label": "createcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L1093"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_createdependencies",
-      "label": "createDependencies()",
-      "norm_label": "createdependencies()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L813"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_createfakerepository",
-      "label": "createFakeRepository()",
-      "norm_label": "createfakerepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L900"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "expensesessioncommands_test_loadcommandservice",
-      "label": "loadCommandService()",
-      "norm_label": "loadcommandservice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
-      "source_location": "L793"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_expensesessioncommands_test_ts",
-      "label": "expenseSessionCommands.test.ts",
-      "norm_label": "expensesessioncommands.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
       "source_location": "L1"
     },
     {
@@ -226029,6 +226152,150 @@
     {
       "community": 310,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
+      "label": "posSessionTracing.ts",
+      "norm_label": "possessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "possessiontracing_buildpossessiontraceevent",
+      "label": "buildPosSessionTraceEvent()",
+      "norm_label": "buildpossessiontraceevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L226"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "possessiontracing_buildpossessiontracerecord",
+      "label": "buildPosSessionTraceRecord()",
+      "norm_label": "buildpossessiontracerecord()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L142"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "possessiontracing_buildtracesummary",
+      "label": "buildTraceSummary()",
+      "norm_label": "buildtracesummary()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L105"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "possessiontracing_createpossessiontracerecorder",
+      "label": "createPosSessionTraceRecorder()",
+      "norm_label": "createpossessiontracerecorder()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L559"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "possessiontracing_formatpaymentmethod",
+      "label": "formatPaymentMethod()",
+      "norm_label": "formatpaymentmethod()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L218"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "possessiontracing_recordpossessiontracebesteffort",
+      "label": "recordPosSessionTraceBestEffort()",
+      "norm_label": "recordpossessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L532"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "possessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts",
+      "source_location": "L524"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_builditem",
+      "label": "buildItem()",
+      "norm_label": "builditem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L1083"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L1077"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_buildsession",
+      "label": "buildSession()",
+      "norm_label": "buildsession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L1073"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_createcommandservice",
+      "label": "createCommandService()",
+      "norm_label": "createcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L1093"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_createdependencies",
+      "label": "createDependencies()",
+      "norm_label": "createdependencies()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L813"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_createfakerepository",
+      "label": "createFakeRepository()",
+      "norm_label": "createfakerepository()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L900"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
+      "id": "expensesessioncommands_test_loadcommandservice",
+      "label": "loadCommandService()",
+      "norm_label": "loadcommandservice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L793"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_expensesessioncommands_test_ts",
+      "label": "expenseSessionCommands.test.ts",
+      "norm_label": "expensesessioncommands.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/expenseSessionCommands.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 312,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "label": "sessionCommands.test.ts",
       "norm_label": "sessioncommands.test.ts",
@@ -226036,7 +226303,7 @@
       "source_location": "L1"
     },
     {
-      "community": 310,
+      "community": 312,
       "file_type": "code",
       "id": "sessioncommands_test_builditem",
       "label": "buildItem()",
@@ -226045,7 +226312,7 @@
       "source_location": "L3408"
     },
     {
-      "community": 310,
+      "community": 312,
       "file_type": "code",
       "id": "sessioncommands_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -226054,7 +226321,7 @@
       "source_location": "L3402"
     },
     {
-      "community": 310,
+      "community": 312,
       "file_type": "code",
       "id": "sessioncommands_test_buildsession",
       "label": "buildSession()",
@@ -226063,7 +226330,7 @@
       "source_location": "L3398"
     },
     {
-      "community": 310,
+      "community": 312,
       "file_type": "code",
       "id": "sessioncommands_test_createcommandservice",
       "label": "createCommandService()",
@@ -226072,7 +226339,7 @@
       "source_location": "L3418"
     },
     {
-      "community": 310,
+      "community": 312,
       "file_type": "code",
       "id": "sessioncommands_test_createdependencies",
       "label": "createDependencies()",
@@ -226081,7 +226348,7 @@
       "source_location": "L3125"
     },
     {
-      "community": 310,
+      "community": 312,
       "file_type": "code",
       "id": "sessioncommands_test_createfakerepository",
       "label": "createFakeRepository()",
@@ -226090,7 +226357,7 @@
       "source_location": "L3222"
     },
     {
-      "community": 310,
+      "community": 312,
       "file_type": "code",
       "id": "sessioncommands_test_loadcommandservice",
       "label": "loadCommandService()",
@@ -226099,7 +226366,7 @@
       "source_location": "L3107"
     },
     {
-      "community": 311,
+      "community": 313,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_projectlocalevents_test_ts",
       "label": "projectLocalEvents.test.ts",
@@ -226108,7 +226375,7 @@
       "source_location": "L1"
     },
     {
-      "community": 311,
+      "community": 313,
       "file_type": "code",
       "id": "projectlocalevents_test_buildexpenserecordedevent",
       "label": "buildExpenseRecordedEvent()",
@@ -226117,7 +226384,7 @@
       "source_location": "L8009"
     },
     {
-      "community": 311,
+      "community": 313,
       "file_type": "code",
       "id": "projectlocalevents_test_buildpendingcheckoutitemdefinedevent",
       "label": "buildPendingCheckoutItemDefinedEvent()",
@@ -226126,7 +226393,7 @@
       "source_location": "L8092"
     },
     {
-      "community": 311,
+      "community": 313,
       "file_type": "code",
       "id": "projectlocalevents_test_buildregistercloseoutreviewfact",
       "label": "buildRegisterCloseoutReviewFact()",
@@ -226135,7 +226402,7 @@
       "source_location": "L9150"
     },
     {
-      "community": 311,
+      "community": 313,
       "file_type": "code",
       "id": "projectlocalevents_test_buildsaleclearedevent",
       "label": "buildSaleClearedEvent()",
@@ -226144,7 +226411,7 @@
       "source_location": "L8145"
     },
     {
-      "community": 311,
+      "community": 313,
       "file_type": "code",
       "id": "projectlocalevents_test_buildsalecompletedevent",
       "label": "buildSaleCompletedEvent()",
@@ -226153,7 +226420,7 @@
       "source_location": "L8046"
     },
     {
-      "community": 311,
+      "community": 313,
       "file_type": "code",
       "id": "projectlocalevents_test_buildserviceline",
       "label": "buildServiceLine()",
@@ -226162,7 +226429,7 @@
       "source_location": "L8125"
     },
     {
-      "community": 311,
+      "community": 313,
       "file_type": "code",
       "id": "projectlocalevents_test_createprojectionrepository",
       "label": "createProjectionRepository()",
@@ -226171,7 +226438,7 @@
       "source_location": "L8164"
     },
     {
-      "community": 312,
+      "community": 314,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_resolveterminalcloudrepair_test_ts",
       "label": "resolveTerminalCloudRepair.test.ts",
@@ -226180,7 +226447,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 314,
       "file_type": "code",
       "id": "resolveterminalcloudrepair_test_buildconflict",
       "label": "buildConflict()",
@@ -226189,7 +226456,7 @@
       "source_location": "L587"
     },
     {
-      "community": 312,
+      "community": 314,
       "file_type": "code",
       "id": "resolveterminalcloudrepair_test_buildctx",
       "label": "buildCtx()",
@@ -226198,7 +226465,7 @@
       "source_location": "L440"
     },
     {
-      "community": 312,
+      "community": 314,
       "file_type": "code",
       "id": "resolveterminalcloudrepair_test_buildevent",
       "label": "buildEvent()",
@@ -226207,7 +226474,7 @@
       "source_location": "L607"
     },
     {
-      "community": 312,
+      "community": 314,
       "file_type": "code",
       "id": "resolveterminalcloudrepair_test_buildquery",
       "label": "buildQuery()",
@@ -226216,7 +226483,7 @@
       "source_location": "L499"
     },
     {
-      "community": 312,
+      "community": 314,
       "file_type": "code",
       "id": "resolveterminalcloudrepair_test_buildstaffprofile",
       "label": "buildStaffProfile()",
@@ -226225,7 +226492,7 @@
       "source_location": "L566"
     },
     {
-      "community": 312,
+      "community": 314,
       "file_type": "code",
       "id": "resolveterminalcloudrepair_test_buildstore",
       "label": "buildStore()",
@@ -226234,7 +226501,7 @@
       "source_location": "L578"
     },
     {
-      "community": 312,
+      "community": 314,
       "file_type": "code",
       "id": "resolveterminalcloudrepair_test_buildterminal",
       "label": "buildTerminal()",
@@ -226243,7 +226510,7 @@
       "source_location": "L553"
     },
     {
-      "community": 313,
+      "community": 315,
       "file_type": "code",
       "id": "livekitremoteassisttransportprovider_buildgrant",
       "label": "buildGrant()",
@@ -226252,7 +226519,7 @@
       "source_location": "L93"
     },
     {
-      "community": 313,
+      "community": 315,
       "file_type": "code",
       "id": "livekitremoteassisttransportprovider_getlivekitconfig",
       "label": "getLiveKitConfig()",
@@ -226261,7 +226528,7 @@
       "source_location": "L77"
     },
     {
-      "community": 313,
+      "community": 315,
       "file_type": "code",
       "id": "livekitremoteassisttransportprovider_isalreadyexistserror",
       "label": "isAlreadyExistsError()",
@@ -226270,7 +226537,7 @@
       "source_location": "L106"
     },
     {
-      "community": 313,
+      "community": 315,
       "file_type": "code",
       "id": "livekitremoteassisttransportprovider_livekitremoteassisttransportprovider",
       "label": "LiveKitRemoteAssistTransportProvider",
@@ -226279,7 +226546,7 @@
       "source_location": "L27"
     },
     {
-      "community": 313,
+      "community": 315,
       "file_type": "code",
       "id": "livekitremoteassisttransportprovider_livekitremoteassisttransportprovider_constructor",
       "label": ".constructor()",
@@ -226288,7 +226555,7 @@
       "source_location": "L30"
     },
     {
-      "community": 313,
+      "community": 315,
       "file_type": "code",
       "id": "livekitremoteassisttransportprovider_livekitremoteassisttransportprovider_ensureroom",
       "label": ".ensureRoom()",
@@ -226297,7 +226564,7 @@
       "source_location": "L54"
     },
     {
-      "community": 313,
+      "community": 315,
       "file_type": "code",
       "id": "livekitremoteassisttransportprovider_livekitremoteassisttransportprovider_issuecredential",
       "label": ".issueCredential()",
@@ -226306,7 +226573,7 @@
       "source_location": "L32"
     },
     {
-      "community": 313,
+      "community": 315,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_infrastructure_transport_livekitremoteassisttransportprovider_ts",
       "label": "LiveKitRemoteAssistTransportProvider.ts",
@@ -226315,88 +226582,88 @@
       "source_location": "L1"
     },
     {
-      "community": 314,
+      "community": 316,
       "file_type": "code",
-      "id": "contract_test_fieldsof",
-      "label": "fieldsOf()",
-      "norm_label": "fieldsof()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L80"
+      "id": "foldversionrepair_boundedlimit",
+      "label": "boundedLimit()",
+      "norm_label": "boundedlimit()",
+      "source_file": "packages/athena-webapp/convex/reports/foldVersionRepair.ts",
+      "source_location": "L99"
     },
     {
-      "community": 314,
+      "community": 316,
       "file_type": "code",
-      "id": "contract_test_headerfor",
-      "label": "headerFor()",
-      "norm_label": "headerfor()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L859"
+      "id": "foldversionrepair_countstalefoldversiondayswithctx",
+      "label": "countStaleFoldVersionDaysWithCtx()",
+      "norm_label": "countstalefoldversiondayswithctx()",
+      "source_file": "packages/athena-webapp/convex/reports/foldVersionRepair.ts",
+      "source_location": "L240"
     },
     {
-      "community": 314,
+      "community": 316,
       "file_type": "code",
-      "id": "contract_test_inclusivedays",
-      "label": "inclusiveDays()",
-      "norm_label": "inclusivedays()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L1103"
+      "id": "foldversionrepair_countuncertifieddayswithctx",
+      "label": "countUncertifiedDaysWithCtx()",
+      "norm_label": "countuncertifieddayswithctx()",
+      "source_file": "packages/athena-webapp/convex/reports/foldVersionRepair.ts",
+      "source_location": "L271"
     },
     {
-      "community": 314,
+      "community": 316,
       "file_type": "code",
-      "id": "contract_test_movementidentityargs",
-      "label": "movementIdentityArgs()",
-      "norm_label": "movementidentityargs()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L489"
+      "id": "foldversionrepair_daypage",
+      "label": "dayPage()",
+      "norm_label": "daypage()",
+      "source_file": "packages/athena-webapp/convex/reports/foldVersionRepair.ts",
+      "source_location": "L113"
     },
     {
-      "community": 314,
+      "community": 316,
       "file_type": "code",
-      "id": "contract_test_seedproductsku",
-      "label": "seedProductSku()",
-      "norm_label": "seedproductsku()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L448"
+      "id": "foldversionrepair_markstalefoldversiondayswithctx",
+      "label": "markStaleFoldVersionDaysWithCtx()",
+      "norm_label": "markstalefoldversiondayswithctx()",
+      "source_file": "packages/athena-webapp/convex/reports/foldVersionRepair.ts",
+      "source_location": "L126"
     },
     {
-      "community": 314,
+      "community": 316,
       "file_type": "code",
-      "id": "contract_test_seedstore",
-      "label": "seedStore()",
-      "norm_label": "seedstore()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L429"
+      "id": "foldversionrepair_needscertifiedrefold",
+      "label": "needsCertifiedRefold()",
+      "norm_label": "needscertifiedrefold()",
+      "source_file": "packages/athena-webapp/convex/reports/foldVersionRepair.ts",
+      "source_location": "L65"
     },
     {
-      "community": 314,
+      "community": 316,
       "file_type": "code",
-      "id": "contract_test_unionliterals",
-      "label": "unionLiterals()",
-      "norm_label": "unionliterals()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L86"
+      "id": "foldversionrepair_skudayrowcountbackfillneeded",
+      "label": "skuDayRowCountBackfillNeeded()",
+      "norm_label": "skudayrowcountbackfillneeded()",
+      "source_file": "packages/athena-webapp/convex/reports/foldVersionRepair.ts",
+      "source_location": "L90"
     },
     {
-      "community": 314,
+      "community": 316,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_contract_test_ts",
-      "label": "contract.test.ts",
-      "norm_label": "contract.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "id": "packages_athena_webapp_convex_reports_foldversionrepair_ts",
+      "label": "foldVersionRepair.ts",
+      "norm_label": "foldversionrepair.ts",
+      "source_file": "packages/athena-webapp/convex/reports/foldVersionRepair.ts",
       "source_location": "L1"
     },
     {
-      "community": 315,
+      "community": 317,
       "file_type": "code",
       "id": "ingest_test_brokenctx",
       "label": "brokenCtx()",
       "norm_label": "brokenctx()",
       "source_file": "packages/athena-webapp/convex/reports/ingest.test.ts",
-      "source_location": "L723"
+      "source_location": "L784"
     },
     {
-      "community": 315,
+      "community": 317,
       "file_type": "code",
       "id": "ingest_test_payment",
       "label": "payment()",
@@ -226405,7 +226672,7 @@
       "source_location": "L507"
     },
     {
-      "community": 315,
+      "community": 317,
       "file_type": "code",
       "id": "ingest_test_readday",
       "label": "readDay()",
@@ -226414,7 +226681,7 @@
       "source_location": "L106"
     },
     {
-      "community": 315,
+      "community": 317,
       "file_type": "code",
       "id": "ingest_test_readdirty",
       "label": "readDirty()",
@@ -226423,7 +226690,7 @@
       "source_location": "L137"
     },
     {
-      "community": 315,
+      "community": 317,
       "file_type": "code",
       "id": "ingest_test_refoldday",
       "label": "refoldDay()",
@@ -226432,7 +226699,7 @@
       "source_location": "L119"
     },
     {
-      "community": 315,
+      "community": 317,
       "file_type": "code",
       "id": "ingest_test_salefact",
       "label": "saleFact()",
@@ -226441,7 +226708,7 @@
       "source_location": "L89"
     },
     {
-      "community": 315,
+      "community": 317,
       "file_type": "code",
       "id": "ingest_test_seed",
       "label": "seed()",
@@ -226450,7 +226717,7 @@
       "source_location": "L33"
     },
     {
-      "community": 315,
+      "community": 317,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_ingest_test_ts",
       "label": "ingest.test.ts",
@@ -226459,7 +226726,7 @@
       "source_location": "L1"
     },
     {
-      "community": 316,
+      "community": 318,
       "file_type": "code",
       "id": "ingest_addmetric",
       "label": "addMetric()",
@@ -226468,7 +226735,7 @@
       "source_location": "L310"
     },
     {
-      "community": 316,
+      "community": 318,
       "file_type": "code",
       "id": "ingest_applytoopenday",
       "label": "applyToOpenDay()",
@@ -226477,7 +226744,7 @@
       "source_location": "L317"
     },
     {
-      "community": 316,
+      "community": 318,
       "file_type": "code",
       "id": "ingest_factdeltas",
       "label": "factDeltas()",
@@ -226486,7 +226753,7 @@
       "source_location": "L91"
     },
     {
-      "community": 316,
+      "community": 318,
       "file_type": "code",
       "id": "ingest_findexistingfact",
       "label": "findExistingFact()",
@@ -226495,7 +226762,7 @@
       "source_location": "L266"
     },
     {
-      "community": 316,
+      "community": 318,
       "file_type": "code",
       "id": "ingest_markdirty",
       "label": "markDirty()",
@@ -226504,16 +226771,16 @@
       "source_location": "L285"
     },
     {
-      "community": 316,
+      "community": 318,
       "file_type": "code",
       "id": "ingest_recordfacts",
       "label": "recordFacts()",
       "norm_label": "recordfacts()",
       "source_file": "packages/athena-webapp/convex/reports/ingest.ts",
-      "source_location": "L539"
+      "source_location": "L564"
     },
     {
-      "community": 316,
+      "community": 318,
       "file_type": "code",
       "id": "ingest_tofactdoc",
       "label": "toFactDoc()",
@@ -226522,7 +226789,7 @@
       "source_location": "L230"
     },
     {
-      "community": 316,
+      "community": 318,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_ingest_ts",
       "label": "ingest.ts",
@@ -226531,7 +226798,7 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 319,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_skumixrange_ts",
       "label": "skuMixRange.ts",
@@ -226540,7 +226807,7 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 319,
       "file_type": "code",
       "id": "skumixrange_aggregatemixsourceday",
       "label": "aggregateMixSourceDay()",
@@ -226549,7 +226816,7 @@
       "source_location": "L203"
     },
     {
-      "community": 317,
+      "community": 319,
       "file_type": "code",
       "id": "skumixrange_ensuremixrangecore",
       "label": "ensureMixRangeCore()",
@@ -226558,7 +226825,7 @@
       "source_location": "L381"
     },
     {
-      "community": 317,
+      "community": 319,
       "file_type": "code",
       "id": "skumixrange_mixretrybackoffms",
       "label": "mixRetryBackoffMs()",
@@ -226567,7 +226834,7 @@
       "source_location": "L479"
     },
     {
-      "community": 317,
+      "community": 319,
       "file_type": "code",
       "id": "skumixrange_readablemixheader",
       "label": "readableMixHeader()",
@@ -226576,7 +226843,7 @@
       "source_location": "L564"
     },
     {
-      "community": 317,
+      "community": 319,
       "file_type": "code",
       "id": "skumixrange_recordmixworkerfailurecore",
       "label": "recordMixWorkerFailureCore()",
@@ -226585,7 +226852,7 @@
       "source_location": "L486"
     },
     {
-      "community": 317,
+      "community": 319,
       "file_type": "code",
       "id": "skumixrange_retryterminalmixrequest",
       "label": "retryTerminalMixRequest()",
@@ -226594,157 +226861,13 @@
       "source_location": "L427"
     },
     {
-      "community": 317,
+      "community": 319,
       "file_type": "code",
       "id": "skumixrange_runmixbatchcore",
       "label": "runMixBatchCore()",
       "norm_label": "runmixbatchcore()",
       "source_file": "packages/athena-webapp/convex/reports/skuMixRange.ts",
       "source_location": "L458"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_weeklyscale_test_ts",
-      "label": "weeklyScale.test.ts",
-      "norm_label": "weeklyscale.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/weeklyScale.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "weeklyscale_test_countprojectionreads",
-      "label": "countProjectionReads()",
-      "norm_label": "countprojectionreads()",
-      "source_file": "packages/athena-webapp/convex/reports/weeklyScale.test.ts",
-      "source_location": "L257"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "weeklyscale_test_handlerof",
-      "label": "handlerOf()",
-      "norm_label": "handlerof()",
-      "source_file": "packages/athena-webapp/convex/reports/weeklyScale.test.ts",
-      "source_location": "L81"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "weeklyscale_test_ledgeridentity",
-      "label": "ledgerIdentity()",
-      "norm_label": "ledgeridentity()",
-      "source_file": "packages/athena-webapp/convex/reports/weeklyScale.test.ts",
-      "source_location": "L677"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "weeklyscale_test_measurepublicprojectionread",
-      "label": "measurePublicProjectionRead()",
-      "norm_label": "measurepublicprojectionread()",
-      "source_file": "packages/athena-webapp/convex/reports/weeklyScale.test.ts",
-      "source_location": "L325"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "weeklyscale_test_percentile95",
-      "label": "percentile95()",
-      "norm_label": "percentile95()",
-      "source_file": "packages/athena-webapp/convex/reports/weeklyScale.test.ts",
-      "source_location": "L320"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "weeklyscale_test_seedacceptedfactscalefixture",
-      "label": "seedAcceptedFactScaleFixture()",
-      "norm_label": "seedacceptedfactscalefixture()",
-      "source_file": "packages/athena-webapp/convex/reports/weeklyScale.test.ts",
-      "source_location": "L134"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "weeklyscale_test_seedstore",
-      "label": "seedStore()",
-      "norm_label": "seedstore()",
-      "source_file": "packages/athena-webapp/convex/reports/weeklyScale.test.ts",
-      "source_location": "L91"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "offers_buildofferproductemailitem",
-      "label": "buildOfferProductEmailItem()",
-      "norm_label": "buildofferproductemailitem()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "offers_createoffer",
-      "label": "createOffer()",
-      "norm_label": "createoffer()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L129"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "offers_formatofferproductprice",
-      "label": "formatOfferProductPrice()",
-      "norm_label": "formatofferproductprice()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "offers_getdiscountedofferproductprice",
-      "label": "getDiscountedOfferProductPrice()",
-      "norm_label": "getdiscountedofferproductprice()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "offers_getupsellproducts",
-      "label": "getUpsellProducts()",
-      "norm_label": "getupsellproducts()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L793"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "offers_isduplicate",
-      "label": "isDuplicate()",
-      "norm_label": "isduplicate()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "offers_updatestorefrontactoremail",
-      "label": "updateStoreFrontActorEmail()",
-      "norm_label": "updatestorefrontactoremail()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L100"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_offers_ts",
-      "label": "offers.ts",
-      "norm_label": "offers.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L1"
     },
     {
       "community": 32,
@@ -227046,6 +227169,150 @@
     {
       "community": 320,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_reports_weeklyscale_test_ts",
+      "label": "weeklyScale.test.ts",
+      "norm_label": "weeklyscale.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/weeklyScale.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "weeklyscale_test_countprojectionreads",
+      "label": "countProjectionReads()",
+      "norm_label": "countprojectionreads()",
+      "source_file": "packages/athena-webapp/convex/reports/weeklyScale.test.ts",
+      "source_location": "L257"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "weeklyscale_test_handlerof",
+      "label": "handlerOf()",
+      "norm_label": "handlerof()",
+      "source_file": "packages/athena-webapp/convex/reports/weeklyScale.test.ts",
+      "source_location": "L81"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "weeklyscale_test_ledgeridentity",
+      "label": "ledgerIdentity()",
+      "norm_label": "ledgeridentity()",
+      "source_file": "packages/athena-webapp/convex/reports/weeklyScale.test.ts",
+      "source_location": "L677"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "weeklyscale_test_measurepublicprojectionread",
+      "label": "measurePublicProjectionRead()",
+      "norm_label": "measurepublicprojectionread()",
+      "source_file": "packages/athena-webapp/convex/reports/weeklyScale.test.ts",
+      "source_location": "L325"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "weeklyscale_test_percentile95",
+      "label": "percentile95()",
+      "norm_label": "percentile95()",
+      "source_file": "packages/athena-webapp/convex/reports/weeklyScale.test.ts",
+      "source_location": "L320"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "weeklyscale_test_seedacceptedfactscalefixture",
+      "label": "seedAcceptedFactScaleFixture()",
+      "norm_label": "seedacceptedfactscalefixture()",
+      "source_file": "packages/athena-webapp/convex/reports/weeklyScale.test.ts",
+      "source_location": "L134"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "weeklyscale_test_seedstore",
+      "label": "seedStore()",
+      "norm_label": "seedstore()",
+      "source_file": "packages/athena-webapp/convex/reports/weeklyScale.test.ts",
+      "source_location": "L91"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "offers_buildofferproductemailitem",
+      "label": "buildOfferProductEmailItem()",
+      "norm_label": "buildofferproductemailitem()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "offers_createoffer",
+      "label": "createOffer()",
+      "norm_label": "createoffer()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L129"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "offers_formatofferproductprice",
+      "label": "formatOfferProductPrice()",
+      "norm_label": "formatofferproductprice()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "offers_getdiscountedofferproductprice",
+      "label": "getDiscountedOfferProductPrice()",
+      "norm_label": "getdiscountedofferproductprice()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "offers_getupsellproducts",
+      "label": "getUpsellProducts()",
+      "norm_label": "getupsellproducts()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L793"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "offers_isduplicate",
+      "label": "isDuplicate()",
+      "norm_label": "isduplicate()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "offers_updatestorefrontactoremail",
+      "label": "updateStoreFrontActorEmail()",
+      "norm_label": "updatestorefrontactoremail()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L100"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_offers_ts",
+      "label": "offers.ts",
+      "norm_label": "offers.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_public_ts",
       "label": "public.ts",
       "norm_label": "public.ts",
@@ -227053,7 +227320,7 @@
       "source_location": "L1"
     },
     {
-      "community": 320,
+      "community": 322,
       "file_type": "code",
       "id": "public_assertdefaultworkflowtraceaccess",
       "label": "assertDefaultWorkflowTraceAccess()",
@@ -227062,7 +227329,7 @@
       "source_location": "L112"
     },
     {
-      "community": 320,
+      "community": 322,
       "file_type": "code",
       "id": "public_assertworkflowtraceaccess",
       "label": "assertWorkflowTraceAccess()",
@@ -227071,7 +227338,7 @@
       "source_location": "L84"
     },
     {
-      "community": 320,
+      "community": 322,
       "file_type": "code",
       "id": "public_getregistersessiontraceidentity",
       "label": "getRegisterSessionTraceIdentity()",
@@ -227080,7 +227347,7 @@
       "source_location": "L127"
     },
     {
-      "community": 320,
+      "community": 322,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbyidwithctx",
       "label": "getWorkflowTraceViewByIdWithCtx()",
@@ -227089,7 +227356,7 @@
       "source_location": "L191"
     },
     {
-      "community": 320,
+      "community": 322,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbylookupwithctx",
       "label": "getWorkflowTraceViewByLookupWithCtx()",
@@ -227098,7 +227365,7 @@
       "source_location": "L267"
     },
     {
-      "community": 320,
+      "community": 322,
       "file_type": "code",
       "id": "public_requireadminworkflowtraceaccess",
       "label": "requireAdminWorkflowTraceAccess()",
@@ -227107,7 +227374,7 @@
       "source_location": "L44"
     },
     {
-      "community": 320,
+      "community": 322,
       "file_type": "code",
       "id": "public_requirefulladminormanagerelevationtraceaccess",
       "label": "requireFullAdminOrManagerElevationTraceAccess()",
@@ -227116,7 +227383,7 @@
       "source_location": "L52"
     },
     {
-      "community": 321,
+      "community": 323,
       "file_type": "code",
       "id": "data_table_row_actions_datatablerowactions",
       "label": "DataTableRowActions()",
@@ -227125,7 +227392,7 @@
       "source_location": "L25"
     },
     {
-      "community": 321,
+      "community": 323,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_row_actions_tsx",
       "label": "data-table-row-actions.tsx",
@@ -227134,7 +227401,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 323,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_row_actions_tsx",
       "label": "data-table-row-actions.tsx",
@@ -227143,7 +227410,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 323,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_row_actions_tsx",
       "label": "data-table-row-actions.tsx",
@@ -227152,7 +227419,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 323,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_row_actions_tsx",
       "label": "data-table-row-actions.tsx",
@@ -227161,7 +227428,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 323,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_row_actions_tsx",
       "label": "data-table-row-actions.tsx",
@@ -227170,7 +227437,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 323,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_row_actions_tsx",
       "label": "data-table-row-actions.tsx",
@@ -227179,7 +227446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 323,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_row_actions_tsx",
       "label": "data-table-row-actions.tsx",
@@ -227188,7 +227455,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 324,
       "file_type": "code",
       "id": "app_sidebar_appsidebar",
       "label": "AppSidebar()",
@@ -227197,7 +227464,7 @@
       "source_location": "L177"
     },
     {
-      "community": 322,
+      "community": 324,
       "file_type": "code",
       "id": "app_sidebar_cn",
       "label": "cn()",
@@ -227206,7 +227473,7 @@
       "source_location": "L366"
     },
     {
-      "community": 322,
+      "community": 324,
       "file_type": "code",
       "id": "app_sidebar_containedsidebartoggle",
       "label": "ContainedSidebarToggle()",
@@ -227215,7 +227482,7 @@
       "source_location": "L107"
     },
     {
-      "community": 322,
+      "community": 324,
       "file_type": "code",
       "id": "app_sidebar_getsidebarsubmenuopenstate",
       "label": "getSidebarSubmenuOpenState()",
@@ -227224,7 +227491,7 @@
       "source_location": "L90"
     },
     {
-      "community": 322,
+      "community": 324,
       "file_type": "code",
       "id": "app_sidebar_resetappsidebarsubmenustatefortests",
       "label": "resetAppSidebarSubmenuStateForTests()",
@@ -227233,7 +227500,7 @@
       "source_location": "L86"
     },
     {
-      "community": 322,
+      "community": 324,
       "file_type": "code",
       "id": "app_sidebar_sidebarmenucollapsible",
       "label": "SidebarMenuCollapsible()",
@@ -227242,7 +227509,7 @@
       "source_location": "L136"
     },
     {
-      "community": 322,
+      "community": 324,
       "file_type": "code",
       "id": "app_sidebar_sidebarmenumetadata",
       "label": "SidebarMenuMetadata()",
@@ -227251,7 +227518,7 @@
       "source_location": "L128"
     },
     {
-      "community": 322,
+      "community": 324,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_sidebar_tsx",
       "label": "app-sidebar.tsx",
@@ -227260,7 +227527,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 325,
       "file_type": "code",
       "id": "authsynchandoff_clearathenaauthsynchandoff",
       "label": "clearAthenaAuthSyncHandoff()",
@@ -227269,7 +227536,7 @@
       "source_location": "L87"
     },
     {
-      "community": 323,
+      "community": 325,
       "file_type": "code",
       "id": "authsynchandoff_failathenaauthsynchandoff",
       "label": "failAthenaAuthSyncHandoff()",
@@ -227278,7 +227545,7 @@
       "source_location": "L95"
     },
     {
-      "community": 323,
+      "community": 325,
       "file_type": "code",
       "id": "authsynchandoff_getathenaauthsynchandoffstatus",
       "label": "getAthenaAuthSyncHandoffStatus()",
@@ -227287,7 +227554,7 @@
       "source_location": "L62"
     },
     {
-      "community": 323,
+      "community": 325,
       "file_type": "code",
       "id": "authsynchandoff_normalizeauthsyncredirect",
       "label": "normalizeAuthSyncRedirect()",
@@ -227296,7 +227563,7 @@
       "source_location": "L25"
     },
     {
-      "community": 323,
+      "community": 325,
       "file_type": "code",
       "id": "authsynchandoff_parsehandoff",
       "label": "parseHandoff()",
@@ -227305,7 +227572,7 @@
       "source_location": "L41"
     },
     {
-      "community": 323,
+      "community": 325,
       "file_type": "code",
       "id": "authsynchandoff_readrawhandoff",
       "label": "readRawHandoff()",
@@ -227314,7 +227581,7 @@
       "source_location": "L33"
     },
     {
-      "community": 323,
+      "community": 325,
       "file_type": "code",
       "id": "authsynchandoff_startathenaauthsynchandoff",
       "label": "startAthenaAuthSyncHandoff()",
@@ -227323,7 +227590,7 @@
       "source_location": "L100"
     },
     {
-      "community": 323,
+      "community": 325,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_authsynchandoff_ts",
       "label": "authSyncHandoff.ts",
@@ -227332,7 +227599,7 @@
       "source_location": "L1"
     },
     {
-      "community": 324,
+      "community": 326,
       "file_type": "code",
       "id": "landingworkspaceshot_apply",
       "label": "apply()",
@@ -227341,7 +227608,7 @@
       "source_location": "L151"
     },
     {
-      "community": 324,
+      "community": 326,
       "file_type": "code",
       "id": "landingworkspaceshot_beginpan",
       "label": "beginPan()",
@@ -227350,7 +227617,7 @@
       "source_location": "L160"
     },
     {
-      "community": 324,
+      "community": 326,
       "file_type": "code",
       "id": "landingworkspaceshot_distance",
       "label": "distance()",
@@ -227359,7 +227626,7 @@
       "source_location": "L157"
     },
     {
-      "community": 324,
+      "community": 326,
       "file_type": "code",
       "id": "landingworkspaceshot_onend",
       "label": "onEnd()",
@@ -227368,7 +227635,7 @@
       "source_location": "L221"
     },
     {
-      "community": 324,
+      "community": 326,
       "file_type": "code",
       "id": "landingworkspaceshot_onkeydown",
       "label": "onKeyDown()",
@@ -227377,7 +227644,7 @@
       "source_location": "L97"
     },
     {
-      "community": 324,
+      "community": 326,
       "file_type": "code",
       "id": "landingworkspaceshot_onmove",
       "label": "onMove()",
@@ -227386,7 +227653,7 @@
       "source_location": "L200"
     },
     {
-      "community": 324,
+      "community": 326,
       "file_type": "code",
       "id": "landingworkspaceshot_onstart",
       "label": "onStart()",
@@ -227395,7 +227662,7 @@
       "source_location": "L167"
     },
     {
-      "community": 324,
+      "community": 326,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_landing_story_landingworkspaceshot_tsx",
       "label": "LandingWorkspaceShot.tsx",
@@ -227404,7 +227671,7 @@
       "source_location": "L1"
     },
     {
-      "community": 325,
+      "community": 327,
       "file_type": "code",
       "id": "customerinfopanel_clearcustomer",
       "label": "clearCustomer()",
@@ -227413,7 +227680,7 @@
       "source_location": "L166"
     },
     {
-      "community": 325,
+      "community": 327,
       "file_type": "code",
       "id": "customerinfopanel_handlecanceledit",
       "label": "handleCancelEdit()",
@@ -227422,7 +227689,7 @@
       "source_location": "L157"
     },
     {
-      "community": 325,
+      "community": 327,
       "file_type": "code",
       "id": "customerinfopanel_handlecreatecustomer",
       "label": "handleCreateCustomer()",
@@ -227431,7 +227698,7 @@
       "source_location": "L84"
     },
     {
-      "community": 325,
+      "community": 327,
       "file_type": "code",
       "id": "customerinfopanel_handlesaveedit",
       "label": "handleSaveEdit()",
@@ -227440,7 +227707,7 @@
       "source_location": "L124"
     },
     {
-      "community": 325,
+      "community": 327,
       "file_type": "code",
       "id": "customerinfopanel_handleselectcustomer",
       "label": "handleSelectCustomer()",
@@ -227449,7 +227716,7 @@
       "source_location": "L68"
     },
     {
-      "community": 325,
+      "community": 327,
       "file_type": "code",
       "id": "customerinfopanel_handlestartedit",
       "label": "handleStartEdit()",
@@ -227458,7 +227725,7 @@
       "source_location": "L114"
     },
     {
-      "community": 325,
+      "community": 327,
       "file_type": "code",
       "id": "customerinfopanel_showcommanderror",
       "label": "showCommandError()",
@@ -227467,7 +227734,7 @@
       "source_location": "L64"
     },
     {
-      "community": 325,
+      "community": 327,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_customerinfopanel_tsx",
       "label": "CustomerInfoPanel.tsx",
@@ -227476,7 +227743,7 @@
       "source_location": "L1"
     },
     {
-      "community": 326,
+      "community": 328,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productentry_test_tsx",
       "label": "ProductEntry.test.tsx",
@@ -227485,7 +227752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 326,
+      "community": 328,
       "file_type": "code",
       "id": "productentry_test_buildquickaddedproduct",
       "label": "buildQuickAddedProduct()",
@@ -227494,7 +227761,7 @@
       "source_location": "L53"
     },
     {
-      "community": 326,
+      "community": 328,
       "file_type": "code",
       "id": "productentry_test_function",
       "label": "function()",
@@ -227503,7 +227770,7 @@
       "source_location": "L134"
     },
     {
-      "community": 326,
+      "community": 328,
       "file_type": "code",
       "id": "productentry_test_harness",
       "label": "Harness()",
@@ -227512,7 +227779,7 @@
       "source_location": "L76"
     },
     {
-      "community": 326,
+      "community": 328,
       "file_type": "code",
       "id": "productentry_test_resizeobserverstub",
       "label": "ResizeObserverStub",
@@ -227521,7 +227788,7 @@
       "source_location": "L23"
     },
     {
-      "community": 326,
+      "community": 328,
       "file_type": "code",
       "id": "productentry_test_resizeobserverstub_disconnect",
       "label": ".disconnect()",
@@ -227530,7 +227797,7 @@
       "source_location": "L26"
     },
     {
-      "community": 326,
+      "community": 328,
       "file_type": "code",
       "id": "productentry_test_resizeobserverstub_observe",
       "label": ".observe()",
@@ -227539,7 +227806,7 @@
       "source_location": "L24"
     },
     {
-      "community": 326,
+      "community": 328,
       "file_type": "code",
       "id": "productentry_test_resizeobserverstub_unobserve",
       "label": ".unobserve()",
@@ -227548,7 +227815,7 @@
       "source_location": "L25"
     },
     {
-      "community": 327,
+      "community": 329,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_receipt_posreceiptsharecontrol_tsx",
       "label": "PosReceiptShareControl.tsx",
@@ -227557,7 +227824,7 @@
       "source_location": "L1"
     },
     {
-      "community": 327,
+      "community": 329,
       "file_type": "code",
       "id": "posreceiptsharecontrol_formatdeliverystatus",
       "label": "formatDeliveryStatus()",
@@ -227566,7 +227833,7 @@
       "source_location": "L76"
     },
     {
-      "community": 327,
+      "community": 329,
       "file_type": "code",
       "id": "posreceiptsharecontrol_formatdeliverytimestamp",
       "label": "formatDeliveryTimestamp()",
@@ -227575,7 +227842,7 @@
       "source_location": "L97"
     },
     {
-      "community": 327,
+      "community": 329,
       "file_type": "code",
       "id": "posreceiptsharecontrol_getdeliverytimestamp",
       "label": "getDeliveryTimestamp()",
@@ -227584,7 +227851,7 @@
       "source_location": "L93"
     },
     {
-      "community": 327,
+      "community": 329,
       "file_type": "code",
       "id": "posreceiptsharecontrol_getlatestreceiptdelivery",
       "label": "getLatestReceiptDelivery()",
@@ -227593,7 +227860,7 @@
       "source_location": "L110"
     },
     {
-      "community": 327,
+      "community": 329,
       "file_type": "code",
       "id": "posreceiptsharecontrol_getsendreceiptlinkaction",
       "label": "getSendReceiptLinkAction()",
@@ -227602,7 +227869,7 @@
       "source_location": "L60"
     },
     {
-      "community": 327,
+      "community": 329,
       "file_type": "code",
       "id": "posreceiptsharecontrol_handlesendreceiptlink",
       "label": "handleSendReceiptLink()",
@@ -227611,157 +227878,13 @@
       "source_location": "L144"
     },
     {
-      "community": 327,
+      "community": 329,
       "file_type": "code",
       "id": "posreceiptsharecontrol_normalizephone",
       "label": "normalizePhone()",
       "norm_label": "normalizephone()",
       "source_file": "packages/athena-webapp/src/components/pos/receipt/PosReceiptShareControl.tsx",
       "source_location": "L72"
-    },
-    {
-      "community": 328,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_modals_welcome_offer_modal_tsx",
-      "label": "welcome-offer-modal.tsx",
-      "norm_label": "welcome-offer-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 328,
-      "file_type": "code",
-      "id": "welcome_offer_modal_handlechange",
-      "label": "handleChange()",
-      "norm_label": "handlechange()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L76"
-    },
-    {
-      "community": 328,
-      "file_type": "code",
-      "id": "welcome_offer_modal_handlecolorchange",
-      "label": "handleColorChange()",
-      "norm_label": "handlecolorchange()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L92"
-    },
-    {
-      "community": 328,
-      "file_type": "code",
-      "id": "welcome_offer_modal_handlenumberchange",
-      "label": "handleNumberChange()",
-      "norm_label": "handlenumberchange()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L83"
-    },
-    {
-      "community": 328,
-      "file_type": "code",
-      "id": "welcome_offer_modal_handleselectchange",
-      "label": "handleSelectChange()",
-      "norm_label": "handleselectchange()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L96"
-    },
-    {
-      "community": 328,
-      "file_type": "code",
-      "id": "welcome_offer_modal_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L104"
-    },
-    {
-      "community": 328,
-      "file_type": "code",
-      "id": "welcome_offer_modal_handleswitchchange",
-      "label": "handleSwitchChange()",
-      "norm_label": "handleswitchchange()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L88"
-    },
-    {
-      "community": 328,
-      "file_type": "code",
-      "id": "welcome_offer_modal_updateimages",
-      "label": "updateImages()",
-      "norm_label": "updateimages()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_remote_assist_posremoteassistruntimehost_tsx",
-      "label": "PosRemoteAssistRuntimeHost.tsx",
-      "norm_label": "posremoteassistruntimehost.tsx",
-      "source_file": "packages/athena-webapp/src/components/remote-assist/PosRemoteAssistRuntimeHost.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "posremoteassistruntimehost_claimruntimehostforterminal",
-      "label": "claimRuntimeHostForTerminal()",
-      "norm_label": "claimruntimehostforterminal()",
-      "source_file": "packages/athena-webapp/src/components/remote-assist/PosRemoteAssistRuntimeHost.tsx",
-      "source_location": "L144"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "posremoteassistruntimehost_createruntimehostownerid",
-      "label": "createRuntimeHostOwnerId()",
-      "norm_label": "createruntimehostownerid()",
-      "source_file": "packages/athena-webapp/src/components/remote-assist/PosRemoteAssistRuntimeHost.tsx",
-      "source_location": "L220"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "posremoteassistruntimehost_getremoteassistruntimestate",
-      "label": "getRemoteAssistRuntimeState()",
-      "norm_label": "getremoteassistruntimestate()",
-      "source_file": "packages/athena-webapp/src/components/remote-assist/PosRemoteAssistRuntimeHost.tsx",
-      "source_location": "L262"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "posremoteassistruntimehost_getruntimehostclaimstorage",
-      "label": "getRuntimeHostClaimStorage()",
-      "norm_label": "getruntimehostclaimstorage()",
-      "source_file": "packages/athena-webapp/src/components/remote-assist/PosRemoteAssistRuntimeHost.tsx",
-      "source_location": "L203"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "posremoteassistruntimehost_posremoteassistruntimehost",
-      "label": "PosRemoteAssistRuntimeHost()",
-      "norm_label": "posremoteassistruntimehost()",
-      "source_file": "packages/athena-webapp/src/components/remote-assist/PosRemoteAssistRuntimeHost.tsx",
-      "source_location": "L28"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "posremoteassistruntimehost_releaseruntimehostclaim",
-      "label": "releaseRuntimeHostClaim()",
-      "norm_label": "releaseruntimehostclaim()",
-      "source_file": "packages/athena-webapp/src/components/remote-assist/PosRemoteAssistRuntimeHost.tsx",
-      "source_location": "L182"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "posremoteassistruntimehost_withruntimetransportstate",
-      "label": "withRuntimeTransportState()",
-      "norm_label": "withruntimetransportstate()",
-      "source_file": "packages/athena-webapp/src/components/remote-assist/PosRemoteAssistRuntimeHost.tsx",
-      "source_location": "L227"
     },
     {
       "community": 33,
@@ -228063,6 +228186,150 @@
     {
       "community": 330,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_modals_welcome_offer_modal_tsx",
+      "label": "welcome-offer-modal.tsx",
+      "norm_label": "welcome-offer-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "welcome_offer_modal_handlechange",
+      "label": "handleChange()",
+      "norm_label": "handlechange()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L76"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "welcome_offer_modal_handlecolorchange",
+      "label": "handleColorChange()",
+      "norm_label": "handlecolorchange()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L92"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "welcome_offer_modal_handlenumberchange",
+      "label": "handleNumberChange()",
+      "norm_label": "handlenumberchange()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L83"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "welcome_offer_modal_handleselectchange",
+      "label": "handleSelectChange()",
+      "norm_label": "handleselectchange()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L96"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "welcome_offer_modal_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L104"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "welcome_offer_modal_handleswitchchange",
+      "label": "handleSwitchChange()",
+      "norm_label": "handleswitchchange()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L88"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "welcome_offer_modal_updateimages",
+      "label": "updateImages()",
+      "norm_label": "updateimages()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_remote_assist_posremoteassistruntimehost_tsx",
+      "label": "PosRemoteAssistRuntimeHost.tsx",
+      "norm_label": "posremoteassistruntimehost.tsx",
+      "source_file": "packages/athena-webapp/src/components/remote-assist/PosRemoteAssistRuntimeHost.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
+      "id": "posremoteassistruntimehost_claimruntimehostforterminal",
+      "label": "claimRuntimeHostForTerminal()",
+      "norm_label": "claimruntimehostforterminal()",
+      "source_file": "packages/athena-webapp/src/components/remote-assist/PosRemoteAssistRuntimeHost.tsx",
+      "source_location": "L144"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
+      "id": "posremoteassistruntimehost_createruntimehostownerid",
+      "label": "createRuntimeHostOwnerId()",
+      "norm_label": "createruntimehostownerid()",
+      "source_file": "packages/athena-webapp/src/components/remote-assist/PosRemoteAssistRuntimeHost.tsx",
+      "source_location": "L220"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
+      "id": "posremoteassistruntimehost_getremoteassistruntimestate",
+      "label": "getRemoteAssistRuntimeState()",
+      "norm_label": "getremoteassistruntimestate()",
+      "source_file": "packages/athena-webapp/src/components/remote-assist/PosRemoteAssistRuntimeHost.tsx",
+      "source_location": "L262"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
+      "id": "posremoteassistruntimehost_getruntimehostclaimstorage",
+      "label": "getRuntimeHostClaimStorage()",
+      "norm_label": "getruntimehostclaimstorage()",
+      "source_file": "packages/athena-webapp/src/components/remote-assist/PosRemoteAssistRuntimeHost.tsx",
+      "source_location": "L203"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
+      "id": "posremoteassistruntimehost_posremoteassistruntimehost",
+      "label": "PosRemoteAssistRuntimeHost()",
+      "norm_label": "posremoteassistruntimehost()",
+      "source_file": "packages/athena-webapp/src/components/remote-assist/PosRemoteAssistRuntimeHost.tsx",
+      "source_location": "L28"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
+      "id": "posremoteassistruntimehost_releaseruntimehostclaim",
+      "label": "releaseRuntimeHostClaim()",
+      "norm_label": "releaseruntimehostclaim()",
+      "source_file": "packages/athena-webapp/src/components/remote-assist/PosRemoteAssistRuntimeHost.tsx",
+      "source_location": "L182"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
+      "id": "posremoteassistruntimehost_withruntimetransportstate",
+      "label": "withRuntimeTransportState()",
+      "norm_label": "withruntimetransportstate()",
+      "source_file": "packages/athena-webapp/src/components/remote-assist/PosRemoteAssistRuntimeHost.tsx",
+      "source_location": "L227"
+    },
+    {
+      "community": 332,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportskumixchart_tsx",
       "label": "ReportSkuMixChart.tsx",
       "norm_label": "reportskumixchart.tsx",
@@ -228070,7 +228337,7 @@
       "source_location": "L1"
     },
     {
-      "community": 330,
+      "community": 332,
       "file_type": "code",
       "id": "reportskumixchart_buildstatuscopy",
       "label": "buildStatusCopy()",
@@ -228079,7 +228346,7 @@
       "source_location": "L63"
     },
     {
-      "community": 330,
+      "community": 332,
       "file_type": "code",
       "id": "reportskumixchart_cn",
       "label": "cn()",
@@ -228088,7 +228355,7 @@
       "source_location": "L550"
     },
     {
-      "community": 330,
+      "community": 332,
       "file_type": "code",
       "id": "reportskumixchart_formatshare",
       "label": "formatShare()",
@@ -228097,7 +228364,7 @@
       "source_location": "L51"
     },
     {
-      "community": 330,
+      "community": 332,
       "file_type": "code",
       "id": "reportskumixchart_formatunits",
       "label": "formatUnits()",
@@ -228106,7 +228373,7 @@
       "source_location": "L455"
     },
     {
-      "community": 330,
+      "community": 332,
       "file_type": "code",
       "id": "reportskumixchart_reportskumixchart",
       "label": "ReportSkuMixChart()",
@@ -228115,7 +228382,7 @@
       "source_location": "L103"
     },
     {
-      "community": 330,
+      "community": 332,
       "file_type": "code",
       "id": "reportskumixchart_rowcolor",
       "label": "rowColor()",
@@ -228124,7 +228391,7 @@
       "source_location": "L45"
     },
     {
-      "community": 330,
+      "community": 332,
       "file_type": "code",
       "id": "reportskumixchart_rowname",
       "label": "rowName()",
@@ -228133,7 +228400,7 @@
       "source_location": "L56"
     },
     {
-      "community": 331,
+      "community": 333,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
       "label": "sidebar.tsx",
@@ -228142,7 +228409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 331,
+      "community": 333,
       "file_type": "code",
       "id": "sidebar_cn",
       "label": "cn()",
@@ -228151,7 +228418,7 @@
       "source_location": "L178"
     },
     {
-      "community": 331,
+      "community": 333,
       "file_type": "code",
       "id": "sidebar_handlekeydown",
       "label": "handleKeyDown()",
@@ -228160,7 +228427,7 @@
       "source_location": "L135"
     },
     {
-      "community": 331,
+      "community": 333,
       "file_type": "code",
       "id": "sidebar_handleonhover",
       "label": "handleOnHover()",
@@ -228169,7 +228436,7 @@
       "source_location": "L254"
     },
     {
-      "community": 331,
+      "community": 333,
       "file_type": "code",
       "id": "sidebar_handleonmouseleave",
       "label": "handleOnMouseLeave()",
@@ -228178,7 +228445,7 @@
       "source_location": "L258"
     },
     {
-      "community": 331,
+      "community": 333,
       "file_type": "code",
       "id": "sidebar_readpersistedsidebaropenstate",
       "label": "readPersistedSidebarOpenState()",
@@ -228187,7 +228454,7 @@
       "source_location": "L45"
     },
     {
-      "community": 331,
+      "community": 333,
       "file_type": "code",
       "id": "sidebar_useoptionalsidebar",
       "label": "useOptionalSidebar()",
@@ -228196,7 +228463,7 @@
       "source_location": "L71"
     },
     {
-      "community": 331,
+      "community": 333,
       "file_type": "code",
       "id": "sidebar_usesidebar",
       "label": "useSidebar()",
@@ -228205,7 +228472,7 @@
       "source_location": "L62"
     },
     {
-      "community": 332,
+      "community": 334,
       "file_type": "code",
       "id": "onlineordersessionoverlay_applyshareddemosessionorderpatches",
       "label": "applySharedDemoSessionOrderPatches()",
@@ -228214,7 +228481,7 @@
       "source_location": "L108"
     },
     {
-      "community": 332,
+      "community": 334,
       "file_type": "code",
       "id": "onlineordersessionoverlay_getsessionstorage",
       "label": "getSessionStorage()",
@@ -228223,7 +228490,7 @@
       "source_location": "L17"
     },
     {
-      "community": 332,
+      "community": 334,
       "file_type": "code",
       "id": "onlineordersessionoverlay_getshareddemosessionorderstoragekey",
       "label": "getSharedDemoSessionOrderStorageKey()",
@@ -228232,7 +228499,7 @@
       "source_location": "L27"
     },
     {
-      "community": 332,
+      "community": 334,
       "file_type": "code",
       "id": "onlineordersessionoverlay_getshareddemosessionorderstorageprefix",
       "label": "getSharedDemoSessionOrderStoragePrefix()",
@@ -228241,7 +228508,7 @@
       "source_location": "L35"
     },
     {
-      "community": 332,
+      "community": 334,
       "file_type": "code",
       "id": "onlineordersessionoverlay_readshareddemosessionorderpatch",
       "label": "readSharedDemoSessionOrderPatch()",
@@ -228250,7 +228517,7 @@
       "source_location": "L42"
     },
     {
-      "community": 332,
+      "community": 334,
       "file_type": "code",
       "id": "onlineordersessionoverlay_readshareddemosessionorderpatches",
       "label": "readSharedDemoSessionOrderPatches()",
@@ -228259,7 +228526,7 @@
       "source_location": "L77"
     },
     {
-      "community": 332,
+      "community": 334,
       "file_type": "code",
       "id": "onlineordersessionoverlay_writeshareddemosessionorderpatch",
       "label": "writeSharedDemoSessionOrderPatch()",
@@ -228268,7 +228535,7 @@
       "source_location": "L60"
     },
     {
-      "community": 332,
+      "community": 334,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_onlineordersessionoverlay_ts",
       "label": "onlineOrderSessionOverlay.ts",
@@ -228277,7 +228544,7 @@
       "source_location": "L1"
     },
     {
-      "community": 333,
+      "community": 335,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
       "label": "useBulkOperations.ts",
@@ -228286,7 +228553,7 @@
       "source_location": "L1"
     },
     {
-      "community": 333,
+      "community": 335,
       "file_type": "code",
       "id": "usebulkoperations_applyoperation",
       "label": "applyOperation()",
@@ -228295,7 +228562,7 @@
       "source_location": "L58"
     },
     {
-      "community": 333,
+      "community": 335,
       "file_type": "code",
       "id": "usebulkoperations_calculatepricewithfee",
       "label": "calculatePriceWithFee()",
@@ -228304,7 +228571,7 @@
       "source_location": "L88"
     },
     {
-      "community": 333,
+      "community": 335,
       "file_type": "code",
       "id": "usebulkoperations_computepreview",
       "label": "computePreview()",
@@ -228313,7 +228580,7 @@
       "source_location": "L128"
     },
     {
-      "community": 333,
+      "community": 335,
       "file_type": "code",
       "id": "usebulkoperations_ismoneyoperation",
       "label": "isMoneyOperation()",
@@ -228322,7 +228589,7 @@
       "source_location": "L101"
     },
     {
-      "community": 333,
+      "community": 335,
       "file_type": "code",
       "id": "usebulkoperations_parseoperationvalue",
       "label": "parseOperationValue()",
@@ -228331,7 +228598,7 @@
       "source_location": "L109"
     },
     {
-      "community": 333,
+      "community": 335,
       "file_type": "code",
       "id": "usebulkoperations_usebulkoperations",
       "label": "useBulkOperations()",
@@ -228340,7 +228607,7 @@
       "source_location": "L190"
     },
     {
-      "community": 333,
+      "community": 335,
       "file_type": "code",
       "id": "usebulkoperations_validateoperationvalue",
       "label": "validateOperationValue()",
@@ -228349,7 +228616,7 @@
       "source_location": "L167"
     },
     {
-      "community": 334,
+      "community": 336,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
       "label": "useExpenseOperations.ts",
@@ -228358,7 +228625,7 @@
       "source_location": "L1"
     },
     {
-      "community": 334,
+      "community": 336,
       "file_type": "code",
       "id": "useexpenseoperations_clonecartitems",
       "label": "cloneCartItems()",
@@ -228367,7 +228634,7 @@
       "source_location": "L16"
     },
     {
-      "community": 334,
+      "community": 336,
       "file_type": "code",
       "id": "useexpenseoperations_createoptimisticexpenseitemid",
       "label": "createOptimisticExpenseItemId()",
@@ -228376,7 +228643,7 @@
       "source_location": "L74"
     },
     {
-      "community": 334,
+      "community": 336,
       "file_type": "code",
       "id": "useexpenseoperations_expensecartitemsourcekey",
       "label": "expenseCartItemSourceKey()",
@@ -228385,7 +228652,7 @@
       "source_location": "L56"
     },
     {
-      "community": 334,
+      "community": 336,
       "file_type": "code",
       "id": "useexpenseoperations_expenselinematchesproduct",
       "label": "expenseLineMatchesProduct()",
@@ -228394,7 +228661,7 @@
       "source_location": "L67"
     },
     {
-      "community": 334,
+      "community": 336,
       "file_type": "code",
       "id": "useexpenseoperations_expenselinesourcekey",
       "label": "expenseLineSourceKey()",
@@ -228403,7 +228670,7 @@
       "source_location": "L43"
     },
     {
-      "community": 334,
+      "community": 336,
       "file_type": "code",
       "id": "useexpenseoperations_mapproducttoexpensecartitem",
       "label": "mapProductToExpenseCartItem()",
@@ -228412,7 +228679,7 @@
       "source_location": "L20"
     },
     {
-      "community": 334,
+      "community": 336,
       "file_type": "code",
       "id": "useexpenseoperations_useexpenseoperations",
       "label": "useExpenseOperations()",
@@ -228421,7 +228688,7 @@
       "source_location": "L84"
     },
     {
-      "community": 335,
+      "community": 337,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_syncstatus_ts",
       "label": "syncStatus.ts",
@@ -228430,7 +228697,7 @@
       "source_location": "L1"
     },
     {
-      "community": 335,
+      "community": 337,
       "file_type": "code",
       "id": "syncstatus_deriveposlocalsyncstatus",
       "label": "derivePosLocalSyncStatus()",
@@ -228439,7 +228706,7 @@
       "source_location": "L67"
     },
     {
-      "community": 335,
+      "community": 337,
       "file_type": "code",
       "id": "syncstatus_getcontiguoussyncedsequence",
       "label": "getContiguousSyncedSequence()",
@@ -228448,7 +228715,7 @@
       "source_location": "L115"
     },
     {
-      "community": 335,
+      "community": 337,
       "file_type": "code",
       "id": "syncstatus_getsyncstate",
       "label": "getSyncState()",
@@ -228457,7 +228724,7 @@
       "source_location": "L159"
     },
     {
-      "community": 335,
+      "community": 337,
       "file_type": "code",
       "id": "syncstatus_islocallysettledsyncstatus",
       "label": "isLocallySettledSyncStatus()",
@@ -228466,7 +228733,7 @@
       "source_location": "L128"
     },
     {
-      "community": 335,
+      "community": 337,
       "file_type": "code",
       "id": "syncstatus_isserverconfirmedlocalresolution",
       "label": "isServerConfirmedLocalResolution()",
@@ -228475,7 +228742,7 @@
       "source_location": "L139"
     },
     {
-      "community": 335,
+      "community": 337,
       "file_type": "code",
       "id": "syncstatus_isserverconvergedsyncevent",
       "label": "isServerConvergedSyncEvent()",
@@ -228484,7 +228751,7 @@
       "source_location": "L151"
     },
     {
-      "community": 335,
+      "community": 337,
       "file_type": "code",
       "id": "syncstatus_mapserversettlementoutcometolocalstate",
       "label": "mapServerSettlementOutcomeToLocalState()",
@@ -228493,7 +228760,7 @@
       "source_location": "L33"
     },
     {
-      "community": 336,
+      "community": 338,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_useregisterlifecycleauthorityruntime_test_ts",
       "label": "useRegisterLifecycleAuthorityRuntime.test.ts",
@@ -228502,7 +228769,7 @@
       "source_location": "L1"
     },
     {
-      "community": 336,
+      "community": 338,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_test_appliedauthorityvalue",
       "label": "appliedAuthorityValue()",
@@ -228511,7 +228778,7 @@
       "source_location": "L103"
     },
     {
-      "community": 336,
+      "community": 338,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_test_createstore",
       "label": "createStore()",
@@ -228520,7 +228787,7 @@
       "source_location": "L85"
     },
     {
-      "community": 336,
+      "community": 338,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_test_releasefirst",
       "label": "releaseFirst()",
@@ -228529,7 +228796,7 @@
       "source_location": "L584"
     },
     {
-      "community": 336,
+      "community": 338,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_test_releaseolder",
       "label": "releaseOlder()",
@@ -228538,7 +228805,7 @@
       "source_location": "L800"
     },
     {
-      "community": 336,
+      "community": 338,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_test_renderruntime",
       "label": "renderRuntime()",
@@ -228547,7 +228814,7 @@
       "source_location": "L117"
     },
     {
-      "community": 336,
+      "community": 338,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_test_rerenderprojection",
       "label": "rerenderProjection()",
@@ -228556,7 +228823,7 @@
       "source_location": "L322"
     },
     {
-      "community": 336,
+      "community": 338,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_test_snapshot",
       "label": "snapshot()",
@@ -228565,7 +228832,7 @@
       "source_location": "L62"
     },
     {
-      "community": 337,
+      "community": 339,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_registercashierpresence_ts",
       "label": "registerCashierPresence.ts",
@@ -228574,7 +228841,7 @@
       "source_location": "L1"
     },
     {
-      "community": 337,
+      "community": 339,
       "file_type": "code",
       "id": "registercashierpresence_canoperateregister",
       "label": "canOperateRegister()",
@@ -228583,7 +228850,7 @@
       "source_location": "L188"
     },
     {
-      "community": 337,
+      "community": 339,
       "file_type": "code",
       "id": "registercashierpresence_getstaffdisplaynamefromauthresult",
       "label": "getStaffDisplayNameFromAuthResult()",
@@ -228592,7 +228859,7 @@
       "source_location": "L107"
     },
     {
-      "community": 337,
+      "community": 339,
       "file_type": "code",
       "id": "registercashierpresence_hasregistermanagerrole",
       "label": "hasRegisterManagerRole()",
@@ -228601,7 +228868,7 @@
       "source_location": "L203"
     },
     {
-      "community": 337,
+      "community": 339,
       "file_type": "code",
       "id": "registercashierpresence_hasregisteroperatorrole",
       "label": "hasRegisterOperatorRole()",
@@ -228610,7 +228877,7 @@
       "source_location": "L197"
     },
     {
-      "community": 337,
+      "community": 339,
       "file_type": "code",
       "id": "registercashierpresence_iscashierpresenceblockingsale",
       "label": "isCashierPresenceBlockingSale()",
@@ -228619,7 +228886,7 @@
       "source_location": "L182"
     },
     {
-      "community": 337,
+      "community": 339,
       "file_type": "code",
       "id": "registercashierpresence_readstaffprooffromauthresult",
       "label": "readStaffProofFromAuthResult()",
@@ -228628,157 +228895,13 @@
       "source_location": "L88"
     },
     {
-      "community": 337,
+      "community": 339,
       "file_type": "code",
       "id": "registercashierpresence_validaterestoredcashierpresence",
       "label": "validateRestoredCashierPresence()",
       "norm_label": "validaterestoredcashierpresence()",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCashierPresence.ts",
       "source_location": "L118"
-    },
-    {
-      "community": 338,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_offline_posappshellreadiness_ts",
-      "label": "posAppShellReadiness.ts",
-      "norm_label": "posappshellreadiness.ts",
-      "source_file": "packages/athena-webapp/src/offline/posAppShellReadiness.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 338,
-      "file_type": "code",
-      "id": "posappshellreadiness_islocaldevappshelldisabled",
-      "label": "isLocalDevAppShellDisabled()",
-      "norm_label": "islocaldevappshelldisabled()",
-      "source_file": "packages/athena-webapp/src/offline/posAppShellReadiness.ts",
-      "source_location": "L169"
-    },
-    {
-      "community": 338,
-      "file_type": "code",
-      "id": "posappshellreadiness_readcachedposappshellreadiness",
-      "label": "readCachedPosAppShellReadiness()",
-      "norm_label": "readcachedposappshellreadiness()",
-      "source_file": "packages/athena-webapp/src/offline/posAppShellReadiness.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 338,
-      "file_type": "code",
-      "id": "posappshellreadiness_readposappshellreadiness",
-      "label": "readPosAppShellReadiness()",
-      "norm_label": "readposappshellreadiness()",
-      "source_file": "packages/athena-webapp/src/offline/posAppShellReadiness.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 338,
-      "file_type": "code",
-      "id": "posappshellreadiness_resolveregisterpath",
-      "label": "resolveRegisterPath()",
-      "norm_label": "resolveregisterpath()",
-      "source_file": "packages/athena-webapp/src/offline/posAppShellReadiness.ts",
-      "source_location": "L190"
-    },
-    {
-      "community": 338,
-      "file_type": "code",
-      "id": "posappshellreadiness_towarmresult",
-      "label": "toWarmResult()",
-      "norm_label": "towarmresult()",
-      "source_file": "packages/athena-webapp/src/offline/posAppShellReadiness.ts",
-      "source_location": "L177"
-    },
-    {
-      "community": 338,
-      "file_type": "code",
-      "id": "posappshellreadiness_waitforactiveserviceworker",
-      "label": "waitForActiveServiceWorker()",
-      "norm_label": "waitforactiveserviceworker()",
-      "source_file": "packages/athena-webapp/src/offline/posAppShellReadiness.ts",
-      "source_location": "L146"
-    },
-    {
-      "community": 338,
-      "file_type": "code",
-      "id": "posappshellreadiness_warmposappshellreadiness",
-      "label": "warmPosAppShellReadiness()",
-      "norm_label": "warmposappshellreadiness()",
-      "source_file": "packages/athena-webapp/src/offline/posAppShellReadiness.ts",
-      "source_location": "L84"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "bag_additemtobag",
-      "label": "addItemToBag()",
-      "norm_label": "additemtobag()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "bag_clearbag",
-      "label": "clearBag()",
-      "norm_label": "clearbag()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "bag_getactivebag",
-      "label": "getActiveBag()",
-      "norm_label": "getactivebag()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "bag_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "bag_removeitemfrombag",
-      "label": "removeItemFromBag()",
-      "norm_label": "removeitemfrombag()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "bag_updatebagitem",
-      "label": "updateBagItem()",
-      "norm_label": "updatebagitem()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "bag_updatebagowner",
-      "label": "updateBagOwner()",
-      "norm_label": "updatebagowner()",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L118"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_bag_ts",
-      "label": "bag.ts",
-      "norm_label": "bag.ts",
-      "source_file": "packages/storefront-webapp/src/api/bag.ts",
-      "source_location": "L1"
     },
     {
       "community": 34,
@@ -229080,6 +229203,150 @@
     {
       "community": 340,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_offline_posappshellreadiness_ts",
+      "label": "posAppShellReadiness.ts",
+      "norm_label": "posappshellreadiness.ts",
+      "source_file": "packages/athena-webapp/src/offline/posAppShellReadiness.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "posappshellreadiness_islocaldevappshelldisabled",
+      "label": "isLocalDevAppShellDisabled()",
+      "norm_label": "islocaldevappshelldisabled()",
+      "source_file": "packages/athena-webapp/src/offline/posAppShellReadiness.ts",
+      "source_location": "L169"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "posappshellreadiness_readcachedposappshellreadiness",
+      "label": "readCachedPosAppShellReadiness()",
+      "norm_label": "readcachedposappshellreadiness()",
+      "source_file": "packages/athena-webapp/src/offline/posAppShellReadiness.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "posappshellreadiness_readposappshellreadiness",
+      "label": "readPosAppShellReadiness()",
+      "norm_label": "readposappshellreadiness()",
+      "source_file": "packages/athena-webapp/src/offline/posAppShellReadiness.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "posappshellreadiness_resolveregisterpath",
+      "label": "resolveRegisterPath()",
+      "norm_label": "resolveregisterpath()",
+      "source_file": "packages/athena-webapp/src/offline/posAppShellReadiness.ts",
+      "source_location": "L190"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "posappshellreadiness_towarmresult",
+      "label": "toWarmResult()",
+      "norm_label": "towarmresult()",
+      "source_file": "packages/athena-webapp/src/offline/posAppShellReadiness.ts",
+      "source_location": "L177"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "posappshellreadiness_waitforactiveserviceworker",
+      "label": "waitForActiveServiceWorker()",
+      "norm_label": "waitforactiveserviceworker()",
+      "source_file": "packages/athena-webapp/src/offline/posAppShellReadiness.ts",
+      "source_location": "L146"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "posappshellreadiness_warmposappshellreadiness",
+      "label": "warmPosAppShellReadiness()",
+      "norm_label": "warmposappshellreadiness()",
+      "source_file": "packages/athena-webapp/src/offline/posAppShellReadiness.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
+      "id": "bag_additemtobag",
+      "label": "addItemToBag()",
+      "norm_label": "additemtobag()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
+      "id": "bag_clearbag",
+      "label": "clearBag()",
+      "norm_label": "clearbag()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L106"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
+      "id": "bag_getactivebag",
+      "label": "getActiveBag()",
+      "norm_label": "getactivebag()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
+      "id": "bag_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
+      "id": "bag_removeitemfrombag",
+      "label": "removeItemFromBag()",
+      "norm_label": "removeitemfrombag()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
+      "id": "bag_updatebagitem",
+      "label": "updateBagItem()",
+      "norm_label": "updatebagitem()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
+      "id": "bag_updatebagowner",
+      "label": "updateBagOwner()",
+      "norm_label": "updatebagowner()",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L118"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_bag_ts",
+      "label": "bag.ts",
+      "norm_label": "bag.ts",
+      "source_file": "packages/storefront-webapp/src/api/bag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 342,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_product_ts",
       "label": "product.ts",
       "norm_label": "product.ts",
@@ -229087,7 +229354,7 @@
       "source_location": "L1"
     },
     {
-      "community": 340,
+      "community": 342,
       "file_type": "code",
       "id": "product_buildquerystring",
       "label": "buildQueryString()",
@@ -229096,7 +229363,7 @@
       "source_location": "L5"
     },
     {
-      "community": 340,
+      "community": 342,
       "file_type": "code",
       "id": "product_getallproducts",
       "label": "getAllProducts()",
@@ -229105,7 +229372,7 @@
       "source_location": "L20"
     },
     {
-      "community": 340,
+      "community": 342,
       "file_type": "code",
       "id": "product_getbaseurl",
       "label": "getBaseUrl()",
@@ -229114,7 +229381,7 @@
       "source_location": "L18"
     },
     {
-      "community": 340,
+      "community": 342,
       "file_type": "code",
       "id": "product_getbestsellers",
       "label": "getBestSellers()",
@@ -229123,7 +229390,7 @@
       "source_location": "L59"
     },
     {
-      "community": 340,
+      "community": 342,
       "file_type": "code",
       "id": "product_getfeatured",
       "label": "getFeatured()",
@@ -229132,7 +229399,7 @@
       "source_location": "L73"
     },
     {
-      "community": 340,
+      "community": 342,
       "file_type": "code",
       "id": "product_getinventorybyskuids",
       "label": "getInventoryBySkuIds()",
@@ -229141,7 +229408,7 @@
       "source_location": "L93"
     },
     {
-      "community": 340,
+      "community": 342,
       "file_type": "code",
       "id": "product_getproduct",
       "label": "getProduct()",
@@ -229150,7 +229417,7 @@
       "source_location": "L40"
     },
     {
-      "community": 341,
+      "community": 343,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_tsx",
       "label": "ShoppingBag.tsx",
@@ -229159,7 +229426,7 @@
       "source_location": "L1"
     },
     {
-      "community": 341,
+      "community": 343,
       "file_type": "code",
       "id": "shoppingbag_handleclickondiscountcode",
       "label": "handleClickOnDiscountCode()",
@@ -229168,7 +229435,7 @@
       "source_location": "L554"
     },
     {
-      "community": 341,
+      "community": 343,
       "file_type": "code",
       "id": "shoppingbag_handledeleteitem",
       "label": "handleDeleteItem()",
@@ -229177,7 +229444,7 @@
       "source_location": "L595"
     },
     {
-      "community": 341,
+      "community": 343,
       "file_type": "code",
       "id": "shoppingbag_handlemovetosaved",
       "label": "handleMoveToSaved()",
@@ -229186,7 +229453,7 @@
       "source_location": "L581"
     },
     {
-      "community": 341,
+      "community": 343,
       "file_type": "code",
       "id": "shoppingbag_handleoncheckoutclick",
       "label": "handleOnCheckoutClick()",
@@ -229195,7 +229462,7 @@
       "source_location": "L505"
     },
     {
-      "community": 341,
+      "community": 343,
       "file_type": "code",
       "id": "shoppingbag_isskuunavailable",
       "label": "isSkuUnavailable()",
@@ -229204,7 +229471,7 @@
       "source_location": "L566"
     },
     {
-      "community": 341,
+      "community": 343,
       "file_type": "code",
       "id": "shoppingbag_pendingitem",
       "label": "PendingItem()",
@@ -229213,7 +229480,7 @@
       "source_location": "L62"
     },
     {
-      "community": 341,
+      "community": 343,
       "file_type": "code",
       "id": "shoppingbag_shoppingbagcheckoutbutton",
       "label": "ShoppingBagCheckoutButton()",
@@ -229222,7 +229489,7 @@
       "source_location": "L110"
     },
     {
-      "community": 342,
+      "community": 344,
       "file_type": "code",
       "id": "coverage_toolchain_parity_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -229231,7 +229498,7 @@
       "source_location": "L14"
     },
     {
-      "community": 342,
+      "community": 344,
       "file_type": "code",
       "id": "coverage_toolchain_parity_test_createpackage",
       "label": "createPackage()",
@@ -229240,7 +229507,7 @@
       "source_location": "L26"
     },
     {
-      "community": 342,
+      "community": 344,
       "file_type": "code",
       "id": "coverage_toolchain_parity_test_installfixturetoolchain",
       "label": "installFixtureToolchain()",
@@ -229249,7 +229516,7 @@
       "source_location": "L64"
     },
     {
-      "community": 342,
+      "community": 344,
       "file_type": "code",
       "id": "coverage_toolchain_parity_test_linkworkspacepackage",
       "label": "linkWorkspacePackage()",
@@ -229258,7 +229525,7 @@
       "source_location": "L33"
     },
     {
-      "community": 342,
+      "community": 344,
       "file_type": "code",
       "id": "coverage_toolchain_parity_test_writefixtureinstaller",
       "label": "writeFixtureInstaller()",
@@ -229267,7 +229534,7 @@
       "source_location": "L75"
     },
     {
-      "community": 342,
+      "community": 344,
       "file_type": "code",
       "id": "coverage_toolchain_parity_test_writefixturemanifests",
       "label": "writeFixtureManifests()",
@@ -229276,7 +229543,7 @@
       "source_location": "L43"
     },
     {
-      "community": 342,
+      "community": 344,
       "file_type": "code",
       "id": "coverage_toolchain_parity_test_writejson",
       "label": "writeJson()",
@@ -229285,7 +229552,7 @@
       "source_location": "L20"
     },
     {
-      "community": 342,
+      "community": 344,
       "file_type": "code",
       "id": "scripts_coverage_toolchain_parity_test_ts",
       "label": "coverage-toolchain-parity.test.ts",
@@ -229294,7 +229561,7 @@
       "source_location": "L1"
     },
     {
-      "community": 343,
+      "community": 345,
       "file_type": "code",
       "id": "harness_behavior_test_createbrowser",
       "label": "createBrowser()",
@@ -229303,7 +229570,7 @@
       "source_location": "L55"
     },
     {
-      "community": 343,
+      "community": 345,
       "file_type": "code",
       "id": "harness_behavior_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -229312,7 +229579,7 @@
       "source_location": "L25"
     },
     {
-      "community": 343,
+      "community": 345,
       "file_type": "code",
       "id": "harness_behavior_test_createplaywrightmodule",
       "label": "createPlaywrightModule()",
@@ -229321,7 +229588,7 @@
       "source_location": "L47"
     },
     {
-      "community": 343,
+      "community": 345,
       "file_type": "code",
       "id": "harness_behavior_test_islistening",
       "label": "isListening()",
@@ -229330,7 +229597,7 @@
       "source_location": "L664"
     },
     {
-      "community": 343,
+      "community": 345,
       "file_type": "code",
       "id": "harness_behavior_test_reservefreeport",
       "label": "reserveFreePort()",
@@ -229339,7 +229606,7 @@
       "source_location": "L652"
     },
     {
-      "community": 343,
+      "community": 345,
       "file_type": "code",
       "id": "harness_behavior_test_reservefreeportforreclaim",
       "label": "reserveFreePortForReclaim()",
@@ -229348,7 +229615,7 @@
       "source_location": "L828"
     },
     {
-      "community": 343,
+      "community": 345,
       "file_type": "code",
       "id": "harness_behavior_test_write",
       "label": "write()",
@@ -229357,7 +229624,7 @@
       "source_location": "L19"
     },
     {
-      "community": 343,
+      "community": 345,
       "file_type": "code",
       "id": "scripts_harness_behavior_test_ts",
       "label": "harness-behavior.test.ts",
@@ -229366,7 +229633,7 @@
       "source_location": "L1"
     },
     {
-      "community": 344,
+      "community": 346,
       "file_type": "code",
       "id": "deposits_test_createauthorizedregisterdepositctx",
       "label": "createAuthorizedRegisterDepositCtx()",
@@ -229375,7 +229642,7 @@
       "source_location": "L293"
     },
     {
-      "community": 344,
+      "community": 346,
       "file_type": "code",
       "id": "deposits_test_createmissingmappingrepairseed",
       "label": "createMissingMappingRepairSeed()",
@@ -229384,7 +229651,7 @@
       "source_location": "L332"
     },
     {
-      "community": 344,
+      "community": 346,
       "file_type": "code",
       "id": "deposits_test_createprojectedinventoryreviewqueryctx",
       "label": "createProjectedInventoryReviewQueryCtx()",
@@ -229393,7 +229660,7 @@
       "source_location": "L194"
     },
     {
-      "community": 344,
+      "community": 346,
       "file_type": "code",
       "id": "deposits_test_createqueryctx",
       "label": "createQueryCtx()",
@@ -229402,7 +229669,7 @@
       "source_location": "L46"
     },
     {
-      "community": 344,
+      "community": 346,
       "file_type": "code",
       "id": "deposits_test_gethandler",
       "label": "getHandler()",
@@ -229411,7 +229678,7 @@
       "source_location": "L42"
     },
     {
-      "community": 344,
+      "community": 346,
       "file_type": "code",
       "id": "deposits_test_getsource",
       "label": "getSource()",
@@ -229420,7 +229687,7 @@
       "source_location": "L38"
     },
     {
-      "community": 344,
+      "community": 346,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_deposits_test_ts",
       "label": "deposits.test.ts",
@@ -229429,7 +229696,7 @@
       "source_location": "L1"
     },
     {
-      "community": 345,
+      "community": 347,
       "file_type": "code",
       "id": "eventdefinitions_containssensitivetext",
       "label": "containsSensitiveText()",
@@ -229438,7 +229705,7 @@
       "source_location": "L166"
     },
     {
-      "community": 345,
+      "community": 347,
       "file_type": "code",
       "id": "eventdefinitions_findregisteredcontextevent",
       "label": "findRegisteredContextEvent()",
@@ -229447,7 +229714,7 @@
       "source_location": "L104"
     },
     {
-      "community": 345,
+      "community": 347,
       "file_type": "code",
       "id": "eventdefinitions_invalidpayloadmessage",
       "label": "invalidPayloadMessage()",
@@ -229456,7 +229723,7 @@
       "source_location": "L139"
     },
     {
-      "community": 345,
+      "community": 347,
       "file_type": "code",
       "id": "eventdefinitions_ispubliccontextvalue",
       "label": "isPublicContextValue()",
@@ -229465,7 +229732,7 @@
       "source_location": "L145"
     },
     {
-      "community": 345,
+      "community": 347,
       "file_type": "code",
       "id": "eventdefinitions_validatepayloadvalue",
       "label": "validatePayloadValue()",
@@ -229474,7 +229741,7 @@
       "source_location": "L155"
     },
     {
-      "community": 345,
+      "community": 347,
       "file_type": "code",
       "id": "eventdefinitions_validateregisteredcontexteventpayload",
       "label": "validateRegisteredContextEventPayload()",
@@ -229483,7 +229750,7 @@
       "source_location": "L117"
     },
     {
-      "community": 345,
+      "community": 347,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_contexttracking_eventdefinitions_ts",
       "label": "eventDefinitions.ts",
@@ -229492,7 +229759,7 @@
       "source_location": "L1"
     },
     {
-      "community": 346,
+      "community": 348,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_whatsappconfig_ts",
       "label": "whatsappConfig.ts",
@@ -229501,7 +229768,7 @@
       "source_location": "L1"
     },
     {
-      "community": 346,
+      "community": 348,
       "file_type": "code",
       "id": "whatsappconfig_buildreceiptshareurl",
       "label": "buildReceiptShareUrl()",
@@ -229510,7 +229777,7 @@
       "source_location": "L43"
     },
     {
-      "community": 346,
+      "community": 348,
       "file_type": "code",
       "id": "whatsappconfig_getwhatsappreceiptconfig",
       "label": "getWhatsAppReceiptConfig()",
@@ -229519,7 +229786,7 @@
       "source_location": "L23"
     },
     {
-      "community": 346,
+      "community": 348,
       "file_type": "code",
       "id": "whatsappconfig_getwhatsappwebhookappsecret",
       "label": "getWhatsAppWebhookAppSecret()",
@@ -229528,7 +229795,7 @@
       "source_location": "L39"
     },
     {
-      "community": 346,
+      "community": 348,
       "file_type": "code",
       "id": "whatsappconfig_getwhatsappwebhookverifytoken",
       "label": "getWhatsAppWebhookVerifyToken()",
@@ -229537,7 +229804,7 @@
       "source_location": "L35"
     },
     {
-      "community": 346,
+      "community": 348,
       "file_type": "code",
       "id": "whatsappconfig_optionalenv",
       "label": "optionalEnv()",
@@ -229546,7 +229813,7 @@
       "source_location": "L11"
     },
     {
-      "community": 346,
+      "community": 348,
       "file_type": "code",
       "id": "whatsappconfig_requiredenv",
       "label": "requiredEnv()",
@@ -229555,7 +229822,7 @@
       "source_location": "L15"
     },
     {
-      "community": 347,
+      "community": 349,
       "file_type": "code",
       "id": "dailymanagerreport_capitalize",
       "label": "capitalize()",
@@ -229564,7 +229831,7 @@
       "source_location": "L740"
     },
     {
-      "community": 347,
+      "community": 349,
       "file_type": "code",
       "id": "dailymanagerreport_compactcomparison",
       "label": "compactComparison()",
@@ -229573,7 +229840,7 @@
       "source_location": "L715"
     },
     {
-      "community": 347,
+      "community": 349,
       "file_type": "code",
       "id": "dailymanagerreport_comparisondetaillabel",
       "label": "comparisonDetailLabel()",
@@ -229582,7 +229849,7 @@
       "source_location": "L736"
     },
     {
-      "community": 347,
+      "community": 349,
       "file_type": "code",
       "id": "dailymanagerreport_hasregistersessionblocker",
       "label": "hasRegisterSessionBlocker()",
@@ -229591,7 +229858,7 @@
       "source_location": "L291"
     },
     {
-      "community": 347,
+      "community": 349,
       "file_type": "code",
       "id": "dailymanagerreport_statuspanelstylefor",
       "label": "statusPanelStyleFor()",
@@ -229600,7 +229867,7 @@
       "source_location": "L774"
     },
     {
-      "community": 347,
+      "community": 349,
       "file_type": "code",
       "id": "dailymanagerreport_summaryvaluestylefor",
       "label": "summaryValueStyleFor()",
@@ -229609,139 +229876,13 @@
       "source_location": "L588"
     },
     {
-      "community": 347,
+      "community": 349,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_dailymanagerreport_tsx",
       "label": "DailyManagerReport.tsx",
       "norm_label": "dailymanagerreport.tsx",
       "source_file": "packages/athena-webapp/convex/emails/DailyManagerReport.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 348,
-      "file_type": "code",
-      "id": "expensetransactions_createexpensetransactionfromsessionhandler",
-      "label": "createExpenseTransactionFromSessionHandler()",
-      "norm_label": "createexpensetransactionfromsessionhandler()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
-      "source_location": "L72"
-    },
-    {
-      "community": 348,
-      "file_type": "code",
-      "id": "expensetransactions_expenseitemhastrustedavailabilityhold",
-      "label": "expenseItemHasTrustedAvailabilityHold()",
-      "norm_label": "expenseitemhastrustedavailabilityhold()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 348,
-      "file_type": "code",
-      "id": "expensetransactions_expenseitemusestrustedinventory",
-      "label": "expenseItemUsesTrustedInventory()",
-      "norm_label": "expenseitemusestrustedinventory()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 348,
-      "file_type": "code",
-      "id": "expensetransactions_expensetransactionerror",
-      "label": "expenseTransactionError()",
-      "norm_label": "expensetransactionerror()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 348,
-      "file_type": "code",
-      "id": "expensetransactions_formatexpensestaffprofilename",
-      "label": "formatExpenseStaffProfileName()",
-      "norm_label": "formatexpensestaffprofilename()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 348,
-      "file_type": "code",
-      "id": "expensetransactions_voidexpensetransactionhandler",
-      "label": "voidExpenseTransactionHandler()",
-      "norm_label": "voidexpensetransactionhandler()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
-      "source_location": "L446"
-    },
-    {
-      "community": 348,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_expensetransactions_ts",
-      "label": "expenseTransactions.ts",
-      "norm_label": "expensetransactions.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_marketing_walkthroughhmac_ts",
-      "label": "walkthroughHmac.ts",
-      "norm_label": "walkthroughhmac.ts",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughHmac.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "walkthroughhmac_createwalkthroughdedupehmac",
-      "label": "createWalkthroughDedupeHmac()",
-      "norm_label": "createwalkthroughdedupehmac()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughHmac.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "walkthroughhmac_getactivewalkthroughhmackey",
-      "label": "getActiveWalkthroughHmacKey()",
-      "norm_label": "getactivewalkthroughhmackey()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughHmac.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "walkthroughhmac_getwalkthroughhmacsecret",
-      "label": "getWalkthroughHmacSecret()",
-      "norm_label": "getwalkthroughhmacsecret()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughHmac.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "walkthroughhmac_getwalkthroughhmacverificationkeys",
-      "label": "getWalkthroughHmacVerificationKeys()",
-      "norm_label": "getwalkthroughhmacverificationkeys()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughHmac.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "walkthroughhmac_matcheswalkthroughtombstone",
-      "label": "matchesWalkthroughTombstone()",
-      "norm_label": "matcheswalkthroughtombstone()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughHmac.ts",
-      "source_location": "L92"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "walkthroughhmac_priorkeyring",
-      "label": "priorKeyring()",
-      "norm_label": "priorkeyring()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughHmac.ts",
-      "source_location": "L8"
     },
     {
       "community": 35,
@@ -230043,6 +230184,132 @@
     {
       "community": 350,
       "file_type": "code",
+      "id": "expensetransactions_createexpensetransactionfromsessionhandler",
+      "label": "createExpenseTransactionFromSessionHandler()",
+      "norm_label": "createexpensetransactionfromsessionhandler()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
+      "source_location": "L72"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "expensetransactions_expenseitemhastrustedavailabilityhold",
+      "label": "expenseItemHasTrustedAvailabilityHold()",
+      "norm_label": "expenseitemhastrustedavailabilityhold()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "expensetransactions_expenseitemusestrustedinventory",
+      "label": "expenseItemUsesTrustedInventory()",
+      "norm_label": "expenseitemusestrustedinventory()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "expensetransactions_expensetransactionerror",
+      "label": "expenseTransactionError()",
+      "norm_label": "expensetransactionerror()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "expensetransactions_formatexpensestaffprofilename",
+      "label": "formatExpenseStaffProfileName()",
+      "norm_label": "formatexpensestaffprofilename()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "expensetransactions_voidexpensetransactionhandler",
+      "label": "voidExpenseTransactionHandler()",
+      "norm_label": "voidexpensetransactionhandler()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
+      "source_location": "L446"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_expensetransactions_ts",
+      "label": "expenseTransactions.ts",
+      "norm_label": "expensetransactions.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_marketing_walkthroughhmac_ts",
+      "label": "walkthroughHmac.ts",
+      "norm_label": "walkthroughhmac.ts",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughHmac.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
+      "id": "walkthroughhmac_createwalkthroughdedupehmac",
+      "label": "createWalkthroughDedupeHmac()",
+      "norm_label": "createwalkthroughdedupehmac()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughHmac.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
+      "id": "walkthroughhmac_getactivewalkthroughhmackey",
+      "label": "getActiveWalkthroughHmacKey()",
+      "norm_label": "getactivewalkthroughhmackey()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughHmac.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
+      "id": "walkthroughhmac_getwalkthroughhmacsecret",
+      "label": "getWalkthroughHmacSecret()",
+      "norm_label": "getwalkthroughhmacsecret()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughHmac.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
+      "id": "walkthroughhmac_getwalkthroughhmacverificationkeys",
+      "label": "getWalkthroughHmacVerificationKeys()",
+      "norm_label": "getwalkthroughhmacverificationkeys()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughHmac.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
+      "id": "walkthroughhmac_matcheswalkthroughtombstone",
+      "label": "matchesWalkthroughTombstone()",
+      "norm_label": "matcheswalkthroughtombstone()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughHmac.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
+      "id": "walkthroughhmac_priorkeyring",
+      "label": "priorKeyring()",
+      "norm_label": "priorkeyring()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughHmac.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 352,
+      "file_type": "code",
       "id": "backfillathenausernormalizedemail_backfillathenausernormalizedemailbatchwithctx",
       "label": "backfillAthenaUserNormalizedEmailBatchWithCtx()",
       "norm_label": "backfillathenausernormalizedemailbatchwithctx()",
@@ -230050,7 +230317,7 @@
       "source_location": "L72"
     },
     {
-      "community": 350,
+      "community": 352,
       "file_type": "code",
       "id": "backfillathenausernormalizedemail_boundedlimit",
       "label": "boundedLimit()",
@@ -230059,7 +230326,7 @@
       "source_location": "L21"
     },
     {
-      "community": 350,
+      "community": 352,
       "file_type": "code",
       "id": "backfillathenausernormalizedemail_candidateforuserwithctx",
       "label": "candidateForUserWithCtx()",
@@ -230068,7 +230335,7 @@
       "source_location": "L42"
     },
     {
-      "community": 350,
+      "community": 352,
       "file_type": "code",
       "id": "backfillathenausernormalizedemail_normalizedidentityfingerprint",
       "label": "normalizedIdentityFingerprint()",
@@ -230077,7 +230344,7 @@
       "source_location": "L34"
     },
     {
-      "community": 350,
+      "community": 352,
       "file_type": "code",
       "id": "backfillathenausernormalizedemail_recordidentityconflictwithctx",
       "label": "recordIdentityConflictWithCtx()",
@@ -230086,7 +230353,7 @@
       "source_location": "L59"
     },
     {
-      "community": 350,
+      "community": 352,
       "file_type": "code",
       "id": "backfillathenausernormalizedemail_tohex",
       "label": "toHex()",
@@ -230095,7 +230362,7 @@
       "source_location": "L28"
     },
     {
-      "community": 350,
+      "community": 352,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_backfillathenausernormalizedemail_ts",
       "label": "backfillAthenaUserNormalizedEmail.ts",
@@ -230104,7 +230371,7 @@
       "source_location": "L1"
     },
     {
-      "community": 351,
+      "community": 353,
       "file_type": "code",
       "id": "backfillreportfactobservedat_backfillreportfactobservedatwithctx",
       "label": "backfillReportFactObservedAtWithCtx()",
@@ -230113,7 +230380,7 @@
       "source_location": "L66"
     },
     {
-      "community": 351,
+      "community": 353,
       "file_type": "code",
       "id": "backfillreportfactobservedat_boundedlimit",
       "label": "boundedLimit()",
@@ -230122,7 +230389,7 @@
       "source_location": "L34"
     },
     {
-      "community": 351,
+      "community": 353,
       "file_type": "code",
       "id": "backfillreportfactobservedat_factpage",
       "label": "factPage()",
@@ -230131,7 +230398,7 @@
       "source_location": "L41"
     },
     {
-      "community": 351,
+      "community": 353,
       "file_type": "code",
       "id": "backfillreportfactobservedat_storefactpage",
       "label": "storeFactPage()",
@@ -230140,7 +230407,7 @@
       "source_location": "L51"
     },
     {
-      "community": 351,
+      "community": 353,
       "file_type": "code",
       "id": "backfillreportfactobservedat_verifyreportfactobservedatwithctx",
       "label": "verifyReportFactObservedAtWithCtx()",
@@ -230149,7 +230416,7 @@
       "source_location": "L142"
     },
     {
-      "community": 351,
+      "community": 353,
       "file_type": "code",
       "id": "backfillreportfactobservedat_verifystorereportfactobservedatwithctx",
       "label": "verifyStoreReportFactObservedAtWithCtx()",
@@ -230158,7 +230425,7 @@
       "source_location": "L161"
     },
     {
-      "community": 351,
+      "community": 353,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_backfillreportfactobservedat_ts",
       "label": "backfillReportFactObservedAt.ts",
@@ -230167,7 +230434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 352,
+      "community": 354,
       "file_type": "code",
       "id": "backfillreportingcyclestart_backfillreportingcyclestartwithctx",
       "label": "backfillReportingCycleStartWithCtx()",
@@ -230176,7 +230443,7 @@
       "source_location": "L50"
     },
     {
-      "community": 352,
+      "community": 354,
       "file_type": "code",
       "id": "backfillreportingcyclestart_boundedlimit",
       "label": "boundedLimit()",
@@ -230185,7 +230452,7 @@
       "source_location": "L33"
     },
     {
-      "community": 352,
+      "community": 354,
       "file_type": "code",
       "id": "backfillreportingcyclestart_schedulepage",
       "label": "schedulePage()",
@@ -230194,7 +230461,7 @@
       "source_location": "L40"
     },
     {
-      "community": 352,
+      "community": 354,
       "file_type": "code",
       "id": "backfillreportingcyclestart_storeschedulepage",
       "label": "storeSchedulePage()",
@@ -230203,7 +230470,7 @@
       "source_location": "L140"
     },
     {
-      "community": 352,
+      "community": 354,
       "file_type": "code",
       "id": "backfillreportingcyclestart_verifyreportingcyclestartwithctx",
       "label": "verifyReportingCycleStartWithCtx()",
@@ -230212,7 +230479,7 @@
       "source_location": "L125"
     },
     {
-      "community": 352,
+      "community": 354,
       "file_type": "code",
       "id": "backfillreportingcyclestart_verifystorereportingcyclestartwithctx",
       "label": "verifyStoreReportingCycleStartWithCtx()",
@@ -230221,7 +230488,7 @@
       "source_location": "L164"
     },
     {
-      "community": 352,
+      "community": 354,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_backfillreportingcyclestart_ts",
       "label": "backfillReportingCycleStart.ts",
@@ -230230,7 +230497,7 @@
       "source_location": "L1"
     },
     {
-      "community": 353,
+      "community": 355,
       "file_type": "code",
       "id": "client_buildheaders",
       "label": "buildHeaders()",
@@ -230239,7 +230506,7 @@
       "source_location": "L20"
     },
     {
-      "community": 353,
+      "community": 355,
       "file_type": "code",
       "id": "client_createcollectionsaccesstoken",
       "label": "createCollectionsAccessToken()",
@@ -230248,7 +230515,7 @@
       "source_location": "L30"
     },
     {
-      "community": 353,
+      "community": 355,
       "file_type": "code",
       "id": "client_encodebasicauth",
       "label": "encodeBasicAuth()",
@@ -230257,7 +230524,7 @@
       "source_location": "L9"
     },
     {
-      "community": 353,
+      "community": 355,
       "file_type": "code",
       "id": "client_getrequesttopaystatus",
       "label": "getRequestToPayStatus()",
@@ -230266,7 +230533,7 @@
       "source_location": "L115"
     },
     {
-      "community": 353,
+      "community": 355,
       "file_type": "code",
       "id": "client_requesttopay",
       "label": "requestToPay()",
@@ -230275,7 +230542,7 @@
       "source_location": "L65"
     },
     {
-      "community": 353,
+      "community": 355,
       "file_type": "code",
       "id": "client_toerror",
       "label": "toError()",
@@ -230284,7 +230551,7 @@
       "source_location": "L13"
     },
     {
-      "community": 353,
+      "community": 355,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_client_ts",
       "label": "client.ts",
@@ -230293,7 +230560,7 @@
       "source_location": "L1"
     },
     {
-      "community": 354,
+      "community": 356,
       "file_type": "code",
       "id": "dailyopening_test_completeddailyclose",
       "label": "completedDailyClose()",
@@ -230302,7 +230569,7 @@
       "source_location": "L250"
     },
     {
-      "community": 354,
+      "community": 356,
       "file_type": "code",
       "id": "dailyopening_test_createdb",
       "label": "createDb()",
@@ -230311,7 +230578,7 @@
       "source_location": "L38"
     },
     {
-      "community": 354,
+      "community": 356,
       "file_type": "code",
       "id": "dailyopening_test_gethandler",
       "label": "getHandler()",
@@ -230320,7 +230587,7 @@
       "source_location": "L277"
     },
     {
-      "community": 354,
+      "community": 356,
       "file_type": "code",
       "id": "dailyopening_test_inventoryreview",
       "label": "inventoryReview()",
@@ -230329,7 +230596,7 @@
       "source_location": "L687"
     },
     {
-      "community": 354,
+      "community": 356,
       "file_type": "code",
       "id": "dailyopening_test_openingapprovalproof",
       "label": "openingApprovalProof()",
@@ -230338,7 +230605,7 @@
       "source_location": "L233"
     },
     {
-      "community": 354,
+      "community": 356,
       "file_type": "code",
       "id": "dailyopening_test_workitem",
       "label": "workItem()",
@@ -230347,7 +230614,7 @@
       "source_location": "L1305"
     },
     {
-      "community": 354,
+      "community": 356,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_dailyopening_test_ts",
       "label": "dailyOpening.test.ts",
@@ -230356,7 +230623,7 @@
       "source_location": "L1"
     },
     {
-      "community": 355,
+      "community": 357,
       "file_type": "code",
       "id": "linking_buildcustomerprofiledraft",
       "label": "buildCustomerProfileDraft()",
@@ -230365,7 +230632,7 @@
       "source_location": "L110"
     },
     {
-      "community": 355,
+      "community": 357,
       "file_type": "code",
       "id": "linking_buildfullname",
       "label": "buildFullName()",
@@ -230374,7 +230641,7 @@
       "source_location": "L85"
     },
     {
-      "community": 355,
+      "community": 357,
       "file_type": "code",
       "id": "linking_findmatchingcustomerprofile",
       "label": "findMatchingCustomerProfile()",
@@ -230383,7 +230650,7 @@
       "source_location": "L172"
     },
     {
-      "community": 355,
+      "community": 357,
       "file_type": "code",
       "id": "linking_normalizelookupvalue",
       "label": "normalizeLookupValue()",
@@ -230392,7 +230659,7 @@
       "source_location": "L58"
     },
     {
-      "community": 355,
+      "community": 357,
       "file_type": "code",
       "id": "linking_normalizephonenumber",
       "label": "normalizePhoneNumber()",
@@ -230401,7 +230668,7 @@
       "source_location": "L62"
     },
     {
-      "community": 355,
+      "community": 357,
       "file_type": "code",
       "id": "linking_splitfullname",
       "label": "splitFullName()",
@@ -230410,7 +230677,7 @@
       "source_location": "L66"
     },
     {
-      "community": 355,
+      "community": 357,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_helpers_linking_ts",
       "label": "linking.ts",
@@ -230419,7 +230686,7 @@
       "source_location": "L1"
     },
     {
-      "community": 356,
+      "community": 358,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessionauthorityrevision_ts",
       "label": "registerSessionAuthorityRevision.ts",
@@ -230428,7 +230695,7 @@
       "source_location": "L1"
     },
     {
-      "community": 356,
+      "community": 358,
       "file_type": "code",
       "id": "registersessionauthorityrevision_buildregistersessionauthoritypatch",
       "label": "buildRegisterSessionAuthorityPatch()",
@@ -230437,7 +230704,7 @@
       "source_location": "L16"
     },
     {
-      "community": 356,
+      "community": 358,
       "file_type": "code",
       "id": "registersessionauthorityrevision_deleteregistersessionwithauthority",
       "label": "deleteRegisterSessionWithAuthority()",
@@ -230446,7 +230713,7 @@
       "source_location": "L66"
     },
     {
-      "community": 356,
+      "community": 358,
       "file_type": "code",
       "id": "registersessionauthorityrevision_initialregistersessionauthorityrevision",
       "label": "initialRegisterSessionAuthorityRevision()",
@@ -230455,7 +230722,7 @@
       "source_location": "L12"
     },
     {
-      "community": 356,
+      "community": 358,
       "file_type": "code",
       "id": "registersessionauthorityrevision_insertregistersessionwithauthority",
       "label": "insertRegisterSessionWithAuthority()",
@@ -230464,7 +230731,7 @@
       "source_location": "L39"
     },
     {
-      "community": 356,
+      "community": 358,
       "file_type": "code",
       "id": "registersessionauthorityrevision_patchregistersessionwithauthority",
       "label": "patchRegisterSessionWithAuthority()",
@@ -230473,7 +230740,7 @@
       "source_location": "L49"
     },
     {
-      "community": 356,
+      "community": 358,
       "file_type": "code",
       "id": "registersessionauthorityrevision_replaceregistersessionwithauthority",
       "label": "replaceRegisterSessionWithAuthority()",
@@ -230482,7 +230749,7 @@
       "source_location": "L75"
     },
     {
-      "community": 357,
+      "community": 359,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessioncloseoutgate_ts",
       "label": "registerSessionCloseoutGate.ts",
@@ -230491,7 +230758,7 @@
       "source_location": "L1"
     },
     {
-      "community": 357,
+      "community": 359,
       "file_type": "code",
       "id": "registersessioncloseoutgate_areregistersessioncloseoutreviewfactsequivalent",
       "label": "areRegisterSessionCloseoutReviewFactsEquivalent()",
@@ -230500,7 +230767,7 @@
       "source_location": "L119"
     },
     {
-      "community": 357,
+      "community": 359,
       "file_type": "code",
       "id": "registersessioncloseoutgate_asboolean",
       "label": "asBoolean()",
@@ -230509,7 +230776,7 @@
       "source_location": "L35"
     },
     {
-      "community": 357,
+      "community": 359,
       "file_type": "code",
       "id": "registersessioncloseoutgate_asnumber",
       "label": "asNumber()",
@@ -230518,7 +230785,7 @@
       "source_location": "L39"
     },
     {
-      "community": 357,
+      "community": 359,
       "file_type": "code",
       "id": "registersessioncloseoutgate_asrecord",
       "label": "asRecord()",
@@ -230527,7 +230794,7 @@
       "source_location": "L27"
     },
     {
-      "community": 357,
+      "community": 359,
       "file_type": "code",
       "id": "registersessioncloseoutgate_buildregistersessioncloseoutreview",
       "label": "buildRegisterSessionCloseoutReview()",
@@ -230536,139 +230803,13 @@
       "source_location": "L64"
     },
     {
-      "community": 357,
+      "community": 359,
       "file_type": "code",
       "id": "registersessioncloseoutgate_getcashcontrolsconfig",
       "label": "getCashControlsConfig()",
       "norm_label": "getcashcontrolsconfig()",
       "source_file": "packages/athena-webapp/convex/operations/registerSessionCloseoutGate.ts",
       "source_location": "L43"
-    },
-    {
-      "community": 358,
-      "file_type": "code",
-      "id": "expensesessiontracing_buildexpensesessiontraceevent",
-      "label": "buildExpenseSessionTraceEvent()",
-      "norm_label": "buildexpensesessiontraceevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
-      "source_location": "L150"
-    },
-    {
-      "community": 358,
-      "file_type": "code",
-      "id": "expensesessiontracing_buildexpensesessiontracerecord",
-      "label": "buildExpenseSessionTraceRecord()",
-      "norm_label": "buildexpensesessiontracerecord()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 358,
-      "file_type": "code",
-      "id": "expensesessiontracing_buildtracesummary",
-      "label": "buildTraceSummary()",
-      "norm_label": "buildtracesummary()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 358,
-      "file_type": "code",
-      "id": "expensesessiontracing_createexpensesessiontracerecorder",
-      "label": "createExpenseSessionTraceRecorder()",
-      "norm_label": "createexpensesessiontracerecorder()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
-      "source_location": "L293"
-    },
-    {
-      "community": 358,
-      "file_type": "code",
-      "id": "expensesessiontracing_recordexpensesessiontracebesteffort",
-      "label": "recordExpenseSessionTraceBestEffort()",
-      "norm_label": "recordexpensesessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
-      "source_location": "L266"
-    },
-    {
-      "community": 358,
-      "file_type": "code",
-      "id": "expensesessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
-      "source_location": "L258"
-    },
-    {
-      "community": 358,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_expensesessiontracing_ts",
-      "label": "expenseSessionTracing.ts",
-      "norm_label": "expensesessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_queries_searchcustomers_ts",
-      "label": "searchCustomers.ts",
-      "norm_label": "searchcustomers.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "searchcustomers_findbystorefrontuser",
-      "label": "findByStoreFrontUser()",
-      "norm_label": "findbystorefrontuser()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "searchcustomers_findpotentialmatches",
-      "label": "findPotentialMatches()",
-      "norm_label": "findpotentialmatches()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L122"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "searchcustomers_getcustomerbyid",
-      "label": "getCustomerById()",
-      "norm_label": "getcustomerbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "searchcustomers_getcustomerprofileidforposcustomer",
-      "label": "getCustomerProfileIdForPosCustomer()",
-      "norm_label": "getcustomerprofileidforposcustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "searchcustomers_getcustomertransactions",
-      "label": "getCustomerTransactions()",
-      "norm_label": "getcustomertransactions()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "searchcustomers_searchcustomers",
-      "label": "searchCustomers()",
-      "norm_label": "searchcustomers()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L27"
     },
     {
       "community": 36,
@@ -230961,6 +231102,132 @@
     {
       "community": 360,
       "file_type": "code",
+      "id": "expensesessiontracing_buildexpensesessiontraceevent",
+      "label": "buildExpenseSessionTraceEvent()",
+      "norm_label": "buildexpensesessiontraceevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
+      "source_location": "L150"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "expensesessiontracing_buildexpensesessiontracerecord",
+      "label": "buildExpenseSessionTraceRecord()",
+      "norm_label": "buildexpensesessiontracerecord()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "expensesessiontracing_buildtracesummary",
+      "label": "buildTraceSummary()",
+      "norm_label": "buildtracesummary()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "expensesessiontracing_createexpensesessiontracerecorder",
+      "label": "createExpenseSessionTraceRecorder()",
+      "norm_label": "createexpensesessiontracerecorder()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
+      "source_location": "L293"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "expensesessiontracing_recordexpensesessiontracebesteffort",
+      "label": "recordExpenseSessionTraceBestEffort()",
+      "norm_label": "recordexpensesessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
+      "source_location": "L266"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "expensesessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
+      "source_location": "L258"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_expensesessiontracing_ts",
+      "label": "expenseSessionTracing.ts",
+      "norm_label": "expensesessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_queries_searchcustomers_ts",
+      "label": "searchCustomers.ts",
+      "norm_label": "searchcustomers.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
+      "id": "searchcustomers_findbystorefrontuser",
+      "label": "findByStoreFrontUser()",
+      "norm_label": "findbystorefrontuser()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
+      "id": "searchcustomers_findpotentialmatches",
+      "label": "findPotentialMatches()",
+      "norm_label": "findpotentialmatches()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L122"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
+      "id": "searchcustomers_getcustomerbyid",
+      "label": "getCustomerById()",
+      "norm_label": "getcustomerbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
+      "id": "searchcustomers_getcustomerprofileidforposcustomer",
+      "label": "getCustomerProfileIdForPosCustomer()",
+      "norm_label": "getcustomerprofileidforposcustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
+      "id": "searchcustomers_getcustomertransactions",
+      "label": "getCustomerTransactions()",
+      "norm_label": "getcustomertransactions()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
+      "id": "searchcustomers_searchcustomers",
+      "label": "searchCustomers()",
+      "norm_label": "searchcustomers()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 362,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_projectionpolicies_ts",
       "label": "projectionPolicies.ts",
       "norm_label": "projectionpolicies.ts",
@@ -230968,7 +231235,7 @@
       "source_location": "L1"
     },
     {
-      "community": 360,
+      "community": 362,
       "file_type": "code",
       "id": "projectionpolicies_classifyprovisionalimportlineage",
       "label": "classifyProvisionalImportLineage()",
@@ -230977,7 +231244,7 @@
       "source_location": "L54"
     },
     {
-      "community": 360,
+      "community": 362,
       "file_type": "code",
       "id": "projectionpolicies_findmixedtrustedandprovisionalskuid",
       "label": "findMixedTrustedAndProvisionalSkuId()",
@@ -230986,7 +231253,7 @@
       "source_location": "L109"
     },
     {
-      "community": 360,
+      "community": 362,
       "file_type": "code",
       "id": "projectionpolicies_isfinalizationclosed",
       "label": "isFinalizationClosed()",
@@ -230995,7 +231262,7 @@
       "source_location": "L179"
     },
     {
-      "community": 360,
+      "community": 362,
       "file_type": "code",
       "id": "projectionpolicies_istrustedinventorysaleitem",
       "label": "isTrustedInventorySaleItem()",
@@ -231004,7 +231271,7 @@
       "source_location": "L148"
     },
     {
-      "community": 360,
+      "community": 362,
       "file_type": "code",
       "id": "projectionpolicies_saleinventorylinekey",
       "label": "saleInventoryLineKey()",
@@ -231013,7 +231280,7 @@
       "source_location": "L45"
     },
     {
-      "community": 360,
+      "community": 362,
       "file_type": "code",
       "id": "projectionpolicies_shouldrecordprovisionalimportsaleevidence",
       "label": "shouldRecordProvisionalImportSaleEvidence()",
@@ -231022,7 +231289,7 @@
       "source_location": "L168"
     },
     {
-      "community": 361,
+      "community": 363,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_registermappingauthorityrevision_ts",
       "label": "registerMappingAuthorityRevision.ts",
@@ -231031,7 +231298,7 @@
       "source_location": "L1"
     },
     {
-      "community": 361,
+      "community": 363,
       "file_type": "code",
       "id": "registermappingauthorityrevision_advanceregistermappingauthority",
       "label": "advanceRegisterMappingAuthority()",
@@ -231040,7 +231307,7 @@
       "source_location": "L36"
     },
     {
-      "community": 361,
+      "community": 363,
       "file_type": "code",
       "id": "registermappingauthorityrevision_buildnextregistermappingauthority",
       "label": "buildNextRegisterMappingAuthority()",
@@ -231049,7 +231316,7 @@
       "source_location": "L17"
     },
     {
-      "community": 361,
+      "community": 363,
       "file_type": "code",
       "id": "registermappingauthorityrevision_createposlocalsyncmappingwithauthority",
       "label": "createPosLocalSyncMappingWithAuthority()",
@@ -231058,7 +231325,7 @@
       "source_location": "L76"
     },
     {
-      "community": 361,
+      "community": 363,
       "file_type": "code",
       "id": "registermappingauthorityrevision_markregistermappingauthorityambiguous",
       "label": "markRegisterMappingAuthorityAmbiguous()",
@@ -231067,7 +231334,7 @@
       "source_location": "L145"
     },
     {
-      "community": 361,
+      "community": 363,
       "file_type": "code",
       "id": "registermappingauthorityrevision_markregistermappingauthoritymapped",
       "label": "markRegisterMappingAuthorityMapped()",
@@ -231076,7 +231343,7 @@
       "source_location": "L155"
     },
     {
-      "community": 361,
+      "community": 363,
       "file_type": "code",
       "id": "registermappingauthorityrevision_tombstoneregistermappingauthority",
       "label": "tombstoneRegisterMappingAuthority()",
@@ -231085,7 +231352,7 @@
       "source_location": "L135"
     },
     {
-      "community": 362,
+      "community": 364,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessionrepository_ts",
       "label": "sessionRepository.ts",
@@ -231094,7 +231361,7 @@
       "source_location": "L1"
     },
     {
-      "community": 362,
+      "community": 364,
       "file_type": "code",
       "id": "sessionrepository_getactivesessionforregisterstate",
       "label": "getActiveSessionForRegisterState()",
@@ -231103,7 +231370,7 @@
       "source_location": "L18"
     },
     {
-      "community": 362,
+      "community": 364,
       "file_type": "code",
       "id": "sessionrepository_listheldsessionsforregisterstate",
       "label": "listHeldSessionsForRegisterState()",
@@ -231112,7 +231379,7 @@
       "source_location": "L26"
     },
     {
-      "community": 362,
+      "community": 364,
       "file_type": "code",
       "id": "sessionrepository_matchesregisteridentity",
       "label": "matchesRegisterIdentity()",
@@ -231121,7 +231388,7 @@
       "source_location": "L119"
     },
     {
-      "community": 362,
+      "community": 364,
       "file_type": "code",
       "id": "sessionrepository_querysessionsbystatus",
       "label": "querySessionsByStatus()",
@@ -231130,7 +231397,7 @@
       "source_location": "L33"
     },
     {
-      "community": 362,
+      "community": 364,
       "file_type": "code",
       "id": "sessionrepository_selectregisterstatelookupstrategy",
       "label": "selectRegisterStateLookupStrategy()",
@@ -231139,7 +231406,7 @@
       "source_location": "L83"
     },
     {
-      "community": 362,
+      "community": 364,
       "file_type": "code",
       "id": "sessionrepository_summarizeregisterstatesessions",
       "label": "summarizeRegisterStateSessions()",
@@ -231148,7 +231415,7 @@
       "source_location": "L97"
     },
     {
-      "community": 363,
+      "community": 365,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_terminalregisterconflictresolution_ts",
       "label": "terminalRegisterConflictResolution.ts",
@@ -231157,7 +231424,7 @@
       "source_location": "L1"
     },
     {
-      "community": 363,
+      "community": 365,
       "file_type": "code",
       "id": "terminalregisterconflictresolution_getblockingregistersessionidfromconflict",
       "label": "getBlockingRegisterSessionIdFromConflict()",
@@ -231166,7 +231433,7 @@
       "source_location": "L122"
     },
     {
-      "community": 363,
+      "community": 365,
       "file_type": "code",
       "id": "terminalregisterconflictresolution_iscurrentterminalregisterconflict",
       "label": "isCurrentTerminalRegisterConflict()",
@@ -231175,7 +231442,7 @@
       "source_location": "L109"
     },
     {
-      "community": 363,
+      "community": 365,
       "file_type": "code",
       "id": "terminalregisterconflictresolution_isregistersessionconflict",
       "label": "isRegisterSessionConflict()",
@@ -231184,7 +231451,7 @@
       "source_location": "L115"
     },
     {
-      "community": 363,
+      "community": 365,
       "file_type": "code",
       "id": "terminalregisterconflictresolution_resolvescopedregistersession",
       "label": "resolveScopedRegisterSession()",
@@ -231193,7 +231460,7 @@
       "source_location": "L136"
     },
     {
-      "community": 363,
+      "community": 365,
       "file_type": "code",
       "id": "terminalregisterconflictresolution_resolveterminalregisterconflict",
       "label": "resolveTerminalRegisterConflict()",
@@ -231202,7 +231469,7 @@
       "source_location": "L22"
     },
     {
-      "community": 363,
+      "community": 365,
       "file_type": "code",
       "id": "terminalregisterconflictresolution_resolveterminalregistersessionconflict",
       "label": "resolveTerminalRegisterSessionConflict()",
@@ -231211,7 +231478,7 @@
       "source_location": "L54"
     },
     {
-      "community": 364,
+      "community": 366,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_terminalappsessions_ts",
       "label": "terminalAppSessions.ts",
@@ -231220,7 +231487,7 @@
       "source_location": "L1"
     },
     {
-      "community": 364,
+      "community": 366,
       "file_type": "code",
       "id": "terminalappsessions_blocked",
       "label": "blocked()",
@@ -231229,7 +231496,7 @@
       "source_location": "L106"
     },
     {
-      "community": 364,
+      "community": 366,
       "file_type": "code",
       "id": "terminalappsessions_buildrecoveryattemptid",
       "label": "buildRecoveryAttemptId()",
@@ -231238,7 +231505,7 @@
       "source_location": "L116"
     },
     {
-      "community": 364,
+      "community": 366,
       "file_type": "code",
       "id": "terminalappsessions_getorganizationmemberforaccount",
       "label": "getOrganizationMemberForAccount()",
@@ -231247,7 +231514,7 @@
       "source_location": "L158"
     },
     {
-      "community": 364,
+      "community": 366,
       "file_type": "code",
       "id": "terminalappsessions_recordrecoveryevent",
       "label": "recordRecoveryEvent()",
@@ -231256,7 +231523,7 @@
       "source_location": "L130"
     },
     {
-      "community": 364,
+      "community": 366,
       "file_type": "code",
       "id": "terminalappsessions_validateposappaccount",
       "label": "validatePosAppAccount()",
@@ -231265,7 +231532,7 @@
       "source_location": "L176"
     },
     {
-      "community": 364,
+      "community": 366,
       "file_type": "code",
       "id": "terminalappsessions_validateterminalappsessionrecoverywithctx",
       "label": "validateTerminalAppSessionRecoveryWithCtx()",
@@ -231274,7 +231541,7 @@
       "source_location": "L196"
     },
     {
-      "community": 365,
+      "community": 367,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_application_sessionservice_ts",
       "label": "sessionService.ts",
@@ -231283,7 +231550,7 @@
       "source_location": "L1"
     },
     {
-      "community": 365,
+      "community": 367,
       "file_type": "code",
       "id": "sessionservice_approveattendedremoteassistsession",
       "label": "approveAttendedRemoteAssistSession()",
@@ -231292,7 +231559,7 @@
       "source_location": "L224"
     },
     {
-      "community": 365,
+      "community": 367,
       "file_type": "code",
       "id": "sessionservice_claimremoteassistsession",
       "label": "claimRemoteAssistSession()",
@@ -231301,7 +231568,7 @@
       "source_location": "L148"
     },
     {
-      "community": 365,
+      "community": 367,
       "file_type": "code",
       "id": "sessionservice_disconnectremoteassistruntimesession",
       "label": "disconnectRemoteAssistRuntimeSession()",
@@ -231310,7 +231577,7 @@
       "source_location": "L321"
     },
     {
-      "community": 365,
+      "community": 367,
       "file_type": "code",
       "id": "sessionservice_endremoteassistsession",
       "label": "endRemoteAssistSession()",
@@ -231319,7 +231586,7 @@
       "source_location": "L282"
     },
     {
-      "community": 365,
+      "community": 367,
       "file_type": "code",
       "id": "sessionservice_findreusableremoteassistsession",
       "label": "findReusableRemoteAssistSession()",
@@ -231328,7 +231595,7 @@
       "source_location": "L367"
     },
     {
-      "community": 365,
+      "community": 367,
       "file_type": "code",
       "id": "sessionservice_startremoteassistsession",
       "label": "startRemoteAssistSession()",
@@ -231337,70 +231604,7 @@
       "source_location": "L41"
     },
     {
-      "community": 366,
-      "file_type": "code",
-      "id": "foldversionrepair_boundedlimit",
-      "label": "boundedLimit()",
-      "norm_label": "boundedlimit()",
-      "source_file": "packages/athena-webapp/convex/reports/foldVersionRepair.ts",
-      "source_location": "L79"
-    },
-    {
-      "community": 366,
-      "file_type": "code",
-      "id": "foldversionrepair_countstalefoldversiondayswithctx",
-      "label": "countStaleFoldVersionDaysWithCtx()",
-      "norm_label": "countstalefoldversiondayswithctx()",
-      "source_file": "packages/athena-webapp/convex/reports/foldVersionRepair.ts",
-      "source_location": "L209"
-    },
-    {
-      "community": 366,
-      "file_type": "code",
-      "id": "foldversionrepair_countuncertifieddayswithctx",
-      "label": "countUncertifiedDaysWithCtx()",
-      "norm_label": "countuncertifieddayswithctx()",
-      "source_file": "packages/athena-webapp/convex/reports/foldVersionRepair.ts",
-      "source_location": "L234"
-    },
-    {
-      "community": 366,
-      "file_type": "code",
-      "id": "foldversionrepair_daypage",
-      "label": "dayPage()",
-      "norm_label": "daypage()",
-      "source_file": "packages/athena-webapp/convex/reports/foldVersionRepair.ts",
-      "source_location": "L93"
-    },
-    {
-      "community": 366,
-      "file_type": "code",
-      "id": "foldversionrepair_markstalefoldversiondayswithctx",
-      "label": "markStaleFoldVersionDaysWithCtx()",
-      "norm_label": "markstalefoldversiondayswithctx()",
-      "source_file": "packages/athena-webapp/convex/reports/foldVersionRepair.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 366,
-      "file_type": "code",
-      "id": "foldversionrepair_needscertifiedrefold",
-      "label": "needsCertifiedRefold()",
-      "norm_label": "needscertifiedrefold()",
-      "source_file": "packages/athena-webapp/convex/reports/foldVersionRepair.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 366,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_foldversionrepair_ts",
-      "label": "foldVersionRepair.ts",
-      "norm_label": "foldversionrepair.ts",
-      "source_file": "packages/athena-webapp/convex/reports/foldVersionRepair.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_weeklyperiods_ts",
       "label": "weeklyPeriods.ts",
@@ -231409,7 +231613,7 @@
       "source_location": "L1"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "weeklyperiods_isincludeddate",
       "label": "isIncludedDate()",
@@ -231418,7 +231622,7 @@
       "source_location": "L55"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "weeklyperiods_parsedate",
       "label": "parseDate()",
@@ -231427,7 +231631,7 @@
       "source_location": "L19"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "weeklyperiods_resolveweeklyperiod",
       "label": "resolveWeeklyPeriod()",
@@ -231436,7 +231640,7 @@
       "source_location": "L91"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "weeklyperiods_schedulefordate",
       "label": "scheduleForDate()",
@@ -231445,7 +231649,7 @@
       "source_location": "L36"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "weeklyperiods_shiftdate",
       "label": "shiftDate()",
@@ -231454,7 +231658,7 @@
       "source_location": "L24"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "weeklyperiods_weekday",
       "label": "weekday()",
@@ -231463,7 +231667,7 @@
       "source_location": "L30"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "catalog_buildposservicecatalogrow",
       "label": "buildPosServiceCatalogRow()",
@@ -231472,7 +231676,7 @@
       "source_location": "L94"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "catalog_buildposservicecheckoutreadiness",
       "label": "buildPosServiceCheckoutReadiness()",
@@ -231481,7 +231685,7 @@
       "source_location": "L141"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "catalog_buildservicecatalogitem",
       "label": "buildServiceCatalogItem()",
@@ -231490,7 +231694,7 @@
       "source_location": "L196"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "catalog_listposservicecatalogsnapshotwithctx",
       "label": "listPosServiceCatalogSnapshotWithCtx()",
@@ -231499,7 +231703,7 @@
       "source_location": "L117"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "catalog_normalizeservicecatalognamekey",
       "label": "normalizeServiceCatalogNameKey()",
@@ -231508,7 +231712,7 @@
       "source_location": "L90"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "catalog_suggesteddepositamount",
       "label": "suggestedDepositAmount()",
@@ -231517,76 +231721,13 @@
       "source_location": "L180"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalog_ts",
       "label": "catalog.ts",
       "norm_label": "catalog.ts",
       "source_file": "packages/athena-webapp/convex/serviceOps/catalog.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_purchaseordertracing_ts",
-      "label": "purchaseOrderTracing.ts",
-      "norm_label": "purchaseordertracing.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrderTracing.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "purchaseordertracing_besteffortrecordpurchaseorderreceivingtracewithctx",
-      "label": "bestEffortRecordPurchaseOrderReceivingTraceWithCtx()",
-      "norm_label": "besteffortrecordpurchaseorderreceivingtracewithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrderTracing.ts",
-      "source_location": "L155"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "purchaseordertracing_besteffortrecordpurchaseorderstatustracewithctx",
-      "label": "bestEffortRecordPurchaseOrderStatusTraceWithCtx()",
-      "norm_label": "besteffortrecordpurchaseorderstatustracewithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrderTracing.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "purchaseordertracing_compactdetails",
-      "label": "compactDetails()",
-      "norm_label": "compactdetails()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrderTracing.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "purchaseordertracing_ensurepurchaseordertracewithctx",
-      "label": "ensurePurchaseOrderTraceWithCtx()",
-      "norm_label": "ensurepurchaseordertracewithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrderTracing.ts",
-      "source_location": "L72"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "purchaseordertracing_getpurchaseordertracestatusat",
-      "label": "getPurchaseOrderTraceStatusAt()",
-      "norm_label": "getpurchaseordertracestatusat()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrderTracing.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "purchaseordertracing_refsfromentries",
-      "label": "refsFromEntries()",
-      "norm_label": "refsfromentries()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrderTracing.ts",
-      "source_location": "L41"
     },
     {
       "community": 37,
@@ -231870,6 +232011,69 @@
     {
       "community": 370,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_purchaseordertracing_ts",
+      "label": "purchaseOrderTracing.ts",
+      "norm_label": "purchaseordertracing.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrderTracing.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "purchaseordertracing_besteffortrecordpurchaseorderreceivingtracewithctx",
+      "label": "bestEffortRecordPurchaseOrderReceivingTraceWithCtx()",
+      "norm_label": "besteffortrecordpurchaseorderreceivingtracewithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrderTracing.ts",
+      "source_location": "L155"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "purchaseordertracing_besteffortrecordpurchaseorderstatustracewithctx",
+      "label": "bestEffortRecordPurchaseOrderStatusTraceWithCtx()",
+      "norm_label": "besteffortrecordpurchaseorderstatustracewithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrderTracing.ts",
+      "source_location": "L106"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "purchaseordertracing_compactdetails",
+      "label": "compactDetails()",
+      "norm_label": "compactdetails()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrderTracing.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "purchaseordertracing_ensurepurchaseordertracewithctx",
+      "label": "ensurePurchaseOrderTraceWithCtx()",
+      "norm_label": "ensurepurchaseordertracewithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrderTracing.ts",
+      "source_location": "L72"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "purchaseordertracing_getpurchaseordertracestatusat",
+      "label": "getPurchaseOrderTraceStatusAt()",
+      "norm_label": "getpurchaseordertracestatusat()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrderTracing.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "purchaseordertracing_refsfromentries",
+      "label": "refsFromEntries()",
+      "norm_label": "refsfromentries()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrderTracing.ts",
+      "source_location": "L41"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
       "id": "analytics_extractpromocodeid",
       "label": "extractPromoCodeId()",
       "norm_label": "extractpromocodeid()",
@@ -231877,7 +232081,7 @@
       "source_location": "L49"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "analytics_getanalyticsbystoreandactionquery",
       "label": "getAnalyticsByStoreAndActionQuery()",
@@ -231886,7 +232090,7 @@
       "source_location": "L154"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "analytics_getanalyticsbystorequery",
       "label": "getAnalyticsByStoreQuery()",
@@ -231895,7 +232099,7 @@
       "source_location": "L59"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "analytics_getcompletedordersquery",
       "label": "getCompletedOrdersQuery()",
@@ -231904,7 +232108,7 @@
       "source_location": "L107"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "analytics_getskumapforproducts",
       "label": "getSkuMapForProducts()",
@@ -231913,7 +232117,7 @@
       "source_location": "L212"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "analytics_getstorefrontactor",
       "label": "getStoreFrontActor()",
@@ -231922,7 +232126,7 @@
       "source_location": "L30"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_analytics_ts",
       "label": "analytics.ts",
@@ -231931,7 +232135,7 @@
       "source_location": "L1"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "customerbehaviortimeline_getcustomeranalyticsquery",
       "label": "getCustomerAnalyticsQuery()",
@@ -231940,7 +232144,7 @@
       "source_location": "L27"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "customerbehaviortimeline_getcustomeroperationaltimelineevents",
       "label": "getCustomerOperationalTimelineEvents()",
@@ -231949,7 +232153,7 @@
       "source_location": "L153"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "customerbehaviortimeline_getproductinfomaps",
       "label": "getProductInfoMaps()",
@@ -231958,7 +232162,7 @@
       "source_location": "L71"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "customerbehaviortimeline_gettimefilterforrange",
       "label": "getTimeFilterForRange()",
@@ -231967,7 +232171,7 @@
       "source_location": "L12"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "customerbehaviortimeline_gettimelineuserdata",
       "label": "getTimelineUserData()",
@@ -231976,7 +232180,7 @@
       "source_location": "L47"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "customerbehaviortimeline_resolvecustomerprofileidfortimeline",
       "label": "resolveCustomerProfileIdForTimeline()",
@@ -231985,7 +232189,7 @@
       "source_location": "L115"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_ts",
       "label": "customerBehaviorTimeline.ts",
@@ -231994,7 +232198,7 @@
       "source_location": "L1"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "onlineorder_clearbagitems",
       "label": "clearBagItems()",
@@ -232003,7 +232207,7 @@
       "source_location": "L56"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "onlineorder_createorderfromcheckoutsession",
       "label": "createOrderFromCheckoutSession()",
@@ -232012,7 +232216,7 @@
       "source_location": "L157"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "onlineorder_findorderbyexternalreference",
       "label": "findOrderByExternalReference()",
@@ -232021,7 +232225,7 @@
       "source_location": "L32"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "onlineorder_findorderbyexternaltransactionid",
       "label": "findOrderByExternalTransactionId()",
@@ -232030,7 +232234,7 @@
       "source_location": "L44"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "onlineorder_generateordernumber",
       "label": "generateOrderNumber()",
@@ -232039,7 +232243,7 @@
       "source_location": "L25"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "onlineorder_returnorderitemstostock",
       "label": "returnOrderItemsToStock()",
@@ -232048,7 +232252,7 @@
       "source_location": "L68"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -232057,7 +232261,7 @@
       "source_location": "L1"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "orderupdateemails_formatorderitems",
       "label": "formatOrderItems()",
@@ -232066,7 +232270,7 @@
       "source_location": "L64"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "orderupdateemails_getdeliveryaddress",
       "label": "getDeliveryAddress()",
@@ -232075,7 +232279,7 @@
       "source_location": "L55"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "orderupdateemails_getlocationdetails",
       "label": "getLocationDetails()",
@@ -232084,7 +232288,7 @@
       "source_location": "L58"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "orderupdateemails_getpickuplocation",
       "label": "getPickupLocation()",
@@ -232093,7 +232297,7 @@
       "source_location": "L52"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "orderupdateemails_handleorderstatusupdate",
       "label": "handleOrderStatusUpdate()",
@@ -232102,7 +232306,7 @@
       "source_location": "L118"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "orderupdateemails_processorderupdateemail",
       "label": "processOrderUpdateEmail()",
@@ -232111,7 +232315,7 @@
       "source_location": "L297"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_orderupdateemails_ts",
       "label": "orderUpdateEmails.ts",
@@ -232120,7 +232324,7 @@
       "source_location": "L1"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "core_appendworkflowtraceeventwithctx",
       "label": "appendWorkflowTraceEventWithCtx()",
@@ -232129,7 +232333,7 @@
       "source_location": "L142"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "core_createworkflowtracewithctx",
       "label": "createWorkflowTraceWithCtx()",
@@ -232138,7 +232342,7 @@
       "source_location": "L87"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "core_getworkflowtracebyidwithctx",
       "label": "getWorkflowTraceByIdWithCtx()",
@@ -232147,7 +232351,7 @@
       "source_location": "L23"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "core_getworkflowtracebylookupwithctx",
       "label": "getWorkflowTraceByLookupWithCtx()",
@@ -232156,7 +232360,7 @@
       "source_location": "L38"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "core_listworkflowtraceeventswithctx",
       "label": "listWorkflowTraceEventsWithCtx()",
@@ -232165,7 +232369,7 @@
       "source_location": "L71"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "core_registerworkflowtracelookupwithctx",
       "label": "registerWorkflowTraceLookupWithCtx()",
@@ -232174,7 +232378,7 @@
       "source_location": "L112"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_core_ts",
       "label": "core.ts",
@@ -232183,7 +232387,7 @@
       "source_location": "L1"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "eventbuilder_buildcontexteventenvelope",
       "label": "buildContextEventEnvelope()",
@@ -232192,7 +232396,7 @@
       "source_location": "L23"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "eventbuilder_buildcontexteventidempotencykey",
       "label": "buildContextEventIdempotencyKey()",
@@ -232201,7 +232405,7 @@
       "source_location": "L103"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "eventbuilder_compactcontextpayload",
       "label": "compactContextPayload()",
@@ -232210,7 +232414,7 @@
       "source_location": "L76"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "eventbuilder_compactcontextvalue",
       "label": "compactContextValue()",
@@ -232219,7 +232423,7 @@
       "source_location": "L132"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "eventbuilder_hashstablevalue",
       "label": "hashStableValue()",
@@ -232228,7 +232432,7 @@
       "source_location": "L119"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "eventbuilder_stablecontextstringify",
       "label": "stableContextStringify()",
@@ -232237,7 +232441,7 @@
       "source_location": "L89"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_intelligence_eventbuilder_ts",
       "label": "eventBuilder.ts",
@@ -232246,7 +232450,7 @@
       "source_location": "L1"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "inventoryimportreviewpayload_buildinventoryimportreviewpayload",
       "label": "buildInventoryImportReviewPayload()",
@@ -232255,7 +232459,7 @@
       "source_location": "L119"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "inventoryimportreviewpayload_getinventoryimportreviewpayloadchunkbytelength",
       "label": "getInventoryImportReviewPayloadChunkByteLength()",
@@ -232264,7 +232468,7 @@
       "source_location": "L28"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "inventoryimportreviewpayload_getutf8bytelength",
       "label": "getUtf8ByteLength()",
@@ -232273,7 +232477,7 @@
       "source_location": "L24"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "inventoryimportreviewpayload_ishighsurrogate",
       "label": "isHighSurrogate()",
@@ -232282,7 +232486,7 @@
       "source_location": "L158"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "inventoryimportreviewpayload_splitinventoryimportreviewrawcontent",
       "label": "splitInventoryImportReviewRawContent()",
@@ -232291,7 +232495,7 @@
       "source_location": "L38"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "inventoryimportreviewpayload_splitinventoryimportreviewrowdecisions",
       "label": "splitInventoryImportReviewRowDecisions()",
@@ -232300,7 +232504,7 @@
       "source_location": "L85"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_inventoryimportreviewpayload_ts",
       "label": "inventoryImportReviewPayload.ts",
@@ -232309,7 +232513,7 @@
       "source_location": "L1"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_shareddemostory_ts",
       "label": "sharedDemoStory.ts",
@@ -232318,7 +232522,7 @@
       "source_location": "L1"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "shareddemostory_shareddemopickuporderamount",
       "label": "sharedDemoPickupOrderAmount()",
@@ -232327,7 +232531,7 @@
       "source_location": "L215"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "shareddemostory_shareddemopickupordertimeline",
       "label": "sharedDemoPickupOrderTimeline()",
@@ -232336,7 +232540,7 @@
       "source_location": "L207"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "shareddemostory_shareddemoproductbysku",
       "label": "sharedDemoProductBySku()",
@@ -232345,7 +232549,7 @@
       "source_location": "L183"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "shareddemostory_shareddemoproductbyslug",
       "label": "sharedDemoProductBySlug()",
@@ -232354,7 +232558,7 @@
       "source_location": "L189"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "shareddemostory_shareddemoproductimageurl",
       "label": "sharedDemoProductImageUrl()",
@@ -232363,7 +232567,7 @@
       "source_location": "L167"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "shareddemostory_shareddemostaffshortname",
       "label": "sharedDemoStaffShortName()",
@@ -232372,7 +232576,7 @@
       "source_location": "L49"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_stockadjustment_ts",
       "label": "stockAdjustment.ts",
@@ -232381,7 +232585,7 @@
       "source_location": "L1"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "stockadjustment_assertstockadjustmentreasoncode",
       "label": "assertStockAdjustmentReasonCode()",
@@ -232390,7 +232594,7 @@
       "source_location": "L25"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "stockadjustment_calculatecyclecountquantitydelta",
       "label": "calculateCycleCountQuantityDelta()",
@@ -232399,7 +232603,7 @@
       "source_location": "L14"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "stockadjustment_hashighstockadjustmentvariance",
       "label": "hasHighStockAdjustmentVariance()",
@@ -232408,7 +232612,7 @@
       "source_location": "L104"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "stockadjustment_requiresstockadjustmentapproval",
       "label": "requiresStockAdjustmentApproval()",
@@ -232417,7 +232621,7 @@
       "source_location": "L122"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "stockadjustment_resolvestockadjustmentquantitydelta",
       "label": "resolveStockAdjustmentQuantityDelta()",
@@ -232426,76 +232630,13 @@
       "source_location": "L50"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "stockadjustment_summarizestockadjustmentlineitems",
       "label": "summarizeStockAdjustmentLineItems()",
       "norm_label": "summarizestockadjustmentlineitems()",
       "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
       "source_location": "L84"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "categorysubcategorymanager_removecategory",
-      "label": "removeCategory()",
-      "norm_label": "removecategory()",
-      "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
-      "source_location": "L189"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "categorysubcategorymanager_removesubcategory",
-      "label": "removeSubcategory()",
-      "norm_label": "removesubcategory()",
-      "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
-      "source_location": "L546"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "categorysubcategorymanager_save",
-      "label": "save()",
-      "norm_label": "save()",
-      "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
-      "source_location": "L106"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "categorysubcategorymanager_sidebar",
-      "label": "Sidebar()",
-      "norm_label": "sidebar()",
-      "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
-      "source_location": "L40"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "categorysubcategorymanager_update",
-      "label": "update()",
-      "norm_label": "update()",
-      "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
-      "source_location": "L131"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "categorysubcategorymanager_updatestorefrontvisibility",
-      "label": "updateStorefrontVisibility()",
-      "norm_label": "updatestorefrontvisibility()",
-      "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
-      "source_location": "L156"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
-      "label": "CategorySubcategoryManager.tsx",
-      "norm_label": "categorysubcategorymanager.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
-      "source_location": "L1"
     },
     {
       "community": 38,
@@ -232779,6 +232920,69 @@
     {
       "community": 380,
       "file_type": "code",
+      "id": "categorysubcategorymanager_removecategory",
+      "label": "removeCategory()",
+      "norm_label": "removecategory()",
+      "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
+      "source_location": "L189"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "categorysubcategorymanager_removesubcategory",
+      "label": "removeSubcategory()",
+      "norm_label": "removesubcategory()",
+      "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
+      "source_location": "L546"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "categorysubcategorymanager_save",
+      "label": "save()",
+      "norm_label": "save()",
+      "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
+      "source_location": "L106"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "categorysubcategorymanager_sidebar",
+      "label": "Sidebar()",
+      "norm_label": "sidebar()",
+      "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
+      "source_location": "L40"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "categorysubcategorymanager_update",
+      "label": "update()",
+      "norm_label": "update()",
+      "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
+      "source_location": "L131"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "categorysubcategorymanager_updatestorefrontvisibility",
+      "label": "updateStorefrontVisibility()",
+      "norm_label": "updatestorefrontvisibility()",
+      "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
+      "source_location": "L156"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
+      "label": "CategorySubcategoryManager.tsx",
+      "norm_label": "categorysubcategorymanager.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_update_updatereadybanner_test_tsx",
       "label": "UpdateReadyBanner.test.tsx",
       "norm_label": "updatereadybanner.test.tsx",
@@ -232786,7 +232990,7 @@
       "source_location": "L1"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "updatereadybanner_test_appmessageblockerprobe",
       "label": "AppMessageBlockerProbe()",
@@ -232795,7 +232999,7 @@
       "source_location": "L88"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "updatereadybanner_test_compatibilitytoastpreferenceprobe",
       "label": "CompatibilityToastPreferenceProbe()",
@@ -232804,7 +233008,7 @@
       "source_location": "L101"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "updatereadybanner_test_coordinatorsnapshotprobe",
       "label": "CoordinatorSnapshotProbe()",
@@ -232813,7 +233017,7 @@
       "source_location": "L122"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "updatereadybanner_test_legacyapplyblockerprobe",
       "label": "LegacyApplyBlockerProbe()",
@@ -232822,7 +233026,7 @@
       "source_location": "L110"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "updatereadybanner_test_probe",
       "label": "Probe()",
@@ -232831,7 +233035,7 @@
       "source_location": "L36"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "updatereadybanner_test_renderwithupdateproviders",
       "label": "renderWithUpdateProviders()",
@@ -232840,7 +233044,7 @@
       "source_location": "L133"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "inputotp_formatrequestdelay",
       "label": "formatRequestDelay()",
@@ -232849,7 +233053,7 @@
       "source_location": "L47"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "inputotp_handleauthsyncfailed",
       "label": "handleAuthSyncFailed()",
@@ -232858,7 +233062,7 @@
       "source_location": "L81"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "inputotp_handlepinchange",
       "label": "handlePinChange()",
@@ -232867,7 +233071,7 @@
       "source_location": "L117"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "inputotp_handlerequestnewcode",
       "label": "handleRequestNewCode()",
@@ -232876,7 +233080,7 @@
       "source_location": "L168"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "inputotp_normalizeotpcode",
       "label": "normalizeOtpCode()",
@@ -232885,7 +233089,7 @@
       "source_location": "L31"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "inputotp_onsubmit",
       "label": "onSubmit()",
@@ -232894,7 +233098,7 @@
       "source_location": "L127"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
       "label": "InputOTP.tsx",
@@ -232903,7 +233107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "inventoryimportview_test_buildcsvrow",
       "label": "buildCsvRow()",
@@ -232912,7 +233116,7 @@
       "source_location": "L82"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "inventoryimportview_test_getlastnavigatesearch",
       "label": "getLastNavigateSearch()",
@@ -232921,7 +233125,7 @@
       "source_location": "L115"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "inventoryimportview_test_getreviewoverlayelement",
       "label": "getReviewOverlayElement()",
@@ -232930,7 +233134,7 @@
       "source_location": "L108"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "inventoryimportview_test_getreviewoverlaysection",
       "label": "getReviewOverlaySection()",
@@ -232939,7 +233143,7 @@
       "source_location": "L104"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "inventoryimportview_test_getsourceimportfieldset",
       "label": "getSourceImportFieldset()",
@@ -232948,7 +233152,7 @@
       "source_location": "L93"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "inventoryimportview_test_getsourcepreviewsection",
       "label": "getSourcePreviewSection()",
@@ -232957,7 +233161,7 @@
       "source_location": "L86"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_inventoryimportview_test_tsx",
       "label": "InventoryImportView.test.tsx",
@@ -232966,7 +233170,7 @@
       "source_location": "L1"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "operationreviewworkspace_operationreviewbucketbody",
       "label": "OperationReviewBucketBody()",
@@ -232975,7 +233179,7 @@
       "source_location": "L77"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "operationreviewworkspace_operationreviewbucketheader",
       "label": "OperationReviewBucketHeader()",
@@ -232984,7 +233188,7 @@
       "source_location": "L62"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "operationreviewworkspace_operationreviewbucketshell",
       "label": "OperationReviewBucketShell()",
@@ -232993,7 +233197,7 @@
       "source_location": "L45"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "operationreviewworkspace_operationreviewbuckettabslist",
       "label": "OperationReviewBucketTabsList()",
@@ -233002,7 +233206,7 @@
       "source_location": "L15"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "operationreviewworkspace_operationreviewbuckettabtrigger",
       "label": "OperationReviewBucketTabTrigger()",
@@ -233011,7 +233215,7 @@
       "source_location": "L30"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "operationreviewworkspace_operationreviewrailshell",
       "label": "OperationReviewRailShell()",
@@ -233020,7 +233224,7 @@
       "source_location": "L94"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationreviewworkspace_tsx",
       "label": "OperationReviewWorkspace.tsx",
@@ -233029,7 +233233,7 @@
       "source_location": "L1"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_test_tsx",
       "label": "StockAdjustmentWorkspace.test.tsx",
@@ -233038,7 +233242,7 @@
       "source_location": "L1"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "stockadjustmentworkspace_test_controlledstockadjustmentworkspace",
       "label": "ControlledStockAdjustmentWorkspace()",
@@ -233047,7 +233251,7 @@
       "source_location": "L2140"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "stockadjustmentworkspace_test_renderstockadjustmentworkspace",
       "label": "renderStockAdjustmentWorkspace()",
@@ -233056,7 +233260,7 @@
       "source_location": "L144"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "stockadjustmentworkspace_test_resizeobserverstub",
       "label": "ResizeObserverStub",
@@ -233065,7 +233269,7 @@
       "source_location": "L14"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "stockadjustmentworkspace_test_resizeobserverstub_disconnect",
       "label": ".disconnect()",
@@ -233074,7 +233278,7 @@
       "source_location": "L17"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "stockadjustmentworkspace_test_resizeobserverstub_observe",
       "label": ".observe()",
@@ -233083,7 +233287,7 @@
       "source_location": "L15"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "stockadjustmentworkspace_test_resizeobserverstub_unobserve",
       "label": ".unobserve()",
@@ -233092,7 +233296,7 @@
       "source_location": "L16"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "cartitems_cartitemproductimage",
       "label": "CartItemProductImage()",
@@ -233101,7 +233305,7 @@
       "source_location": "L72"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "cartitems_cartitemquantitycontrol",
       "label": "CartItemQuantityControl()",
@@ -233110,7 +233314,7 @@
       "source_location": "L100"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "cartitems_cn",
       "label": "cn()",
@@ -233119,7 +233323,7 @@
       "source_location": "L366"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "cartitems_formatcartattributeparts",
       "label": "formatCartAttributeParts()",
@@ -233128,7 +233332,7 @@
       "source_location": "L60"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "cartitems_normalizecartattribute",
       "label": "normalizeCartAttribute()",
@@ -233137,7 +233341,7 @@
       "source_location": "L51"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "cartitems_normalizecartquantityinput",
       "label": "normalizeCartQuantityInput()",
@@ -233146,7 +233350,7 @@
       "source_location": "L40"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cartitems_tsx",
       "label": "CartItems.tsx",
@@ -233155,7 +233359,7 @@
       "source_location": "L1"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_paymentview_tsx",
       "label": "PaymentView.tsx",
@@ -233164,7 +233368,7 @@
       "source_location": "L1"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "paymentview_cn",
       "label": "cn()",
@@ -233173,7 +233377,7 @@
       "source_location": "L417"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "paymentview_handleaddpayment",
       "label": "handleAddPayment()",
@@ -233182,7 +233386,7 @@
       "source_location": "L188"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "paymentview_handleamountblur",
       "label": "handleAmountBlur()",
@@ -233191,7 +233395,7 @@
       "source_location": "L266"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "paymentview_handleamountchange",
       "label": "handleAmountChange()",
@@ -233200,7 +233404,7 @@
       "source_location": "L244"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "paymentview_handlekeypadpress",
       "label": "handleKeypadPress()",
@@ -233209,7 +233413,7 @@
       "source_location": "L288"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "paymentview_setamountfromtouch",
       "label": "setAmountFromTouch()",
@@ -233218,7 +233422,7 @@
       "source_location": "L272"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_receivingview_tsx",
       "label": "ReceivingView.tsx",
@@ -233227,7 +233431,7 @@
       "source_location": "L1"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "receivingview_builddefaultconfirmedunitcosts",
       "label": "buildDefaultConfirmedUnitCosts()",
@@ -233236,7 +233440,7 @@
       "source_location": "L89"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "receivingview_builddefaultreceivedquantities",
       "label": "buildDefaultReceivedQuantities()",
@@ -233245,7 +233449,7 @@
       "source_location": "L80"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "receivingview_buildreceivedquantitiesaftersubmission",
       "label": "buildReceivedQuantitiesAfterSubmission()",
@@ -233254,7 +233458,7 @@
       "source_location": "L100"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "receivingview_buildsubmissionkey",
       "label": "buildSubmissionKey()",
@@ -233263,7 +233467,7 @@
       "source_location": "L62"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "receivingview_parselineitemdescription",
       "label": "parseLineItemDescription()",
@@ -233272,7 +233476,7 @@
       "source_location": "L66"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "receivingview_receivingview",
       "label": "ReceivingView()",
@@ -233281,7 +233485,7 @@
       "source_location": "L126"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_quickaddproductdialog_test_tsx",
       "label": "QuickAddProductDialog.test.tsx",
@@ -233290,7 +233494,7 @@
       "source_location": "L1"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "quickaddproductdialog_test_buildskusearchresult",
       "label": "buildSkuSearchResult()",
@@ -233299,7 +233503,7 @@
       "source_location": "L82"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "quickaddproductdialog_test_renderquickadddialog",
       "label": "renderQuickAddDialog()",
@@ -233308,7 +233512,7 @@
       "source_location": "L26"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "quickaddproductdialog_test_resizeobserverstub",
       "label": "ResizeObserverStub",
@@ -233317,7 +233521,7 @@
       "source_location": "L8"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "quickaddproductdialog_test_resizeobserverstub_disconnect",
       "label": ".disconnect()",
@@ -233326,7 +233530,7 @@
       "source_location": "L11"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "quickaddproductdialog_test_resizeobserverstub_observe",
       "label": ".observe()",
@@ -233335,76 +233539,13 @@
       "source_location": "L9"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "quickaddproductdialog_test_resizeobserverstub_unobserve",
       "label": ".unobserve()",
       "norm_label": ".unobserve()",
       "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.test.tsx",
       "source_location": "L10"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_test_tsx",
-      "label": "Products.test.tsx",
-      "norm_label": "products.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/Products.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "products_test_makeproduct",
-      "label": "makeProduct()",
-      "norm_label": "makeproduct()",
-      "source_file": "packages/athena-webapp/src/components/products/Products.test.tsx",
-      "source_location": "L830"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "products_test_makeskusearchresult",
-      "label": "makeSkuSearchResult()",
-      "norm_label": "makeskusearchresult()",
-      "source_file": "packages/athena-webapp/src/components/products/Products.test.tsx",
-      "source_location": "L903"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "products_test_resizeobserverstub",
-      "label": "ResizeObserverStub",
-      "norm_label": "resizeobserverstub",
-      "source_file": "packages/athena-webapp/src/components/products/Products.test.tsx",
-      "source_location": "L42"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "products_test_resizeobserverstub_disconnect",
-      "label": ".disconnect()",
-      "norm_label": ".disconnect()",
-      "source_file": "packages/athena-webapp/src/components/products/Products.test.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "products_test_resizeobserverstub_observe",
-      "label": ".observe()",
-      "norm_label": ".observe()",
-      "source_file": "packages/athena-webapp/src/components/products/Products.test.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "products_test_resizeobserverstub_unobserve",
-      "label": ".unobserve()",
-      "norm_label": ".unobserve()",
-      "source_file": "packages/athena-webapp/src/components/products/Products.test.tsx",
-      "source_location": "L44"
     },
     {
       "community": 39,
@@ -233688,6 +233829,69 @@
     {
       "community": 390,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_test_tsx",
+      "label": "Products.test.tsx",
+      "norm_label": "products.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/Products.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "products_test_makeproduct",
+      "label": "makeProduct()",
+      "norm_label": "makeproduct()",
+      "source_file": "packages/athena-webapp/src/components/products/Products.test.tsx",
+      "source_location": "L830"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "products_test_makeskusearchresult",
+      "label": "makeSkuSearchResult()",
+      "norm_label": "makeskusearchresult()",
+      "source_file": "packages/athena-webapp/src/components/products/Products.test.tsx",
+      "source_location": "L903"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "products_test_resizeobserverstub",
+      "label": "ResizeObserverStub",
+      "norm_label": "resizeobserverstub",
+      "source_file": "packages/athena-webapp/src/components/products/Products.test.tsx",
+      "source_location": "L42"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "products_test_resizeobserverstub_disconnect",
+      "label": ".disconnect()",
+      "norm_label": ".disconnect()",
+      "source_file": "packages/athena-webapp/src/components/products/Products.test.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "products_test_resizeobserverstub_observe",
+      "label": ".observe()",
+      "norm_label": ".observe()",
+      "source_file": "packages/athena-webapp/src/components/products/Products.test.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "products_test_resizeobserverstub_unobserve",
+      "label": ".unobserve()",
+      "norm_label": ".unobserve()",
+      "source_file": "packages/athena-webapp/src/components/products/Products.test.tsx",
+      "source_location": "L44"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportdayspanel_tsx",
       "label": "ReportDaysPanel.tsx",
       "norm_label": "reportdayspanel.tsx",
@@ -233695,61 +233899,61 @@
       "source_location": "L1"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "reportdayspanel_cn",
       "label": "cn()",
       "norm_label": "cn()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
-      "source_location": "L495"
+      "source_location": "L541"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "reportdayspanel_handlemixretry",
       "label": "handleMixRetry()",
       "norm_label": "handlemixretry()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
-      "source_location": "L367"
+      "source_location": "L413"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "reportdayspanel_isinselectedrange",
       "label": "isInSelectedRange()",
       "norm_label": "isinselectedrange()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
-      "source_location": "L407"
+      "source_location": "L453"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "reportdayspanel_isselectedday",
       "label": "isSelectedDay()",
       "norm_label": "isselectedday()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
-      "source_location": "L405"
+      "source_location": "L451"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "reportdayspanel_pagecontainingdate",
       "label": "pageContainingDate()",
       "norm_label": "pagecontainingdate()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
-      "source_location": "L53"
+      "source_location": "L55"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "reportdayspanel_selectday",
       "label": "selectDay()",
       "norm_label": "selectday()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
-      "source_location": "L409"
+      "source_location": "L455"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
       "label": "ServiceAppointmentsView.tsx",
@@ -233758,7 +233962,7 @@
       "source_location": "L1"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "serviceappointmentsview_applycommandresult",
       "label": "applyCommandResult()",
@@ -233767,7 +233971,7 @@
       "source_location": "L143"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "serviceappointmentsview_async",
       "label": "async()",
@@ -233776,7 +233980,7 @@
       "source_location": "L439"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "serviceappointmentsview_formatdatetimelocal",
       "label": "formatDateTimeLocal()",
@@ -233785,7 +233989,7 @@
       "source_location": "L113"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "serviceappointmentsview_handlesubmit",
       "label": "handleSubmit()",
@@ -233794,7 +233998,7 @@
       "source_location": "L161"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "serviceappointmentsview_parsedatetimelocal",
       "label": "parseDateTimeLocal()",
@@ -233803,7 +234007,7 @@
       "source_location": "L108"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "serviceappointmentsview_withsavestate",
       "label": "withSaveState()",
@@ -233812,7 +234016,7 @@
       "source_location": "L578"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecatalogview_tsx",
       "label": "ServiceCatalogView.tsx",
@@ -233821,7 +234025,7 @@
       "source_location": "L1"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "servicecatalogview_cn",
       "label": "cn()",
@@ -233830,7 +234034,7 @@
       "source_location": "L467"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "servicecatalogview_handlechange",
       "label": "handleChange()",
@@ -233839,7 +234043,7 @@
       "source_location": "L137"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "servicecatalogview_handleedit",
       "label": "handleEdit()",
@@ -233848,7 +234052,7 @@
       "source_location": "L150"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "servicecatalogview_handlereset",
       "label": "handleReset()",
@@ -233857,7 +234061,7 @@
       "source_location": "L156"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "servicecatalogview_handlesubmit",
       "label": "handleSubmit()",
@@ -233866,7 +234070,7 @@
       "source_location": "L162"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "servicecatalogview_withsavestate",
       "label": "withSaveState()",
@@ -233875,7 +234079,7 @@
       "source_location": "L574"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemocatalogsearchfixture_ts",
       "label": "sharedDemoCatalogSearchFixture.ts",
@@ -233884,7 +234088,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "shareddemocatalogsearchfixture_createshareddemocatalogsearchresults",
       "label": "createSharedDemoCatalogSearchResults()",
@@ -233893,7 +234097,7 @@
       "source_location": "L123"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "shareddemocatalogsearchfixture_searchablevalues",
       "label": "searchableValues()",
@@ -233902,7 +234106,7 @@
       "source_location": "L58"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "shareddemocatalogsearchfixture_shareddemocatalogsearchproductid",
       "label": "sharedDemoCatalogSearchProductId()",
@@ -233911,7 +234115,7 @@
       "source_location": "L42"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "shareddemocatalogsearchfixture_shareddemocatalogsearchskuid",
       "label": "sharedDemoCatalogSearchSkuId()",
@@ -233920,7 +234124,7 @@
       "source_location": "L38"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "shareddemocatalogsearchfixture_subcategoryfor",
       "label": "subcategoryFor()",
@@ -233929,7 +234133,7 @@
       "source_location": "L46"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "shareddemocatalogsearchfixture_toresult",
       "label": "toResult()",
@@ -233938,7 +234142,7 @@
       "source_location": "L72"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "operatingdate_getlocaldatefromoperatingdate",
       "label": "getLocalDateFromOperatingDate()",
@@ -233947,7 +234151,7 @@
       "source_location": "L70"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "operatingdate_getlocaloperatingdate",
       "label": "getLocalOperatingDate()",
@@ -233956,7 +234160,7 @@
       "source_location": "L40"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "operatingdate_getlocaloperatingdaterange",
       "label": "getLocalOperatingDateRange()",
@@ -233965,7 +234169,7 @@
       "source_location": "L51"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "operatingdate_getlocaloperatingdaterangefromsearch",
       "label": "getLocalOperatingDateRangeFromSearch()",
@@ -233974,7 +234178,7 @@
       "source_location": "L93"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "operatingdate_getoperatingclocknow",
       "label": "getOperatingClockNow()",
@@ -233983,7 +234187,7 @@
       "source_location": "L28"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "operatingdate_setoperatingclockoverride",
       "label": "setOperatingClockOverride()",
@@ -233992,7 +234196,7 @@
       "source_location": "L23"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_operations_operatingdate_ts",
       "label": "operatingDate.ts",
@@ -234001,7 +234205,7 @@
       "source_location": "L1"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
       "label": "payments.ts",
@@ -234010,7 +234214,7 @@
       "source_location": "L1"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "payments_calculateposchange",
       "label": "calculatePosChange()",
@@ -234019,7 +234223,7 @@
       "source_location": "L8"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "payments_calculateposremainingdue",
       "label": "calculatePosRemainingDue()",
@@ -234028,7 +234232,7 @@
       "source_location": "L25"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "payments_calculatepostotalpaid",
       "label": "calculatePosTotalPaid()",
@@ -234037,7 +234241,7 @@
       "source_location": "L19"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "payments_ispospaymentsufficient",
       "label": "isPosPaymentSufficient()",
@@ -234046,7 +234250,7 @@
       "source_location": "L12"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "payments_normalizenoncashoverpayment",
       "label": "normalizeNonCashOverpayment()",
@@ -234055,7 +234259,7 @@
       "source_location": "L32"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "payments_roundposamount",
       "label": "roundPosAmount()",
@@ -234064,7 +234268,7 @@
       "source_location": "L83"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_session_ts",
       "label": "session.ts",
@@ -234073,7 +234277,7 @@
       "source_location": "L1"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "session_deriveregisterphase",
       "label": "deriveRegisterPhase()",
@@ -234082,7 +234286,7 @@
       "source_location": "L3"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "session_hasactiveregistersession",
       "label": "hasActiveRegisterSession()",
@@ -234091,7 +234295,7 @@
       "source_location": "L33"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "session_hasresumableregistersession",
       "label": "hasResumableRegisterSession()",
@@ -234100,7 +234304,7 @@
       "source_location": "L39"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "session_isregisterreadytostart",
       "label": "isRegisterReadyToStart()",
@@ -234109,7 +234313,7 @@
       "source_location": "L45"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "session_requirescashier",
       "label": "requiresCashier()",
@@ -234118,7 +234322,7 @@
       "source_location": "L29"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "session_requiresterminal",
       "label": "requiresTerminal()",
@@ -234127,7 +234331,7 @@
       "source_location": "L25"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "localsyncdraincoordinator_buildruntimesyncdebug",
       "label": "buildRuntimeSyncDebug()",
@@ -234136,7 +234340,7 @@
       "source_location": "L50"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "localsyncdraincoordinator_compareuploadableeventorder",
       "label": "compareUploadableEventOrder()",
@@ -234145,7 +234349,7 @@
       "source_location": "L118"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "localsyncdraincoordinator_getreviewdiagnosticsevents",
       "label": "getReviewDiagnosticsEvents()",
@@ -234154,7 +234358,7 @@
       "source_location": "L131"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "localsyncdraincoordinator_getruntimeuploadtrigger",
       "label": "getRuntimeUploadTrigger()",
@@ -234163,7 +234367,7 @@
       "source_location": "L103"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "localsyncdraincoordinator_ispendinguploadcandidate",
       "label": "isPendingUploadCandidate()",
@@ -234172,7 +234376,7 @@
       "source_location": "L163"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "localsyncdraincoordinator_startstatusonlyruntimetriggers",
       "label": "startStatusOnlyRuntimeTriggers()",
@@ -234181,7 +234385,7 @@
       "source_location": "L27"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localsyncdraincoordinator_ts",
       "label": "localSyncDrainCoordinator.ts",
@@ -234190,7 +234394,7 @@
       "source_location": "L1"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registerlifecycleauthorityrollout_ts",
       "label": "registerLifecycleAuthorityRollout.ts",
@@ -234199,7 +234403,7 @@
       "source_location": "L1"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "registerlifecycleauthorityrollout_getregisterlifecycleauthorityrolloutpolicy",
       "label": "getRegisterLifecycleAuthorityRolloutPolicy()",
@@ -234208,7 +234412,7 @@
       "source_location": "L37"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "registerlifecycleauthorityrollout_isrolloutmode",
       "label": "isRolloutMode()",
@@ -234217,7 +234421,7 @@
       "source_location": "L78"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "registerlifecycleauthorityrollout_resolveregisterlifecycleauthorityrolloutcohort",
       "label": "resolveRegisterLifecycleAuthorityRolloutCohort()",
@@ -234226,7 +234430,7 @@
       "source_location": "L64"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "registerlifecycleauthorityrollout_resolveregisterlifecycleauthorityrolloutpolicy",
       "label": "resolveRegisterLifecycleAuthorityRolloutPolicy()",
@@ -234235,7 +234439,7 @@
       "source_location": "L14"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "registerlifecycleauthorityrollout_shouldapplyregisterlifecycleauthority",
       "label": "shouldApplyRegisterLifecycleAuthority()",
@@ -234244,76 +234448,13 @@
       "source_location": "L54"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "registerlifecycleauthorityrollout_shouldsubscribetoregisterlifecycleauthority",
       "label": "shouldSubscribeToRegisterLifecycleAuthority()",
       "norm_label": "shouldsubscribetoregisterlifecycleauthority()",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerLifecycleAuthorityRollout.ts",
       "source_location": "L48"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_syncstatuspresentation_ts",
-      "label": "syncStatusPresentation.ts",
-      "norm_label": "syncstatuspresentation.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "syncstatuspresentation_buildpossyncstatuspresentation",
-      "label": "buildPosSyncStatusPresentation()",
-      "norm_label": "buildpossyncstatuspresentation()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.ts",
-      "source_location": "L200"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "syncstatuspresentation_formatposreconciliationtype",
-      "label": "formatPosReconciliationType()",
-      "norm_label": "formatposreconciliationtype()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.ts",
-      "source_location": "L231"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "syncstatuspresentation_isduplicatelocalidreviewitem",
-      "label": "isDuplicateLocalIdReviewItem()",
-      "norm_label": "isduplicatelocalidreviewitem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.ts",
-      "source_location": "L170"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "syncstatuspresentation_isduplicatepossessionsalereviewitem",
-      "label": "isDuplicatePosSessionSaleReviewItem()",
-      "norm_label": "isduplicatepossessionsalereviewitem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.ts",
-      "source_location": "L187"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "syncstatuspresentation_isregistercloseoutreviewitem",
-      "label": "isRegisterCloseoutReviewItem()",
-      "norm_label": "isregistercloseoutreviewitem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.ts",
-      "source_location": "L151"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "syncstatuspresentation_normalizestatus",
-      "label": "normalizeStatus()",
-      "norm_label": "normalizestatus()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.ts",
-      "source_location": "L125"
     },
     {
       "community": 4,
@@ -235290,6 +235431,69 @@
     {
       "community": 400,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_syncstatuspresentation_ts",
+      "label": "syncStatusPresentation.ts",
+      "norm_label": "syncstatuspresentation.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "syncstatuspresentation_buildpossyncstatuspresentation",
+      "label": "buildPosSyncStatusPresentation()",
+      "norm_label": "buildpossyncstatuspresentation()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.ts",
+      "source_location": "L200"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "syncstatuspresentation_formatposreconciliationtype",
+      "label": "formatPosReconciliationType()",
+      "norm_label": "formatposreconciliationtype()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.ts",
+      "source_location": "L231"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "syncstatuspresentation_isduplicatelocalidreviewitem",
+      "label": "isDuplicateLocalIdReviewItem()",
+      "norm_label": "isduplicatelocalidreviewitem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.ts",
+      "source_location": "L170"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "syncstatuspresentation_isduplicatepossessionsalereviewitem",
+      "label": "isDuplicatePosSessionSaleReviewItem()",
+      "norm_label": "isduplicatepossessionsalereviewitem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.ts",
+      "source_location": "L187"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "syncstatuspresentation_isregistercloseoutreviewitem",
+      "label": "isRegisterCloseoutReviewItem()",
+      "norm_label": "isregistercloseoutreviewitem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.ts",
+      "source_location": "L151"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "syncstatuspresentation_normalizestatus",
+      "label": "normalizeStatus()",
+      "norm_label": "normalizestatus()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.ts",
+      "source_location": "L125"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
       "id": "calculationservice_calculatecarttotals",
       "label": "calculateCartTotals()",
       "norm_label": "calculatecarttotals()",
@@ -235297,7 +235501,7 @@
       "source_location": "L28"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "calculationservice_calculatechange",
       "label": "calculateChange()",
@@ -235306,7 +235510,7 @@
       "source_location": "L42"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "calculationservice_calculateitemtotal",
       "label": "calculateItemTotal()",
@@ -235315,7 +235519,7 @@
       "source_location": "L35"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "calculationservice_formatcurrency",
       "label": "formatCurrency()",
@@ -235324,7 +235528,7 @@
       "source_location": "L49"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "calculationservice_geteffectiveprice",
       "label": "getEffectivePrice()",
@@ -235333,7 +235537,7 @@
       "source_location": "L70"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "calculationservice_ispaymentsufficient",
       "label": "isPaymentSufficient()",
@@ -235342,7 +235546,7 @@
       "source_location": "L59"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_services_calculationservice_ts",
       "label": "calculationService.ts",
@@ -235351,7 +235555,7 @@
       "source_location": "L1"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
       "label": "reference-fixtures.tsx",
@@ -235360,7 +235564,7 @@
       "source_location": "L1"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "reference_fixtures_compacttable",
       "label": "CompactTable()",
@@ -235369,7 +235573,7 @@
       "source_location": "L263"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "reference_fixtures_framecard",
       "label": "FrameCard()",
@@ -235378,7 +235582,7 @@
       "source_location": "L163"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "reference_fixtures_lanecard",
       "label": "LaneCard()",
@@ -235387,7 +235591,7 @@
       "source_location": "L213"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "reference_fixtures_metrictile",
       "label": "MetricTile()",
@@ -235396,7 +235600,7 @@
       "source_location": "L194"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "reference_fixtures_minitrendchart",
       "label": "MiniTrendChart()",
@@ -235405,7 +235609,7 @@
       "source_location": "L240"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "reference_fixtures_referencepageshell",
       "label": "ReferencePageShell()",
@@ -235414,7 +235618,7 @@
       "source_location": "L145"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_savedbag_ts",
       "label": "savedBag.ts",
@@ -235423,7 +235627,7 @@
       "source_location": "L1"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "savedbag_additemtosavedbag",
       "label": "addItemToSavedBag()",
@@ -235432,7 +235636,7 @@
       "source_location": "L25"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "savedbag_getactivesavedbag",
       "label": "getActiveSavedBag()",
@@ -235441,7 +235645,7 @@
       "source_location": "L10"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "savedbag_getbaseurl",
       "label": "getBaseUrl()",
@@ -235450,7 +235654,7 @@
       "source_location": "L8"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "savedbag_removeitemfromsavedbag",
       "label": "removeItemFromSavedBag()",
@@ -235459,7 +235663,7 @@
       "source_location": "L91"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "savedbag_updatesavedbagitem",
       "label": "updateSavedBagItem()",
@@ -235468,7 +235672,7 @@
       "source_location": "L61"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "savedbag_updatesavedbagowner",
       "label": "updateSavedBagOwner()",
@@ -235477,7 +235681,7 @@
       "source_location": "L109"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "delivery_diff_fingerprint_collectdeliverabledifffingerprint",
       "label": "collectDeliverableDiffFingerprint()",
@@ -235486,7 +235690,7 @@
       "source_location": "L59"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "delivery_diff_fingerprint_gitenv",
       "label": "gitEnv()",
@@ -235495,7 +235699,7 @@
       "source_location": "L51"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "delivery_diff_fingerprint_isdeliverablefingerprintpath",
       "label": "isDeliverableFingerprintPath()",
@@ -235504,7 +235708,7 @@
       "source_location": "L15"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "delivery_diff_fingerprint_normalizerepopath",
       "label": "normalizeRepoPath()",
@@ -235513,7 +235717,7 @@
       "source_location": "L5"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "delivery_diff_fingerprint_rungit",
       "label": "runGit()",
@@ -235522,7 +235726,7 @@
       "source_location": "L34"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "delivery_diff_fingerprint_sortuniquepaths",
       "label": "sortUniquePaths()",
@@ -235531,7 +235735,7 @@
       "source_location": "L9"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "scripts_delivery_diff_fingerprint_ts",
       "label": "delivery-diff-fingerprint.ts",
@@ -235540,7 +235744,7 @@
       "source_location": "L1"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "frontend_dependency_parity_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -235549,7 +235753,7 @@
       "source_location": "L13"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "frontend_dependency_parity_test_createpackage",
       "label": "createPackage()",
@@ -235558,7 +235762,7 @@
       "source_location": "L25"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "frontend_dependency_parity_test_installfixturepackages",
       "label": "installFixturePackages()",
@@ -235567,7 +235771,7 @@
       "source_location": "L70"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "frontend_dependency_parity_test_writefixtureinstaller",
       "label": "writeFixtureInstaller()",
@@ -235576,7 +235780,7 @@
       "source_location": "L111"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "frontend_dependency_parity_test_writefixturemanifests",
       "label": "writeFixtureManifests()",
@@ -235585,7 +235789,7 @@
       "source_location": "L40"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "frontend_dependency_parity_test_writejson",
       "label": "writeJson()",
@@ -235594,7 +235798,7 @@
       "source_location": "L19"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "scripts_frontend_dependency_parity_test_ts",
       "label": "frontend-dependency-parity.test.ts",
@@ -235603,7 +235807,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
       "label": "storefront-runtime-api.ts",
@@ -235612,7 +235816,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "storefront_runtime_api_emitsignal",
       "label": "emitSignal()",
@@ -235621,7 +235825,7 @@
       "source_location": "L210"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "storefront_runtime_api_handlecheckoutsessionfetch",
       "label": "handleCheckoutSessionFetch()",
@@ -235630,7 +235834,7 @@
       "source_location": "L214"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "storefront_runtime_api_handlecheckoutsessionupdate",
       "label": "handleCheckoutSessionUpdate()",
@@ -235639,7 +235843,7 @@
       "source_location": "L236"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "storefront_runtime_api_jsonresponse",
       "label": "jsonResponse()",
@@ -235648,7 +235852,7 @@
       "source_location": "L201"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "storefront_runtime_api_shutdown",
       "label": "shutdown()",
@@ -235657,7 +235861,7 @@
       "source_location": "L421"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "storefront_runtime_api_withcorsheaders",
       "label": "withCorsHeaders()",
@@ -235666,7 +235870,7 @@
       "source_location": "L186"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "harness_janitor_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -235675,7 +235879,7 @@
       "source_location": "L29"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "harness_janitor_test_overwritefreshgenerateddocs",
       "label": "overwriteFreshGeneratedDocs()",
@@ -235684,7 +235888,7 @@
       "source_location": "L46"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "harness_janitor_test_overwritefreshgraphifyartifacts",
       "label": "overwriteFreshGraphifyArtifacts()",
@@ -235693,7 +235897,7 @@
       "source_location": "L54"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "harness_janitor_test_seedartifacts",
       "label": "seedArtifacts()",
@@ -235702,7 +235906,7 @@
       "source_location": "L35"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "harness_janitor_test_sortpaths",
       "label": "sortPaths()",
@@ -235711,7 +235915,7 @@
       "source_location": "L61"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "harness_janitor_test_write",
       "label": "write()",
@@ -235720,7 +235924,7 @@
       "source_location": "L23"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "scripts_harness_janitor_test_ts",
       "label": "harness-janitor.test.ts",
@@ -235729,7 +235933,7 @@
       "source_location": "L1"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "harness_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -235738,7 +235942,7 @@
       "source_location": "L25"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "harness_review_test_error",
       "label": "error()",
@@ -235747,7 +235951,7 @@
       "source_location": "L293"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "harness_review_test_initializegithistory",
       "label": "initializeGitHistory()",
@@ -235756,7 +235960,7 @@
       "source_location": "L262"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "harness_review_test_log",
       "label": "log()",
@@ -235765,7 +235969,7 @@
       "source_location": "L292"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "harness_review_test_rungit",
       "label": "runGit()",
@@ -235774,7 +235978,7 @@
       "source_location": "L248"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "harness_review_test_write",
       "label": "write()",
@@ -235783,7 +235987,7 @@
       "source_location": "L19"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "scripts_harness_review_test_ts",
       "label": "harness-review.test.ts",
@@ -235792,7 +235996,7 @@
       "source_location": "L1"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "landed_change_report_check_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -235801,7 +236005,7 @@
       "source_location": "L16"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "landed_change_report_check_test_gitenv",
       "label": "gitEnv()",
@@ -235810,7 +236014,7 @@
       "source_location": "L51"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "landed_change_report_check_test_linechanges",
       "label": "lineChanges()",
@@ -235819,7 +236023,7 @@
       "source_location": "L67"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "landed_change_report_check_test_rungit",
       "label": "runGit()",
@@ -235828,7 +236032,7 @@
       "source_location": "L36"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "landed_change_report_check_test_validreport",
       "label": "validReport()",
@@ -235837,7 +236041,7 @@
       "source_location": "L76"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "landed_change_report_check_test_write",
       "label": "write()",
@@ -235846,67 +236050,13 @@
       "source_location": "L30"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "scripts_landed_change_report_check_test_ts",
       "label": "landed-change-report-check.test.ts",
       "norm_label": "landed-change-report-check.test.ts",
       "source_file": "scripts/landed-change-report-check.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_automation_scheduledrunledger_ts",
-      "label": "scheduledRunLedger.ts",
-      "norm_label": "scheduledrunledger.ts",
-      "source_file": "packages/athena-webapp/convex/automation/scheduledRunLedger.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "scheduledrunledger_besteffortrecordscheduledrunevidence",
-      "label": "bestEffortRecordScheduledRunEvidence()",
-      "norm_label": "besteffortrecordscheduledrunevidence()",
-      "source_file": "packages/athena-webapp/convex/automation/scheduledRunLedger.ts",
-      "source_location": "L147"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "scheduledrunledger_buildscheduledrunkey",
-      "label": "buildScheduledRunKey()",
-      "norm_label": "buildscheduledrunkey()",
-      "source_file": "packages/athena-webapp/convex/automation/scheduledRunLedger.ts",
-      "source_location": "L60"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "scheduledrunledger_derivescheduledrunoutcome",
-      "label": "deriveScheduledRunOutcome()",
-      "norm_label": "derivescheduledrunoutcome()",
-      "source_file": "packages/athena-webapp/convex/automation/scheduledRunLedger.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "scheduledrunledger_recordscheduledrunevidencewithctx",
-      "label": "recordScheduledRunEvidenceWithCtx()",
-      "norm_label": "recordscheduledrunevidencewithctx()",
-      "source_file": "packages/athena-webapp/convex/automation/scheduledRunLedger.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "scheduledrunledger_resolvescheduledwindow",
-      "label": "resolveScheduledWindow()",
-      "norm_label": "resolvescheduledwindow()",
-      "source_file": "packages/athena-webapp/convex/automation/scheduledRunLedger.ts",
-      "source_location": "L46"
     },
     {
       "community": 41,
@@ -236190,6 +236340,60 @@
     {
       "community": 410,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_automation_scheduledrunledger_ts",
+      "label": "scheduledRunLedger.ts",
+      "norm_label": "scheduledrunledger.ts",
+      "source_file": "packages/athena-webapp/convex/automation/scheduledRunLedger.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "scheduledrunledger_besteffortrecordscheduledrunevidence",
+      "label": "bestEffortRecordScheduledRunEvidence()",
+      "norm_label": "besteffortrecordscheduledrunevidence()",
+      "source_file": "packages/athena-webapp/convex/automation/scheduledRunLedger.ts",
+      "source_location": "L147"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "scheduledrunledger_buildscheduledrunkey",
+      "label": "buildScheduledRunKey()",
+      "norm_label": "buildscheduledrunkey()",
+      "source_file": "packages/athena-webapp/convex/automation/scheduledRunLedger.ts",
+      "source_location": "L60"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "scheduledrunledger_derivescheduledrunoutcome",
+      "label": "deriveScheduledRunOutcome()",
+      "norm_label": "derivescheduledrunoutcome()",
+      "source_file": "packages/athena-webapp/convex/automation/scheduledRunLedger.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "scheduledrunledger_recordscheduledrunevidencewithctx",
+      "label": "recordScheduledRunEvidenceWithCtx()",
+      "norm_label": "recordscheduledrunevidencewithctx()",
+      "source_file": "packages/athena-webapp/convex/automation/scheduledRunLedger.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "scheduledrunledger_resolvescheduledwindow",
+      "label": "resolveScheduledWindow()",
+      "norm_label": "resolvescheduledwindow()",
+      "source_file": "packages/athena-webapp/convex/automation/scheduledRunLedger.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
       "id": "index_valkeyclient",
       "label": "ValkeyClient",
       "norm_label": "valkeyclient",
@@ -236197,7 +236401,7 @@
       "source_location": "L4"
     },
     {
-      "community": 410,
+      "community": 411,
       "file_type": "code",
       "id": "index_valkeyclient_constructor",
       "label": ".constructor()",
@@ -236206,7 +236410,7 @@
       "source_location": "L11"
     },
     {
-      "community": 410,
+      "community": 411,
       "file_type": "code",
       "id": "index_valkeyclient_get",
       "label": ".get()",
@@ -236215,7 +236419,7 @@
       "source_location": "L20"
     },
     {
-      "community": 410,
+      "community": 411,
       "file_type": "code",
       "id": "index_valkeyclient_invalidate",
       "label": ".invalidate()",
@@ -236224,7 +236428,7 @@
       "source_location": "L75"
     },
     {
-      "community": 410,
+      "community": 411,
       "file_type": "code",
       "id": "index_valkeyclient_set",
       "label": ".set()",
@@ -236233,7 +236437,7 @@
       "source_location": "L48"
     },
     {
-      "community": 410,
+      "community": 411,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cache_index_ts",
       "label": "index.ts",
@@ -236242,7 +236446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_walkthroughrequests_ts",
       "label": "walkthroughRequests.ts",
@@ -236251,7 +236455,7 @@
       "source_location": "L1"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "walkthroughrequests_canonical",
       "label": "canonical()",
@@ -236260,7 +236464,7 @@
       "source_location": "L24"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "walkthroughrequests_evaluatewalkthroughingress",
       "label": "evaluateWalkthroughIngress()",
@@ -236269,7 +236473,7 @@
       "source_location": "L16"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "walkthroughrequests_isvalidbody",
       "label": "isValidBody()",
@@ -236278,7 +236482,7 @@
       "source_location": "L26"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "walkthroughrequests_sha256",
       "label": "sha256()",
@@ -236287,7 +236491,7 @@
       "source_location": "L25"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "walkthroughrequests_text",
       "label": "text()",
@@ -236296,7 +236500,7 @@
       "source_location": "L23"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_security_ts",
       "label": "security.ts",
@@ -236305,7 +236509,7 @@
       "source_location": "L1"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "security_buildcanonicalcheckoutproducts",
       "label": "buildCanonicalCheckoutProducts()",
@@ -236314,7 +236518,7 @@
       "source_location": "L42"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "security_hasvalidpositivequantity",
       "label": "hasValidPositiveQuantity()",
@@ -236323,7 +236527,7 @@
       "source_location": "L27"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "security_isamounttampered",
       "label": "isAmountTampered()",
@@ -236332,7 +236536,7 @@
       "source_location": "L65"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "security_isauthorizedresourceowner",
       "label": "isAuthorizedResourceOwner()",
@@ -236341,7 +236545,7 @@
       "source_location": "L31"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "security_isduplicatechargesuccess",
       "label": "isDuplicateChargeSuccess()",
@@ -236350,7 +236554,7 @@
       "source_location": "L76"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "catalogimport_test_buildtrustedconversionargs",
       "label": "buildTrustedConversionArgs()",
@@ -236359,7 +236563,7 @@
       "source_location": "L397"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "catalogimport_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -236368,7 +236572,7 @@
       "source_location": "L144"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "catalogimport_test_gethandler",
       "label": "getHandler()",
@@ -236377,7 +236581,7 @@
       "source_location": "L140"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "catalogimport_test_readtrustedconversionbinding",
       "label": "readTrustedConversionBinding()",
@@ -236386,7 +236590,7 @@
       "source_location": "L383"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "catalogimport_test_seedtrustedconversiondata",
       "label": "seedTrustedConversionData()",
@@ -236395,7 +236599,7 @@
       "source_location": "L289"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_catalogimport_test_ts",
       "label": "catalogImport.test.ts",
@@ -236404,7 +236608,7 @@
       "source_location": "L1"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "expensesessions_expensesessionerror",
       "label": "expenseSessionError()",
@@ -236413,7 +236617,7 @@
       "source_location": "L47"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "expensesessions_loadexpensesessionitems",
       "label": "loadExpenseSessionItems()",
@@ -236422,7 +236626,7 @@
       "source_location": "L114"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "expensesessions_mapexpensesessionvalidationerror",
       "label": "mapExpenseSessionValidationError()",
@@ -236431,7 +236635,7 @@
       "source_location": "L95"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "expensesessions_recordexpensesessionlifecycletrace",
       "label": "recordExpenseSessionLifecycleTrace()",
@@ -236440,7 +236644,7 @@
       "source_location": "L139"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "expensesessions_usererrorfromexpensesessioncommandfailure",
       "label": "userErrorFromExpenseSessionCommandFailure()",
@@ -236449,7 +236653,7 @@
       "source_location": "L61"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessions_ts",
       "label": "expenseSessions.ts",
@@ -236458,7 +236662,7 @@
       "source_location": "L1"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "backfillreportfactobservedat_test_createctx",
       "label": "createCtx()",
@@ -236467,7 +236671,7 @@
       "source_location": "L20"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "backfillreportfactobservedat_test_createstoreverificationctx",
       "label": "createStoreVerificationCtx()",
@@ -236476,7 +236680,7 @@
       "source_location": "L58"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "backfillreportfactobservedat_test_finishbackfill",
       "label": "finishBackfill()",
@@ -236485,7 +236689,7 @@
       "source_location": "L96"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "backfillreportfactobservedat_test_finishverification",
       "label": "finishVerification()",
@@ -236494,7 +236698,7 @@
       "source_location": "L116"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "backfillreportfactobservedat_test_observedatfield",
       "label": "observedAtField()",
@@ -236503,7 +236707,7 @@
       "source_location": "L264"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_backfillreportfactobservedat_test_ts",
       "label": "backfillReportFactObservedAt.test.ts",
@@ -236512,7 +236716,7 @@
       "source_location": "L1"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "backfillstorecurrencycase_backfillstorecurrencycasewithctx",
       "label": "backfillStoreCurrencyCaseWithCtx()",
@@ -236521,7 +236725,7 @@
       "source_location": "L70"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "backfillstorecurrencycase_boundedlimit",
       "label": "boundedLimit()",
@@ -236530,7 +236734,7 @@
       "source_location": "L43"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "backfillstorecurrencycase_needsnormalization",
       "label": "needsNormalization()",
@@ -236539,7 +236743,7 @@
       "source_location": "L66"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "backfillstorecurrencycase_storepage",
       "label": "storePage()",
@@ -236548,7 +236752,7 @@
       "source_location": "L50"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "backfillstorecurrencycase_verifystorecurrencycasewithctx",
       "label": "verifyStoreCurrencyCaseWithCtx()",
@@ -236557,7 +236761,7 @@
       "source_location": "L133"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_backfillstorecurrencycase_ts",
       "label": "backfillStoreCurrencyCase.ts",
@@ -236566,7 +236770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "actors_getoperationactorathenauserid",
       "label": "getOperationActorAthenaUserId()",
@@ -236575,7 +236779,7 @@
       "source_location": "L20"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "actors_isnormaluseroperationactor",
       "label": "isNormalUserOperationActor()",
@@ -236584,7 +236788,7 @@
       "source_location": "L8"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "actors_ispublicoperationactor",
       "label": "isPublicOperationActor()",
@@ -236593,7 +236797,7 @@
       "source_location": "L12"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "actors_isshareddemooperationactor",
       "label": "isSharedDemoOperationActor()",
@@ -236602,7 +236806,7 @@
       "source_location": "L4"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "actors_requireoperationactorathenauserid",
       "label": "requireOperationActorAthenaUserId()",
@@ -236611,7 +236815,7 @@
       "source_location": "L31"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_actors_ts",
       "label": "actors.ts",
@@ -236620,7 +236824,7 @@
       "source_location": "L1"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "approval_builddailycloseapprovalsubject",
       "label": "buildDailyCloseApprovalSubject()",
@@ -236629,7 +236833,7 @@
       "source_location": "L15"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "approval_builddailyclosecarryforwardapprovalrequirement",
       "label": "buildDailyCloseCarryForwardApprovalRequirement()",
@@ -236638,7 +236842,7 @@
       "source_location": "L101"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "approval_builddailyclosecarryforwardapprovalsubject",
       "label": "buildDailyCloseCarryForwardApprovalSubject()",
@@ -236647,7 +236851,7 @@
       "source_location": "L88"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "approval_builddailyclosecompletionapprovalrequirement",
       "label": "buildDailyCloseCompletionApprovalRequirement()",
@@ -236656,7 +236860,7 @@
       "source_location": "L26"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "approval_builddailyclosereopenapprovalrequirement",
       "label": "buildDailyCloseReopenApprovalRequirement()",
@@ -236665,66 +236869,12 @@
       "source_location": "L54"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_dailyclose_approval_ts",
       "label": "approval.ts",
       "norm_label": "approval.ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose/approval.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "eventbuilders_buildonlineorderoperationaleventmessage",
-      "label": "buildOnlineOrderOperationalEventMessage()",
-      "norm_label": "buildonlineorderoperationaleventmessage()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/eventBuilders.ts",
-      "source_location": "L68"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "eventbuilders_buildoperationaleventmessage",
-      "label": "buildOperationalEventMessage()",
-      "norm_label": "buildoperationaleventmessage()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/eventBuilders.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "eventbuilders_buildstockadjustmentoperationaleventmessage",
-      "label": "buildStockAdjustmentOperationalEventMessage()",
-      "norm_label": "buildstockadjustmentoperationaleventmessage()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/eventBuilders.ts",
-      "source_location": "L93"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "eventbuilders_formatonlineorderlabel",
-      "label": "formatOnlineOrderLabel()",
-      "norm_label": "formatonlineorderlabel()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/eventBuilders.ts",
-      "source_location": "L112"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "eventbuilders_formatstockadjustmentsubjectdetail",
-      "label": "formatStockAdjustmentSubjectDetail()",
-      "norm_label": "formatstockadjustmentsubjectdetail()",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/eventBuilders.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_helpers_eventbuilders_ts",
-      "label": "eventBuilders.ts",
-      "norm_label": "eventbuilders.ts",
-      "source_file": "packages/athena-webapp/convex/operations/helpers/eventBuilders.ts",
       "source_location": "L1"
     },
     {
@@ -237000,6 +237150,60 @@
     {
       "community": 420,
       "file_type": "code",
+      "id": "eventbuilders_buildonlineorderoperationaleventmessage",
+      "label": "buildOnlineOrderOperationalEventMessage()",
+      "norm_label": "buildonlineorderoperationaleventmessage()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/eventBuilders.ts",
+      "source_location": "L68"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "eventbuilders_buildoperationaleventmessage",
+      "label": "buildOperationalEventMessage()",
+      "norm_label": "buildoperationaleventmessage()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/eventBuilders.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "eventbuilders_buildstockadjustmentoperationaleventmessage",
+      "label": "buildStockAdjustmentOperationalEventMessage()",
+      "norm_label": "buildstockadjustmentoperationaleventmessage()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/eventBuilders.ts",
+      "source_location": "L93"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "eventbuilders_formatonlineorderlabel",
+      "label": "formatOnlineOrderLabel()",
+      "norm_label": "formatonlineorderlabel()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/eventBuilders.ts",
+      "source_location": "L112"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "eventbuilders_formatstockadjustmentsubjectdetail",
+      "label": "formatStockAdjustmentSubjectDetail()",
+      "norm_label": "formatstockadjustmentsubjectdetail()",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/eventBuilders.ts",
+      "source_location": "L106"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_helpers_eventbuilders_ts",
+      "label": "eventBuilders.ts",
+      "norm_label": "eventbuilders.ts",
+      "source_file": "packages/athena-webapp/convex/operations/helpers/eventBuilders.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_serviceintake_test_ts",
       "label": "serviceIntake.test.ts",
       "norm_label": "serviceintake.test.ts",
@@ -237007,7 +237211,7 @@
       "source_location": "L1"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "serviceintake_test_buildcreateserviceintakeargs",
       "label": "buildCreateServiceIntakeArgs()",
@@ -237016,7 +237220,7 @@
       "source_location": "L38"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "serviceintake_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -237025,7 +237229,7 @@
       "source_location": "L52"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "serviceintake_test_createserviceintakebehaviorctx",
       "label": "createServiceIntakeBehaviorCtx()",
@@ -237034,7 +237238,7 @@
       "source_location": "L96"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "serviceintake_test_gethandler",
       "label": "getHandler()",
@@ -237043,7 +237247,7 @@
       "source_location": "L34"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "serviceintake_test_getsource",
       "label": "getSource()",
@@ -237052,7 +237256,7 @@
       "source_location": "L30"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "completetransaction_test_createvoidctx",
       "label": "createVoidCtx()",
@@ -237061,7 +237265,7 @@
       "source_location": "L219"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "completetransaction_test_expectnocompletionsideeffects",
       "label": "expectNoCompletionSideEffects()",
@@ -237070,7 +237274,7 @@
       "source_location": "L197"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "completetransaction_test_expectnovoidbusinesssideeffects",
       "label": "expectNoVoidBusinessSideEffects()",
@@ -237079,7 +237283,7 @@
       "source_location": "L211"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "completetransaction_test_seeddirect",
       "label": "seedDirect()",
@@ -237088,7 +237292,7 @@
       "source_location": "L4778"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "completetransaction_test_seeddirecthappypath",
       "label": "seedDirectHappyPath()",
@@ -237097,7 +237301,7 @@
       "source_location": "L4625"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_completetransaction_test_ts",
       "label": "completeTransaction.test.ts",
@@ -237106,7 +237310,7 @@
       "source_location": "L1"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_registerlifecycleauthority_test_ts",
       "label": "registerLifecycleAuthority.test.ts",
@@ -237115,7 +237319,7 @@
       "source_location": "L1"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "registerlifecycleauthority_test_createrepository",
       "label": "createRepository()",
@@ -237124,7 +237328,7 @@
       "source_location": "L675"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "registerlifecycleauthority_test_mapping",
       "label": "mapping()",
@@ -237133,7 +237337,7 @@
       "source_location": "L741"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "registerlifecycleauthority_test_mappingauthority",
       "label": "mappingAuthority()",
@@ -237142,7 +237346,7 @@
       "source_location": "L708"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "registerlifecycleauthority_test_registersession",
       "label": "registerSession()",
@@ -237151,7 +237355,7 @@
       "source_location": "L760"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "registerlifecycleauthority_test_terminal",
       "label": "terminal()",
@@ -237160,7 +237364,7 @@
       "source_location": "L726"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "localsyncrepository_areconflictdetailsequivalent",
       "label": "areConflictDetailsEquivalent()",
@@ -237169,7 +237373,7 @@
       "source_location": "L62"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "localsyncrepository_createconvexlocalsyncrepository",
       "label": "createConvexLocalSyncRepository()",
@@ -237178,7 +237382,7 @@
       "source_location": "L152"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "localsyncrepository_omitundefined",
       "label": "omitUndefined()",
@@ -237187,7 +237391,7 @@
       "source_location": "L56"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "localsyncrepository_reportfactsfromlocalsyncingressargs",
       "label": "reportFactsFromLocalSyncIngressArgs()",
@@ -237196,7 +237400,7 @@
       "source_location": "L107"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "localsyncrepository_trimoptional",
       "label": "trimOptional()",
@@ -237205,7 +237409,7 @@
       "source_location": "L92"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_localsyncrepository_ts",
       "label": "localSyncRepository.ts",
@@ -237214,7 +237418,7 @@
       "source_location": "L1"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_sync_ts",
       "label": "sync.ts",
@@ -237223,7 +237427,7 @@
       "source_location": "L1"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "sync_isvariancereviewforcloseout",
       "label": "isVarianceReviewForCloseout()",
@@ -237232,7 +237436,7 @@
       "source_location": "L453"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "sync_readapprovalrequeststatuses",
       "label": "readApprovalRequestStatuses()",
@@ -237241,7 +237445,7 @@
       "source_location": "L434"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "sync_scheduleregistercloseoutnotifications",
       "label": "scheduleRegisterCloseoutNotifications()",
@@ -237250,7 +237454,7 @@
       "source_location": "L279"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "sync_shareddemocapabilityforsyncevent",
       "label": "sharedDemoCapabilityForSyncEvent()",
@@ -237259,7 +237463,7 @@
       "source_location": "L110"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "sync_wasvariancenotifiedbeforerail",
       "label": "wasVarianceNotifiedBeforeRail()",
@@ -237268,7 +237472,7 @@
       "source_location": "L469"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_telemetry_ts",
       "label": "telemetry.ts",
@@ -237277,7 +237481,7 @@
       "source_location": "L1"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "telemetry_cleaneventtext",
       "label": "cleanEventText()",
@@ -237286,7 +237490,7 @@
       "source_location": "L66"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "telemetry_cleanoptionaleventtext",
       "label": "cleanOptionalEventText()",
@@ -237295,7 +237499,7 @@
       "source_location": "L70"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "telemetry_requirepostelemetryaccess",
       "label": "requirePosTelemetryAccess()",
@@ -237304,7 +237508,7 @@
       "source_location": "L96"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "telemetry_sanitizeclienteventmetadata",
       "label": "sanitizeClientEventMetadata()",
@@ -237313,7 +237517,7 @@
       "source_location": "L77"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "telemetry_truncate",
       "label": "truncate()",
@@ -237322,7 +237526,7 @@
       "source_location": "L59"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_transportinternal_test_ts",
       "label": "transportInternal.test.ts",
@@ -237331,7 +237535,7 @@
       "source_location": "L1"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "transportinternal_test_buildclient",
       "label": "buildClient()",
@@ -237340,7 +237544,7 @@
       "source_location": "L342"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "transportinternal_test_buildruntimectx",
       "label": "buildRuntimeCtx()",
@@ -237349,7 +237553,7 @@
       "source_location": "L318"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "transportinternal_test_buildsession",
       "label": "buildSession()",
@@ -237358,7 +237562,7 @@
       "source_location": "L352"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "transportinternal_test_buildterminal",
       "label": "buildTerminal()",
@@ -237367,7 +237571,7 @@
       "source_location": "L365"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "transportinternal_test_gethandler",
       "label": "getHandler()",
@@ -237376,7 +237580,7 @@
       "source_location": "L34"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "foldday_comparefacts",
       "label": "compareFacts()",
@@ -237385,7 +237589,7 @@
       "source_location": "L90"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "foldday_foldday",
       "label": "foldDay()",
@@ -237394,7 +237598,7 @@
       "source_location": "L121"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "foldday_revenuecontribution",
       "label": "revenueContribution()",
@@ -237403,7 +237607,7 @@
       "source_location": "L103"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "foldday_zerodaymetrics",
       "label": "zeroDayMetrics()",
@@ -237412,7 +237616,7 @@
       "source_location": "L46"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "foldday_zeroskuaccumulator",
       "label": "zeroSkuAccumulator()",
@@ -237421,7 +237625,7 @@
       "source_location": "L72"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_foldday_ts",
       "label": "foldDay.ts",
@@ -237430,7 +237634,7 @@
       "source_location": "L1"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "operatingday_configuredtimezone",
       "label": "configuredTimezone()",
@@ -237439,7 +237643,7 @@
       "source_location": "L52"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "operatingday_isvalidtimezone",
       "label": "isValidTimezone()",
@@ -237448,7 +237652,7 @@
       "source_location": "L27"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "operatingday_localdatelabel",
       "label": "localDateLabel()",
@@ -237457,7 +237661,7 @@
       "source_location": "L38"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "operatingday_resolveoperatingdate",
       "label": "resolveOperatingDate()",
@@ -237466,7 +237670,7 @@
       "source_location": "L98"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "operatingday_resolvestoretimezone",
       "label": "resolveStoreTimezone()",
@@ -237475,67 +237679,13 @@
       "source_location": "L68"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_operatingday_ts",
       "label": "operatingDay.ts",
       "norm_label": "operatingday.ts",
       "source_file": "packages/athena-webapp/convex/reports/operatingDay.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_reseed_test_ts",
-      "label": "reseed.test.ts",
-      "norm_label": "reseed.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/reseed.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "reseed_test_at",
-      "label": "at()",
-      "norm_label": "at()",
-      "source_file": "packages/athena-webapp/convex/reports/reseed.test.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "reseed_test_factsignature",
-      "label": "factSignature()",
-      "norm_label": "factsignature()",
-      "source_file": "packages/athena-webapp/convex/reports/reseed.test.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "reseed_test_resumereseed",
-      "label": "resumeReseed()",
-      "norm_label": "resumereseed()",
-      "source_file": "packages/athena-webapp/convex/reports/reseed.test.ts",
-      "source_location": "L99"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "reseed_test_runreseed",
-      "label": "runReseed()",
-      "norm_label": "runreseed()",
-      "source_file": "packages/athena-webapp/convex/reports/reseed.test.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "reseed_test_seedfullday",
-      "label": "seedFullDay()",
-      "norm_label": "seedfullday()",
-      "source_file": "packages/athena-webapp/convex/reports/reseed.test.ts",
-      "source_location": "L140"
     },
     {
       "community": 43,
@@ -237553,7 +237703,7 @@
       "label": "cleanMetadataValue()",
       "norm_label": "cleanmetadatavalue()",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L1316"
+      "source_location": "L1334"
     },
     {
       "community": 43,
@@ -237562,7 +237712,7 @@
       "label": "cycleStartDateForWeeklyReportId()",
       "norm_label": "cyclestartdateforweeklyreportid()",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L114"
+      "source_location": "L117"
     },
     {
       "community": 43,
@@ -237571,7 +237721,7 @@
       "label": "decodeCursor()",
       "norm_label": "decodecursor()",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L997"
+      "source_location": "L1015"
     },
     {
       "community": 43,
@@ -237580,7 +237730,7 @@
       "label": "encodeCursor()",
       "norm_label": "encodecursor()",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L993"
+      "source_location": "L1011"
     },
     {
       "community": 43,
@@ -237589,7 +237739,7 @@
       "label": "finalScheduledDate()",
       "norm_label": "finalscheduleddate()",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L244"
+      "source_location": "L247"
     },
     {
       "community": 43,
@@ -237598,7 +237748,7 @@
       "label": "hasWeeklyPostures()",
       "norm_label": "hasweeklypostures()",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L311"
+      "source_location": "L314"
     },
     {
       "community": 43,
@@ -237607,7 +237757,7 @@
       "label": "inclusiveDaySpan()",
       "norm_label": "inclusivedayspan()",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L415"
+      "source_location": "L418"
     },
     {
       "community": 43,
@@ -237616,7 +237766,7 @@
       "label": "inventoryAttentionProjection()",
       "norm_label": "inventoryattentionprojection()",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L155"
+      "source_location": "L158"
     },
     {
       "community": 43,
@@ -237625,7 +237775,7 @@
       "label": "livePosTransactionCount()",
       "norm_label": "livepostransactioncount()",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L1026"
+      "source_location": "L1044"
     },
     {
       "community": 43,
@@ -237634,7 +237784,7 @@
       "label": "precedingEqualRange()",
       "norm_label": "precedingequalrange()",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L1376"
+      "source_location": "L1394"
     },
     {
       "community": 43,
@@ -237643,7 +237793,7 @@
       "label": "priorNetSalesChange()",
       "norm_label": "priornetsaleschange()",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L137"
+      "source_location": "L140"
     },
     {
       "community": 43,
@@ -237652,7 +237802,7 @@
       "label": "priorPeriodDateRange()",
       "norm_label": "priorperioddaterange()",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L1059"
+      "source_location": "L1077"
     },
     {
       "community": 43,
@@ -237661,7 +237811,7 @@
       "label": "priorPeriodProjection()",
       "norm_label": "priorperiodprojection()",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L202"
+      "source_location": "L205"
     },
     {
       "community": 43,
@@ -237670,7 +237820,7 @@
       "label": "requireValidDateRange()",
       "norm_label": "requirevaliddaterange()",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L425"
+      "source_location": "L428"
     },
     {
       "community": 43,
@@ -237679,7 +237829,7 @@
       "label": "requireWeeklyHistoryPagination()",
       "norm_label": "requireweeklyhistorypagination()",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L89"
+      "source_location": "L92"
     },
     {
       "community": 43,
@@ -237688,7 +237838,7 @@
       "label": "resolveSkuIdentity()",
       "norm_label": "resolveskuidentity()",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L1325"
+      "source_location": "L1343"
     },
     {
       "community": 43,
@@ -237697,7 +237847,7 @@
       "label": "skuRangeTotals()",
       "norm_label": "skurangetotals()",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L1385"
+      "source_location": "L1403"
     },
     {
       "community": 43,
@@ -237706,7 +237856,7 @@
       "label": "sum()",
       "norm_label": "sum()",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L1623"
+      "source_location": "L1641"
     },
     {
       "community": 43,
@@ -237715,7 +237865,7 @@
       "label": "toAcceptedWeeklyProjection()",
       "norm_label": "toacceptedweeklyprojection()",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L353"
+      "source_location": "L356"
     },
     {
       "community": 43,
@@ -237724,7 +237874,7 @@
       "label": "toReportDayRow()",
       "norm_label": "toreportdayrow()",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L439"
+      "source_location": "L442"
     },
     {
       "community": 43,
@@ -237733,7 +237883,7 @@
       "label": "toSkuPeriodRow()",
       "norm_label": "toskuperiodrow()",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L461"
+      "source_location": "L466"
     },
     {
       "community": 43,
@@ -237742,7 +237892,7 @@
       "label": "toWeeklyCurrentProjection()",
       "norm_label": "toweeklycurrentprojection()",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L317"
+      "source_location": "L320"
     },
     {
       "community": 43,
@@ -237751,7 +237901,7 @@
       "label": "transactionCountsForDays()",
       "norm_label": "transactioncountsfordays()",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L1086"
+      "source_location": "L1104"
     },
     {
       "community": 43,
@@ -237760,7 +237910,7 @@
       "label": "variancePostureProjection()",
       "norm_label": "variancepostureprojection()",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L170"
+      "source_location": "L173"
     },
     {
       "community": 43,
@@ -237769,7 +237919,7 @@
       "label": "weeklyAmendmentProjection()",
       "norm_label": "weeklyamendmentprojection()",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L228"
+      "source_location": "L231"
     },
     {
       "community": 43,
@@ -237778,7 +237928,7 @@
       "label": "weeklyOwnerRoutes()",
       "norm_label": "weeklyownerroutes()",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L255"
+      "source_location": "L258"
     },
     {
       "community": 43,
@@ -237787,7 +237937,7 @@
       "label": "weeklyReportId()",
       "norm_label": "weeklyreportid()",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L110"
+      "source_location": "L113"
     },
     {
       "community": 43,
@@ -237796,7 +237946,7 @@
       "label": "weeklySummary()",
       "norm_label": "weeklysummary()",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L120"
+      "source_location": "L123"
     },
     {
       "community": 43,
@@ -237805,10 +237955,64 @@
       "label": "withSkuIdentity()",
       "norm_label": "withskuidentity()",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L1357"
+      "source_location": "L1375"
     },
     {
       "community": 430,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_reports_reseed_test_ts",
+      "label": "reseed.test.ts",
+      "norm_label": "reseed.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/reseed.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "reseed_test_at",
+      "label": "at()",
+      "norm_label": "at()",
+      "source_file": "packages/athena-webapp/convex/reports/reseed.test.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "reseed_test_factsignature",
+      "label": "factSignature()",
+      "norm_label": "factsignature()",
+      "source_file": "packages/athena-webapp/convex/reports/reseed.test.ts",
+      "source_location": "L116"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "reseed_test_resumereseed",
+      "label": "resumeReseed()",
+      "norm_label": "resumereseed()",
+      "source_file": "packages/athena-webapp/convex/reports/reseed.test.ts",
+      "source_location": "L99"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "reseed_test_runreseed",
+      "label": "runReseed()",
+      "norm_label": "runreseed()",
+      "source_file": "packages/athena-webapp/convex/reports/reseed.test.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "reseed_test_seedfullday",
+      "label": "seedFullDay()",
+      "norm_label": "seedfullday()",
+      "source_file": "packages/athena-webapp/convex/reports/reseed.test.ts",
+      "source_location": "L140"
+    },
+    {
+      "community": 431,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_verify_test_ts",
       "label": "verify.test.ts",
@@ -237817,7 +238021,7 @@
       "source_location": "L1"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "verify_test_at",
       "label": "at()",
@@ -237826,7 +238030,7 @@
       "source_location": "L35"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "verify_test_folddirtydays",
       "label": "foldDirtyDays()",
@@ -237835,7 +238039,7 @@
       "source_location": "L57"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "verify_test_runreseed",
       "label": "runReseed()",
@@ -237844,7 +238048,7 @@
       "source_location": "L44"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "verify_test_seedfoldedpaymentday",
       "label": "seedFoldedPaymentDay()",
@@ -237853,7 +238057,7 @@
       "source_location": "L883"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "verify_test_seedverifiableday",
       "label": "seedVerifiableDay()",
@@ -237862,7 +238066,7 @@
       "source_location": "L100"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_weeklyinventory_ts",
       "label": "weeklyInventory.ts",
@@ -237871,7 +238075,7 @@
       "source_location": "L1"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "weeklyinventory_classifyweeklyinventorygroup",
       "label": "classifyWeeklyInventoryGroup()",
@@ -237880,7 +238084,7 @@
       "source_location": "L56"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "weeklyinventory_issyncedsaleinventoryreviewgroup",
       "label": "isSyncedSaleInventoryReviewGroup()",
@@ -237889,7 +238093,7 @@
       "source_location": "L101"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "weeklyinventory_projectfrozenweeklyinventoryattention",
       "label": "projectFrozenWeeklyInventoryAttention()",
@@ -237898,7 +238102,7 @@
       "source_location": "L144"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "weeklyinventory_projectliveweeklyinventoryattention",
       "label": "projectLiveWeeklyInventoryAttention()",
@@ -237907,7 +238111,7 @@
       "source_location": "L110"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "weeklyinventory_summarizeweeklyinventoryattention",
       "label": "summarizeWeeklyInventoryAttention()",
@@ -237916,7 +238120,7 @@
       "source_location": "L82"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "orderemailservice_buildorderstatusmessage",
       "label": "buildOrderStatusMessage()",
@@ -237925,7 +238129,7 @@
       "source_location": "L49"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "orderemailservice_buildpickupdetails",
       "label": "buildPickupDetails()",
@@ -237934,7 +238138,7 @@
       "source_location": "L77"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "orderemailservice_sendpaymentverificationemails",
       "label": "sendPaymentVerificationEmails()",
@@ -237943,7 +238147,7 @@
       "source_location": "L217"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "orderemailservice_sendpodorderemails",
       "label": "sendPODOrderEmails()",
@@ -237952,7 +238156,7 @@
       "source_location": "L96"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "orderemailservice_shouldsendtoadmins",
       "label": "shouldSendToAdmins()",
@@ -237961,7 +238165,7 @@
       "source_location": "L42"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
       "label": "orderEmailService.ts",
@@ -237970,7 +238174,7 @@
       "source_location": "L1"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "actor_getshareddemoactorwithctx",
       "label": "getSharedDemoActorWithCtx()",
@@ -237979,7 +238183,7 @@
       "source_location": "L14"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "actor_requirereadyshareddemostorecapabilityifapplicable",
       "label": "requireReadySharedDemoStoreCapabilityIfApplicable()",
@@ -237988,7 +238192,7 @@
       "source_location": "L92"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "actor_requireshareddemoactorwithctx",
       "label": "requireSharedDemoActorWithCtx()",
@@ -237997,7 +238201,7 @@
       "source_location": "L57"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "actor_requireshareddemocapabilityifapplicable",
       "label": "requireSharedDemoCapabilityIfApplicable()",
@@ -238006,7 +238210,7 @@
       "source_location": "L66"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "actor_requireshareddemostorecapabilityifapplicable",
       "label": "requireSharedDemoStoreCapabilityIfApplicable()",
@@ -238015,7 +238219,7 @@
       "source_location": "L78"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_actor_ts",
       "label": "actor.ts",
@@ -238024,7 +238228,7 @@
       "source_location": "L1"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "adjustments_test_createapprovaldecisionmutationctx",
       "label": "createApprovalDecisionMutationCtx()",
@@ -238033,7 +238237,7 @@
       "source_location": "L305"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "adjustments_test_createinventorysnapshotqueryctx",
       "label": "createInventorySnapshotQueryCtx()",
@@ -238042,7 +238246,7 @@
       "source_location": "L57"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "adjustments_test_createsubmissionmutationctx",
       "label": "createSubmissionMutationCtx()",
@@ -238051,7 +238255,7 @@
       "source_location": "L506"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "adjustments_test_gethandler",
       "label": "getHandler()",
@@ -238060,7 +238264,7 @@
       "source_location": "L53"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "adjustments_test_getsource",
       "label": "getSource()",
@@ -238069,7 +238273,7 @@
       "source_location": "L49"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
       "label": "adjustments.test.ts",
@@ -238078,7 +238282,7 @@
       "source_location": "L1"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_ts",
       "label": "vendors.ts",
@@ -238087,7 +238291,7 @@
       "source_location": "L1"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "vendors_createvendorcommandwithctx",
       "label": "createVendorCommandWithCtx()",
@@ -238096,7 +238300,7 @@
       "source_location": "L124"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "vendors_createvendorwithctx",
       "label": "createVendorWithCtx()",
@@ -238105,7 +238309,7 @@
       "source_location": "L75"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "vendors_mapcreatevendorerror",
       "label": "mapCreateVendorError()",
@@ -238114,7 +238318,7 @@
       "source_location": "L46"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "vendors_normalizevendorlookupkey",
       "label": "normalizeVendorLookupKey()",
@@ -238123,7 +238327,7 @@
       "source_location": "L38"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "vendors_trimoptional",
       "label": "trimOptional()",
@@ -238132,7 +238336,7 @@
       "source_location": "L33"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_returnexchangeoperations_ts",
       "label": "returnExchangeOperations.ts",
@@ -238141,7 +238345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "returnexchangeoperations_buildonlineorderreportedreturns",
       "label": "buildOnlineOrderReportedReturns()",
@@ -238150,7 +238354,7 @@
       "source_location": "L73"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "returnexchangeoperations_buildonlineorderreturnexchangeplan",
       "label": "buildOnlineOrderReturnExchangePlan()",
@@ -238159,7 +238363,7 @@
       "source_location": "L137"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "returnexchangeoperations_getapprovalreason",
       "label": "getApprovalReason()",
@@ -238168,7 +238372,7 @@
       "source_location": "L112"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "returnexchangeoperations_getkind",
       "label": "getKind()",
@@ -238177,7 +238381,7 @@
       "source_location": "L96"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "returnexchangeoperations_getlinerefundamount",
       "label": "getLineRefundAmount()",
@@ -238186,7 +238390,7 @@
       "source_location": "L92"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "onlineorder_test_createunauthorizednormalorderctx",
       "label": "createUnauthorizedNormalOrderCtx()",
@@ -238195,7 +238399,7 @@
       "source_location": "L164"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "onlineorder_test_gethandler",
       "label": "getHandler()",
@@ -238204,7 +238408,7 @@
       "source_location": "L160"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "onlineorder_test_getsource",
       "label": "getSource()",
@@ -238213,7 +238417,7 @@
       "source_location": "L156"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "onlineorder_test_readstorefrontfacts",
       "label": "readStorefrontFacts()",
@@ -238222,7 +238426,7 @@
       "source_location": "L150"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "onlineorder_test_seedfulfillableorder",
       "label": "seedFulfillableOrder()",
@@ -238231,7 +238435,7 @@
       "source_location": "L29"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorder_test_ts",
       "label": "onlineOrder.test.ts",
@@ -238240,7 +238444,7 @@
       "source_location": "L1"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storetime_storetimeauthority_ts",
       "label": "storeTimeAuthority.ts",
@@ -238249,7 +238453,7 @@
       "source_location": "L1"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "storetimeauthority_assertstoretimezoneversioncanbeinserted",
       "label": "assertStoreTimezoneVersionCanBeInserted()",
@@ -238258,7 +238462,7 @@
       "source_location": "L50"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "storetimeauthority_includesoccurrence",
       "label": "includesOccurrence()",
@@ -238267,7 +238471,7 @@
       "source_location": "L18"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "storetimeauthority_intervalsoverlap",
       "label": "intervalsOverlap()",
@@ -238276,7 +238480,7 @@
       "source_location": "L41"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "storetimeauthority_localdate",
       "label": "localDate()",
@@ -238285,67 +238489,13 @@
       "source_location": "L28"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "storetimeauthority_resolvestoretimeauthority",
       "label": "resolveStoreTimeAuthority()",
       "norm_label": "resolvestoretimeauthority()",
       "source_file": "packages/athena-webapp/convex/storeTime/storeTimeAuthority.ts",
       "source_location": "L84"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_adapters_purchaseorder_ts",
-      "label": "purchaseOrder.ts",
-      "norm_label": "purchaseorder.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/purchaseOrder.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "purchaseorder_buildpurchaseorderreceivinglookup",
-      "label": "buildPurchaseOrderReceivingLookup()",
-      "norm_label": "buildpurchaseorderreceivinglookup()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/purchaseOrder.ts",
-      "source_location": "L162"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "purchaseorder_buildpurchaseordertraceseed",
-      "label": "buildPurchaseOrderTraceSeed()",
-      "norm_label": "buildpurchaseordertraceseed()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/purchaseOrder.ts",
-      "source_location": "L82"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "purchaseorder_compactdetails",
-      "label": "compactDetails()",
-      "norm_label": "compactdetails()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/purchaseOrder.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "purchaseorder_formatpurchaseorderlabel",
-      "label": "formatPurchaseOrderLabel()",
-      "norm_label": "formatpurchaseorderlabel()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/purchaseOrder.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "purchaseorder_normalizelookup",
-      "label": "normalizeLookup()",
-      "norm_label": "normalizelookup()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/purchaseOrder.ts",
-      "source_location": "L53"
     },
     {
       "community": 44,
@@ -238620,6 +238770,60 @@
     {
       "community": 440,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_adapters_purchaseorder_ts",
+      "label": "purchaseOrder.ts",
+      "norm_label": "purchaseorder.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/purchaseOrder.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "purchaseorder_buildpurchaseorderreceivinglookup",
+      "label": "buildPurchaseOrderReceivingLookup()",
+      "norm_label": "buildpurchaseorderreceivinglookup()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/purchaseOrder.ts",
+      "source_location": "L162"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "purchaseorder_buildpurchaseordertraceseed",
+      "label": "buildPurchaseOrderTraceSeed()",
+      "norm_label": "buildpurchaseordertraceseed()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/purchaseOrder.ts",
+      "source_location": "L82"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "purchaseorder_compactdetails",
+      "label": "compactDetails()",
+      "norm_label": "compactdetails()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/purchaseOrder.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "purchaseorder_formatpurchaseorderlabel",
+      "label": "formatPurchaseOrderLabel()",
+      "norm_label": "formatpurchaseorderlabel()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/purchaseOrder.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "purchaseorder_normalizelookup",
+      "label": "normalizeLookup()",
+      "norm_label": "normalizelookup()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/purchaseOrder.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
       "id": "convexpaginationantipatterncheck_find_block_end",
       "label": "find_block_end()",
       "norm_label": "find_block_end()",
@@ -238627,7 +238831,7 @@
       "source_location": "L123"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_list_convex_files",
       "label": "list_convex_files()",
@@ -238636,7 +238840,7 @@
       "source_location": "L187"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_main",
       "label": "main()",
@@ -238645,7 +238849,7 @@
       "source_location": "L207"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_scan_file",
       "label": "scan_file()",
@@ -238654,7 +238858,7 @@
       "source_location": "L137"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_strip_code",
       "label": "strip_code()",
@@ -238663,7 +238867,7 @@
       "source_location": "L9"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "packages_athena_webapp_scripts_convexpaginationantipatterncheck_py",
       "label": "convexPaginationAntiPatternCheck.py",
@@ -238672,7 +238876,7 @@
       "source_location": "L1"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "commandresult_approvalrequired",
       "label": "approvalRequired()",
@@ -238681,7 +238885,7 @@
       "source_location": "L62"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "commandresult_isapprovalrequiredresult",
       "label": "isApprovalRequiredResult()",
@@ -238690,7 +238894,7 @@
       "source_location": "L77"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "commandresult_isusererrorresult",
       "label": "isUserErrorResult()",
@@ -238699,7 +238903,7 @@
       "source_location": "L71"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "commandresult_ok",
       "label": "ok()",
@@ -238708,7 +238912,7 @@
       "source_location": "L48"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "commandresult_usererror",
       "label": "userError()",
@@ -238717,7 +238921,7 @@
       "source_location": "L55"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_commandresult_ts",
       "label": "commandResult.ts",
@@ -238726,7 +238930,7 @@
       "source_location": "L1"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "homepageranking_comparehomepagerankeditems",
       "label": "compareHomepageRankedItems()",
@@ -238735,7 +238939,7 @@
       "source_location": "L22"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "homepageranking_gethomepagesortrank",
       "label": "getHomepageSortRank()",
@@ -238744,7 +238948,7 @@
       "source_location": "L9"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "homepageranking_getnexthomepagerank",
       "label": "getNextHomepageRank()",
@@ -238753,7 +238957,7 @@
       "source_location": "L40"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "homepageranking_getpresentedhomepagerank",
       "label": "getPresentedHomepageRank()",
@@ -238762,7 +238966,7 @@
       "source_location": "L15"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "homepageranking_sorthomepagerankeditems",
       "label": "sortHomepageRankedItems()",
@@ -238771,7 +238975,7 @@
       "source_location": "L36"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_homepageranking_ts",
       "label": "homepageRanking.ts",
@@ -238780,7 +238984,7 @@
       "source_location": "L1"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_poslocalsynccontract_ts",
       "label": "posLocalSyncContract.ts",
@@ -238789,7 +238993,7 @@
       "source_location": "L1"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "poslocalsynccontract_canuploadposlocalsynclocaleventtype",
       "label": "canUploadPosLocalSyncLocalEventType()",
@@ -238798,7 +239002,7 @@
       "source_location": "L143"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "poslocalsynccontract_eventtypesfromcontract",
       "label": "eventTypesFromContract()",
@@ -238807,7 +239011,7 @@
       "source_location": "L60"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "poslocalsynccontract_getposlocalsynceventcontractforlocaleventtype",
       "label": "getPosLocalSyncEventContractForLocalEventType()",
@@ -238816,7 +239020,7 @@
       "source_location": "L123"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "poslocalsynccontract_getposlocalsynceventtypeforlocaleventtype",
       "label": "getPosLocalSyncEventTypeForLocalEventType()",
@@ -238825,7 +239029,7 @@
       "source_location": "L136"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "poslocalsynccontract_isposlocalsynceventtype",
       "label": "isPosLocalSyncEventType()",
@@ -238834,7 +239038,7 @@
       "source_location": "L117"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_registersessionstatus_ts",
       "label": "registerSessionStatus.ts",
@@ -238843,7 +239047,7 @@
       "source_location": "L1"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "registersessionstatus_includesregistersessionstatus",
       "label": "includesRegisterSessionStatus()",
@@ -238852,7 +239056,7 @@
       "source_location": "L38"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "registersessionstatus_iscashcontrolvisibleregistersessionstatus",
       "label": "isCashControlVisibleRegisterSessionStatus()",
@@ -238861,7 +239065,7 @@
       "source_location": "L62"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "registersessionstatus_isposusableregistersessionstatus",
       "label": "isPosUsableRegisterSessionStatus()",
@@ -238870,7 +239074,7 @@
       "source_location": "L48"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "registersessionstatus_isregistersessionconflictblockingstatus",
       "label": "isRegisterSessionConflictBlockingStatus()",
@@ -238879,7 +239083,7 @@
       "source_location": "L55"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "registersessionstatus_isregistersessionstatus",
       "label": "isRegisterSessionStatus()",
@@ -238888,7 +239092,7 @@
       "source_location": "L29"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_workflowtrace_ts",
       "label": "workflowTrace.ts",
@@ -238897,7 +239101,7 @@
       "source_location": "L1"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "workflowtrace_assertobjectkeysareminimized",
       "label": "assertObjectKeysAreMinimized()",
@@ -238906,7 +239110,7 @@
       "source_location": "L44"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "workflowtrace_assertworkflowtracedetailsareminimized",
       "label": "assertWorkflowTraceDetailsAreMinimized()",
@@ -238915,7 +239119,7 @@
       "source_location": "L67"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "workflowtrace_createworkflowtraceid",
       "label": "createWorkflowTraceId()",
@@ -238924,7 +239128,7 @@
       "source_location": "L93"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "workflowtrace_normalizeworkflowtraceeventkey",
       "label": "normalizeWorkflowTraceEventKey()",
@@ -238933,7 +239137,7 @@
       "source_location": "L83"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "workflowtrace_normalizeworkflowtracelookupvalue",
       "label": "normalizeWorkflowTraceLookupValue()",
@@ -238942,7 +239146,7 @@
       "source_location": "L73"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productcategorization_tsx",
       "label": "ProductCategorization.tsx",
@@ -238951,7 +239155,7 @@
       "source_location": "L1"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "productcategorization_getproductname",
       "label": "getProductName()",
@@ -238960,7 +239164,7 @@
       "source_location": "L327"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "productcategorization_handleclose",
       "label": "handleClose()",
@@ -238969,7 +239173,7 @@
       "source_location": "L234"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "productcategorization_handleproductposvisibility",
       "label": "handleProductPosVisibility()",
@@ -238978,7 +239182,7 @@
       "source_location": "L284"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "productcategorization_handleproductvisibility",
       "label": "handleProductVisibility()",
@@ -238987,7 +239191,7 @@
       "source_location": "L274"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "productcategorization_setinitialselectedoption",
       "label": "setInitialSelectedOption()",
@@ -238996,7 +239200,7 @@
       "source_location": "L261"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "data_table_toolbar_datatabletoolbar",
       "label": "DataTableToolbar()",
@@ -239005,7 +239209,7 @@
       "source_location": "L23"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -239014,7 +239218,7 @@
       "source_location": "L1"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -239023,7 +239227,7 @@
       "source_location": "L1"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -239032,7 +239236,7 @@
       "source_location": "L1"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -239041,7 +239245,7 @@
       "source_location": "L1"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -239050,7 +239254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
       "label": "selectable-data-provider.tsx",
@@ -239059,7 +239263,7 @@
       "source_location": "L1"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
       "label": "selectable-data-provider.tsx",
@@ -239068,7 +239272,7 @@
       "source_location": "L1"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
       "label": "selectable-data-provider.tsx",
@@ -239077,7 +239281,7 @@
       "source_location": "L1"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
       "label": "selectable-data-provider.tsx",
@@ -239086,7 +239290,7 @@
       "source_location": "L1"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "selectable_data_provider_selectedproductsprovider",
       "label": "SelectedProductsProvider()",
@@ -239095,67 +239299,13 @@
       "source_location": "L16"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "selectable_data_provider_useselectedproducts",
       "label": "useSelectedProducts()",
       "norm_label": "useselectedproducts()",
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
       "source_location": "L37"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "flipnumber_defaultformatvalue",
-      "label": "defaultFormatValue()",
-      "norm_label": "defaultformatvalue()",
-      "source_file": "packages/athena-webapp/src/components/common/FlipNumber.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "flipnumber_flipnumber",
-      "label": "FlipNumber()",
-      "norm_label": "flipnumber()",
-      "source_file": "packages/athena-webapp/src/components/common/FlipNumber.tsx",
-      "source_location": "L249"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "flipnumber_fliptext",
-      "label": "FlipText()",
-      "norm_label": "fliptext()",
-      "source_file": "packages/athena-webapp/src/components/common/FlipNumber.tsx",
-      "source_location": "L47"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "flipnumber_renderflipglyphs",
-      "label": "renderFlipGlyphs()",
-      "norm_label": "renderflipglyphs()",
-      "source_file": "packages/athena-webapp/src/components/common/FlipNumber.tsx",
-      "source_location": "L24"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "flipnumber_renderfliptext",
-      "label": "renderFlipText()",
-      "norm_label": "renderfliptext()",
-      "source_file": "packages/athena-webapp/src/components/common/FlipNumber.tsx",
-      "source_location": "L37"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_common_flipnumber_tsx",
-      "label": "FlipNumber.tsx",
-      "norm_label": "flipnumber.tsx",
-      "source_file": "packages/athena-webapp/src/components/common/FlipNumber.tsx",
-      "source_location": "L1"
     },
     {
       "community": 45,
@@ -239421,6 +239571,60 @@
     {
       "community": 450,
       "file_type": "code",
+      "id": "flipnumber_defaultformatvalue",
+      "label": "defaultFormatValue()",
+      "norm_label": "defaultformatvalue()",
+      "source_file": "packages/athena-webapp/src/components/common/FlipNumber.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "flipnumber_flipnumber",
+      "label": "FlipNumber()",
+      "norm_label": "flipnumber()",
+      "source_file": "packages/athena-webapp/src/components/common/FlipNumber.tsx",
+      "source_location": "L249"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "flipnumber_fliptext",
+      "label": "FlipText()",
+      "norm_label": "fliptext()",
+      "source_file": "packages/athena-webapp/src/components/common/FlipNumber.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "flipnumber_renderflipglyphs",
+      "label": "renderFlipGlyphs()",
+      "norm_label": "renderflipglyphs()",
+      "source_file": "packages/athena-webapp/src/components/common/FlipNumber.tsx",
+      "source_location": "L24"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "flipnumber_renderfliptext",
+      "label": "renderFlipText()",
+      "norm_label": "renderfliptext()",
+      "source_file": "packages/athena-webapp/src/components/common/FlipNumber.tsx",
+      "source_location": "L37"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_common_flipnumber_tsx",
+      "label": "FlipNumber.tsx",
+      "norm_label": "flipnumber.tsx",
+      "source_file": "packages/athena-webapp/src/components/common/FlipNumber.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
       "id": "bannermessageeditor_getcountdownstatus",
       "label": "getCountdownStatus()",
       "norm_label": "getcountdownstatus()",
@@ -239428,7 +239632,7 @@
       "source_location": "L130"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "bannermessageeditor_handleactivetoggle",
       "label": "handleActiveToggle()",
@@ -239437,7 +239641,7 @@
       "source_location": "L90"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "bannermessageeditor_handleclear",
       "label": "handleClear()",
@@ -239446,7 +239650,7 @@
       "source_location": "L65"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "bannermessageeditor_handlecountdownchange",
       "label": "handleCountdownChange()",
@@ -239455,7 +239659,7 @@
       "source_location": "L120"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "bannermessageeditor_handlesave",
       "label": "handleSave()",
@@ -239464,7 +239668,7 @@
       "source_location": "L45"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bannermessageeditor_tsx",
       "label": "BannerMessageEditor.tsx",
@@ -239473,7 +239677,7 @@
       "source_location": "L1"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "bestsellers_bestsellers",
       "label": "bestSellers()",
@@ -239482,7 +239686,7 @@
       "source_location": "L157"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "bestsellers_handleremovebestseller",
       "label": "handleRemoveBestSeller()",
@@ -239491,7 +239695,7 @@
       "source_location": "L66"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "bestsellers_movebestseller",
       "label": "moveBestSeller()",
@@ -239500,7 +239704,7 @@
       "source_location": "L126"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "bestsellers_ondragend",
       "label": "onDragEnd()",
@@ -239509,7 +239713,7 @@
       "source_location": "L76"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "bestsellers_saveorder",
       "label": "saveOrder()",
@@ -239518,7 +239722,7 @@
       "source_location": "L104"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
       "label": "BestSellers.tsx",
@@ -239527,7 +239731,7 @@
       "source_location": "L1"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "featuredsection_formatstoredcurrencyamount",
       "label": "formatStoredCurrencyAmount()",
@@ -239536,7 +239740,7 @@
       "source_location": "L215"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "featuredsection_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -239545,7 +239749,7 @@
       "source_location": "L66"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "featuredsection_movefeatureditem",
       "label": "moveFeaturedItem()",
@@ -239554,7 +239758,7 @@
       "source_location": "L128"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "featuredsection_ondragend",
       "label": "onDragEnd()",
@@ -239563,7 +239767,7 @@
       "source_location": "L78"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "featuredsection_saveorder",
       "label": "saveOrder()",
@@ -239572,7 +239776,7 @@
       "source_location": "L106"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
       "label": "FeaturedSection.tsx",
@@ -239581,7 +239785,7 @@
       "source_location": "L1"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_landing_story_scenechrome_tsx",
       "label": "SceneChrome.tsx",
@@ -239590,7 +239794,7 @@
       "source_location": "L1"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "scenechrome_appshellexhibit",
       "label": "AppShellExhibit()",
@@ -239599,7 +239803,7 @@
       "source_location": "L131"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "scenechrome_automationbeat",
       "label": "AutomationBeat()",
@@ -239608,7 +239812,7 @@
       "source_location": "L272"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "scenechrome_possyncbadge",
       "label": "PosSyncBadge()",
@@ -239617,7 +239821,7 @@
       "source_location": "L248"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "scenechrome_workspaceexhibit",
       "label": "WorkspaceExhibit()",
@@ -239626,7 +239830,7 @@
       "source_location": "L80"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "scenechrome_workspaceframe",
       "label": "WorkspaceFrame()",
@@ -239635,7 +239839,7 @@
       "source_location": "L39"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "dailyclosehistoryview_test_historyrecord",
       "label": "historyRecord()",
@@ -239644,7 +239848,7 @@
       "source_location": "L190"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "dailyclosehistoryview_test_mockprotectedstate",
       "label": "mockProtectedState()",
@@ -239653,7 +239857,7 @@
       "source_location": "L241"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "dailyclosehistoryview_test_mockqueries",
       "label": "mockQueries()",
@@ -239662,7 +239866,7 @@
       "source_location": "L255"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "dailyclosehistoryview_test_snapshot",
       "label": "snapshot()",
@@ -239671,7 +239875,7 @@
       "source_location": "L104"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "dailyclosehistoryview_test_storedreportsnapshot",
       "label": "storedReportSnapshot()",
@@ -239680,7 +239884,7 @@
       "source_location": "L171"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_dailyclosehistoryview_test_tsx",
       "label": "DailyCloseHistoryView.test.tsx",
@@ -239689,7 +239893,7 @@
       "source_location": "L1"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "dailyopeningview_test_async",
       "label": "async()",
@@ -239698,7 +239902,7 @@
       "source_location": "L124"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "dailyopeningview_test_disconnect",
       "label": "disconnect()",
@@ -239707,7 +239911,7 @@
       "source_location": "L359"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "dailyopeningview_test_formatexpectedtimestamp",
       "label": "formatExpectedTimestamp()",
@@ -239716,7 +239920,7 @@
       "source_location": "L258"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "dailyopeningview_test_observe",
       "label": "observe()",
@@ -239725,7 +239929,7 @@
       "source_location": "L360"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "dailyopeningview_test_unobserve",
       "label": "unobserve()",
@@ -239734,7 +239938,7 @@
       "source_location": "L361"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_dailyopeningview_test_tsx",
       "label": "DailyOpeningView.test.tsx",
@@ -239743,7 +239947,7 @@
       "source_location": "L1"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_skuactivityuntrustedsales_tsx",
       "label": "SkuActivityUntrustedSales.tsx",
@@ -239752,7 +239956,7 @@
       "source_location": "L1"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "skuactivityuntrustedsales_cn",
       "label": "cn()",
@@ -239761,7 +239965,7 @@
       "source_location": "L207"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "skuactivityuntrustedsales_formatcountlabel",
       "label": "formatCountLabel()",
@@ -239770,7 +239974,7 @@
       "source_location": "L139"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "skuactivityuntrustedsales_handlesourcepagechange",
       "label": "handleSourcePageChange()",
@@ -239779,7 +239983,7 @@
       "source_location": "L932"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "skuactivityuntrustedsales_sourcematchesevidencequery",
       "label": "sourceMatchesEvidenceQuery()",
@@ -239788,7 +239992,7 @@
       "source_location": "L147"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "skuactivityuntrustedsales_usedetailstickyposition",
       "label": "useDetailStickyPosition()",
@@ -239797,7 +240001,7 @@
       "source_location": "L83"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_useapprovedcommand_tsx",
       "label": "useApprovedCommand.tsx",
@@ -239806,7 +240010,7 @@
       "source_location": "L1"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "useapprovedcommand_buildapprovalretryargs",
       "label": "buildApprovalRetryArgs()",
@@ -239815,7 +240019,7 @@
       "source_location": "L90"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "useapprovedcommand_getasyncapprovalrequestid",
       "label": "getAsyncApprovalRequestId()",
@@ -239824,7 +240028,7 @@
       "source_location": "L78"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "useapprovedcommand_hasasyncapprovalrequest",
       "label": "hasAsyncApprovalRequest()",
@@ -239833,7 +240037,7 @@
       "source_location": "L72"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "useapprovedcommand_hasinlinemanagerproof",
       "label": "hasInlineManagerProof()",
@@ -239842,7 +240046,7 @@
       "source_location": "L66"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "useapprovedcommand_useapprovedcommand",
       "label": "useApprovedCommand()",
@@ -239851,7 +240055,7 @@
       "source_location": "L102"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_test_tsx",
       "label": "PaymentsAddedList.test.tsx",
@@ -239860,7 +240064,7 @@
       "source_location": "L1"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "paymentsaddedlist_test_deferred",
       "label": "deferred()",
@@ -239869,7 +240073,7 @@
       "source_location": "L46"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "paymentsaddedlist_test_getsummaryamount",
       "label": "getSummaryAmount()",
@@ -239878,7 +240082,7 @@
       "source_location": "L28"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "paymentsaddedlist_test_getsummarylabel",
       "label": "getSummaryLabel()",
@@ -239887,7 +240091,7 @@
       "source_location": "L19"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "paymentsaddedlist_test_getsummarypanel",
       "label": "getSummaryPanel()",
@@ -239896,67 +240100,13 @@
       "source_location": "L41"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "paymentsaddedlist_test_stripwhitespace",
       "label": "stripWhitespace()",
       "norm_label": "stripwhitespace()",
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.test.tsx",
       "source_location": "L15"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
-      "label": "PointOfSaleView.tsx",
-      "norm_label": "pointofsaleview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "pointofsaleview_formatnextopeninglabel",
-      "label": "formatNextOpeningLabel()",
-      "norm_label": "formatnextopeninglabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
-      "source_location": "L131"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "pointofsaleview_formatstorehourstimelabel",
-      "label": "formatStoreHoursTimeLabel()",
-      "norm_label": "formatstorehourstimelabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "pointofsaleview_formatstorelocaldatelabel",
-      "label": "formatStoreLocalDateLabel()",
-      "norm_label": "formatstorelocaldatelabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
-      "source_location": "L116"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "pointofsaleview_formatstorelocaldatetime",
-      "label": "formatStoreLocalDateTime()",
-      "norm_label": "formatstorelocaldatetime()",
-      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
-      "source_location": "L79"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "pointofsaleview_useminutenow",
-      "label": "useMinuteNow()",
-      "norm_label": "useminutenow()",
-      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
-      "source_location": "L144"
     },
     {
       "community": 46,
@@ -240222,6 +240372,60 @@
     {
       "community": 460,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
+      "label": "PointOfSaleView.tsx",
+      "norm_label": "pointofsaleview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "pointofsaleview_formatnextopeninglabel",
+      "label": "formatNextOpeningLabel()",
+      "norm_label": "formatnextopeninglabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
+      "source_location": "L131"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "pointofsaleview_formatstorehourstimelabel",
+      "label": "formatStoreHoursTimeLabel()",
+      "norm_label": "formatstorehourstimelabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "pointofsaleview_formatstorelocaldatelabel",
+      "label": "formatStoreLocalDateLabel()",
+      "norm_label": "formatstorelocaldatelabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
+      "source_location": "L116"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "pointofsaleview_formatstorelocaldatetime",
+      "label": "formatStoreLocalDateTime()",
+      "norm_label": "formatstorelocaldatetime()",
+      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
+      "source_location": "L79"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "pointofsaleview_useminutenow",
+      "label": "useMinuteNow()",
+      "norm_label": "useminutenow()",
+      "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
+      "source_location": "L144"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_posregisteropeningguard_tsx",
       "label": "POSRegisterOpeningGuard.tsx",
       "norm_label": "posregisteropeningguard.tsx",
@@ -240229,7 +240433,7 @@
       "source_location": "L1"
     },
     {
-      "community": 460,
+      "community": 461,
       "file_type": "code",
       "id": "posregisteropeningguard_getlocaloperatingdate",
       "label": "getLocalOperatingDate()",
@@ -240238,7 +240442,7 @@
       "source_location": "L65"
     },
     {
-      "community": 460,
+      "community": 461,
       "file_type": "code",
       "id": "posregisteropeningguard_getlocaloperatingdaterange",
       "label": "getLocalOperatingDateRange()",
@@ -240247,7 +240451,7 @@
       "source_location": "L73"
     },
     {
-      "community": 460,
+      "community": 461,
       "file_type": "code",
       "id": "posregisteropeningguard_if",
       "label": "if()",
@@ -240256,7 +240460,7 @@
       "source_location": "L689"
     },
     {
-      "community": 460,
+      "community": 461,
       "file_type": "code",
       "id": "posregisteropeningguard_isbrowseroffline",
       "label": "isBrowserOffline()",
@@ -240265,7 +240469,7 @@
       "source_location": "L92"
     },
     {
-      "community": 460,
+      "community": 461,
       "file_type": "code",
       "id": "posregisteropeningguard_posregisteropeningguard",
       "label": "POSRegisterOpeningGuard()",
@@ -240274,7 +240478,7 @@
       "source_location": "L96"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
       "label": "TransactionView.test.tsx",
@@ -240283,7 +240487,7 @@
       "source_location": "L1"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "transactionview_test_async",
       "label": "async()",
@@ -240292,7 +240496,7 @@
       "source_location": "L199"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "transactionview_test_deferred",
       "label": "deferred()",
@@ -240301,7 +240505,7 @@
       "source_location": "L15"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "transactionview_test_mocktransactionmutations",
       "label": "mockTransactionMutations()",
@@ -240310,7 +240514,7 @@
       "source_location": "L554"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "transactionview_test_paymentapprovalrequirement",
       "label": "paymentApprovalRequirement()",
@@ -240319,7 +240523,7 @@
       "source_location": "L473"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "transactionview_test_voidapprovalrequirement",
       "label": "voidApprovalRequirement()",
@@ -240328,7 +240532,7 @@
       "source_location": "L506"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_test_tsx",
       "label": "ProcurementView.test.tsx",
@@ -240337,7 +240541,7 @@
       "source_location": "L1"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "procurementview_test_choosedraftvendor",
       "label": "chooseDraftVendor()",
@@ -240346,7 +240550,7 @@
       "source_location": "L367"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "procurementview_test_chooseprocurementmode",
       "label": "chooseProcurementMode()",
@@ -240355,7 +240559,7 @@
       "source_location": "L357"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "procurementview_test_installmutationmocks",
       "label": "installMutationMocks()",
@@ -240364,7 +240568,7 @@
       "source_location": "L323"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "procurementview_test_makeproductskusearchresult",
       "label": "makeProductSkuSearchResult()",
@@ -240373,67 +240577,13 @@
       "source_location": "L294"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "procurementview_test_makerecommendation",
       "label": "makeRecommendation()",
       "norm_label": "makerecommendation()",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.test.tsx",
       "source_location": "L285"
-    },
-    {
-      "community": 463,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reports_reportdayspanel_test_tsx",
-      "label": "ReportDaysPanel.test.tsx",
-      "norm_label": "reportdayspanel.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 463,
-      "file_type": "code",
-      "id": "reportdayspanel_test_constructor",
-      "label": "constructor()",
-      "norm_label": "constructor()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.test.tsx",
-      "source_location": "L1046"
-    },
-    {
-      "community": 463,
-      "file_type": "code",
-      "id": "reportdayspanel_test_installmixqueries",
-      "label": "installMixQueries()",
-      "norm_label": "installmixqueries()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.test.tsx",
-      "source_location": "L1718"
-    },
-    {
-      "community": 463,
-      "file_type": "code",
-      "id": "reportdayspanel_test_isodateoffset",
-      "label": "isoDateOffset()",
-      "norm_label": "isodateoffset()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.test.tsx",
-      "source_location": "L101"
-    },
-    {
-      "community": 463,
-      "file_type": "code",
-      "id": "reportdayspanel_test_livemixreadercalls",
-      "label": "liveMixReaderCalls()",
-      "norm_label": "livemixreadercalls()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.test.tsx",
-      "source_location": "L1734"
-    },
-    {
-      "community": 463,
-      "file_type": "code",
-      "id": "reportdayspanel_test_mixvisibleresult",
-      "label": "mixVisibleResult()",
-      "norm_label": "mixvisibleresult()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.test.tsx",
-      "source_location": "L1703"
     },
     {
       "community": 464,
@@ -241023,60 +241173,6 @@
     {
       "community": 470,
       "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L101"
-    },
-    {
-      "community": 470,
-      "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 470,
-      "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 470,
-      "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 470,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 470,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 471,
-      "file_type": "code",
       "id": "managerelevationcontext_getstaffdisplayname",
       "label": "getStaffDisplayName()",
       "norm_label": "getstaffdisplayname()",
@@ -241084,7 +241180,7 @@
       "source_location": "L64"
     },
     {
-      "community": 471,
+      "community": 470,
       "file_type": "code",
       "id": "managerelevationcontext_managerelevationprovider",
       "label": "ManagerElevationProvider()",
@@ -241093,7 +241189,7 @@
       "source_location": "L87"
     },
     {
-      "community": 471,
+      "community": 470,
       "file_type": "code",
       "id": "managerelevationcontext_tostaffauthenticationresult",
       "label": "toStaffAuthenticationResult()",
@@ -241102,7 +241198,7 @@
       "source_location": "L74"
     },
     {
-      "community": 471,
+      "community": 470,
       "file_type": "code",
       "id": "managerelevationcontext_usemanagerelevation",
       "label": "useManagerElevation()",
@@ -241111,7 +241207,7 @@
       "source_location": "L242"
     },
     {
-      "community": 471,
+      "community": 470,
       "file_type": "code",
       "id": "managerelevationcontext_useoptionalmanagerelevation",
       "label": "useOptionalManagerElevation()",
@@ -241120,7 +241216,7 @@
       "source_location": "L251"
     },
     {
-      "community": 471,
+      "community": 470,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_managerelevationcontext_tsx",
       "label": "ManagerElevationContext.tsx",
@@ -241129,7 +241225,7 @@
       "source_location": "L1"
     },
     {
-      "community": 472,
+      "community": 471,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
       "label": "useExpenseSessions.ts",
@@ -241138,7 +241234,7 @@
       "source_location": "L1"
     },
     {
-      "community": 472,
+      "community": 471,
       "file_type": "code",
       "id": "useexpensesessions_useexpenseactivesession",
       "label": "useExpenseActiveSession()",
@@ -241147,7 +241243,7 @@
       "source_location": "L42"
     },
     {
-      "community": 472,
+      "community": 471,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesession",
       "label": "useExpenseSession()",
@@ -241156,7 +241252,7 @@
       "source_location": "L32"
     },
     {
-      "community": 472,
+      "community": 471,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessioncreate",
       "label": "useExpenseSessionCreate()",
@@ -241165,7 +241261,7 @@
       "source_location": "L62"
     },
     {
-      "community": 472,
+      "community": 471,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessionupdate",
       "label": "useExpenseSessionUpdate()",
@@ -241174,7 +241270,7 @@
       "source_location": "L101"
     },
     {
-      "community": 472,
+      "community": 471,
       "file_type": "code",
       "id": "useexpensesessions_useexpensestoresessions",
       "label": "useExpenseStoreSessions()",
@@ -241183,7 +241279,7 @@
       "source_location": "L10"
     },
     {
-      "community": 473,
+      "community": 472,
       "file_type": "code",
       "id": "capabilities_canaccesscashcontrolssurface",
       "label": "canAccessCashControlsSurface()",
@@ -241192,7 +241288,7 @@
       "source_location": "L54"
     },
     {
-      "community": 473,
+      "community": 472,
       "file_type": "code",
       "id": "capabilities_canaccessfulladminsurface",
       "label": "canAccessFullAdminSurface()",
@@ -241201,7 +241297,7 @@
       "source_location": "L41"
     },
     {
-      "community": 473,
+      "community": 472,
       "file_type": "code",
       "id": "capabilities_canaccessstoredaysurface",
       "label": "canAccessStoreDaySurface()",
@@ -241210,7 +241306,7 @@
       "source_location": "L47"
     },
     {
-      "community": 473,
+      "community": 472,
       "file_type": "code",
       "id": "capabilities_canviewfinancialdetails",
       "label": "canViewFinancialDetails()",
@@ -241219,7 +241315,7 @@
       "source_location": "L61"
     },
     {
-      "community": 473,
+      "community": 472,
       "file_type": "code",
       "id": "capabilities_getsurfaceaccess",
       "label": "getSurfaceAccess()",
@@ -241228,7 +241324,7 @@
       "source_location": "L68"
     },
     {
-      "community": 473,
+      "community": 472,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_access_capabilities_ts",
       "label": "capabilities.ts",
@@ -241237,7 +241333,7 @@
       "source_location": "L1"
     },
     {
-      "community": 474,
+      "community": 473,
       "file_type": "code",
       "id": "behaviorutils_calculateengagementmetrics",
       "label": "calculateEngagementMetrics()",
@@ -241246,7 +241342,7 @@
       "source_location": "L173"
     },
     {
-      "community": 474,
+      "community": 473,
       "file_type": "code",
       "id": "behaviorutils_calculateriskindicators",
       "label": "calculateRiskIndicators()",
@@ -241255,7 +241351,7 @@
       "source_location": "L71"
     },
     {
-      "community": 474,
+      "community": 473,
       "file_type": "code",
       "id": "behaviorutils_getactivitypriority",
       "label": "getActivityPriority()",
@@ -241264,7 +241360,7 @@
       "source_location": "L251"
     },
     {
-      "community": 474,
+      "community": 473,
       "file_type": "code",
       "id": "behaviorutils_getcustomerjourneystage",
       "label": "getCustomerJourneyStage()",
@@ -241273,7 +241369,7 @@
       "source_location": "L36"
     },
     {
-      "community": 474,
+      "community": 473,
       "file_type": "code",
       "id": "behaviorutils_getjourneystageinfo",
       "label": "getJourneyStageInfo()",
@@ -241282,7 +241378,7 @@
       "source_location": "L277"
     },
     {
-      "community": 474,
+      "community": 473,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
       "label": "behaviorUtils.ts",
@@ -241291,7 +241387,7 @@
       "source_location": "L1"
     },
     {
-      "community": 475,
+      "community": 474,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
       "label": "results.ts",
@@ -241300,7 +241396,7 @@
       "source_location": "L1"
     },
     {
-      "community": 475,
+      "community": 474,
       "file_type": "code",
       "id": "results_isposusecasesuccess",
       "label": "isPosUseCaseSuccess()",
@@ -241309,7 +241405,7 @@
       "source_location": "L134"
     },
     {
-      "community": 475,
+      "community": 474,
       "file_type": "code",
       "id": "results_mapcommandoutcome",
       "label": "mapCommandOutcome()",
@@ -241318,7 +241414,7 @@
       "source_location": "L69"
     },
     {
-      "community": 475,
+      "community": 474,
       "file_type": "code",
       "id": "results_mapcommandresult",
       "label": "mapCommandResult()",
@@ -241327,7 +241423,7 @@
       "source_location": "L86"
     },
     {
-      "community": 475,
+      "community": 474,
       "file_type": "code",
       "id": "results_maplegacymutationresult",
       "label": "mapLegacyMutationResult()",
@@ -241336,7 +241432,7 @@
       "source_location": "L52"
     },
     {
-      "community": 475,
+      "community": 474,
       "file_type": "code",
       "id": "results_mapthrownerror",
       "label": "mapThrownError()",
@@ -241345,7 +241441,7 @@
       "source_location": "L103"
     },
     {
-      "community": 476,
+      "community": 475,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registerlifecycleauthoritycandidates_ts",
       "label": "registerLifecycleAuthorityCandidates.ts",
@@ -241354,7 +241450,7 @@
       "source_location": "L1"
     },
     {
-      "community": 476,
+      "community": 475,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_deriveregisterlifecycleauthoritycandidates",
       "label": "deriveRegisterLifecycleAuthorityCandidates()",
@@ -241363,7 +241459,7 @@
       "source_location": "L45"
     },
     {
-      "community": 476,
+      "community": 475,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_isboundedidentifier",
       "label": "isBoundedIdentifier()",
@@ -241372,7 +241468,7 @@
       "source_location": "L220"
     },
     {
-      "community": 476,
+      "community": 475,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_iseligibleregistermapping",
       "label": "isEligibleRegisterMapping()",
@@ -241381,7 +241477,7 @@
       "source_location": "L167"
     },
     {
-      "community": 476,
+      "community": 475,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_legacymappingmatchesactivesession",
       "label": "legacyMappingMatchesActiveSession()",
@@ -241390,7 +241486,7 @@
       "source_location": "L182"
     },
     {
-      "community": 476,
+      "community": 475,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_mappingcandidate",
       "label": "mappingCandidate()",
@@ -241399,7 +241495,7 @@
       "source_location": "L194"
     },
     {
-      "community": 477,
+      "community": 476,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_useposlocalsyncruntime_test_ts",
       "label": "usePosLocalSyncRuntime.test.ts",
@@ -241408,7 +241504,7 @@
       "source_location": "L1"
     },
     {
-      "community": 477,
+      "community": 476,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_buildlocalevent",
       "label": "buildLocalEvent()",
@@ -241417,7 +241513,7 @@
       "source_location": "L7332"
     },
     {
-      "community": 477,
+      "community": 476,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_buildrecoverycommand",
       "label": "buildRecoveryCommand()",
@@ -241426,7 +241522,7 @@
       "source_location": "L7355"
     },
     {
-      "community": 477,
+      "community": 476,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_buildrecoverycommandstore",
       "label": "buildRecoveryCommandStore()",
@@ -241435,7 +241531,7 @@
       "source_location": "L7374"
     },
     {
-      "community": 477,
+      "community": 476,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_deferred",
       "label": "deferred()",
@@ -241444,7 +241540,7 @@
       "source_location": "L103"
     },
     {
-      "community": 477,
+      "community": 476,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_storefactory",
       "label": "storeFactory()",
@@ -241453,7 +241549,7 @@
       "source_location": "L347"
     },
     {
-      "community": 478,
+      "community": 477,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
       "label": "selectors.ts",
@@ -241462,7 +241558,7 @@
       "source_location": "L1"
     },
     {
-      "community": 478,
+      "community": 477,
       "file_type": "code",
       "id": "selectors_buildregisterheaderstate",
       "label": "buildRegisterHeaderState()",
@@ -241471,7 +241567,7 @@
       "source_location": "L28"
     },
     {
-      "community": 478,
+      "community": 477,
       "file_type": "code",
       "id": "selectors_buildregisterinfostate",
       "label": "buildRegisterInfoState()",
@@ -241480,7 +241576,7 @@
       "source_location": "L37"
     },
     {
-      "community": 478,
+      "community": 477,
       "file_type": "code",
       "id": "selectors_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -241489,7 +241585,7 @@
       "source_location": "L12"
     },
     {
-      "community": 478,
+      "community": 477,
       "file_type": "code",
       "id": "selectors_getregistercustomerinfo",
       "label": "getRegisterCustomerInfo()",
@@ -241498,7 +241594,7 @@
       "source_location": "L6"
     },
     {
-      "community": 478,
+      "community": 477,
       "file_type": "code",
       "id": "selectors_isregistersessionactive",
       "label": "isRegisterSessionActive()",
@@ -241507,7 +241603,7 @@
       "source_location": "L49"
     },
     {
-      "community": 479,
+      "community": 478,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
       "label": "toastService.ts",
@@ -241516,7 +241612,7 @@
       "source_location": "L1"
     },
     {
-      "community": 479,
+      "community": 478,
       "file_type": "code",
       "id": "toastservice_handleposoperation",
       "label": "handlePOSOperation()",
@@ -241525,7 +241621,7 @@
       "source_location": "L171"
     },
     {
-      "community": 479,
+      "community": 478,
       "file_type": "code",
       "id": "toastservice_showinventoryerror",
       "label": "showInventoryError()",
@@ -241534,7 +241630,7 @@
       "source_location": "L302"
     },
     {
-      "community": 479,
+      "community": 478,
       "file_type": "code",
       "id": "toastservice_shownoactivesessionerror",
       "label": "showNoActiveSessionError()",
@@ -241543,7 +241639,7 @@
       "source_location": "L319"
     },
     {
-      "community": 479,
+      "community": 478,
       "file_type": "code",
       "id": "toastservice_showsessionexpirederror",
       "label": "showSessionExpiredError()",
@@ -241552,7 +241648,7 @@
       "source_location": "L312"
     },
     {
-      "community": 479,
+      "community": 478,
       "file_type": "code",
       "id": "toastservice_showvalidationerror",
       "label": "showValidationError()",
@@ -241561,268 +241657,7 @@
       "source_location": "L293"
     },
     {
-      "community": 48,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
-      "label": "RegisterSessionView.tsx",
-      "norm_label": "registersessionview.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "registersessionview_activityfiltermatches",
-      "label": "activityFilterMatches()",
-      "norm_label": "activityfiltermatches()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L652"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "registersessionview_cashcontrolsfinancialvalue",
-      "label": "CashControlsFinancialValue()",
-      "norm_label": "cashcontrolsfinancialvalue()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L606"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "registersessionview_formatactivitycoveragestate",
-      "label": "formatActivityCoverageState()",
-      "norm_label": "formatactivitycoveragestate()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L673"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "registersessionview_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L596"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "registersessionview_formatstatuslabel",
-      "label": "formatStatusLabel()",
-      "norm_label": "formatstatuslabel()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L635"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "registersessionview_formatstoredamountforinput",
-      "label": "formatStoredAmountForInput()",
-      "norm_label": "formatstoredamountforinput()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L624"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "registersessionview_formattimestamp",
-      "label": "formatTimestamp()",
-      "norm_label": "formattimestamp()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L628"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "registersessionview_getactivityattentioncount",
-      "label": "getActivityAttentionCount()",
-      "norm_label": "getactivityattentioncount()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L719"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "registersessionview_getactivitycoveragecopy",
-      "label": "getActivityCoverageCopy()",
-      "norm_label": "getactivitycoveragecopy()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L688"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "registersessionview_getactivityrowkey",
-      "label": "getActivityRowKey()",
-      "norm_label": "getactivityrowkey()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L727"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "registersessionview_getactivitystatusdotclass",
-      "label": "getActivityStatusDotClass()",
-      "norm_label": "getactivitystatusdotclass()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L704"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "registersessionview_if",
-      "label": "if()",
-      "norm_label": "if()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L1123"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "registersessionview_ismanagerstaff",
-      "label": "isManagerStaff()",
-      "norm_label": "ismanagerstaff()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L589"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "registersessionview_onauthenticatecloseoutreviewapproval",
-      "label": "onAuthenticateCloseoutReviewApproval()",
-      "norm_label": "onauthenticatecloseoutreviewapproval()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L6094"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "registersessionview_onauthenticateforapproval",
-      "label": "onAuthenticateForApproval()",
-      "norm_label": "onauthenticateforapproval()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L6145"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "registersessionview_onauthenticatestaff",
-      "label": "onAuthenticateStaff()",
-      "norm_label": "onauthenticatestaff()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L6072"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "registersessionview_oncorrectopeningfloat",
-      "label": "onCorrectOpeningFloat()",
-      "norm_label": "oncorrectopeningfloat()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L6237"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "registersessionview_onfinalizecloseout",
-      "label": "onFinalizeCloseout()",
-      "norm_label": "onfinalizecloseout()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L6042"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "registersessionview_onrecorddeposit",
-      "label": "onRecordDeposit()",
-      "norm_label": "onrecorddeposit()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L5952"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "registersessionview_onreopencloseout",
-      "label": "onReopenCloseout()",
-      "norm_label": "onreopencloseout()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L6205"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "registersessionview_onresolvesyncreview",
-      "label": "onResolveSyncReview()",
-      "norm_label": "onresolvesyncreview()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L5978"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "registersessionview_onreviewcloseout",
-      "label": "onReviewCloseout()",
-      "norm_label": "onreviewcloseout()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L6175"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "registersessionview_onsubmitcloseout",
-      "label": "onSubmitCloseout()",
-      "norm_label": "onsubmitcloseout()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L6003"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "registersessionview_parseactivityfiltersearchvalue",
-      "label": "parseActivityFilterSearchValue()",
-      "norm_label": "parseactivityfiltersearchvalue()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L755"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "registersessionview_parseactivitypagesearchvalue",
-      "label": "parseActivityPageSearchValue()",
-      "norm_label": "parseactivitypagesearchvalue()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L744"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "registersessionview_parsereceiptactivitysummary",
-      "label": "parseReceiptActivitySummary()",
-      "norm_label": "parsereceiptactivitysummary()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L734"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "registersessionview_switch",
-      "label": "switch()",
-      "norm_label": "switch()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L1282"
-    },
-    {
-      "community": 48,
-      "file_type": "code",
-      "id": "registersessionview_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
-      "source_location": "L584"
-    },
-    {
-      "community": 480,
+      "community": 479,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_skusearch_productskusearchadapters_ts",
       "label": "productSkuSearchAdapters.ts",
@@ -241831,7 +241666,7 @@
       "source_location": "L1"
     },
     {
-      "community": 480,
+      "community": 479,
       "file_type": "code",
       "id": "productskusearchadapters_buildadminskusearchoption",
       "label": "buildAdminSkuSearchOption()",
@@ -241840,7 +241675,7 @@
       "source_location": "L80"
     },
     {
-      "community": 480,
+      "community": 479,
       "file_type": "code",
       "id": "productskusearchadapters_buildadminskusearchoptions",
       "label": "buildAdminSkuSearchOptions()",
@@ -241849,7 +241684,7 @@
       "source_location": "L132"
     },
     {
-      "community": 480,
+      "community": 479,
       "file_type": "code",
       "id": "productskusearchadapters_compactjoin",
       "label": "compactJoin()",
@@ -241858,7 +241693,7 @@
       "source_location": "L73"
     },
     {
-      "community": 480,
+      "community": 479,
       "file_type": "code",
       "id": "productskusearchadapters_groupadminskusearchoptionsbyproduct",
       "label": "groupAdminSkuSearchOptionsByProduct()",
@@ -241867,7 +241702,7 @@
       "source_location": "L138"
     },
     {
-      "community": 480,
+      "community": 479,
       "file_type": "code",
       "id": "productskusearchadapters_presentationtext",
       "label": "presentationText()",
@@ -241876,7 +241711,268 @@
       "source_location": "L66"
     },
     {
-      "community": 481,
+      "community": 48,
+      "file_type": "code",
+      "id": "packages_athena_webapp_shared_reportscontract_ts",
+      "label": "reportsContract.ts",
+      "norm_label": "reportscontract.ts",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reportscontract_addweekmetrics",
+      "label": "addWeekMetrics()",
+      "norm_label": "addweekmetrics()",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L244"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reportscontract_admissiblemovementdayrevision",
+      "label": "admissibleMovementDayRevision()",
+      "norm_label": "admissiblemovementdayrevision()",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L1232"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reportscontract_combineweekcompleteness",
+      "label": "combineWeekCompleteness()",
+      "norm_label": "combineweekcompleteness()",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L317"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reportscontract_computemixrequestkey",
+      "label": "computeMixRequestKey()",
+      "norm_label": "computemixrequestkey()",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L1428"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reportscontract_computemovementrequestkey",
+      "label": "computeMovementRequestKey()",
+      "norm_label": "computemovementrequestkey()",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L1209"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reportscontract_dayperiodkey",
+      "label": "dayPeriodKey()",
+      "norm_label": "dayperiodkey()",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L709"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reportscontract_derivemixrequestlifecycle",
+      "label": "deriveMixRequestLifecycle()",
+      "norm_label": "derivemixrequestlifecycle()",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L1475"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reportscontract_derivemovementrequestlifecycle",
+      "label": "deriveMovementRequestLifecycle()",
+      "norm_label": "derivemovementrequestlifecycle()",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L1339"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reportscontract_derivepaymentposture",
+      "label": "derivePaymentPosture()",
+      "norm_label": "derivepaymentposture()",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L576"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reportscontract_descendingsortkey",
+      "label": "descendingSortKey()",
+      "norm_label": "descendingsortkey()",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L763"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reportscontract_inclusiveoperatingdayspan",
+      "label": "inclusiveOperatingDaySpan()",
+      "norm_label": "inclusiveoperatingdayspan()",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L1124"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reportscontract_isreportingtodayinprogress",
+      "label": "isReportingTodayInProgress()",
+      "norm_label": "isreportingtodayinprogress()",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reportscontract_isvalidoperatingdatelabel",
+      "label": "isValidOperatingDateLabel()",
+      "norm_label": "isvalidoperatingdatelabel()",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L1112"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reportscontract_mixrequestkeyidentity",
+      "label": "mixRequestKeyIdentity()",
+      "norm_label": "mixrequestkeyidentity()",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L1413"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reportscontract_mixunitssoldsortkey",
+      "label": "mixUnitsSoldSortKey()",
+      "norm_label": "mixunitssoldsortkey()",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L1443"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reportscontract_monthperiodkey",
+      "label": "monthPeriodKey()",
+      "norm_label": "monthperiodkey()",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L713"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reportscontract_movementabsnetunitssortkey",
+      "label": "movementAbsNetUnitsSortKey()",
+      "norm_label": "movementabsnetunitssortkey()",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L1275"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reportscontract_movementpagecount",
+      "label": "movementPageCount()",
+      "norm_label": "movementpagecount()",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L1325"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reportscontract_movementrequestkeyidentity",
+      "label": "movementRequestKeyIdentity()",
+      "norm_label": "movementrequestkeyidentity()",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L1189"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reportscontract_movementsourcerowmatchesrevision",
+      "label": "movementSourceRowMatchesRevision()",
+      "norm_label": "movementsourcerowmatchesrevision()",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L1254"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reportscontract_normalizecurrencycode",
+      "label": "normalizeCurrencyCode()",
+      "norm_label": "normalizecurrencycode()",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L773"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reportscontract_normalizeweekmetrics",
+      "label": "normalizeWeekMetrics()",
+      "norm_label": "normalizeweekmetrics()",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L211"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reportscontract_periodkeysforoperatingdate",
+      "label": "periodKeysForOperatingDate()",
+      "norm_label": "periodkeysforoperatingdate()",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L752"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reportscontract_skumixsyncrowprobe",
+      "label": "skuMixSyncRowProbe()",
+      "norm_label": "skumixsyncrowprobe()",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L1050"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reportscontract_trailingsixmonthsstart",
+      "label": "trailingSixMonthsStart()",
+      "norm_label": "trailingsixmonthsstart()",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L728"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reportscontract_trailingthreemonthsstart",
+      "label": "trailingThreeMonthsStart()",
+      "norm_label": "trailingthreemonthsstart()",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L718"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reportscontract_validatereportrangerequest",
+      "label": "validateReportRangeRequest()",
+      "norm_label": "validatereportrangerequest()",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L1139"
+    },
+    {
+      "community": 48,
+      "file_type": "code",
+      "id": "reportscontract_weekperiodkey",
+      "label": "weekPeriodKey()",
+      "norm_label": "weekperiodkey()",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L742"
+    },
+    {
+      "community": 480,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_stockops_skusearch_ts",
       "label": "skuSearch.ts",
@@ -241885,7 +241981,7 @@
       "source_location": "L1"
     },
     {
-      "community": 481,
+      "community": 480,
       "file_type": "code",
       "id": "skusearch_isbarcodeshapedsearchquery",
       "label": "isBarcodeShapedSearchQuery()",
@@ -241894,7 +241990,7 @@
       "source_location": "L49"
     },
     {
-      "community": 481,
+      "community": 480,
       "file_type": "code",
       "id": "skusearch_matchesskusearchterms",
       "label": "matchesSkuSearchTerms()",
@@ -241903,7 +241999,7 @@
       "source_location": "L11"
     },
     {
-      "community": 481,
+      "community": 480,
       "file_type": "code",
       "id": "skusearch_normalizeidentifier",
       "label": "normalizeIdentifier()",
@@ -241912,7 +242008,7 @@
       "source_location": "L53"
     },
     {
-      "community": 481,
+      "community": 480,
       "file_type": "code",
       "id": "skusearch_normalizeskusearchquery",
       "label": "normalizeSkuSearchQuery()",
@@ -241921,7 +242017,7 @@
       "source_location": "L7"
     },
     {
-      "community": 481,
+      "community": 480,
       "file_type": "code",
       "id": "skusearch_scoreskusearchterms",
       "label": "scoreSkuSearchTerms()",
@@ -241930,7 +242026,7 @@
       "source_location": "L18"
     },
     {
-      "community": 482,
+      "community": 481,
       "file_type": "code",
       "id": "packages_athena_webapp_src_offline_posappshellroutes_ts",
       "label": "posAppShellRoutes.ts",
@@ -241939,7 +242035,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 481,
       "file_type": "code",
       "id": "posappshellroutes_isexcludedfromposappshellcache",
       "label": "isExcludedFromPosAppShellCache()",
@@ -241948,7 +242044,7 @@
       "source_location": "L53"
     },
     {
-      "community": 482,
+      "community": 481,
       "file_type": "code",
       "id": "posappshellroutes_isposappshellnavigationrequest",
       "label": "isPosAppShellNavigationRequest()",
@@ -241957,7 +242053,7 @@
       "source_location": "L71"
     },
     {
-      "community": 482,
+      "community": 481,
       "file_type": "code",
       "id": "posappshellroutes_isposappshellroutepath",
       "label": "isPosAppShellRoutePath()",
@@ -241966,7 +242062,7 @@
       "source_location": "L48"
     },
     {
-      "community": 482,
+      "community": 481,
       "file_type": "code",
       "id": "posappshellroutes_isposappshellstaticassetrequest",
       "label": "isPosAppShellStaticAssetRequest()",
@@ -241975,7 +242071,7 @@
       "source_location": "L88"
     },
     {
-      "community": 482,
+      "community": 481,
       "file_type": "code",
       "id": "posappshellroutes_readheader",
       "label": "readHeader()",
@@ -241984,7 +242080,7 @@
       "source_location": "L107"
     },
     {
-      "community": 483,
+      "community": 482,
       "file_type": "code",
       "id": "packages_athena_webapp_src_offline_posappshellserviceworkerstaging_test_ts",
       "label": "posAppShellServiceWorkerStaging.test.ts",
@@ -241993,7 +242089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 483,
+      "community": 482,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_createserviceworkerfixture",
       "label": "createServiceWorkerFixture()",
@@ -242002,7 +242098,7 @@
       "source_location": "L32"
     },
     {
-      "community": 483,
+      "community": 482,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_memorycache",
       "label": "MemoryCache",
@@ -242011,7 +242107,7 @@
       "source_location": "L14"
     },
     {
-      "community": 483,
+      "community": 482,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_memorycache_keys",
       "label": ".keys()",
@@ -242020,7 +242116,7 @@
       "source_location": "L27"
     },
     {
-      "community": 483,
+      "community": 482,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_memorycache_match",
       "label": ".match()",
@@ -242029,7 +242125,7 @@
       "source_location": "L17"
     },
     {
-      "community": 483,
+      "community": 482,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_memorycache_put",
       "label": ".put()",
@@ -242038,7 +242134,7 @@
       "source_location": "L22"
     },
     {
-      "community": 484,
+      "community": 483,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
       "label": "procurement.index.tsx",
@@ -242047,7 +242143,7 @@
       "source_location": "L1"
     },
     {
-      "community": 484,
+      "community": 483,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementmodesearch",
       "label": "getNextProcurementModeSearch()",
@@ -242056,7 +242152,7 @@
       "source_location": "L19"
     },
     {
-      "community": 484,
+      "community": 483,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementpagesearch",
       "label": "getNextProcurementPageSearch()",
@@ -242065,7 +242161,7 @@
       "source_location": "L37"
     },
     {
-      "community": 484,
+      "community": 483,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementquerysearch",
       "label": "getNextProcurementQuerySearch()",
@@ -242074,7 +242170,7 @@
       "source_location": "L47"
     },
     {
-      "community": 484,
+      "community": 483,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementselectedskusearch",
       "label": "getNextProcurementSelectedSkuSearch()",
@@ -242083,7 +242179,7 @@
       "source_location": "L62"
     },
     {
-      "community": 484,
+      "community": 483,
       "file_type": "code",
       "id": "procurement_index_procurementroute",
       "label": "ProcurementRoute()",
@@ -242092,7 +242188,7 @@
       "source_location": "L88"
     },
     {
-      "community": 485,
+      "community": 484,
       "file_type": "code",
       "id": "login_layout_completependingauthsync",
       "label": "completePendingAuthSync()",
@@ -242101,7 +242197,7 @@
       "source_location": "L145"
     },
     {
-      "community": 485,
+      "community": 484,
       "file_type": "code",
       "id": "login_layout_handlependingauthsync",
       "label": "handlePendingAuthSync()",
@@ -242110,7 +242206,7 @@
       "source_location": "L95"
     },
     {
-      "community": 485,
+      "community": 484,
       "file_type": "code",
       "id": "login_layout_navigationtargetforredirect",
       "label": "navigationTargetForRedirect()",
@@ -242119,7 +242215,7 @@
       "source_location": "L33"
     },
     {
-      "community": 485,
+      "community": 484,
       "file_type": "code",
       "id": "login_layout_sleep",
       "label": "sleep()",
@@ -242128,7 +242224,7 @@
       "source_location": "L29"
     },
     {
-      "community": 485,
+      "community": 484,
       "file_type": "code",
       "id": "login_layout_usedocumentscrolllock",
       "label": "useDocumentScrollLock()",
@@ -242137,7 +242233,7 @@
       "source_location": "L45"
     },
     {
-      "community": 485,
+      "community": 484,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_login_layout_tsx",
       "label": "-login-layout.tsx",
@@ -242146,7 +242242,7 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 485,
       "file_type": "code",
       "id": "organizationsettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -242155,7 +242251,7 @@
       "source_location": "L155"
     },
     {
-      "community": 486,
+      "community": 485,
       "file_type": "code",
       "id": "organizationsettingsview_navigation",
       "label": "Navigation()",
@@ -242164,7 +242260,7 @@
       "source_location": "L197"
     },
     {
-      "community": 486,
+      "community": 485,
       "file_type": "code",
       "id": "organizationsettingsview_onsubmit",
       "label": "onSubmit()",
@@ -242173,7 +242269,7 @@
       "source_location": "L104"
     },
     {
-      "community": 486,
+      "community": 485,
       "file_type": "code",
       "id": "organizationsettingsview_organizationsettings",
       "label": "OrganizationSettings()",
@@ -242182,7 +242278,7 @@
       "source_location": "L25"
     },
     {
-      "community": 486,
+      "community": 485,
       "file_type": "code",
       "id": "organizationsettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -242191,7 +242287,7 @@
       "source_location": "L72"
     },
     {
-      "community": 486,
+      "community": 485,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
       "label": "OrganizationSettingsView.tsx",
@@ -242200,7 +242296,7 @@
       "source_location": "L1"
     },
     {
-      "community": 487,
+      "community": 486,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
       "label": "StoreSettingsView.tsx",
@@ -242209,7 +242305,7 @@
       "source_location": "L1"
     },
     {
-      "community": 487,
+      "community": 486,
       "file_type": "code",
       "id": "storesettingsview_handledeleteallproductsinstore",
       "label": "handleDeleteAllProductsInStore()",
@@ -242218,7 +242314,7 @@
       "source_location": "L231"
     },
     {
-      "community": 487,
+      "community": 486,
       "file_type": "code",
       "id": "storesettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -242227,7 +242323,7 @@
       "source_location": "L167"
     },
     {
-      "community": 487,
+      "community": 486,
       "file_type": "code",
       "id": "storesettingsview_onsubmit",
       "label": "onSubmit()",
@@ -242236,7 +242332,7 @@
       "source_location": "L116"
     },
     {
-      "community": 487,
+      "community": 486,
       "file_type": "code",
       "id": "storesettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -242245,7 +242341,7 @@
       "source_location": "L83"
     },
     {
-      "community": 487,
+      "community": 486,
       "file_type": "code",
       "id": "storesettingsview_storesettings",
       "label": "StoreSettings()",
@@ -242254,7 +242350,7 @@
       "source_location": "L29"
     },
     {
-      "community": 488,
+      "community": 487,
       "file_type": "code",
       "id": "devfixtureactivation_usedailyclosefixture",
       "label": "useDailyCloseFixture()",
@@ -242263,7 +242359,7 @@
       "source_location": "L102"
     },
     {
-      "community": 488,
+      "community": 487,
       "file_type": "code",
       "id": "devfixtureactivation_usedailyopeningfixture",
       "label": "useDailyOpeningFixture()",
@@ -242272,7 +242368,7 @@
       "source_location": "L96"
     },
     {
-      "community": 488,
+      "community": 487,
       "file_type": "code",
       "id": "devfixtureactivation_usedailyoperationsfixture",
       "label": "useDailyOperationsFixture()",
@@ -242281,7 +242377,7 @@
       "source_location": "L90"
     },
     {
-      "community": 488,
+      "community": 487,
       "file_type": "code",
       "id": "devfixtureactivation_useposhubfixture",
       "label": "usePosHubFixture()",
@@ -242290,7 +242386,7 @@
       "source_location": "L108"
     },
     {
-      "community": 488,
+      "community": 487,
       "file_type": "code",
       "id": "devfixtureactivation_useworkspacefixture",
       "label": "useWorkspaceFixture()",
@@ -242299,7 +242395,7 @@
       "source_location": "L46"
     },
     {
-      "community": 488,
+      "community": 487,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_operations_devfixtureactivation_ts",
       "label": "devFixtureActivation.ts",
@@ -242308,7 +242404,7 @@
       "source_location": "L1"
     },
     {
-      "community": 489,
+      "community": 488,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
       "label": "storybook-shell.tsx",
@@ -242317,7 +242413,7 @@
       "source_location": "L1"
     },
     {
-      "community": 489,
+      "community": 488,
       "file_type": "code",
       "id": "storybook_shell_storybookcallout",
       "label": "StorybookCallout()",
@@ -242326,7 +242422,7 @@
       "source_location": "L76"
     },
     {
-      "community": 489,
+      "community": 488,
       "file_type": "code",
       "id": "storybook_shell_storybooklist",
       "label": "StorybookList()",
@@ -242335,7 +242431,7 @@
       "source_location": "L55"
     },
     {
-      "community": 489,
+      "community": 488,
       "file_type": "code",
       "id": "storybook_shell_storybookpillrow",
       "label": "StorybookPillRow()",
@@ -242344,7 +242440,7 @@
       "source_location": "L88"
     },
     {
-      "community": 489,
+      "community": 488,
       "file_type": "code",
       "id": "storybook_shell_storybooksection",
       "label": "StorybookSection()",
@@ -242353,7 +242449,7 @@
       "source_location": "L34"
     },
     {
-      "community": 489,
+      "community": 488,
       "file_type": "code",
       "id": "storybook_shell_storybookshell",
       "label": "StorybookShell()",
@@ -242362,268 +242458,7 @@
       "source_location": "L13"
     },
     {
-      "community": 49,
-      "file_type": "code",
-      "id": "harness_scorecard_builddocumentationstatus",
-      "label": "buildDocumentationStatus()",
-      "norm_label": "builddocumentationstatus()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L299"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "harness_scorecard_buildemptyhistorymetric",
-      "label": "buildEmptyHistoryMetric()",
-      "norm_label": "buildemptyhistorymetric()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L606"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "harness_scorecard_buildgraphifystatus",
-      "label": "buildGraphifyStatus()",
-      "norm_label": "buildgraphifystatus()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L323"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "harness_scorecard_buildinferentialsummarynote",
-      "label": "buildInferentialSummaryNote()",
-      "norm_label": "buildinferentialsummarynote()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L339"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "harness_scorecard_buildsummary",
-      "label": "buildSummary()",
-      "norm_label": "buildsummary()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L351"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "harness_scorecard_collectharnessscorecard",
-      "label": "collectHarnessScorecard()",
-      "norm_label": "collectharnessscorecard()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L817"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "harness_scorecard_countmissingsnippets",
-      "label": "countMissingSnippets()",
-      "norm_label": "countmissingsnippets()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L292"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "harness_scorecard_createfilesystem",
-      "label": "createFileSystem()",
-      "norm_label": "createfilesystem()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L248"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "harness_scorecard_extractscenarionames",
-      "label": "extractScenarioNames()",
-      "norm_label": "extractscenarionames()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L279"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "harness_scorecard_extractscenariosection",
-      "label": "extractScenarioSection()",
-      "norm_label": "extractscenariosection()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L257"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "harness_scorecard_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L227"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "harness_scorecard_getdocumentedscenarioexpectations",
-      "label": "getDocumentedScenarioExpectations()",
-      "norm_label": "getdocumentedscenarioexpectations()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L507"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "harness_scorecard_hasanyharnessdocs",
-      "label": "hasAnyHarnessDocs()",
-      "norm_label": "hasanyharnessdocs()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L426"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "harness_scorecard_inspectappdocumentation",
-      "label": "inspectAppDocumentation()",
-      "norm_label": "inspectappdocumentation()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L443"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "harness_scorecard_inspectdeliveryrunartifact",
-      "label": "inspectDeliveryRunArtifact()",
-      "norm_label": "inspectdeliveryrunartifact()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L761"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "harness_scorecard_inspectgraphifyartifacts",
-      "label": "inspectGraphifyArtifacts()",
-      "norm_label": "inspectgraphifyartifacts()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L789"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "harness_scorecard_inspectinferentialartifact",
-      "label": "inspectInferentialArtifact()",
-      "norm_label": "inspectinferentialartifact()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L520"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "harness_scorecard_inspectinferentialhistory",
-      "label": "inspectInferentialHistory()",
-      "norm_label": "inspectinferentialhistory()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L616"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "harness_scorecard_inspectruntimetrendartifact",
-      "label": "inspectRuntimeTrendArtifact()",
-      "norm_label": "inspectruntimetrendartifact()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L668"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "harness_scorecard_inspectruntimetrendhistory",
-      "label": "inspectRuntimeTrendHistory()",
-      "norm_label": "inspectruntimetrendhistory()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L711"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "harness_scorecard_ishealthyinferentialstatus",
-      "label": "isHealthyInferentialStatus()",
-      "norm_label": "ishealthyinferentialstatus()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L335"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "harness_scorecard_isruntimescenarioname",
-      "label": "isRuntimeScenarioName()",
-      "norm_label": "isruntimescenarioname()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L223"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "harness_scorecard_listdirectory",
-      "label": "listDirectory()",
-      "norm_label": "listdirectory()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L240"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "harness_scorecard_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L213"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "harness_scorecard_readjsonfile",
-      "label": "readJsonFile()",
-      "norm_label": "readjsonfile()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L236"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "harness_scorecard_readtextfile",
-      "label": "readTextFile()",
-      "norm_label": "readtextfile()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L244"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "harness_scorecard_runharnessscorecard",
-      "label": "runHarnessScorecard()",
-      "norm_label": "runharnessscorecard()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L915"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "harness_scorecard_sortunique",
-      "label": "sortUnique()",
-      "norm_label": "sortunique()",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L217"
-    },
-    {
-      "community": 49,
-      "file_type": "code",
-      "id": "scripts_harness_scorecard_ts",
-      "label": "harness-scorecard.ts",
-      "norm_label": "harness-scorecard.ts",
-      "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 490,
+      "community": 489,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_postransaction_ts",
       "label": "posTransaction.ts",
@@ -242632,7 +242467,7 @@
       "source_location": "L1"
     },
     {
-      "community": 490,
+      "community": 489,
       "file_type": "code",
       "id": "postransaction_fetchpostransaction",
       "label": "fetchPosTransaction()",
@@ -242641,7 +242476,7 @@
       "source_location": "L69"
     },
     {
-      "community": 490,
+      "community": 489,
       "file_type": "code",
       "id": "postransaction_getbaseurl",
       "label": "getBaseUrl()",
@@ -242650,7 +242485,7 @@
       "source_location": "L57"
     },
     {
-      "community": 490,
+      "community": 489,
       "file_type": "code",
       "id": "postransaction_getpostransactionbyreceipttoken",
       "label": "getPosTransactionByReceiptToken()",
@@ -242659,7 +242494,7 @@
       "source_location": "L90"
     },
     {
-      "community": 490,
+      "community": 489,
       "file_type": "code",
       "id": "postransaction_postransactionreceipterror",
       "label": "PosTransactionReceiptError",
@@ -242668,7 +242503,7 @@
       "source_location": "L59"
     },
     {
-      "community": 490,
+      "community": 489,
       "file_type": "code",
       "id": "postransaction_postransactionreceipterror_constructor",
       "label": ".constructor()",
@@ -242677,7 +242512,268 @@
       "source_location": "L62"
     },
     {
-      "community": 491,
+      "community": 49,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_tsx",
+      "label": "RegisterSessionView.tsx",
+      "norm_label": "registersessionview.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registersessionview_activityfiltermatches",
+      "label": "activityFilterMatches()",
+      "norm_label": "activityfiltermatches()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L652"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registersessionview_cashcontrolsfinancialvalue",
+      "label": "CashControlsFinancialValue()",
+      "norm_label": "cashcontrolsfinancialvalue()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L606"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registersessionview_formatactivitycoveragestate",
+      "label": "formatActivityCoverageState()",
+      "norm_label": "formatactivitycoveragestate()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L673"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registersessionview_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L596"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registersessionview_formatstatuslabel",
+      "label": "formatStatusLabel()",
+      "norm_label": "formatstatuslabel()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L635"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registersessionview_formatstoredamountforinput",
+      "label": "formatStoredAmountForInput()",
+      "norm_label": "formatstoredamountforinput()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L624"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registersessionview_formattimestamp",
+      "label": "formatTimestamp()",
+      "norm_label": "formattimestamp()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L628"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registersessionview_getactivityattentioncount",
+      "label": "getActivityAttentionCount()",
+      "norm_label": "getactivityattentioncount()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L719"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registersessionview_getactivitycoveragecopy",
+      "label": "getActivityCoverageCopy()",
+      "norm_label": "getactivitycoveragecopy()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L688"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registersessionview_getactivityrowkey",
+      "label": "getActivityRowKey()",
+      "norm_label": "getactivityrowkey()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L727"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registersessionview_getactivitystatusdotclass",
+      "label": "getActivityStatusDotClass()",
+      "norm_label": "getactivitystatusdotclass()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L704"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registersessionview_if",
+      "label": "if()",
+      "norm_label": "if()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L1123"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registersessionview_ismanagerstaff",
+      "label": "isManagerStaff()",
+      "norm_label": "ismanagerstaff()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L589"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registersessionview_onauthenticatecloseoutreviewapproval",
+      "label": "onAuthenticateCloseoutReviewApproval()",
+      "norm_label": "onauthenticatecloseoutreviewapproval()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L6094"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registersessionview_onauthenticateforapproval",
+      "label": "onAuthenticateForApproval()",
+      "norm_label": "onauthenticateforapproval()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L6145"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registersessionview_onauthenticatestaff",
+      "label": "onAuthenticateStaff()",
+      "norm_label": "onauthenticatestaff()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L6072"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registersessionview_oncorrectopeningfloat",
+      "label": "onCorrectOpeningFloat()",
+      "norm_label": "oncorrectopeningfloat()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L6237"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registersessionview_onfinalizecloseout",
+      "label": "onFinalizeCloseout()",
+      "norm_label": "onfinalizecloseout()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L6042"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registersessionview_onrecorddeposit",
+      "label": "onRecordDeposit()",
+      "norm_label": "onrecorddeposit()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L5952"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registersessionview_onreopencloseout",
+      "label": "onReopenCloseout()",
+      "norm_label": "onreopencloseout()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L6205"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registersessionview_onresolvesyncreview",
+      "label": "onResolveSyncReview()",
+      "norm_label": "onresolvesyncreview()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L5978"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registersessionview_onreviewcloseout",
+      "label": "onReviewCloseout()",
+      "norm_label": "onreviewcloseout()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L6175"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registersessionview_onsubmitcloseout",
+      "label": "onSubmitCloseout()",
+      "norm_label": "onsubmitcloseout()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L6003"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registersessionview_parseactivityfiltersearchvalue",
+      "label": "parseActivityFilterSearchValue()",
+      "norm_label": "parseactivityfiltersearchvalue()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L755"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registersessionview_parseactivitypagesearchvalue",
+      "label": "parseActivityPageSearchValue()",
+      "norm_label": "parseactivitypagesearchvalue()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L744"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registersessionview_parsereceiptactivitysummary",
+      "label": "parseReceiptActivitySummary()",
+      "norm_label": "parsereceiptactivitysummary()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L734"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registersessionview_switch",
+      "label": "switch()",
+      "norm_label": "switch()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L1282"
+    },
+    {
+      "community": 49,
+      "file_type": "code",
+      "id": "registersessionview_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx",
+      "source_location": "L584"
+    },
+    {
+      "community": 490,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_promocodes_ts",
       "label": "promoCodes.ts",
@@ -242686,7 +242782,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 490,
       "file_type": "code",
       "id": "promocodes_getbaseurl",
       "label": "getBaseUrl()",
@@ -242695,7 +242791,7 @@
       "source_location": "L4"
     },
     {
-      "community": 491,
+      "community": 490,
       "file_type": "code",
       "id": "promocodes_getpromocodeitems",
       "label": "getPromoCodeItems()",
@@ -242704,7 +242800,7 @@
       "source_location": "L49"
     },
     {
-      "community": 491,
+      "community": 490,
       "file_type": "code",
       "id": "promocodes_getpromocodes",
       "label": "getPromoCodes()",
@@ -242713,7 +242809,7 @@
       "source_location": "L34"
     },
     {
-      "community": 491,
+      "community": 490,
       "file_type": "code",
       "id": "promocodes_getredeemedpromocodes",
       "label": "getRedeemedPromoCodes()",
@@ -242722,7 +242818,7 @@
       "source_location": "L74"
     },
     {
-      "community": 491,
+      "community": 490,
       "file_type": "code",
       "id": "promocodes_redeempromocode",
       "label": "redeemPromoCode()",
@@ -242731,7 +242827,7 @@
       "source_location": "L6"
     },
     {
-      "community": 492,
+      "community": 491,
       "file_type": "code",
       "id": "billingdetails_clearform",
       "label": "clearForm()",
@@ -242740,7 +242836,7 @@
       "source_location": "L173"
     },
     {
-      "community": 492,
+      "community": 491,
       "file_type": "code",
       "id": "billingdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -242749,7 +242845,7 @@
       "source_location": "L102"
     },
     {
-      "community": 492,
+      "community": 491,
       "file_type": "code",
       "id": "billingdetails_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -242758,7 +242854,7 @@
       "source_location": "L201"
     },
     {
-      "community": 492,
+      "community": 491,
       "file_type": "code",
       "id": "billingdetails_onsubmit",
       "label": "onSubmit()",
@@ -242767,7 +242863,7 @@
       "source_location": "L150"
     },
     {
-      "community": 492,
+      "community": 491,
       "file_type": "code",
       "id": "billingdetails_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -242776,7 +242872,7 @@
       "source_location": "L155"
     },
     {
-      "community": 492,
+      "community": 491,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
       "label": "BillingDetails.tsx",
@@ -242785,7 +242881,7 @@
       "source_location": "L1"
     },
     {
-      "community": 493,
+      "community": 492,
       "file_type": "code",
       "id": "homehero_test_attachmedia",
       "label": "attachMedia()",
@@ -242794,7 +242890,7 @@
       "source_location": "L22"
     },
     {
-      "community": 493,
+      "community": 492,
       "file_type": "code",
       "id": "homehero_test_destroy",
       "label": "destroy()",
@@ -242803,7 +242899,7 @@
       "source_location": "L24"
     },
     {
-      "community": 493,
+      "community": 492,
       "file_type": "code",
       "id": "homehero_test_issupported",
       "label": "isSupported()",
@@ -242812,7 +242908,7 @@
       "source_location": "L18"
     },
     {
-      "community": 493,
+      "community": 492,
       "file_type": "code",
       "id": "homehero_test_loadsource",
       "label": "loadSource()",
@@ -242821,7 +242917,7 @@
       "source_location": "L21"
     },
     {
-      "community": 493,
+      "community": 492,
       "file_type": "code",
       "id": "homehero_test_on",
       "label": "on()",
@@ -242830,7 +242926,7 @@
       "source_location": "L23"
     },
     {
-      "community": 493,
+      "community": 492,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homehero_test_tsx",
       "label": "HomeHero.test.tsx",
@@ -242839,7 +242935,7 @@
       "source_location": "L1"
     },
     {
-      "community": 494,
+      "community": 493,
       "file_type": "code",
       "id": "mobileproductactions_collapseonpageclick",
       "label": "collapseOnPageClick()",
@@ -242848,7 +242944,7 @@
       "source_location": "L76"
     },
     {
-      "community": 494,
+      "community": 493,
       "file_type": "code",
       "id": "mobileproductactions_handleconfirm",
       "label": "handleConfirm()",
@@ -242857,7 +242953,7 @@
       "source_location": "L120"
     },
     {
-      "community": 494,
+      "community": 493,
       "file_type": "code",
       "id": "mobileproductactions_handleprimaryaction",
       "label": "handlePrimaryAction()",
@@ -242866,7 +242962,7 @@
       "source_location": "L129"
     },
     {
-      "community": 494,
+      "community": 493,
       "file_type": "code",
       "id": "mobileproductactions_handlesecondaryaction",
       "label": "handleSecondaryAction()",
@@ -242875,7 +242971,7 @@
       "source_location": "L133"
     },
     {
-      "community": 494,
+      "community": 493,
       "file_type": "code",
       "id": "mobileproductactions_updateposition",
       "label": "updatePosition()",
@@ -242884,7 +242980,7 @@
       "source_location": "L44"
     },
     {
-      "community": 494,
+      "community": 493,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
       "label": "MobileProductActions.tsx",
@@ -242893,7 +242989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 494,
       "file_type": "code",
       "id": "checkoutexpired_checkoutexpired",
       "label": "CheckoutExpired()",
@@ -242902,7 +242998,7 @@
       "source_location": "L9"
     },
     {
-      "community": 495,
+      "community": 494,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessiongeneric",
       "label": "CheckoutSessionGeneric()",
@@ -242911,7 +243007,7 @@
       "source_location": "L73"
     },
     {
-      "community": 495,
+      "community": 494,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessionnotfound",
       "label": "CheckoutSessionNotFound()",
@@ -242920,7 +243016,7 @@
       "source_location": "L54"
     },
     {
-      "community": 495,
+      "community": 494,
       "file_type": "code",
       "id": "checkoutexpired_handlesendemail",
       "label": "handleSendEmail()",
@@ -242929,7 +243025,7 @@
       "source_location": "L98"
     },
     {
-      "community": 495,
+      "community": 494,
       "file_type": "code",
       "id": "checkoutexpired_nocheckoutsession",
       "label": "NoCheckoutSession()",
@@ -242938,12 +243034,66 @@
       "source_location": "L33"
     },
     {
-      "community": 495,
+      "community": 494,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
       "label": "CheckoutExpired.tsx",
       "norm_label": "checkoutexpired.tsx",
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 495,
+      "file_type": "code",
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L101"
+    },
+    {
+      "community": 495,
+      "file_type": "code",
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 495,
+      "file_type": "code",
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 495,
+      "file_type": "code",
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 495,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 495,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1"
     },
     {
@@ -243849,254 +243999,263 @@
     {
       "community": 50,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_storeconfigv2_ts",
-      "label": "storeConfigV2.ts",
-      "norm_label": "storeconfigv2.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L1"
+      "id": "harness_scorecard_builddocumentationstatus",
+      "label": "buildDocumentationStatus()",
+      "norm_label": "builddocumentationstatus()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L299"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "storeconfigv2_asarray",
-      "label": "asArray()",
-      "norm_label": "asarray()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L77"
+      "id": "harness_scorecard_buildemptyhistorymetric",
+      "label": "buildEmptyHistoryMetric()",
+      "norm_label": "buildemptyhistorymetric()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L606"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "storeconfigv2_asboolean",
-      "label": "asBoolean()",
-      "norm_label": "asboolean()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L69"
+      "id": "harness_scorecard_buildgraphifystatus",
+      "label": "buildGraphifyStatus()",
+      "norm_label": "buildgraphifystatus()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L323"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "storeconfigv2_asmtnmomosetupstatus",
-      "label": "asMtnMomoSetupStatus()",
-      "norm_label": "asmtnmomosetupstatus()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L165"
+      "id": "harness_scorecard_buildinferentialsummarynote",
+      "label": "buildInferentialSummaryNote()",
+      "norm_label": "buildinferentialsummarynote()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L339"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "storeconfigv2_asnumber",
-      "label": "asNumber()",
-      "norm_label": "asnumber()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L61"
+      "id": "harness_scorecard_buildsummary",
+      "label": "buildSummary()",
+      "norm_label": "buildsummary()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L351"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "storeconfigv2_asoptionalarray",
-      "label": "asOptionalArray()",
-      "norm_label": "asoptionalarray()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L88"
+      "id": "harness_scorecard_collectharnessscorecard",
+      "label": "collectHarnessScorecard()",
+      "norm_label": "collectharnessscorecard()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L817"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "storeconfigv2_asrecord",
-      "label": "asRecord()",
-      "norm_label": "asrecord()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L57"
+      "id": "harness_scorecard_countmissingsnippets",
+      "label": "countMissingSnippets()",
+      "norm_label": "countmissingsnippets()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L292"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "storeconfigv2_assignordelete",
-      "label": "assignOrDelete()",
-      "norm_label": "assignordelete()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L525"
+      "id": "harness_scorecard_createfilesystem",
+      "label": "createFileSystem()",
+      "norm_label": "createfilesystem()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L248"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "storeconfigv2_asstring",
-      "label": "asString()",
-      "norm_label": "asstring()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L65"
+      "id": "harness_scorecard_extractscenarionames",
+      "label": "extractScenarioNames()",
+      "norm_label": "extractscenarionames()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L279"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "storeconfigv2_cleanundefined",
-      "label": "cleanUndefined()",
-      "norm_label": "cleanundefined()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L153"
+      "id": "harness_scorecard_extractscenariosection",
+      "label": "extractScenarioSection()",
+      "norm_label": "extractscenariosection()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L257"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "storeconfigv2_deepmerge",
-      "label": "deepMerge()",
-      "norm_label": "deepmerge()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L496"
+      "id": "harness_scorecard_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L227"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "storeconfigv2_firstdefined",
-      "label": "firstDefined()",
-      "norm_label": "firstdefined()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L99"
+      "id": "harness_scorecard_getdocumentedscenarioexpectations",
+      "label": "getDocumentedScenarioExpectations()",
+      "norm_label": "getdocumentedscenarioexpectations()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L507"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "storeconfigv2_getunknownstoreconfigrootkeys",
-      "label": "getUnknownStoreConfigRootKeys()",
-      "norm_label": "getunknownstoreconfigrootkeys()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L634"
+      "id": "harness_scorecard_hasanyharnessdocs",
+      "label": "hasAnyHarnessDocs()",
+      "norm_label": "hasanyharnessdocs()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L426"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "storeconfigv2_hasmtnmomoreceivingaccountdetails",
-      "label": "hasMtnMomoReceivingAccountDetails()",
-      "norm_label": "hasmtnmomoreceivingaccountdetails()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L178"
+      "id": "harness_scorecard_inspectappdocumentation",
+      "label": "inspectAppDocumentation()",
+      "norm_label": "inspectappdocumentation()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L443"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "storeconfigv2_islegacyrootkey",
-      "label": "isLegacyRootKey()",
-      "norm_label": "islegacyrootkey()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "id": "harness_scorecard_inspectdeliveryrunartifact",
+      "label": "inspectDeliveryRunArtifact()",
+      "norm_label": "inspectdeliveryrunartifact()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L761"
+    },
+    {
+      "community": 50,
+      "file_type": "code",
+      "id": "harness_scorecard_inspectgraphifyartifacts",
+      "label": "inspectGraphifyArtifacts()",
+      "norm_label": "inspectgraphifyartifacts()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L789"
+    },
+    {
+      "community": 50,
+      "file_type": "code",
+      "id": "harness_scorecard_inspectinferentialartifact",
+      "label": "inspectInferentialArtifact()",
+      "norm_label": "inspectinferentialartifact()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L520"
+    },
+    {
+      "community": 50,
+      "file_type": "code",
+      "id": "harness_scorecard_inspectinferentialhistory",
+      "label": "inspectInferentialHistory()",
+      "norm_label": "inspectinferentialhistory()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L616"
+    },
+    {
+      "community": 50,
+      "file_type": "code",
+      "id": "harness_scorecard_inspectruntimetrendartifact",
+      "label": "inspectRuntimeTrendArtifact()",
+      "norm_label": "inspectruntimetrendartifact()",
+      "source_file": "scripts/harness-scorecard.ts",
       "source_location": "L668"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "storeconfigv2_isplainobject",
-      "label": "isPlainObject()",
-      "norm_label": "isplainobject()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L53"
+      "id": "harness_scorecard_inspectruntimetrendhistory",
+      "label": "inspectRuntimeTrendHistory()",
+      "norm_label": "inspectruntimetrendhistory()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L711"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "storeconfigv2_isstorecheckoutdisabled",
-      "label": "isStoreCheckoutDisabled()",
-      "norm_label": "isstorecheckoutdisabled()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L642"
+      "id": "harness_scorecard_ishealthyinferentialstatus",
+      "label": "isHealthyInferentialStatus()",
+      "norm_label": "ishealthyinferentialstatus()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L335"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "storeconfigv2_isv2rootkey",
-      "label": "isV2RootKey()",
-      "norm_label": "isv2rootkey()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L672"
+      "id": "harness_scorecard_isruntimescenarioname",
+      "label": "isRuntimeScenarioName()",
+      "norm_label": "isruntimescenarioname()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L223"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "storeconfigv2_mapmtnmomoreceivingaccount",
-      "label": "mapMtnMomoReceivingAccount()",
-      "norm_label": "mapmtnmomoreceivingaccount()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L191"
+      "id": "harness_scorecard_listdirectory",
+      "label": "listDirectory()",
+      "norm_label": "listdirectory()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L240"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "storeconfigv2_mappromotion",
-      "label": "mapPromotion()",
-      "norm_label": "mappromotion()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L111"
+      "id": "harness_scorecard_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L213"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "storeconfigv2_mapstreamreel",
-      "label": "mapStreamReel()",
-      "norm_label": "mapstreamreel()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L115"
+      "id": "harness_scorecard_readjsonfile",
+      "label": "readJsonFile()",
+      "norm_label": "readjsonfile()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L236"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "storeconfigv2_mirrorlegacykeys",
-      "label": "mirrorLegacyKeys()",
-      "norm_label": "mirrorlegacykeys()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L538"
+      "id": "harness_scorecard_readtextfile",
+      "label": "readTextFile()",
+      "norm_label": "readtextfile()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L244"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "storeconfigv2_normalizemtnmomoreceivingaccounts",
-      "label": "normalizeMtnMomoReceivingAccounts()",
-      "norm_label": "normalizemtnmomoreceivingaccounts()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L214"
+      "id": "harness_scorecard_runharnessscorecard",
+      "label": "runHarnessScorecard()",
+      "norm_label": "runharnessscorecard()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L915"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "storeconfigv2_normalizestoreconfig",
-      "label": "normalizeStoreConfig()",
-      "norm_label": "normalizestoreconfig()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L492"
+      "id": "harness_scorecard_sortunique",
+      "label": "sortUnique()",
+      "norm_label": "sortunique()",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L217"
     },
     {
       "community": 50,
       "file_type": "code",
-      "id": "storeconfigv2_normalizewaivedeliveryfees",
-      "label": "normalizeWaiveDeliveryFees()",
-      "norm_label": "normalizewaivedeliveryfees()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L135"
-    },
-    {
-      "community": 50,
-      "file_type": "code",
-      "id": "storeconfigv2_patchv2config",
-      "label": "patchV2Config()",
-      "norm_label": "patchv2config()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L516"
-    },
-    {
-      "community": 50,
-      "file_type": "code",
-      "id": "storeconfigv2_removelegacyrootkeysfromconfig",
-      "label": "removeLegacyRootKeysFromConfig()",
-      "norm_label": "removelegacyrootkeysfromconfig()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L651"
-    },
-    {
-      "community": 50,
-      "file_type": "code",
-      "id": "storeconfigv2_tov2config",
-      "label": "toV2Config()",
-      "norm_label": "tov2config()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
-      "source_location": "L231"
+      "id": "scripts_harness_scorecard_ts",
+      "label": "harness-scorecard.ts",
+      "norm_label": "harness-scorecard.ts",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L1"
     },
     {
       "community": 500,
@@ -244596,254 +244755,254 @@
     {
       "community": 51,
       "file_type": "code",
-      "id": "packages_athena_webapp_shared_reportscontract_ts",
-      "label": "reportsContract.ts",
-      "norm_label": "reportscontract.ts",
-      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "id": "packages_athena_webapp_convex_inventory_storeconfigv2_ts",
+      "label": "storeConfigV2.ts",
+      "norm_label": "storeconfigv2.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L1"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "reportscontract_addweekmetrics",
-      "label": "addWeekMetrics()",
-      "norm_label": "addweekmetrics()",
-      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L244"
+      "id": "storeconfigv2_asarray",
+      "label": "asArray()",
+      "norm_label": "asarray()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L77"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "reportscontract_admissiblemovementdayrevision",
-      "label": "admissibleMovementDayRevision()",
-      "norm_label": "admissiblemovementdayrevision()",
-      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1162"
+      "id": "storeconfigv2_asboolean",
+      "label": "asBoolean()",
+      "norm_label": "asboolean()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L69"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "reportscontract_combineweekcompleteness",
-      "label": "combineWeekCompleteness()",
-      "norm_label": "combineweekcompleteness()",
-      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L317"
+      "id": "storeconfigv2_asmtnmomosetupstatus",
+      "label": "asMtnMomoSetupStatus()",
+      "norm_label": "asmtnmomosetupstatus()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L165"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "reportscontract_computemixrequestkey",
-      "label": "computeMixRequestKey()",
-      "norm_label": "computemixrequestkey()",
-      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1358"
+      "id": "storeconfigv2_asnumber",
+      "label": "asNumber()",
+      "norm_label": "asnumber()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L61"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "reportscontract_computemovementrequestkey",
-      "label": "computeMovementRequestKey()",
-      "norm_label": "computemovementrequestkey()",
-      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1139"
+      "id": "storeconfigv2_asoptionalarray",
+      "label": "asOptionalArray()",
+      "norm_label": "asoptionalarray()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L88"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "reportscontract_dayperiodkey",
-      "label": "dayPeriodKey()",
-      "norm_label": "dayperiodkey()",
-      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L709"
+      "id": "storeconfigv2_asrecord",
+      "label": "asRecord()",
+      "norm_label": "asrecord()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L57"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "reportscontract_derivemixrequestlifecycle",
-      "label": "deriveMixRequestLifecycle()",
-      "norm_label": "derivemixrequestlifecycle()",
-      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1405"
+      "id": "storeconfigv2_assignordelete",
+      "label": "assignOrDelete()",
+      "norm_label": "assignordelete()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L525"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "reportscontract_derivemovementrequestlifecycle",
-      "label": "deriveMovementRequestLifecycle()",
-      "norm_label": "derivemovementrequestlifecycle()",
-      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1269"
+      "id": "storeconfigv2_asstring",
+      "label": "asString()",
+      "norm_label": "asstring()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L65"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "reportscontract_derivepaymentposture",
-      "label": "derivePaymentPosture()",
-      "norm_label": "derivepaymentposture()",
-      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L576"
+      "id": "storeconfigv2_cleanundefined",
+      "label": "cleanUndefined()",
+      "norm_label": "cleanundefined()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L153"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "reportscontract_descendingsortkey",
-      "label": "descendingSortKey()",
-      "norm_label": "descendingsortkey()",
-      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L763"
+      "id": "storeconfigv2_deepmerge",
+      "label": "deepMerge()",
+      "norm_label": "deepmerge()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L496"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "reportscontract_inclusiveoperatingdayspan",
-      "label": "inclusiveOperatingDaySpan()",
-      "norm_label": "inclusiveoperatingdayspan()",
-      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1054"
+      "id": "storeconfigv2_firstdefined",
+      "label": "firstDefined()",
+      "norm_label": "firstdefined()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L99"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "reportscontract_isreportingtodayinprogress",
-      "label": "isReportingTodayInProgress()",
-      "norm_label": "isreportingtodayinprogress()",
-      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L83"
+      "id": "storeconfigv2_getunknownstoreconfigrootkeys",
+      "label": "getUnknownStoreConfigRootKeys()",
+      "norm_label": "getunknownstoreconfigrootkeys()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L634"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "reportscontract_isvalidoperatingdatelabel",
-      "label": "isValidOperatingDateLabel()",
-      "norm_label": "isvalidoperatingdatelabel()",
-      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1042"
+      "id": "storeconfigv2_hasmtnmomoreceivingaccountdetails",
+      "label": "hasMtnMomoReceivingAccountDetails()",
+      "norm_label": "hasmtnmomoreceivingaccountdetails()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L178"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "reportscontract_mixrequestkeyidentity",
-      "label": "mixRequestKeyIdentity()",
-      "norm_label": "mixrequestkeyidentity()",
-      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1343"
+      "id": "storeconfigv2_islegacyrootkey",
+      "label": "isLegacyRootKey()",
+      "norm_label": "islegacyrootkey()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L668"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "reportscontract_mixunitssoldsortkey",
-      "label": "mixUnitsSoldSortKey()",
-      "norm_label": "mixunitssoldsortkey()",
-      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1373"
+      "id": "storeconfigv2_isplainobject",
+      "label": "isPlainObject()",
+      "norm_label": "isplainobject()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L53"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "reportscontract_monthperiodkey",
-      "label": "monthPeriodKey()",
-      "norm_label": "monthperiodkey()",
-      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L713"
+      "id": "storeconfigv2_isstorecheckoutdisabled",
+      "label": "isStoreCheckoutDisabled()",
+      "norm_label": "isstorecheckoutdisabled()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L642"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "reportscontract_movementabsnetunitssortkey",
-      "label": "movementAbsNetUnitsSortKey()",
-      "norm_label": "movementabsnetunitssortkey()",
-      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1205"
+      "id": "storeconfigv2_isv2rootkey",
+      "label": "isV2RootKey()",
+      "norm_label": "isv2rootkey()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L672"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "reportscontract_movementpagecount",
-      "label": "movementPageCount()",
-      "norm_label": "movementpagecount()",
-      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1255"
+      "id": "storeconfigv2_mapmtnmomoreceivingaccount",
+      "label": "mapMtnMomoReceivingAccount()",
+      "norm_label": "mapmtnmomoreceivingaccount()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L191"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "reportscontract_movementrequestkeyidentity",
-      "label": "movementRequestKeyIdentity()",
-      "norm_label": "movementrequestkeyidentity()",
-      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1119"
+      "id": "storeconfigv2_mappromotion",
+      "label": "mapPromotion()",
+      "norm_label": "mappromotion()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L111"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "reportscontract_movementsourcerowmatchesrevision",
-      "label": "movementSourceRowMatchesRevision()",
-      "norm_label": "movementsourcerowmatchesrevision()",
-      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1184"
+      "id": "storeconfigv2_mapstreamreel",
+      "label": "mapStreamReel()",
+      "norm_label": "mapstreamreel()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L115"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "reportscontract_normalizecurrencycode",
-      "label": "normalizeCurrencyCode()",
-      "norm_label": "normalizecurrencycode()",
-      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L773"
+      "id": "storeconfigv2_mirrorlegacykeys",
+      "label": "mirrorLegacyKeys()",
+      "norm_label": "mirrorlegacykeys()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L538"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "reportscontract_normalizeweekmetrics",
-      "label": "normalizeWeekMetrics()",
-      "norm_label": "normalizeweekmetrics()",
-      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L211"
+      "id": "storeconfigv2_normalizemtnmomoreceivingaccounts",
+      "label": "normalizeMtnMomoReceivingAccounts()",
+      "norm_label": "normalizemtnmomoreceivingaccounts()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L214"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "reportscontract_periodkeysforoperatingdate",
-      "label": "periodKeysForOperatingDate()",
-      "norm_label": "periodkeysforoperatingdate()",
-      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L752"
+      "id": "storeconfigv2_normalizestoreconfig",
+      "label": "normalizeStoreConfig()",
+      "norm_label": "normalizestoreconfig()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L492"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "reportscontract_trailingsixmonthsstart",
-      "label": "trailingSixMonthsStart()",
-      "norm_label": "trailingsixmonthsstart()",
-      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L728"
+      "id": "storeconfigv2_normalizewaivedeliveryfees",
+      "label": "normalizeWaiveDeliveryFees()",
+      "norm_label": "normalizewaivedeliveryfees()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L135"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "reportscontract_trailingthreemonthsstart",
-      "label": "trailingThreeMonthsStart()",
-      "norm_label": "trailingthreemonthsstart()",
-      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L718"
+      "id": "storeconfigv2_patchv2config",
+      "label": "patchV2Config()",
+      "norm_label": "patchv2config()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L516"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "reportscontract_validatereportrangerequest",
-      "label": "validateReportRangeRequest()",
-      "norm_label": "validatereportrangerequest()",
-      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1069"
+      "id": "storeconfigv2_removelegacyrootkeysfromconfig",
+      "label": "removeLegacyRootKeysFromConfig()",
+      "norm_label": "removelegacyrootkeysfromconfig()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L651"
     },
     {
       "community": 51,
       "file_type": "code",
-      "id": "reportscontract_weekperiodkey",
-      "label": "weekPeriodKey()",
-      "norm_label": "weekperiodkey()",
-      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L742"
+      "id": "storeconfigv2_tov2config",
+      "label": "toV2Config()",
+      "norm_label": "tov2config()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
+      "source_location": "L231"
     },
     {
       "community": 510,
@@ -256021,7 +256180,7 @@
       "label": "certifiedDay()",
       "norm_label": "certifiedday()",
       "source_file": "packages/athena-webapp/convex/reports/foldVersionRepair.test.ts",
-      "source_location": "L153"
+      "source_location": "L159"
     },
     {
       "community": 674,
@@ -256030,7 +256189,7 @@
       "label": "createCtx()",
       "norm_label": "createctx()",
       "source_file": "packages/athena-webapp/convex/reports/foldVersionRepair.test.ts",
-      "source_location": "L35"
+      "source_location": "L36"
     },
     {
       "community": 674,
@@ -256039,7 +256198,7 @@
       "label": "day()",
       "norm_label": "day()",
       "source_file": "packages/athena-webapp/convex/reports/foldVersionRepair.test.ts",
-      "source_location": "L137"
+      "source_location": "L138"
     },
     {
       "community": 674,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2759
-- Graph nodes: 11538
-- Graph edges: 14170
+- Graph nodes: 11545
+- Graph edges: 14178
 - Communities: 2684
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (15 edges, Community 140) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (6 edges, Community 296) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (6 edges, Community 298) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `createRedisClient()` (4 edges, Community 140) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossCluster()` (4 edges, Community 140) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossClusterWithPipeline()` (4 edges, Community 140) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/convex/reports/contract.test.ts
+++ b/packages/athena-webapp/convex/reports/contract.test.ts
@@ -35,6 +35,8 @@ import {
   REPORT_RANGE_TTL_MS,
   REPORT_DRILLDOWN_RANGE_MAX_DAYS,
   REPORT_SKU_MIX_SYNC_MAX_DAYS,
+  REPORT_SKU_MIX_SYNC_ROW_BUDGET,
+  skuMixSyncRowProbe,
   REPORT_TRAILING_SIX_MONTHS_MAX_DAYS,
   REPORTS_FOLD_VERSION,
   trailingSixMonthsStart,
@@ -1188,5 +1190,99 @@ describe("U1 six-month vocabulary and named ceilings", () => {
       sku_movement: 184,
       sku_mix: 184,
     });
+  });
+});
+
+describe("skuMixSyncRowProbe", () => {
+  const day = (operatingDate: string, skuDayRowCount?: number) => ({
+    operatingDate,
+    ...(skuDayRowCount === undefined ? {} : { skuDayRowCount }),
+  });
+  const probe = (
+    rows: { operatingDate: string; skuDayRowCount?: number }[],
+    range?: Partial<{
+      coverageEndDate: string;
+      coverageStartDate: string;
+      endDate: string;
+      startDate: string;
+    }>,
+  ) =>
+    skuMixSyncRowProbe({
+      coverageEndDate: "2026-07-05",
+      coverageStartDate: "2026-07-01",
+      endDate: "2026-07-05",
+      rows,
+      startDate: "2026-07-01",
+      ...range,
+    });
+
+  it("sums the folded row counts across the range", () => {
+    expect(
+      probe([day("2026-07-01", 30), day("2026-07-03", 12), day("2026-07-05", 8)]),
+    ).toBe(50);
+  });
+
+  it("keeps the budget strictly under the reader's fail-closed cap", () => {
+    // The gap is the whole point: the probe sizes rows folded a moment before
+    // the read, so it must leave room for a concurrent fold to add some.
+    expect(REPORT_SKU_MIX_SYNC_ROW_BUDGET).toBeLessThan(5_000);
+  });
+
+  it("counts an absent day as zero — reportDay is sparse", () => {
+    // No document means no activity means no reportSkuDay rows. Treating a
+    // gap as unknown would make quiet ranges — the cheapest ones — unprovable.
+    expect(probe([day("2026-07-02", 5)])).toBe(5);
+    expect(probe([])).toBe(0);
+  });
+
+  it("ignores rows outside the requested range", () => {
+    // The days rail loads a superset of the mix selection, so this is the
+    // normal case, not an edge one.
+    expect(
+      probe([day("2026-07-01", 100), day("2026-07-03", 7)], {
+        endDate: "2026-07-04",
+        startDate: "2026-07-02",
+      }),
+    ).toBe(7);
+  });
+
+  it("is indeterminate when a day in range predates the count", () => {
+    expect(probe([day("2026-07-01", 30), day("2026-07-03")])).toBeUndefined();
+  });
+
+  it("is determinate when the uncounted day falls outside the range", () => {
+    expect(
+      probe([day("2026-07-01"), day("2026-07-04", 9)], {
+        coverageStartDate: "2026-07-01",
+        endDate: "2026-07-05",
+        startDate: "2026-07-03",
+      }),
+    ).toBe(9);
+  });
+
+  it("is indeterminate when coverage is narrower than the range", () => {
+    // Row presence cannot prove the reader looked: a range extending past the
+    // loaded window would otherwise sum to a confident understatement.
+    expect(
+      probe([day("2026-07-01", 4)], {
+        coverageEndDate: "2026-07-03",
+        endDate: "2026-07-05",
+      }),
+    ).toBeUndefined();
+    expect(
+      probe([day("2026-07-05", 4)], {
+        coverageStartDate: "2026-07-03",
+        startDate: "2026-07-01",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("accepts coverage wider than the range", () => {
+    expect(
+      probe([day("2026-07-03", 6)], {
+        coverageEndDate: "2026-08-01",
+        coverageStartDate: "2026-06-01",
+      }),
+    ).toBe(6);
   });
 });

--- a/packages/athena-webapp/convex/reports/foldVersionRepair.test.ts
+++ b/packages/athena-webapp/convex/reports/foldVersionRepair.test.ts
@@ -15,6 +15,7 @@ type DayRow = {
   operatingDate: string;
   foldVersion: number;
   certifiedFoldRevision?: number;
+  skuDayRowCount?: number;
 };
 
 type DirtyRow = {
@@ -149,12 +150,20 @@ function day(
   };
 }
 
-/** A fully repaired row: current fold version AND a certified revision. */
+/**
+ * A fully repaired row: current fold version, a certified revision, AND the
+ * U8 `skuDayRowCount`. A row missing any of the three is still refold-bait,
+ * so this helper must carry all of them or every "leaves it alone" assertion
+ * silently stops testing what it claims to.
+ */
 function certifiedDay(
   operatingDate: string,
   storeId: string = String(STORE),
 ): DayRow {
-  return day(operatingDate, REPORTS_FOLD_VERSION, storeId, 1);
+  return {
+    ...day(operatingDate, REPORTS_FOLD_VERSION, storeId, 1),
+    skuDayRowCount: 12,
+  };
 }
 
 describe("fold version repair", () => {
@@ -263,6 +272,51 @@ describe("fold version repair", () => {
     expect(
       harness.dirtyRows.map((row) => [row.operatingDate, row.reason]),
     ).toEqual([["2026-07-01", "fold_version_bump"]]);
+  });
+
+  it("marks a certified day that predates the sku row count, and says why", async () => {
+    // The U8 backfill: fully trustworthy rows whose only gap is the mix
+    // probe's sizing hint. Counted separately from `missingRevisionCount` so
+    // the operator does not read a performance backfill as a trust failure.
+    const harness = createCtx([
+      { ...certifiedDay("2026-07-01"), skuDayRowCount: undefined },
+      certifiedDay("2026-07-02"),
+    ]);
+
+    const result = await markStaleFoldVersionDaysWithCtx(harness.ctx, {
+      storeId: STORE,
+    });
+
+    expect(result).toMatchObject({
+      isDone: true,
+      markedCount: 1,
+      staleCount: 1,
+      missingRevisionCount: 0,
+      missingSkuDayRowCountCount: 1,
+    });
+    expect(
+      harness.dirtyRows.map((row) => [row.operatingDate, row.reason]),
+    ).toEqual([["2026-07-01", "fold_version_bump"]]);
+  });
+
+  it("treats a zero sku row count as measured, not missing", async () => {
+    // A day that folded no SKU rows stores 0. Confusing that with "unknown"
+    // would put every quiet day into a permanent refold loop, and would make
+    // the mix probe unable to prove exactly the ranges that are cheapest.
+    const harness = createCtx([
+      { ...certifiedDay("2026-07-01"), skuDayRowCount: 0 },
+    ]);
+
+    const result = await markStaleFoldVersionDaysWithCtx(harness.ctx, {
+      storeId: STORE,
+    });
+
+    expect(result).toMatchObject({
+      markedCount: 0,
+      staleCount: 0,
+      missingSkuDayRowCountCount: 0,
+    });
+    expect(harness.dirtyRows).toEqual([]);
   });
 
   it("drives itself to completion when autoContinue is set", async () => {

--- a/packages/athena-webapp/convex/reports/foldVersionRepair.ts
+++ b/packages/athena-webapp/convex/reports/foldVersionRepair.ts
@@ -73,6 +73,26 @@ export function needsCertifiedRefold(day: {
   );
 }
 
+/**
+ * The U8 backfill predicate: a day folded before `skuDayRowCount` existed.
+ *
+ * Kept separate from `needsCertifiedRefold` because it is a different claim —
+ * certification is the movement lane's TRUST boundary, this is only the mix
+ * lane's SIZING hint. A day missing the count is fully trustworthy; the mix
+ * probe simply cannot size it and falls back to the span rule (see
+ * `skuMixSyncRowProbe`). Merging the two would make `countUncertifiedDays`
+ * report a movement-readiness failure for what is a performance shortfall.
+ *
+ * Deliberately no fold-version bump: the fold's OUTPUT is unchanged, so
+ * refolding is not a correctness repair and must not invalidate certified
+ * provenance for stores that are already movement-ready.
+ */
+export function skuDayRowCountBackfillNeeded(day: {
+  skuDayRowCount?: number | null;
+}): boolean {
+  return day.skuDayRowCount === undefined || day.skuDayRowCount === null;
+}
+
 const DEFAULT_LIMIT = 25;
 const MAX_LIMIT = 100;
 
@@ -109,12 +129,22 @@ export async function markStaleFoldVersionDaysWithCtx(
 ) {
   const now = Date.now();
   const page = await dayPage(ctx, args);
-  const stale = page.page.filter(needsCertifiedRefold);
+  const stale = page.page.filter(
+    (day) => needsCertifiedRefold(day) || skuDayRowCountBackfillNeeded(day),
+  );
   // Current-version rows that were never revision-certified (an anomaly once
   // fold stamping is live, since a version bump ships with it) — reported
-  // separately so the operator can tell the two staleness causes apart.
+  // separately so the operator can tell the staleness causes apart. Tested
+  // directly rather than inferred from "stale AND current version", which
+  // since U8 also matches a certified day that only wants the row count.
   const missingRevisionCount = stale.filter(
-    (day) => day.foldVersion === REPORTS_FOLD_VERSION,
+    (day) =>
+      day.foldVersion === REPORTS_FOLD_VERSION &&
+      (day.certifiedFoldRevision === undefined ||
+        day.certifiedFoldRevision === null),
+  ).length;
+  const missingSkuDayRowCountCount = stale.filter(
+    skuDayRowCountBackfillNeeded,
   ).length;
 
   let markedCount = 0;
@@ -190,6 +220,7 @@ export async function markStaleFoldVersionDaysWithCtx(
     alreadyQueuedCount,
     staleCount: stale.length,
     missingRevisionCount,
+    missingSkuDayRowCountCount,
     // Cumulative across an `autoContinue` chain; equal to this batch when the
     // caller is driving the cursor itself.
     totals,
@@ -219,6 +250,12 @@ export async function countStaleFoldVersionDaysWithCtx(
     staleCount: page.page.filter(
       (day) => day.foldVersion !== REPORTS_FOLD_VERSION,
     ).length,
+    // U8 backfill drain gauge. Reported here rather than on
+    // `countUncertifiedDays` because a missing count is not an uncertified
+    // day: the mix probe degrades to the span rule, the movement lane is
+    // unaffected, and conflating them would gate a rollout on a hint.
+    missingSkuDayRowCountCount: page.page.filter(skuDayRowCountBackfillNeeded)
+      .length,
   };
 }
 

--- a/packages/athena-webapp/convex/reports/ingest.test.ts
+++ b/packages/athena-webapp/convex/reports/ingest.test.ts
@@ -705,6 +705,67 @@ describe("recordFacts — day routing", () => {
     });
   });
 
+  it("keeps skuDayRowCount exact across incremental sku-row inserts", async () => {
+    // The mix probe's between-folds guarantee (U8): the open day's published
+    // count tracks the rows ingest itself inserts. A new SKU's first fact
+    // grows it; more facts for a counted SKU do not.
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      const { skuId, otherSkuId, storeId } = await seed(ctx);
+
+      await recordFacts(ctx, storeId, [saleFact({ productSkuId: skuId })]);
+      expect(await readDay(ctx, storeId, TODAY)).toMatchObject({
+        skuDayRowCount: 1,
+      });
+
+      await recordFacts(ctx, storeId, [
+        saleFact({ productSkuId: skuId, sourceId: "txn_2" }),
+        saleFact({ productSkuId: otherSkuId, sourceId: "txn_3" }),
+      ]);
+      const day = await readDay(ctx, storeId, TODAY);
+      expect(day).toMatchObject({ factCount: 3, skuDayRowCount: 2 });
+      // eslint-disable-next-line @convex-dev/no-collect-in-query -- convex-test fixture read, not a production query
+      expect(await ctx.db.query("reportSkuDay").collect()).toHaveLength(2);
+    });
+  });
+
+  it("stores a zero skuDayRowCount for a day opened without SKU attribution", async () => {
+    // Zero is a measurement, not a gap: the probe must be able to prove this
+    // day cheap rather than falling back to the span rule on it.
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      const { storeId } = await seed(ctx);
+      await recordFacts(ctx, storeId, [saleFact()]);
+      expect(await readDay(ctx, storeId, TODAY)).toMatchObject({
+        skuDayRowCount: 0,
+      });
+    });
+  });
+
+  it("leaves skuDayRowCount absent on a pre-U8 day rather than guessing", async () => {
+    // The base is unknown, so base + inserts would be a guess presented as a
+    // measurement. The day stays unprovable until its backfill refold.
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      const { skuId, storeId } = await seed(ctx);
+      await recordFacts(ctx, storeId, [saleFact({ productSkuId: skuId })]);
+      const day = await readDay(ctx, storeId, TODAY);
+      await ctx.db.patch("reportDay", day!._id, {
+        skuDayRowCount: undefined,
+      });
+
+      await recordFacts(ctx, storeId, [
+        saleFact({ productSkuId: skuId, sourceId: "txn_2" }),
+      ]);
+      const patched = await readDay(ctx, storeId, TODAY);
+      expect(patched?.factCount).toBe(2);
+      expect(patched?.skuDayRowCount).toBeUndefined();
+    });
+  });
+
   it("does nothing at all for an empty fact list", async () => {
     vi.spyOn(Date, "now").mockReturnValue(NOW);
     const t = convexTest(schema, modules);

--- a/packages/athena-webapp/convex/reports/ingest.ts
+++ b/packages/athena-webapp/convex/reports/ingest.ts
@@ -448,48 +448,10 @@ async function applyToOpenDay(
         Math.abs(base.paymentsRefundedMinor)
       : 0);
 
-  const dayPatch = {
-    ...next,
-    currency: base.currency,
-    status: existing?.status ?? ("open" as const),
-    foldVersion: base.foldVersion,
-    factCount,
-    lastFactRecordedAt,
-    flags,
-    paymentPosture: derivePaymentPosture({
-      collectedMinor: next.paymentsCollectedMinor,
-      refundedMinor: next.paymentsRefundedMinor,
-      allocatedMinor: next.paymentAllocatedMinor,
-      allocationOmittedMinor:
-        priorAllocationOmittedMinor + batchAllocationOmittedMinor,
-    }),
-  };
-
-  if (existing) {
-    await ctx.db.patch("reportDay", existing._id, dayPatch);
-  } else {
-    await ctx.db.insert("reportDay", {
-      storeId,
-      operatingDate,
-      ...dayPatch,
-    });
-
-    // Rollover: opening a new day is the moment any *older* still-open day
-    // stops being current. Dirty it so the sweeper folds it to `provisional`
-    // (day_open folds preserve `open`; late_fact folds do not) — without this,
-    // a day that never gets a close would stay `open` forever.
-    const recentDays = await ctx.db
-      .query("reportDay")
-      .withIndex("by_storeId_operatingDate", (q) => q.eq("storeId", storeId))
-      .order("desc")
-      .take(ROLLOVER_OPEN_DAY_SCAN);
-    for (const day of recentDays) {
-      if (day.operatingDate < operatingDate && day.status === "open") {
-        await markDirty(ctx, storeId, day.operatingDate, "late_fact");
-      }
-    }
-  }
-
+  // SKU rows are upserted BEFORE the day doc so the day's `skuDayRowCount`
+  // can include this batch's inserts in the same write — the count and the
+  // rows must come out of one mutation or the mix probe reads drift (U8).
+  let insertedSkuRowCount = 0;
   for (const [productSkuId, entry] of skuDeltas) {
     const skuId = productSkuId as Id<"productSku">;
     const existingSku = await ctx.db
@@ -528,6 +490,69 @@ async function applyToOpenDay(
         operatingDate,
         ...merged,
       });
+      insertedSkuRowCount += 1;
+    }
+  }
+
+  /**
+   * The day's published SKU-row size, kept exact between folds (U8):
+   *
+   *   - new day: this batch's inserts are its only rows, so the count is
+   *     exactly `insertedSkuRowCount`;
+   *   - existing day with a count: the base plus this batch's inserts —
+   *     patches touched existing rows and deletes never happen here (only the
+   *     fold removes rows);
+   *   - existing day without a count (pre-U8): stays absent. The base is
+   *     unknown, so any number written here would be a guess presented as a
+   *     measurement; `undefined` on patch erases nothing that exists, and the
+   *     backfill refold supplies the real value.
+   */
+  const skuDayRowCount = existing
+    ? existing.skuDayRowCount === undefined
+      ? undefined
+      : existing.skuDayRowCount + insertedSkuRowCount
+    : insertedSkuRowCount;
+
+  const dayPatch = {
+    ...next,
+    currency: base.currency,
+    status: existing?.status ?? ("open" as const),
+    foldVersion: base.foldVersion,
+    factCount,
+    skuDayRowCount,
+    lastFactRecordedAt,
+    flags,
+    paymentPosture: derivePaymentPosture({
+      collectedMinor: next.paymentsCollectedMinor,
+      refundedMinor: next.paymentsRefundedMinor,
+      allocatedMinor: next.paymentAllocatedMinor,
+      allocationOmittedMinor:
+        priorAllocationOmittedMinor + batchAllocationOmittedMinor,
+    }),
+  };
+
+  if (existing) {
+    await ctx.db.patch("reportDay", existing._id, dayPatch);
+  } else {
+    await ctx.db.insert("reportDay", {
+      storeId,
+      operatingDate,
+      ...dayPatch,
+    });
+
+    // Rollover: opening a new day is the moment any *older* still-open day
+    // stops being current. Dirty it so the sweeper folds it to `provisional`
+    // (day_open folds preserve `open`; late_fact folds do not) — without this,
+    // a day that never gets a close would stay `open` forever.
+    const recentDays = await ctx.db
+      .query("reportDay")
+      .withIndex("by_storeId_operatingDate", (q) => q.eq("storeId", storeId))
+      .order("desc")
+      .take(ROLLOVER_OPEN_DAY_SCAN);
+    for (const day of recentDays) {
+      if (day.operatingDate < operatingDate && day.status === "open") {
+        await markDirty(ctx, storeId, day.operatingDate, "late_fact");
+      }
     }
   }
 }

--- a/packages/athena-webapp/convex/reports/queries.test.ts
+++ b/packages/athena-webapp/convex/reports/queries.test.ts
@@ -522,11 +522,25 @@ describe("listDays", () => {
 });
 
 describe("listRangeSkuMix", () => {
-  it("still rejects a range spanning more than 92 days after the U7 drill-down raise", async () => {
-    // The synchronous mix reader keeps its 92-day server cap on purpose: the
-    // client routes only <=2-day spans here (U5); longer spans use the async
-    // snapshot. Widening this cap would let a direct caller exceed what the
-    // 5,000-row synchronous read can serve.
+  it("serves a range past the legacy 92-day cap now that the client sizes the read", async () => {
+    // U8 moved this reader from the 92-day proxy cap to the 184-day
+    // drill-down ceiling. The client no longer proves a range is cheap by
+    // being short — it sums folded `skuDayRowCount` totals — so a long, quiet
+    // range is a legitimate synchronous request and must not be refused on
+    // span alone. The row cap below is what actually bounds this read.
+    const t = convexTest(schema, modules);
+    const { storeId } = await seedStore(t);
+    const result = await t.run((ctx) =>
+      handlerOf(listRangeSkuMix)(ctx, {
+        storeId,
+        startDate: "2026-01-01",
+        endDate: "2026-04-03", // 93 days inclusive
+      }),
+    );
+    expect(result).toEqual({ rows: [], skuCount: 0, totalUnitsSold: 0 });
+  });
+
+  it("still rejects a range past the 184-day drill-down ceiling", async () => {
     const t = convexTest(schema, modules);
     const { storeId } = await seedStore(t);
     await expect(
@@ -534,10 +548,44 @@ describe("listRangeSkuMix", () => {
         handlerOf(listRangeSkuMix)(ctx, {
           storeId,
           startDate: "2026-01-01",
-          endDate: "2026-04-03", // 93 days inclusive
+          endDate: "2026-07-04", // 185 days inclusive
         }),
       ),
-    ).rejects.toThrow(/92 days/);
+    ).rejects.toThrow(/184 days/);
+  });
+
+  it("still fails closed past the row cap, whatever the span", async () => {
+    // The bound that replaced the span proxy. A probe-approved range that
+    // grew between the sizing and the read must hit this, not silently
+    // present an understated mix.
+    const t = convexTest(schema, modules);
+    const { storeId } = await seedStore(t);
+    const productSkuId = await seedSku(t, storeId);
+    await t.run(async (ctx) => {
+      for (let index = 0; index <= 5_000; index += 1) {
+        await ctx.db.insert("reportSkuDay", {
+          storeId,
+          productSkuId,
+          operatingDate: "2026-01-01",
+          unitsSold: 1,
+          unitsReturned: 0,
+          grossSalesMinor: 100,
+          netSalesMinor: 100,
+          refundsMinor: 0,
+          uncostedRevenueMinor: 0,
+          grossProfitMinor: 100,
+        });
+      }
+    });
+    await expect(
+      t.run((ctx) =>
+        handlerOf(listRangeSkuMix)(ctx, {
+          storeId,
+          startDate: "2026-01-01",
+          endDate: "2026-01-01",
+        }),
+      ),
+    ).rejects.toThrow(/too much activity/);
   });
 
   it("returns the five leading SKUs by units and groups the remainder", async () => {

--- a/packages/athena-webapp/convex/reports/queries.ts
+++ b/packages/athena-webapp/convex/reports/queries.ts
@@ -63,13 +63,16 @@ import { transactionCountFromCloseSummary } from "./transactionCounts";
  */
 
 /**
- * Span ceiling for the SYNCHRONOUS range readers only (`listRangeSkuMix`,
- * `listRangeSkuMovement`). Deliberately narrower than
- * `REPORT_DRILLDOWN_RANGE_MAX_DAYS` (184): both readers serve a single
- * bounded 5,000-row read, and U5's span routing sends anything longer than
- * two days to the async range-snapshot lifecycle instead. The drill-down
- * surfaces (`listDays`, `getSkuDetail`) validate against the shared 184-day
- * constant directly.
+ * Span ceiling for the legacy synchronous movement reader
+ * (`listRangeSkuMovement`). Deliberately narrower than
+ * `REPORT_DRILLDOWN_RANGE_MAX_DAYS` (184): it serves a single bounded
+ * 5,000-row read with no way to size that read in advance, so a narrow span
+ * is the only available proxy for a bounded cost.
+ *
+ * `listRangeSkuMix` used this too until U8, when the days rail began
+ * publishing exact `skuDayRowCount` totals — it can now size the read
+ * directly and validates against the 184-day drill-down ceiling instead. The
+ * drill-down surfaces (`listDays`, `getSkuDetail`) always did.
  */
 const RANGE_SYNC_READER_MAX_SPAN_DAYS = 92;
 const RANGE_SKU_MIX_ROW_LIMIT = 5_000;
@@ -443,6 +446,8 @@ function toReportDayRow(doc: Doc<"reportDay">): ReportDayRow {
     currency: doc.currency,
     flags: doc.flags,
     factCount: doc.factCount,
+    // Undefined for the pre-U8 generation; the probe treats that as unknown.
+    skuDayRowCount: doc.skuDayRowCount,
     closeVarianceMinor: doc.closeVarianceMinor,
     postCloseNetSalesDeltaMinor: doc.postCloseNetSalesDeltaMinor,
     grossSalesMinor: doc.grossSalesMinor,
@@ -786,12 +791,25 @@ export const listRangeSkuMix = query({
   },
   handler: async (ctx, args): Promise<ReportSkuMixData> => {
     await requireReportsStoreAccess(ctx, args.storeId);
-    // Sync path only: spans over REPORT_SKU_MIX_SYNC_MAX_DAYS are routed to
-    // the async snapshot by the client; this server cap stays at 92 (U7).
+    /**
+     * Span ceiling widened to the drill-down maximum in U8. The span is no
+     * longer what bounds this read — `RANGE_SKU_MIX_ROW_LIMIT` is, and it
+     * always was. Until U8 the client could only prove a range was cheap by
+     * being short (<=2 days), so a narrow span cap was the proxy; now it
+     * proves it directly from folded `skuDayRowCount` totals
+     * (`skuMixSyncRowProbe`) and can legitimately ask for a 120-day range
+     * that reads 3,000 rows. Rejecting that on span alone would send a read
+     * this reader can serve to the async snapshot instead.
+     *
+     * The row cap below still fails closed, and it is the real bound: no span
+     * this validator now admits can exceed it without the `.take()` tripping.
+     * The legacy movement reader keeps `RANGE_SYNC_READER_MAX_SPAN_DAYS` —
+     * it has no probe, so span remains its only proxy.
+     */
     requireValidDateRange(
       args.startDate,
       args.endDate,
-      RANGE_SYNC_READER_MAX_SPAN_DAYS,
+      REPORT_DRILLDOWN_RANGE_MAX_DAYS,
     );
 
     // SKU-day density depends on both range length and catalogue breadth.

--- a/packages/athena-webapp/convex/reports/sweeper.test.ts
+++ b/packages/athena-webapp/convex/reports/sweeper.test.ts
@@ -586,6 +586,53 @@ describe("dirty-mark lifecycle", () => {
       ctx.db.query("reportSkuDay").collect(),
     );
     expect(skuDays).toHaveLength(0);
+    // The published count follows the rows down to zero. A day that shed its
+    // last SKU row must not keep advertising the old size — the mix probe
+    // would then route a range it cannot actually size.
+    const day = await t.run(async (ctx) =>
+      ctx.db
+        .query("reportDay")
+        .withIndex("by_storeId_operatingDate", (q) =>
+          q.eq("storeId", storeId).eq("operatingDate", "2026-07-28"),
+        )
+        .unique(),
+    );
+    expect(day?.skuDayRowCount).toBe(0);
+  });
+
+  it("publishes a sku row count equal to the rows the same fold wrote", async () => {
+    // The probe's whole basis: this number and those rows come out of one
+    // mutation, so they cannot drift. Asserted against the actual row count
+    // rather than a literal, so a fold that writes a different number of rows
+    // fails here instead of silently mis-sizing every mix read.
+    const t = convexTest(schema, modules);
+    const { storeId, productSkuId } = await seedStore(t, "sweep-row-count");
+    allow(storeId);
+
+    await insertSaleFact(t, {
+      storeId,
+      productSkuId,
+      operatingDate: "2026-07-28",
+      sourceId: "row-count-1",
+      netAmountMinor: 2_500,
+      quantity: 2,
+    });
+    await mark(t, storeId, "2026-07-28");
+    await sweep(t);
+
+    const { day, skuDays } = await t.run(async (ctx) => ({
+      day: await ctx.db
+        .query("reportDay")
+        .withIndex("by_storeId_operatingDate", (q) =>
+          q.eq("storeId", storeId).eq("operatingDate", "2026-07-28"),
+        )
+        .unique(),
+      // eslint-disable-next-line @convex-dev/no-collect-in-query -- convex-test fixture read, not a production query
+      skuDays: await ctx.db.query("reportSkuDay").collect(),
+    }));
+
+    expect(skuDays.length).toBeGreaterThan(0);
+    expect(day?.skuDayRowCount).toBe(skuDays.length);
   });
 
   it("folds a day_open mark keeping the day open, and does not re-mark it", async () => {

--- a/packages/athena-webapp/convex/reports/sweeper.ts
+++ b/packages/athena-webapp/convex/reports/sweeper.ts
@@ -357,6 +357,11 @@ export async function foldAndReplaceDay(
     foldVersion: REPORTS_FOLD_VERSION,
     certifiedFoldRevision,
     factCount: result.day.factCount,
+    // The fold's SKU map IS the day's row set: every entry is patched or
+    // inserted below, and every existing row absent from it is deleted. So
+    // this size equals the post-fold `reportSkuDay` count exactly, written in
+    // the same mutation that writes those rows — it cannot disagree with them.
+    skuDayRowCount: result.skuDays.size,
     lastFactRecordedAt: result.day.lastFactRecordedAt,
     flags: result.day.flags,
     paymentPosture: result.day.paymentPosture,

--- a/packages/athena-webapp/convex/schemas/reports/derived.ts
+++ b/packages/athena-webapp/convex/schemas/reports/derived.ts
@@ -374,6 +374,16 @@ export const reportDaySchema = v.object({
   foldedAt: v.optional(v.number()),
   foldVersion: v.number(),
   factCount: v.number(),
+  /**
+   * Exact number of `reportSkuDay` rows this day's fold wrote — the size of
+   * the SKU-mix read for this day, published so the days rail can route the
+   * mix chart without issuing the read (`skuMixSyncRowProbe`).
+   *
+   * Optional: days folded before U8 carry none. Absent means UNKNOWN, not
+   * zero — a day with no SKU activity stores 0. `skuDayRowCountBackfillNeeded`
+   * marks the pre-U8 generation for refold.
+   */
+  skuDayRowCount: v.optional(v.number()),
   lastFactRecordedAt: v.number(),
   flags: dayFlags,
   // Optional while legacy projections refresh; every new fold writes it.

--- a/packages/athena-webapp/shared/reportsContract.ts
+++ b/packages/athena-webapp/shared/reportsContract.ts
@@ -838,6 +838,14 @@ export type ReportDayRow = ReportDayMetrics & {
   currency: string;
   flags: ReportDayFlags;
   factCount: number;
+  /**
+   * Exact count of `reportSkuDay` rows the fold wrote for this day.
+   *
+   * Carried so the days rail can SIZE the SKU-mix read before it is issued
+   * (`skuMixSyncRowProbe`). Optional: days folded before U8 carry none, and a
+   * missing count means "unknown", never zero — see the probe.
+   */
+  skuDayRowCount?: number;
   closeVarianceMinor?: number;
   postCloseNetSalesDeltaMinor?: number;
 };
@@ -1002,6 +1010,68 @@ export const REPORT_RANGE_MAX_DAYS_BY_KIND = {
  * (U1); U5's span routing applies it.
  */
 export const REPORT_SKU_MIX_SYNC_MAX_DAYS = 2 as const;
+
+/**
+ * Row budget the SKU-mix probe must clear to route a span synchronously.
+ *
+ * Deliberately below `RANGE_SKU_MIX_ROW_LIMIT` (5,000). The probe reads day
+ * counts folded a moment ago; the mix read happens after. A concurrent fold
+ * can add rows in between, so the 1,000-row gap absorbs that drift rather
+ * than letting the reader's fail-closed throw reach the operator as "choose a
+ * shorter range". Sized against production: wigclub's busiest day folds 88
+ * SKU rows, so the gap covers eleven such days landing mid-flight.
+ */
+export const REPORT_SKU_MIX_SYNC_ROW_BUDGET = 4_000 as const;
+
+/**
+ * Size a SKU-mix range from the days rail before paying for it.
+ *
+ * The span rule this supplements (`REPORT_SKU_MIX_SYNC_MAX_DAYS`) is calibrated
+ * to the fold's 2,000-rows-per-day ceiling — a bound real stores sit far below
+ * (wigclub's median day: 30 rows), so a 3-day selection was buying an async
+ * snapshot to fold a few hundred rows. The days rail already loads one
+ * `reportDay` doc per day for the same window and each carries its exact
+ * `skuDayRowCount`, so the cost of the mix read is knowable for free.
+ *
+ * Returns the summed row count when EVERY day of `[startDate, endDate]` is
+ * accounted for, or `undefined` when it is not provable — the caller must then
+ * fall back to the span rule. Indeterminate cases, all of which must stay
+ * indeterminate rather than defaulting to zero:
+ *
+ *   - `rows` does not span the requested range (the days rail loaded a
+ *     narrower window than the mix selection covers), or
+ *   - a row inside the range predates the count and carries `undefined`.
+ *
+ * Absent rows are NOT indeterminate: `reportDay` is sparse, and a day with no
+ * document had no activity and therefore no `reportSkuDay` rows. That is why
+ * `coverageStartDate`/`coverageEndDate` are required — they prove the reader
+ * looked at the range, which row presence alone cannot.
+ */
+export function skuMixSyncRowProbe({
+  coverageEndDate,
+  coverageStartDate,
+  endDate,
+  rows,
+  startDate,
+}: {
+  coverageEndDate: string;
+  coverageStartDate: string;
+  endDate: string;
+  rows: readonly Pick<ReportDayRow, "operatingDate" | "skuDayRowCount">[];
+  startDate: string;
+}): number | undefined {
+  if (coverageStartDate > startDate || coverageEndDate < endDate) {
+    return undefined;
+  }
+
+  let total = 0;
+  for (const row of rows) {
+    if (row.operatingDate < startDate || row.operatingDate > endDate) continue;
+    if (row.skuDayRowCount === undefined) return undefined;
+    total += row.skuDayRowCount;
+  }
+  return total;
+}
 
 /** Rows per movement page — Top movers shows one page, Granular pages by it. */
 export const REPORT_MOVEMENT_PAGE_SIZE = 20 as const;

--- a/packages/athena-webapp/src/components/reports/ReportDaysPanel.test.tsx
+++ b/packages/athena-webapp/src/components/reports/ReportDaysPanel.test.tsx
@@ -68,6 +68,51 @@ import {
 import { getLocalOperatingDate } from "@/lib/operations/operatingDate";
 import { formatOperatingDate, formatReportDateRange } from "./reportFormat";
 
+/**
+ * Day rows spanning `[startDate, endDate]`, each publishing the exact number
+ * of `reportSkuDay` rows its fold wrote. `skuDayRowCount: undefined` models
+ * the pre-U8 generation, which the mix probe must treat as unknown.
+ */
+function daysWithSkuRowCounts(
+  startDate: string,
+  endDate: string,
+  skuDayRowCount: number | undefined,
+) {
+  const rows = [];
+  for (let date = startDate; date <= endDate; date = isoDateOffset(date, 1)) {
+    rows.push({
+      operatingDate: date,
+      status: "reconciled" as const,
+      currency: "USD",
+      flags: {},
+      factCount: skuDayRowCount ?? 0,
+      ...(skuDayRowCount === undefined ? {} : { skuDayRowCount }),
+      grossSalesMinor: 0,
+      netSalesMinor: 0,
+      refundsMinor: 0,
+      unitsSold: 0,
+      unitsReturned: 0,
+      uncostedRevenueMinor: 0,
+      grossProfitMinor: 0,
+      paymentsCollectedMinor: 0,
+      paymentsRefundedMinor: 0,
+      paymentAllocatedMinor: 0,
+    });
+  }
+  return rows;
+}
+
+/** Route every read but `listDays` to `undefined`, so only routing is under test. */
+function onlyDaysRead(days: unknown) {
+  return (functionReference: unknown, args: unknown) => {
+    if (args === "skip") return undefined;
+    return getFunctionName(functionReference as never) ===
+      "reports/queries:listDays"
+      ? days
+      : undefined;
+  };
+}
+
 const baseProps = {
   startDate: "2026-07-15",
   endDate: "2026-07-28",
@@ -143,12 +188,16 @@ describe("ReportDaysPanel shared demo", () => {
   });
 
   it("keeps the days read live and admits the multi-day mix for a real store", () => {
-    useQuery.mockReturnValue([]);
+    // 14 days at 400 folded SKU rows each = 5,600, past the sync budget, so
+    // this range genuinely needs the snapshot.
+    useQuery.mockImplementation(
+      onlyDaysRead(daysWithSkuRowCounts(startDate, endDate, 400)),
+    );
 
     render(<ReportDaysPanel {...demoProps} />);
 
-    // The 14-day mix span routes through admission, not the sync reader,
-    // so the only live subscription on mount is the days table.
+    // Mix routes through admission, not the sync reader, so the only live
+    // subscription on mount is the days table.
     expect(
       useQuery.mock.calls.map((call) => call[1]).filter((a) => a !== "skip"),
     ).toEqual([{ storeId: "store-1", startDate, endDate }]);
@@ -156,6 +205,107 @@ describe("ReportDaysPanel shared demo", () => {
       storeId: "store-1",
       startDate,
       endDate,
+    });
+  });
+
+  /**
+   * U8 routing. The span rule alone sent every range over two days to
+   * admission; the probe keeps the ones the reader can provably serve on the
+   * synchronous path, and falls back to the span rule whenever it cannot
+   * prove the size.
+   */
+  describe("sku mix row probe", () => {
+    const syncMixCalls = () =>
+      useQuery.mock.calls.filter(
+        ([reference, args]) =>
+          args !== "skip" &&
+          getFunctionName(reference as never) ===
+            "reports/queries:listRangeSkuMix",
+      );
+
+    it("keeps a multi-day range synchronous when the folded rows clear the budget", () => {
+      // 14 days at 30 rows each = 420 rows: what wigclub's median day folds,
+      // and two orders of magnitude inside the 5,000-row reader cap.
+      useQuery.mockImplementation(
+        onlyDaysRead(daysWithSkuRowCounts(startDate, endDate, 30)),
+      );
+
+      render(<ReportDaysPanel {...demoProps} />);
+
+      expect(syncMixCalls().map(([, args]) => args)).toEqual([
+        { storeId: "store-1", startDate, endDate },
+      ]);
+      // The whole point: no admission, no polling, no snapshot build.
+      expect(ensureMixRange).not.toHaveBeenCalled();
+    });
+
+    it("admits the snapshot when the folded rows exceed the budget", () => {
+      useQuery.mockImplementation(
+        onlyDaysRead(daysWithSkuRowCounts(startDate, endDate, 300)),
+      );
+
+      render(<ReportDaysPanel {...demoProps} />);
+
+      expect(syncMixCalls()).toHaveLength(0);
+      expect(ensureMixRange).toHaveBeenCalledWith({
+        storeId: "store-1",
+        startDate,
+        endDate,
+      });
+    });
+
+    it("falls back to the span rule when any day predates the row count", () => {
+      // One unmeasurable day makes the whole range unprovable — the total is
+      // unknown, not "the rest of the days", so this must not route sync.
+      const days = daysWithSkuRowCounts(startDate, endDate, 10);
+      delete (days[3] as { skuDayRowCount?: number }).skuDayRowCount;
+      useQuery.mockImplementation(onlyDaysRead(days));
+
+      render(<ReportDaysPanel {...demoProps} />);
+
+      expect(syncMixCalls()).toHaveLength(0);
+      expect(ensureMixRange).toHaveBeenCalled();
+    });
+
+    it("holds admission until the days read settles, then routes on the verdict", () => {
+      // Firing ensure on the span rule while the probe is unresolved would
+      // consume admission budget for a range the probe may prove cheap a
+      // moment later — the exact spend this feature exists to prevent.
+      useQuery.mockImplementation(onlyDaysRead(undefined));
+
+      const { rerender } = render(<ReportDaysPanel {...demoProps} />);
+
+      expect(syncMixCalls()).toHaveLength(0);
+      expect(ensureMixRange).not.toHaveBeenCalled();
+
+      // The days rail settles cheap: the range routes sync, and the deferral
+      // means no admission was ever spent on it.
+      useQuery.mockImplementation(
+        onlyDaysRead(daysWithSkuRowCounts(startDate, endDate, 30)),
+      );
+      rerender(<ReportDaysPanel {...demoProps} />);
+
+      expect(syncMixCalls().map(([, args]) => args)).toContainEqual({
+        storeId: "store-1",
+        startDate,
+        endDate,
+      });
+      expect(ensureMixRange).not.toHaveBeenCalled();
+    });
+
+    it("still routes a single day synchronously with no probe at all", () => {
+      // The span floor is independent of loaded data: a day click cannot
+      // regress just because the days rail has not answered yet.
+      useQuery.mockImplementation(onlyDaysRead(undefined));
+
+      render(
+        <ReportDaysPanel {...demoProps} selectedDate={endDate} />,
+      );
+
+      expect(syncMixCalls().map(([, args]) => args)).toEqual([
+        { storeId: "store-1", startDate: endDate, endDate },
+      ]);
+      expect(ensureMixRange).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx
+++ b/packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx
@@ -24,6 +24,8 @@ import {
 import {
   inclusiveOperatingDaySpan,
   REPORT_SKU_MIX_SYNC_MAX_DAYS,
+  REPORT_SKU_MIX_SYNC_ROW_BUDGET,
+  skuMixSyncRowProbe,
   type ReportMixLifecycle,
 } from "~/shared/reportsContract";
 import { EmptyState } from "@/components/states/empty/empty-state";
@@ -162,19 +164,61 @@ export function ReportDaysPanel({
   const skuMixStartDate = selectedDate ?? startDate;
   const skuMixEndDate = selectedDate ?? endDate;
   /**
-   * Span routing (U5): selections of at most `REPORT_SKU_MIX_SYNC_MAX_DAYS`
-   * inclusive days — every day click, the dominant ambient interaction — stay
-   * on the synchronous `listRangeSkuMix` reader forever. Provably safe: the
-   * fold bounds `reportSkuDay` at 2,000 rows per operating day, so a 2-day
-   * span reads at most 4,000 rows, strictly under the reader's 5,000-row cap
-   * (see the constant's provability comment in shared/reportsContract.ts).
-   * Longer spans use the admitted snapshot lifecycle instead, whose 184-day
-   * ceiling the server enforces via `REPORT_RANGE_MAX_DAYS_BY_KIND.sku_mix`;
-   * ambient browsing therefore never consumes async admission budget.
+   * Mix routing, in two tiers.
+   *
+   * TIER 1 — span (U5), the floor that never depends on loaded data:
+   * selections of at most `REPORT_SKU_MIX_SYNC_MAX_DAYS` inclusive days stay
+   * synchronous unconditionally. Provably safe from the fold's 2,000-row
+   * per-day bound alone: a 2-day span reads at most 4,000 rows, under the
+   * reader's 5,000-row cap.
+   *
+   * TIER 2 — measured size (U8): that 2,000-row bound is a worst case real
+   * stores sit far below, so the span rule sent 3-day selections to the
+   * async snapshot to fold a few hundred rows. The days rail has already
+   * loaded one `reportDay` per day of this very window and each publishes its
+   * exact `skuDayRowCount`, so the read can be sized for free. When the sum
+   * clears `REPORT_SKU_MIX_SYNC_ROW_BUDGET`, the range is provably cheap and
+   * stays synchronous whatever its span.
+   *
+   * The probe sizes from `liveDays` — the RAW subscription result — never the
+   * stable seam's `days`, which holds the PREVIOUS range's rows while a new
+   * one loads. Stale rows against current coverage bounds would all fall
+   * outside the new range and sum to a confident 0: "provably cheap", proven
+   * on nothing. The raw result is `undefined` exactly while its args are in
+   * flight, so staleness is unrepresentable here.
+   *
+   * The probe returns `undefined` when it cannot prove the total — the days
+   * rail hasn't settled, its window is narrower than the selection, or a day
+   * predates the count. Ranges past the budget (or unprovable after the days
+   * rail settles) use the admitted snapshot lifecycle, whose 184-day ceiling
+   * the server enforces via `REPORT_RANGE_MAX_DAYS_BY_KIND.sku_mix`.
    */
+  const mixProbeRowCount =
+    liveDays === undefined
+      ? undefined
+      : skuMixSyncRowProbe({
+          coverageEndDate: tableEndDate,
+          coverageStartDate: tableStartDate,
+          endDate: skuMixEndDate,
+          rows: liveDays,
+          startDate: skuMixStartDate,
+        });
   const isSyncMixSpan =
     inclusiveOperatingDaySpan(skuMixStartDate, skuMixEndDate) <=
-    REPORT_SKU_MIX_SYNC_MAX_DAYS;
+      REPORT_SKU_MIX_SYNC_MAX_DAYS ||
+    (mixProbeRowCount !== undefined &&
+      mixProbeRowCount <= REPORT_SKU_MIX_SYNC_ROW_BUDGET);
+  /**
+   * Admission waits for the verdict. While the days read is in flight the
+   * probe is unresolved, and firing `ensureMixRange` on the span rule alone
+   * would consume admission budget for a range the probe may prove cheap a
+   * moment later — the exact spend this feature exists to prevent. The days
+   * read is already loading for the table itself, so the wait adds no new
+   * round-trip; a genuinely heavy range pays one table-load of latency before
+   * admission, which the held-snapshot UI absorbs. Demo mode never reaches
+   * here (`useLiveQuery` is false and the fixture answers synchronously).
+   */
+  const isMixRoutingSettled = isSyncMixSpan || liveDays !== undefined;
   const storeId = activeStore?._id;
   const liveSkuMix = useQuery(
     api.reports.queries.listRangeSkuMix,
@@ -202,7 +246,9 @@ export function ReportDaysPanel({
   const [mixEnsureFailed, setMixEnsureFailed] = useState(false);
   const ensureMixRange = useMutation(api.reports.skuMixRange.ensureMixRange);
   const retryMixRange = useMutation(api.reports.skuMixRange.retryMixRange);
-  const asyncMixEnabled = Boolean(!isSyncMixSpan && storeId && useLiveQuery);
+  const asyncMixEnabled = Boolean(
+    !isSyncMixSpan && isMixRoutingSettled && storeId && useLiveQuery,
+  );
 
   useEffect(() => {
     if (!asyncMixEnabled || !storeId) return;


### PR DESCRIPTION
Routes the Reports SKU mix chart by the **measured cost** of its read rather than by span, so ambient selections stop paying for admission control and a snapshot build.

## Why

The mix chart sent every selection longer than two days through `ensureMixRange`, a `retryAfterMs` poll loop, and a scheduled snapshot build. That threshold was provable — the fold bounds `reportSkuDay` at 2,000 rows per operating day, so a two-day span reads at most 4,000, under the reader's 5,000-row cap — but it is calibrated to a ceiling production sits far below.

Measured against prod wigclub: the busiest day in seventeen months folds **88** SKU rows, the median folds **30**, and the entire 184-day window reads **2,366** — inside the synchronous cap. The chart was buying admission control to fold a few hundred rows.

Two alternatives were measured and rejected:

- **The days rail cannot supply the data.** `reportDay` holds store-wide daily scalars; the pie slices by SKU, which exists only in `reportSkuDay`. Same metric name, different grain.
- **The month rollup rail is not worth it.** `reportPeriodSkuRollup` compresses only 1.0×–2.8× per month (2,366 → 1,082 across the window). Wigclub's catalogue is long-tail — 628 distinct SKUs over 2,366 SKU-days — and pre-aggregating by month only helps when SKUs repeat across days.

## What

The fold already knows the number. `result.skuDays` **is** the day's row set — every entry patched or inserted, every existing row absent from it deleted — so its size equals the post-fold `reportSkuDay` count exactly. The sweeper writes it in the same mutation as those rows, and the days rail publishes it as `skuDayRowCount`.

Routing became two tiers:

| Selection | Before | After |
|---|---|---|
| 1 day | sync | sync |
| 3 days | **admission + snapshot** | sync |
| 31 days | **admission + snapshot** | sync |
| 92 days | admission + snapshot | sync |
| 184 days | admission + snapshot | admission + snapshot |

Decisions worth reviewing:

- **Unknown is not zero, but an absent row is.** A missing count makes the range indeterminate and falls back to the span rule. A missing `reportDay` doc counts as zero — the table is sparse (108 docs across 511 calendar days) and no doc means no activity. Coverage bounds are required arguments because row presence cannot prove the reader looked.
- **Budget 4,000 against a 5,000 cap.** Sizing and reading are separated in time; the gap absorbs a concurrent fold rather than surfacing the reader's fail-closed throw as "choose a shorter range".
- **`ingest.ts` is a second writer.** Its SKU upserts moved ahead of the day write so a batch's inserts land in the same patch. A pre-U8 day stays uncounted rather than guessing from an unknown base.
- **`listRangeSkuMix` moves off the 92-day proxy cap** to the 184-day drill-down ceiling. Span was never its real bound; the row cap is, and still fails closed. The legacy movement reader keeps 92 — it has no probe.
- **`skuDayRowCountBackfillNeeded` is separate from `needsCertifiedRefold`.** Certification is the movement lane's *trust* boundary; this is the mix lane's *sizing* hint. Merging them would make a performance shortfall read as a movement-readiness failure on `countUncertifiedDays`. This also fixes `missingRevisionCount`, which inferred its answer from "stale AND current version" rather than testing the revision.

## Validation

- `bun run pr:athena` green — **7,783** webapp tests / 679 files, **186** storefront tests / 34 files, proof recorded.
- Prod data reconciliation: 1,130/1,130 month-SKU rollup pairs matched a local re-fold; `reportDay.unitsSold` equalled the sum of its SKU rows on all 108 days.
- **Dev end-to-end backfill**: 73/73 days counted, 73/73 published counts equal the actual `reportSkuDay` row count (830 rows, 830 summed).

## Operational

No schema migration and **no fold-version bump** — the fold's output is unchanged, and bumping would invalidate certified provenance for movement-ready stores.

Historical settled days never refold under normal traffic, so a backfill via `markStaleFoldVersionDays` is **required** for wide ranges to become provable; without it the feature self-heals forward at one day per day. Those refolds advance `certifiedFoldRevision`, so range snapshots covering refolded days go `terminal_source_stale` and rebuild on next ensure — **run off-peak**.

> ⚠️ That snapshot-invalidation cascade is **untested**: the dev drain reported `rangesComputed: 0` throughout, so nothing exercised it. The production backfill will be its first real run.

At wigclub's current rate the full 184-day window legitimately exceeds the cap from roughly 2026-10-07 and stays on the async rail. The win is everything narrower.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
