### PR TITLE
perf(reports): rebuild a sweep's rollups once per batch instead of once per day

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 11546 nodes · 14180 edges · 2684 communities detected
+- 11548 nodes · 14182 edges · 2684 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -3310,144 +3310,144 @@ Cohesion: 0.13
 Nodes (0):
 
 ### Community 147 - "Community 147"
+Cohesion: 0.13
+Nodes (0):
+
+### Community 148 - "Community 148"
 Cohesion: 0.3
 Nodes (14): applyBaselineDocumentsWithCtx(), applyRestoreLeaseWithCtx(), assertSharedDemoWriteEpoch(), baselineMatches(), beginRestore(), beginRestoreLeaseWithCtx(), completeRestore(), completeRestoreLeaseWithCtx() (+6 more)
 
-### Community 148 - "Community 148"
+### Community 149 - "Community 149"
 Cohesion: 0.28
 Nodes (13): advancePurchaseOrderToOrderedCommandWithCtx(), advancePurchaseOrderToOrderedWithCtx(), assertValidPurchaseOrderStatusTransition(), buildPurchaseOrderNumber(), calculatePurchaseOrderTotals(), createPurchaseOrderCommandWithCtx(), createPurchaseOrderWithCtx(), getStatusesToOrdered() (+5 more)
 
-### Community 149 - "Community 149"
+### Community 150 - "Community 150"
 Cohesion: 0.25
 Nodes (13): assertDistinctReceivingLineItems(), assertReceivablePurchaseOrderStatus(), assertReceivingLineQuantities(), assertReceivingReplayMatches(), buildReceivingBatchSourceId(), calculatePurchaseOrderReceivingStatus(), calculateReceivingBatchTotals(), listPurchaseOrderLineItems() (+5 more)
 
-### Community 150 - "Community 150"
+### Community 151 - "Community 151"
 Cohesion: 0.17
 Nodes (6): buildServerPricedCheckoutProducts(), calculateItemsSubtotal(), deriveDeliveryOptionFromAddress(), isDeliveryFeeWaived(), normalizeDeliveryOption(), resolveServerDeliveryFee()
 
-### Community 151 - "Community 151"
+### Community 152 - "Community 152"
 Cohesion: 0.28
 Nodes (14): buildActorRefs(), buildReturnExchangeTraceEvent(), buildReturnExchangeTraceRecord(), buildTraceEvent(), buildTraceRecord(), compactDetails(), recordOnlineOrderReturnExchangeTraceBestEffort(), recordOnlineOrderTraceBestEffort() (+6 more)
 
-### Community 152 - "Community 152"
+### Community 153 - "Community 153"
 Cohesion: 0.2
 Nodes (9): canReuseCloudRegisterSessionForLocalOpen(), canSupersedeReviewedRegisterSessionForLocalOpen(), drawerAuthorityMatchesActiveRegisterSession(), getSaleBlockingDrawerAuthority(), isDrawerAuthoritySaleBlocking(), isRegisterSessionConflictBlocking(), isRegisterSessionReplacementBlocking(), isRegisterSessionSaleUsable() (+1 more)
 
-### Community 153 - "Community 153"
+### Community 154 - "Community 154"
 Cohesion: 0.18
 Nodes (6): buildTrustedInventoryFinalizationPayload(), buildTrustedInventoryMoneyPayload(), getTrustedInventoryReviewValidationMessage(), isNonNegativeInteger(), parseVariantDisplayMoney(), resolveTrustedInventoryReviewState()
 
-### Community 154 - "Community 154"
+### Community 155 - "Community 155"
 Cohesion: 0.14
 Nodes (2): handleEnterReviewMode(), saveInventoryImportRouteDraft()
 
-### Community 155 - "Community 155"
+### Community 156 - "Community 156"
 Cohesion: 0.17
 Nodes (6): formatOperatingDateFilterLabel(), formatPaymentMethod(), getEmptyTransactionTitle(), getNextTransactionPageSearch(), getNextTransactionPaymentFilterSearch(), getNextTransactionTimeFilterSearch()
 
-### Community 156 - "Community 156"
+### Community 157 - "Community 157"
 Cohesion: 0.17
 Nodes (4): formatQuickAddDialogError(), handleAttachBarcode(), handleQuickAddSubmit(), validateQuickAddLookupCode()
 
-### Community 157 - "Community 157"
+### Community 158 - "Community 158"
 Cohesion: 0.15
 Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
 
-### Community 158 - "Community 158"
+### Community 159 - "Community 159"
 Cohesion: 0.19
 Nodes (6): buildOperationalWorkItem(), createOperationalWorkItemWithCtx(), metadataArrayCount(), metadataNumber(), projectOperationalWorkItemForQueue(), sanitizeOperationalWorkItemDetails()
 
-### Community 159 - "Community 159"
+### Community 160 - "Community 160"
 Cohesion: 0.35
 Nodes (12): assertRoleConfiguration(), buildRoleAssignmentDrafts(), buildStaffFullName(), buildStaffProfileResult(), createStaffProfileWithCtx(), ensureLinkedUserAvailable(), getStaffProfileByIdWithCtx(), normalizeOptionalString() (+4 more)
 
-### Community 160 - "Community 160"
+### Community 161 - "Community 161"
 Cohesion: 0.22
 Nodes (10): buildTerminalCloudRepairPreconditionHash(), buildTerminalCloudRepairPreview(), canProjectRegisterOpenForTerminalCloudRepair(), classifyTerminalCloudRepairConflict(), containsBusinessFacts(), getRepairOpenRegisterCloseoutReviewState(), getRepairRegisterSessionCloseoutBoundaryAt(), isDuplicateRegisterOpenConflict() (+2 more)
 
-### Community 161 - "Community 161"
+### Community 162 - "Community 162"
 Cohesion: 0.15
 Nodes (2): period(), withCloses()
 
-### Community 162 - "Community 162"
+### Community 163 - "Community 163"
 Cohesion: 0.26
 Nodes (9): clearPaymentEditing(), handleCancelEdit(), handleClearPayments(), handleRemovePayment(), handleSaveEdit(), handleStartEdit(), resetPaymentCollectionControls(), setPaymentEditing() (+1 more)
 
-### Community 163 - "Community 163"
+### Community 164 - "Community 164"
 Cohesion: 0.23
 Nodes (11): buildDayTransactions(), buildItems(), buildPaymentProductMixes(), buildTransaction(), createSharedDemoTransactionFixtures(), findProductMix(), formatOperatingDate(), getSharedDemoTransactionFixture() (+3 more)
 
-### Community 164 - "Community 164"
+### Community 165 - "Community 165"
 Cohesion: 0.18
 Nodes (5): handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts(), trimToUndefined()
 
-### Community 165 - "Community 165"
+### Community 166 - "Community 166"
 Cohesion: 0.24
 Nodes (8): canonicalizeWalkthroughPayload(), normalizeWalkthroughEmail(), normalizeWalkthroughText(), readPublicErrorCode(), resolveWalkthroughRequestUrl(), stripControlCharacters(), submitWalkthroughRequest(), WalkthroughSubmissionIdentity
 
-### Community 166 - "Community 166"
+### Community 167 - "Community 167"
 Cohesion: 0.18
 Nodes (5): isOverpayPaymentMethod(), isValidEmail(), isValidPhone(), validateCustomer(), validatePaymentAmount()
 
-### Community 167 - "Community 167"
+### Community 168 - "Community 168"
 Cohesion: 0.22
 Nodes (6): buildParticipantIdentity(), getDataPublishRouting(), getParticipantRole(), isAllowedSender(), LiveKitRemoteAssistClient, parseParticipantRole()
 
-### Community 168 - "Community 168"
+### Community 169 - "Community 169"
 Cohesion: 0.26
 Nodes (12): bestFuzzyTokenScore(), compactSearchText(), createFuzzySearchEntry(), isProbablySameToken(), levenshteinDistance(), normalizeFuzzySearchText(), scoreCompactFieldContains(), scoreFuzzySearchEntry() (+4 more)
 
-### Community 169 - "Community 169"
+### Community 170 - "Community 170"
 Cohesion: 0.16
 Nodes (3): getPosHubRouteParams(), getRouteParamsForPattern(), getStoreWorkspaceRouteParams()
 
-### Community 170 - "Community 170"
+### Community 171 - "Community 171"
 Cohesion: 0.26
 Nodes (12): deleteHeadBranch(), enablePullRequestAutoMerge(), encodeGitRefPath(), ghJson(), HelpRequested, mergePullRequest(), parseArgs(), parseMergeMethod() (+4 more)
 
-### Community 171 - "Community 171"
+### Community 172 - "Community 172"
+Cohesion: 0.23
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
+
+### Community 173 - "Community 173"
 Cohesion: 0.31
 Nodes (12): backfillStoreSchedulesFromLegacyPolicyWithCtx(), buildBackfillRow(), buildCandidateWeeklyWindows(), compatibilityMetadata(), compatibilityOnlyRow(), findExistingScheduleToSkip(), firstPolicy(), isValidMinute() (+4 more)
 
-### Community 172 - "Community 172"
+### Community 174 - "Community 174"
 Cohesion: 0.28
 Nodes (11): defineCashControlsRead(), defineDailyCloseRead(), defineDailyOperationsRead(), defineInventoryCatalogRead(), defineInventoryCostOverlayRead(), defineOnlineOrdersRead(), defineOperationalWorkRead(), defineOrganizationRead() (+3 more)
 
-### Community 173 - "Community 173"
+### Community 175 - "Community 175"
 Cohesion: 0.33
 Nodes (11): closeCandidateOperatingRange(), emptyCloseSummary(), exactStatuses(), frozenFinancialSourceCounts(), frozenWeekMetricForDate(), matchesRequestedOperatingRange(), normalizeFrozenPaymentTotals(), recordValue() (+3 more)
 
-### Community 174 - "Community 174"
+### Community 176 - "Community 176"
 Cohesion: 0.29
 Nodes (12): buildCtx(), buildInventoryMovement(), buildMapping(), buildProductSku(), buildRegisterSession(), buildStaffProfile(), buildStore(), buildTerminal() (+4 more)
 
-### Community 175 - "Community 175"
+### Community 177 - "Community 177"
 Cohesion: 0.26
 Nodes (10): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), ensurePaymentAllocationReportingWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), matchesExistingAllocation(), matchesKeyedAllocation(), paymentAllocationReportingDimensions() (+2 more)
 
-### Community 176 - "Community 176"
+### Community 178 - "Community 178"
 Cohesion: 0.26
 Nodes (10): createCustomer(), fullNameFromParts(), guestResult(), linkToGuest(), linkToStoreFrontUser(), posCustomerResult(), resolveGuestMatch(), resolvePosCustomerSelection() (+2 more)
 
-### Community 177 - "Community 177"
+### Community 179 - "Community 179"
 Cohesion: 0.18
 Nodes (4): findActivePendingCheckoutLookupAliasByCode(), listProductSkusByProductId(), normalizeLookupCode(), readAllQueryResults()
 
-### Community 178 - "Community 178"
+### Community 180 - "Community 180"
 Cohesion: 0.23
 Nodes (7): admitOne(), allow(), ensure(), headerByKey(), seedSkus(), seedStore(), twoDayFixture()
 
-### Community 179 - "Community 179"
-Cohesion: 0.15
-Nodes (0):
-
-### Community 180 - "Community 180"
+### Community 181 - "Community 181"
 Cohesion: 0.26
 Nodes (10): archivedProductNestedOrigin(), buildVariantSkuMoneyPayload(), createVariantSku(), decodeOriginValue(), deleteActiveProduct(), getArchivedProductRedirect(), modifyProduct(), onSubmit() (+2 more)
-
-### Community 181 - "Community 181"
-Cohesion: 0.23
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 182 - "Community 182"
 Cohesion: 0.17
@@ -3890,28 +3890,28 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 292 - "Community 292"
-Cohesion: 0.42
-Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
-
-### Community 293 - "Community 293"
-Cohesion: 0.36
-Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
-
-### Community 294 - "Community 294"
-Cohesion: 0.22
-Nodes (0):
-
-### Community 295 - "Community 295"
 Cohesion: 0.31
 Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
-### Community 296 - "Community 296"
-Cohesion: 0.39
-Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
+### Community 293 - "Community 293"
+Cohesion: 0.42
+Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 297 - "Community 297"
+### Community 294 - "Community 294"
+Cohesion: 0.36
+Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
+
+### Community 295 - "Community 295"
+Cohesion: 0.22
+Nodes (0):
+
+### Community 296 - "Community 296"
 Cohesion: 0.31
 Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+
+### Community 297 - "Community 297"
+Cohesion: 0.39
+Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
 
 ### Community 298 - "Community 298"
 Cohesion: 0.22

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -71999,7 +71999,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L71",
+      "source_location": "L109",
       "target": "sweeper_test_allow",
       "weight": 1
     },
@@ -72011,7 +72011,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L93",
+      "source_location": "L131",
       "target": "sweeper_test_close",
       "weight": 1
     },
@@ -72023,7 +72023,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L1629",
+      "source_location": "L1899",
       "target": "sweeper_test_insertmovementheader",
       "weight": 1
     },
@@ -72035,7 +72035,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L224",
+      "source_location": "L262",
       "target": "sweeper_test_insertsalefact",
       "weight": 1
     },
@@ -72047,7 +72047,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L1254",
+      "source_location": "L1292",
       "target": "sweeper_test_insertweeklyclosefixture",
       "weight": 1
     },
@@ -72059,7 +72059,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L265",
+      "source_location": "L303",
       "target": "sweeper_test_mark",
       "weight": 1
     },
@@ -72071,8 +72071,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L284",
+      "source_location": "L322",
       "target": "sweeper_test_marksof",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_reports_sweeper_test_ts",
+      "_tgt": "sweeper_test_monthof",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_reports_sweeper_test_ts",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
+      "source_location": "L1430",
+      "target": "sweeper_test_monthof",
       "weight": 1
     },
     {
@@ -72083,8 +72095,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L1626",
+      "source_location": "L1896",
       "target": "sweeper_test_movementconstants",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_reports_sweeper_test_ts",
+      "_tgt": "sweeper_test_periodsfor",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_reports_sweeper_test_ts",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
+      "source_location": "L1498",
+      "target": "sweeper_test_periodsfor",
       "weight": 1
     },
     {
@@ -72095,7 +72119,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L1328",
+      "source_location": "L1598",
       "target": "sweeper_test_readdocs",
       "weight": 1
     },
@@ -72107,7 +72131,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L150",
+      "source_location": "L188",
       "target": "sweeper_test_seedstore",
       "weight": 1
     },
@@ -72119,7 +72143,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L282",
+      "source_location": "L320",
       "target": "sweeper_test_sweep",
       "weight": 1
     },
@@ -72131,7 +72155,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L1661",
+      "source_location": "L1931",
       "target": "sweeper_test_withfrozenscheduler",
       "weight": 1
     },
@@ -72143,7 +72167,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L511",
+      "source_location": "L537",
       "target": "sweeper_computependingranges",
       "weight": 1
     },
@@ -72155,7 +72179,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L113",
+      "source_location": "L121",
       "target": "sweeper_daycapexceeded",
       "weight": 1
     },
@@ -72167,7 +72191,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L549",
+      "source_location": "L575",
       "target": "sweeper_expirerangeresults",
       "weight": 1
     },
@@ -72179,7 +72203,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L494",
+      "source_location": "L520",
       "target": "sweeper_findopenoperatingdate",
       "weight": 1
     },
@@ -72191,7 +72215,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L283",
+      "source_location": "L291",
       "target": "sweeper_foldandreplaceday",
       "weight": 1
     },
@@ -72203,7 +72227,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L232",
+      "source_location": "L240",
       "target": "sweeper_loadacceptedclose",
       "weight": 1
     },
@@ -72215,7 +72239,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L458",
+      "source_location": "L484",
       "target": "sweeper_markdaydirty",
       "weight": 1
     },
@@ -72227,7 +72251,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L256",
+      "source_location": "L264",
       "target": "sweeper_openpolicyforreason",
       "weight": 1
     },
@@ -72239,7 +72263,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L136",
+      "source_location": "L144",
       "target": "sweeper_parsestoreallowlist",
       "weight": 1
     },
@@ -72251,7 +72275,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L581",
+      "source_location": "L607",
       "target": "sweeper_rangesnapshotkindconfigs",
       "weight": 1
     },
@@ -72263,7 +72287,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L146",
+      "source_location": "L154",
       "target": "sweeper_readstoreallowlist",
       "weight": 1
     },
@@ -72275,7 +72299,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L198",
+      "source_location": "L206",
       "target": "sweeper_selectacceptedclose",
       "weight": 1
     },
@@ -72287,7 +72311,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L585",
+      "source_location": "L611",
       "target": "sweeper_sweepwithctx",
       "weight": 1
     },
@@ -72299,7 +72323,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L214",
+      "source_location": "L222",
       "target": "sweeper_tocloseref",
       "weight": 1
     },
@@ -72311,7 +72335,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L154",
+      "source_location": "L162",
       "target": "sweeper_tofoldfact",
       "weight": 1
     },
@@ -160067,7 +160091,7 @@
       "relation": "method",
       "source": "sweeper_daycapexceeded",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L114",
+      "source_location": "L122",
       "target": "sweeper_daycapexceeded_constructor",
       "weight": 1
     },
@@ -160079,7 +160103,7 @@
       "relation": "calls",
       "source": "sweeper_loadacceptedclose",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L345",
+      "source_location": "L369",
       "target": "sweeper_foldandreplaceday",
       "weight": 1
     },
@@ -160091,7 +160115,7 @@
       "relation": "calls",
       "source": "sweeper_tocloseref",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L346",
+      "source_location": "L370",
       "target": "sweeper_foldandreplaceday",
       "weight": 1
     },
@@ -160103,7 +160127,7 @@
       "relation": "calls",
       "source": "sweeper_selectacceptedclose",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L244",
+      "source_location": "L252",
       "target": "sweeper_loadacceptedclose",
       "weight": 1
     },
@@ -160115,7 +160139,7 @@
       "relation": "calls",
       "source": "sweeper_parsestoreallowlist",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L147",
+      "source_location": "L155",
       "target": "sweeper_readstoreallowlist",
       "weight": 1
     },
@@ -160127,7 +160151,7 @@
       "relation": "calls",
       "source": "sweeper_computependingranges",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L683",
+      "source_location": "L721",
       "target": "sweeper_sweepwithctx",
       "weight": 1
     },
@@ -160139,7 +160163,7 @@
       "relation": "calls",
       "source": "sweeper_expirerangeresults",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L734",
+      "source_location": "L772",
       "target": "sweeper_sweepwithctx",
       "weight": 1
     },
@@ -160151,7 +160175,7 @@
       "relation": "calls",
       "source": "sweeper_foldandreplaceday",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L649",
+      "source_location": "L675",
       "target": "sweeper_sweepwithctx",
       "weight": 1
     },
@@ -160163,7 +160187,7 @@
       "relation": "calls",
       "source": "sweeper_markdaydirty",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L671",
+      "source_location": "L698",
       "target": "sweeper_sweepwithctx",
       "weight": 1
     },
@@ -160175,7 +160199,7 @@
       "relation": "calls",
       "source": "sweeper_openpolicyforreason",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L650",
+      "source_location": "L676",
       "target": "sweeper_sweepwithctx",
       "weight": 1
     },
@@ -160187,7 +160211,7 @@
       "relation": "calls",
       "source": "sweeper_rangesnapshotkindconfigs",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L742",
+      "source_location": "L780",
       "target": "sweeper_sweepwithctx",
       "weight": 1
     },
@@ -160199,7 +160223,7 @@
       "relation": "calls",
       "source": "sweeper_readstoreallowlist",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L587",
+      "source_location": "L613",
       "target": "sweeper_sweepwithctx",
       "weight": 1
     },
@@ -177976,7 +178000,7 @@
       "label": "computePendingRanges()",
       "norm_label": "computependingranges()",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L511"
+      "source_location": "L537"
     },
     {
       "community": 114,
@@ -177985,7 +178009,7 @@
       "label": "DayCapExceeded",
       "norm_label": "daycapexceeded",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L113"
+      "source_location": "L121"
     },
     {
       "community": 114,
@@ -177994,7 +178018,7 @@
       "label": ".constructor()",
       "norm_label": ".constructor()",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L114"
+      "source_location": "L122"
     },
     {
       "community": 114,
@@ -178003,7 +178027,7 @@
       "label": "expireRangeResults()",
       "norm_label": "expirerangeresults()",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L549"
+      "source_location": "L575"
     },
     {
       "community": 114,
@@ -178012,7 +178036,7 @@
       "label": "findOpenOperatingDate()",
       "norm_label": "findopenoperatingdate()",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L494"
+      "source_location": "L520"
     },
     {
       "community": 114,
@@ -178021,7 +178045,7 @@
       "label": "foldAndReplaceDay()",
       "norm_label": "foldandreplaceday()",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L283"
+      "source_location": "L291"
     },
     {
       "community": 114,
@@ -178030,7 +178054,7 @@
       "label": "loadAcceptedClose()",
       "norm_label": "loadacceptedclose()",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L232"
+      "source_location": "L240"
     },
     {
       "community": 114,
@@ -178039,7 +178063,7 @@
       "label": "markDayDirty()",
       "norm_label": "markdaydirty()",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L458"
+      "source_location": "L484"
     },
     {
       "community": 114,
@@ -178048,7 +178072,7 @@
       "label": "openPolicyForReason()",
       "norm_label": "openpolicyforreason()",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L256"
+      "source_location": "L264"
     },
     {
       "community": 114,
@@ -178057,7 +178081,7 @@
       "label": "parseStoreAllowlist()",
       "norm_label": "parsestoreallowlist()",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L136"
+      "source_location": "L144"
     },
     {
       "community": 114,
@@ -178066,7 +178090,7 @@
       "label": "rangeSnapshotKindConfigs()",
       "norm_label": "rangesnapshotkindconfigs()",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L581"
+      "source_location": "L607"
     },
     {
       "community": 114,
@@ -178075,7 +178099,7 @@
       "label": "readStoreAllowlist()",
       "norm_label": "readstoreallowlist()",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L146"
+      "source_location": "L154"
     },
     {
       "community": 114,
@@ -178084,7 +178108,7 @@
       "label": "selectAcceptedClose()",
       "norm_label": "selectacceptedclose()",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L198"
+      "source_location": "L206"
     },
     {
       "community": 114,
@@ -178093,7 +178117,7 @@
       "label": "sweepWithCtx()",
       "norm_label": "sweepwithctx()",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L585"
+      "source_location": "L611"
     },
     {
       "community": 114,
@@ -178102,7 +178126,7 @@
       "label": "toCloseRef()",
       "norm_label": "tocloseref()",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L214"
+      "source_location": "L222"
     },
     {
       "community": 114,
@@ -178111,7 +178135,7 @@
       "label": "toFoldFact()",
       "norm_label": "tofoldfact()",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L154"
+      "source_location": "L162"
     },
     {
       "community": 1140,
@@ -189933,137 +189957,137 @@
     {
       "community": 147,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_shareddemo_restore_ts",
-      "label": "restore.ts",
-      "norm_label": "restore.ts",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
+      "id": "packages_athena_webapp_convex_reports_sweeper_test_ts",
+      "label": "sweeper.test.ts",
+      "norm_label": "sweeper.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
       "source_location": "L1"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "restore_applybaselinedocumentswithctx",
-      "label": "applyBaselineDocumentsWithCtx()",
-      "norm_label": "applybaselinedocumentswithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
-      "source_location": "L123"
+      "id": "sweeper_test_allow",
+      "label": "allow()",
+      "norm_label": "allow()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
+      "source_location": "L109"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "restore_applyrestoreleasewithctx",
-      "label": "applyRestoreLeaseWithCtx()",
-      "norm_label": "applyrestoreleasewithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
-      "source_location": "L278"
+      "id": "sweeper_test_close",
+      "label": "close()",
+      "norm_label": "close()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
+      "source_location": "L131"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "restore_assertshareddemowriteepoch",
-      "label": "assertSharedDemoWriteEpoch()",
-      "norm_label": "assertshareddemowriteepoch()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
-      "source_location": "L78"
+      "id": "sweeper_test_insertmovementheader",
+      "label": "insertMovementHeader()",
+      "norm_label": "insertmovementheader()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
+      "source_location": "L1899"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "restore_baselinematches",
-      "label": "baselineMatches()",
-      "norm_label": "baselinematches()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
-      "source_location": "L88"
+      "id": "sweeper_test_insertsalefact",
+      "label": "insertSaleFact()",
+      "norm_label": "insertsalefact()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
+      "source_location": "L262"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "restore_beginrestore",
-      "label": "beginRestore()",
-      "norm_label": "beginrestore()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
-      "source_location": "L57"
+      "id": "sweeper_test_insertweeklyclosefixture",
+      "label": "insertWeeklyCloseFixture()",
+      "norm_label": "insertweeklyclosefixture()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
+      "source_location": "L1292"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "restore_beginrestoreleasewithctx",
-      "label": "beginRestoreLeaseWithCtx()",
-      "norm_label": "beginrestoreleasewithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
-      "source_location": "L212"
+      "id": "sweeper_test_mark",
+      "label": "mark()",
+      "norm_label": "mark()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
+      "source_location": "L303"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "restore_completerestore",
-      "label": "completeRestore()",
-      "norm_label": "completerestore()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
-      "source_location": "L99"
+      "id": "sweeper_test_marksof",
+      "label": "marksOf()",
+      "norm_label": "marksof()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
+      "source_location": "L322"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "restore_completerestoreleasewithctx",
-      "label": "completeRestoreLeaseWithCtx()",
-      "norm_label": "completerestoreleasewithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
-      "source_location": "L336"
+      "id": "sweeper_test_monthof",
+      "label": "monthOf()",
+      "norm_label": "monthof()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
+      "source_location": "L1430"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "restore_failrestoreleasewithctx",
-      "label": "failRestoreLeaseWithCtx()",
-      "norm_label": "failrestoreleasewithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
-      "source_location": "L380"
+      "id": "sweeper_test_movementconstants",
+      "label": "movementConstants()",
+      "norm_label": "movementconstants()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
+      "source_location": "L1896"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "restore_readrestorestatewithctx",
-      "label": "readRestoreStateWithCtx()",
-      "norm_label": "readrestorestatewithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
-      "source_location": "L176"
+      "id": "sweeper_test_periodsfor",
+      "label": "periodsFor()",
+      "norm_label": "periodsfor()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
+      "source_location": "L1498"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "restore_requirecurrentshareddemobaseline",
-      "label": "requireCurrentSharedDemoBaseline()",
-      "norm_label": "requirecurrentshareddemobaseline()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
-      "source_location": "L48"
+      "id": "sweeper_test_readdocs",
+      "label": "readDocs()",
+      "norm_label": "readdocs()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
+      "source_location": "L1598"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "restore_requirematchingrestorelease",
-      "label": "requireMatchingRestoreLease()",
-      "norm_label": "requirematchingrestorelease()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
-      "source_location": "L186"
+      "id": "sweeper_test_seedstore",
+      "label": "seedStore()",
+      "norm_label": "seedstore()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
+      "source_location": "L188"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "restore_requirereadyshareddemowritewithctx",
-      "label": "requireReadySharedDemoWriteWithCtx()",
-      "norm_label": "requirereadyshareddemowritewithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
-      "source_location": "L459"
+      "id": "sweeper_test_sweep",
+      "label": "sweep()",
+      "norm_label": "sweep()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
+      "source_location": "L320"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "restore_schedulerestorecontinuation",
-      "label": "scheduleRestoreContinuation()",
-      "norm_label": "schedulerestorecontinuation()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
-      "source_location": "L201"
+      "id": "sweeper_test_withfrozenscheduler",
+      "label": "withFrozenScheduler()",
+      "norm_label": "withfrozenscheduler()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
+      "source_location": "L1931"
     },
     {
       "community": 1470,
@@ -190248,137 +190272,137 @@
     {
       "community": 148,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_purchaseorders_ts",
-      "label": "purchaseOrders.ts",
-      "norm_label": "purchaseorders.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "id": "packages_athena_webapp_convex_shareddemo_restore_ts",
+      "label": "restore.ts",
+      "norm_label": "restore.ts",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
       "source_location": "L1"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "purchaseorders_advancepurchaseordertoorderedcommandwithctx",
-      "label": "advancePurchaseOrderToOrderedCommandWithCtx()",
-      "norm_label": "advancepurchaseordertoorderedcommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L670"
+      "id": "restore_applybaselinedocumentswithctx",
+      "label": "applyBaselineDocumentsWithCtx()",
+      "norm_label": "applybaselinedocumentswithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
+      "source_location": "L123"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "purchaseorders_advancepurchaseordertoorderedwithctx",
-      "label": "advancePurchaseOrderToOrderedWithCtx()",
-      "norm_label": "advancepurchaseordertoorderedwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L646"
+      "id": "restore_applyrestoreleasewithctx",
+      "label": "applyRestoreLeaseWithCtx()",
+      "norm_label": "applyrestoreleasewithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
+      "source_location": "L278"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "purchaseorders_assertvalidpurchaseorderstatustransition",
-      "label": "assertValidPurchaseOrderStatusTransition()",
-      "norm_label": "assertvalidpurchaseorderstatustransition()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L155"
+      "id": "restore_assertshareddemowriteepoch",
+      "label": "assertSharedDemoWriteEpoch()",
+      "norm_label": "assertshareddemowriteepoch()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
+      "source_location": "L78"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "purchaseorders_buildpurchaseordercommitmentstatusdelta",
-      "label": "buildPurchaseOrderCommitmentStatusDelta()",
-      "norm_label": "buildpurchaseordercommitmentstatusdelta()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L100"
+      "id": "restore_baselinematches",
+      "label": "baselineMatches()",
+      "norm_label": "baselinematches()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
+      "source_location": "L88"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "purchaseorders_buildpurchaseordernumber",
-      "label": "buildPurchaseOrderNumber()",
-      "norm_label": "buildpurchaseordernumber()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L170"
+      "id": "restore_beginrestore",
+      "label": "beginRestore()",
+      "norm_label": "beginrestore()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
+      "source_location": "L57"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "purchaseorders_calculatepurchaseordertotals",
-      "label": "calculatePurchaseOrderTotals()",
-      "norm_label": "calculatepurchaseordertotals()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L124"
+      "id": "restore_beginrestoreleasewithctx",
+      "label": "beginRestoreLeaseWithCtx()",
+      "norm_label": "beginrestoreleasewithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
+      "source_location": "L212"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "purchaseorders_createpurchaseordercommandwithctx",
-      "label": "createPurchaseOrderCommandWithCtx()",
-      "norm_label": "createpurchaseordercommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L472"
+      "id": "restore_completerestore",
+      "label": "completeRestore()",
+      "norm_label": "completerestore()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
+      "source_location": "L99"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "purchaseorders_createpurchaseorderwithctx",
-      "label": "createPurchaseOrderWithCtx()",
-      "norm_label": "createpurchaseorderwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L337"
+      "id": "restore_completerestoreleasewithctx",
+      "label": "completeRestoreLeaseWithCtx()",
+      "norm_label": "completerestoreleasewithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
+      "source_location": "L336"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "purchaseorders_getstatusestoordered",
-      "label": "getStatusesToOrdered()",
-      "norm_label": "getstatusestoordered()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L630"
+      "id": "restore_failrestoreleasewithctx",
+      "label": "failRestoreLeaseWithCtx()",
+      "norm_label": "failrestoreleasewithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
+      "source_location": "L380"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "purchaseorders_mappurchaseordercommanderror",
-      "label": "mapPurchaseOrderCommandError()",
-      "norm_label": "mappurchaseordercommanderror()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L192"
+      "id": "restore_readrestorestatewithctx",
+      "label": "readRestoreStateWithCtx()",
+      "norm_label": "readrestorestatewithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
+      "source_location": "L176"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "purchaseorders_mappurchaseorderstatustoworkitemstatus",
-      "label": "mapPurchaseOrderStatusToWorkItemStatus()",
-      "norm_label": "mappurchaseorderstatustoworkitemstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L174"
+      "id": "restore_requirecurrentshareddemobaseline",
+      "label": "requireCurrentSharedDemoBaseline()",
+      "norm_label": "requirecurrentshareddemobaseline()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
+      "source_location": "L48"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "purchaseorders_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L119"
+      "id": "restore_requirematchingrestorelease",
+      "label": "requireMatchingRestoreLease()",
+      "norm_label": "requirematchingrestorelease()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
+      "source_location": "L186"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "purchaseorders_updatepurchaseorderstatuscommandwithctx",
-      "label": "updatePurchaseOrderStatusCommandWithCtx()",
-      "norm_label": "updatepurchaseorderstatuscommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L613"
+      "id": "restore_requirereadyshareddemowritewithctx",
+      "label": "requireReadySharedDemoWriteWithCtx()",
+      "norm_label": "requirereadyshareddemowritewithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
+      "source_location": "L459"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "purchaseorders_updatepurchaseorderstatuswithctx",
-      "label": "updatePurchaseOrderStatusWithCtx()",
-      "norm_label": "updatepurchaseorderstatuswithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L500"
+      "id": "restore_schedulerestorecontinuation",
+      "label": "scheduleRestoreContinuation()",
+      "norm_label": "schedulerestorecontinuation()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
+      "source_location": "L201"
     },
     {
       "community": 1480,
@@ -190563,137 +190587,137 @@
     {
       "community": 149,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_receiving_ts",
-      "label": "receiving.ts",
-      "norm_label": "receiving.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "id": "packages_athena_webapp_convex_stockops_purchaseorders_ts",
+      "label": "purchaseOrders.ts",
+      "norm_label": "purchaseorders.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
       "source_location": "L1"
     },
     {
       "community": 149,
       "file_type": "code",
-      "id": "receiving_assertdistinctreceivinglineitems",
-      "label": "assertDistinctReceivingLineItems()",
-      "norm_label": "assertdistinctreceivinglineitems()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L153"
+      "id": "purchaseorders_advancepurchaseordertoorderedcommandwithctx",
+      "label": "advancePurchaseOrderToOrderedCommandWithCtx()",
+      "norm_label": "advancepurchaseordertoorderedcommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L670"
     },
     {
       "community": 149,
       "file_type": "code",
-      "id": "receiving_assertreceivablepurchaseorderstatus",
-      "label": "assertReceivablePurchaseOrderStatus()",
-      "norm_label": "assertreceivablepurchaseorderstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L129"
+      "id": "purchaseorders_advancepurchaseordertoorderedwithctx",
+      "label": "advancePurchaseOrderToOrderedWithCtx()",
+      "norm_label": "advancepurchaseordertoorderedwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L646"
     },
     {
       "community": 149,
       "file_type": "code",
-      "id": "receiving_assertreceivinglinequantities",
-      "label": "assertReceivingLineQuantities()",
-      "norm_label": "assertreceivinglinequantities()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L139"
+      "id": "purchaseorders_assertvalidpurchaseorderstatustransition",
+      "label": "assertValidPurchaseOrderStatusTransition()",
+      "norm_label": "assertvalidpurchaseorderstatustransition()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L155"
     },
     {
       "community": 149,
       "file_type": "code",
-      "id": "receiving_assertreceivingreplaymatches",
-      "label": "assertReceivingReplayMatches()",
-      "norm_label": "assertreceivingreplaymatches()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L68"
+      "id": "purchaseorders_buildpurchaseordercommitmentstatusdelta",
+      "label": "buildPurchaseOrderCommitmentStatusDelta()",
+      "norm_label": "buildpurchaseordercommitmentstatusdelta()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L100"
     },
     {
       "community": 149,
       "file_type": "code",
-      "id": "receiving_buildreceivingbatchsourceid",
-      "label": "buildReceivingBatchSourceId()",
-      "norm_label": "buildreceivingbatchsourceid()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L201"
+      "id": "purchaseorders_buildpurchaseordernumber",
+      "label": "buildPurchaseOrderNumber()",
+      "norm_label": "buildpurchaseordernumber()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L170"
     },
     {
       "community": 149,
       "file_type": "code",
-      "id": "receiving_calculatepurchaseorderreceivingstatus",
-      "label": "calculatePurchaseOrderReceivingStatus()",
-      "norm_label": "calculatepurchaseorderreceivingstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "id": "purchaseorders_calculatepurchaseordertotals",
+      "label": "calculatePurchaseOrderTotals()",
+      "norm_label": "calculatepurchaseordertotals()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L124"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "purchaseorders_createpurchaseordercommandwithctx",
+      "label": "createPurchaseOrderCommandWithCtx()",
+      "norm_label": "createpurchaseordercommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L472"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "purchaseorders_createpurchaseorderwithctx",
+      "label": "createPurchaseOrderWithCtx()",
+      "norm_label": "createpurchaseorderwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L337"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "purchaseorders_getstatusestoordered",
+      "label": "getStatusesToOrdered()",
+      "norm_label": "getstatusestoordered()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L630"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "purchaseorders_mappurchaseordercommanderror",
+      "label": "mapPurchaseOrderCommandError()",
+      "norm_label": "mappurchaseordercommanderror()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L192"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "purchaseorders_mappurchaseorderstatustoworkitemstatus",
+      "label": "mapPurchaseOrderStatusToWorkItemStatus()",
+      "norm_label": "mappurchaseorderstatustoworkitemstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L174"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "purchaseorders_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
       "source_location": "L119"
     },
     {
       "community": 149,
       "file_type": "code",
-      "id": "receiving_calculatereceivingbatchtotals",
-      "label": "calculateReceivingBatchTotals()",
-      "norm_label": "calculatereceivingbatchtotals()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L98"
+      "id": "purchaseorders_updatepurchaseorderstatuscommandwithctx",
+      "label": "updatePurchaseOrderStatusCommandWithCtx()",
+      "norm_label": "updatepurchaseorderstatuscommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L613"
     },
     {
       "community": 149,
       "file_type": "code",
-      "id": "receiving_listpurchaseorderlineitems",
-      "label": "listPurchaseOrderLineItems()",
-      "norm_label": "listpurchaseorderlineitems()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L208"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "receiving_mapreceivepurchaseorderbatcherror",
-      "label": "mapReceivePurchaseOrderBatchError()",
-      "norm_label": "mapreceivepurchaseorderbatcherror()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L539"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "receiving_normalizeconfirmedreceiptcost",
-      "label": "normalizeConfirmedReceiptCost()",
-      "norm_label": "normalizeconfirmedreceiptcost()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "receiving_receivepurchaseorderbatchcommandwithctx",
-      "label": "receivePurchaseOrderBatchCommandWithCtx()",
-      "norm_label": "receivepurchaseorderbatchcommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L589"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "receiving_receivepurchaseorderbatchwithctx",
-      "label": "receivePurchaseOrderBatchWithCtx()",
-      "norm_label": "receivepurchaseorderbatchwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L239"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "receiving_summarizereceivingskudeltas",
-      "label": "summarizeReceivingSkuDeltas()",
-      "norm_label": "summarizereceivingskudeltas()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L169"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "receiving_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L40"
+      "id": "purchaseorders_updatepurchaseorderstatuswithctx",
+      "label": "updatePurchaseOrderStatusWithCtx()",
+      "norm_label": "updatepurchaseorderstatuswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L500"
     },
     {
       "community": 1490,
@@ -191274,137 +191298,137 @@
     {
       "community": 150,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_paymenthelpers_ts",
-      "label": "paymentHelpers.ts",
-      "norm_label": "paymenthelpers.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "id": "packages_athena_webapp_convex_stockops_receiving_ts",
+      "label": "receiving.ts",
+      "norm_label": "receiving.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
       "source_location": "L1"
     },
     {
       "community": 150,
       "file_type": "code",
-      "id": "paymenthelpers_buildserverpricedcheckoutproducts",
-      "label": "buildServerPricedCheckoutProducts()",
-      "norm_label": "buildserverpricedcheckoutproducts()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L43"
+      "id": "receiving_assertdistinctreceivinglineitems",
+      "label": "assertDistinctReceivingLineItems()",
+      "norm_label": "assertdistinctreceivinglineitems()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L153"
     },
     {
       "community": 150,
       "file_type": "code",
-      "id": "paymenthelpers_calculateitemssubtotal",
-      "label": "calculateItemsSubtotal()",
-      "norm_label": "calculateitemssubtotal()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L35"
+      "id": "receiving_assertreceivablepurchaseorderstatus",
+      "label": "assertReceivablePurchaseOrderStatus()",
+      "norm_label": "assertreceivablepurchaseorderstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L129"
     },
     {
       "community": 150,
       "file_type": "code",
-      "id": "paymenthelpers_calculateorderamount",
-      "label": "calculateOrderAmount()",
-      "norm_label": "calculateorderamount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L266"
+      "id": "receiving_assertreceivinglinequantities",
+      "label": "assertReceivingLineQuantities()",
+      "norm_label": "assertreceivinglinequantities()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L139"
     },
     {
       "community": 150,
       "file_type": "code",
-      "id": "paymenthelpers_calculaterewardpoints",
-      "label": "calculateRewardPoints()",
-      "norm_label": "calculaterewardpoints()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L286"
+      "id": "receiving_assertreceivingreplaymatches",
+      "label": "assertReceivingReplayMatches()",
+      "norm_label": "assertreceivingreplaymatches()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L68"
     },
     {
       "community": 150,
       "file_type": "code",
-      "id": "paymenthelpers_derivedeliveryoptionfromaddress",
-      "label": "deriveDeliveryOptionFromAddress()",
-      "norm_label": "derivedeliveryoptionfromaddress()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L92"
+      "id": "receiving_buildreceivingbatchsourceid",
+      "label": "buildReceivingBatchSourceId()",
+      "norm_label": "buildreceivingbatchsourceid()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L201"
     },
     {
       "community": 150,
       "file_type": "code",
-      "id": "paymenthelpers_extractorderitems",
-      "label": "extractOrderItems()",
-      "norm_label": "extractorderitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L249"
+      "id": "receiving_calculatepurchaseorderreceivingstatus",
+      "label": "calculatePurchaseOrderReceivingStatus()",
+      "norm_label": "calculatepurchaseorderreceivingstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L119"
     },
     {
       "community": 150,
       "file_type": "code",
-      "id": "paymenthelpers_generatepodreference",
-      "label": "generatePODReference()",
-      "norm_label": "generatepodreference()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L240"
+      "id": "receiving_calculatereceivingbatchtotals",
+      "label": "calculateReceivingBatchTotals()",
+      "norm_label": "calculatereceivingbatchtotals()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L98"
     },
     {
       "community": 150,
       "file_type": "code",
-      "id": "paymenthelpers_getorderdiscountvalue",
-      "label": "getOrderDiscountValue()",
-      "norm_label": "getorderdiscountvalue()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L308"
+      "id": "receiving_listpurchaseorderlineitems",
+      "label": "listPurchaseOrderLineItems()",
+      "norm_label": "listpurchaseorderlineitems()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L208"
     },
     {
       "community": 150,
       "file_type": "code",
-      "id": "paymenthelpers_getremainingrefundablebalance",
-      "label": "getRemainingRefundableBalance()",
-      "norm_label": "getremainingrefundablebalance()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L207"
+      "id": "receiving_mapreceivepurchaseorderbatcherror",
+      "label": "mapReceivePurchaseOrderBatchError()",
+      "norm_label": "mapreceivepurchaseorderbatcherror()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L539"
     },
     {
       "community": 150,
       "file_type": "code",
-      "id": "paymenthelpers_isdeliveryfeewaived",
-      "label": "isDeliveryFeeWaived()",
-      "norm_label": "isdeliveryfeewaived()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L110"
+      "id": "receiving_normalizeconfirmedreceiptcost",
+      "label": "normalizeConfirmedReceiptCost()",
+      "norm_label": "normalizeconfirmedreceiptcost()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L45"
     },
     {
       "community": 150,
       "file_type": "code",
-      "id": "paymenthelpers_normalizedeliveryoption",
-      "label": "normalizeDeliveryOption()",
-      "norm_label": "normalizedeliveryoption()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L80"
+      "id": "receiving_receivepurchaseorderbatchcommandwithctx",
+      "label": "receivePurchaseOrderBatchCommandWithCtx()",
+      "norm_label": "receivepurchaseorderbatchcommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L589"
     },
     {
       "community": 150,
       "file_type": "code",
-      "id": "paymenthelpers_resolverefundamount",
-      "label": "resolveRefundAmount()",
-      "norm_label": "resolverefundamount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L218"
+      "id": "receiving_receivepurchaseorderbatchwithctx",
+      "label": "receivePurchaseOrderBatchWithCtx()",
+      "norm_label": "receivepurchaseorderbatchwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L239"
     },
     {
       "community": 150,
       "file_type": "code",
-      "id": "paymenthelpers_resolveserverdeliveryfee",
-      "label": "resolveServerDeliveryFee()",
-      "norm_label": "resolveserverdeliveryfee()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L151"
+      "id": "receiving_summarizereceivingskudeltas",
+      "label": "summarizeReceivingSkuDeltas()",
+      "norm_label": "summarizereceivingskudeltas()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L169"
     },
     {
       "community": 150,
       "file_type": "code",
-      "id": "paymenthelpers_validatepaymentamount",
-      "label": "validatePaymentAmount()",
-      "norm_label": "validatepaymentamount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L294"
+      "id": "receiving_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L40"
     },
     {
       "community": 1500,
@@ -191589,137 +191613,137 @@
     {
       "community": 151,
       "file_type": "code",
-      "id": "onlineordertracing_buildactorrefs",
-      "label": "buildActorRefs()",
-      "norm_label": "buildactorrefs()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 151,
-      "file_type": "code",
-      "id": "onlineordertracing_buildreturnexchangetraceevent",
-      "label": "buildReturnExchangeTraceEvent()",
-      "norm_label": "buildreturnexchangetraceevent()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
-      "source_location": "L287"
-    },
-    {
-      "community": 151,
-      "file_type": "code",
-      "id": "onlineordertracing_buildreturnexchangetracerecord",
-      "label": "buildReturnExchangeTraceRecord()",
-      "norm_label": "buildreturnexchangetracerecord()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
-      "source_location": "L283"
-    },
-    {
-      "community": 151,
-      "file_type": "code",
-      "id": "onlineordertracing_buildtraceevent",
-      "label": "buildTraceEvent()",
-      "norm_label": "buildtraceevent()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
-      "source_location": "L149"
-    },
-    {
-      "community": 151,
-      "file_type": "code",
-      "id": "onlineordertracing_buildtracerecord",
-      "label": "buildTraceRecord()",
-      "norm_label": "buildtracerecord()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
-      "source_location": "L105"
-    },
-    {
-      "community": 151,
-      "file_type": "code",
-      "id": "onlineordertracing_compactdetails",
-      "label": "compactDetails()",
-      "norm_label": "compactdetails()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
-      "source_location": "L99"
-    },
-    {
-      "community": 151,
-      "file_type": "code",
-      "id": "onlineordertracing_recordonlineorderreturnexchangetracebesteffort",
-      "label": "recordOnlineOrderReturnExchangeTraceBestEffort()",
-      "norm_label": "recordonlineorderreturnexchangetracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
-      "source_location": "L396"
-    },
-    {
-      "community": 151,
-      "file_type": "code",
-      "id": "onlineordertracing_recordonlineordertracebesteffort",
-      "label": "recordOnlineOrderTraceBestEffort()",
-      "norm_label": "recordonlineordertracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
-      "source_location": "L352"
-    },
-    {
-      "community": 151,
-      "file_type": "code",
-      "id": "onlineordertracing_resolvestoreorganizationid",
-      "label": "resolveStoreOrganizationId()",
-      "norm_label": "resolvestoreorganizationid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 151,
-      "file_type": "code",
-      "id": "onlineordertracing_returnexchangemessage",
-      "label": "returnExchangeMessage()",
-      "norm_label": "returnexchangemessage()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
-      "source_location": "L260"
-    },
-    {
-      "community": 151,
-      "file_type": "code",
-      "id": "onlineordertracing_returnexchangestep",
-      "label": "returnExchangeStep()",
-      "norm_label": "returnexchangestep()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
-      "source_location": "L237"
-    },
-    {
-      "community": 151,
-      "file_type": "code",
-      "id": "onlineordertracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
-      "source_location": "L344"
-    },
-    {
-      "community": 151,
-      "file_type": "code",
-      "id": "onlineordertracing_statusmessage",
-      "label": "statusMessage()",
-      "norm_label": "statusmessage()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
-      "source_location": "L131"
-    },
-    {
-      "community": 151,
-      "file_type": "code",
-      "id": "onlineordertracing_statusstep",
-      "label": "statusStep()",
-      "norm_label": "statusstep()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
-      "source_location": "L114"
-    },
-    {
-      "community": 151,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_onlineordertracing_ts",
-      "label": "onlineOrderTracing.ts",
-      "norm_label": "onlineordertracing.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
+      "id": "packages_athena_webapp_convex_storefront_helpers_paymenthelpers_ts",
+      "label": "paymentHelpers.ts",
+      "norm_label": "paymenthelpers.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "paymenthelpers_buildserverpricedcheckoutproducts",
+      "label": "buildServerPricedCheckoutProducts()",
+      "norm_label": "buildserverpricedcheckoutproducts()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "paymenthelpers_calculateitemssubtotal",
+      "label": "calculateItemsSubtotal()",
+      "norm_label": "calculateitemssubtotal()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "paymenthelpers_calculateorderamount",
+      "label": "calculateOrderAmount()",
+      "norm_label": "calculateorderamount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L266"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "paymenthelpers_calculaterewardpoints",
+      "label": "calculateRewardPoints()",
+      "norm_label": "calculaterewardpoints()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L286"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "paymenthelpers_derivedeliveryoptionfromaddress",
+      "label": "deriveDeliveryOptionFromAddress()",
+      "norm_label": "derivedeliveryoptionfromaddress()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "paymenthelpers_extractorderitems",
+      "label": "extractOrderItems()",
+      "norm_label": "extractorderitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L249"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "paymenthelpers_generatepodreference",
+      "label": "generatePODReference()",
+      "norm_label": "generatepodreference()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L240"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "paymenthelpers_getorderdiscountvalue",
+      "label": "getOrderDiscountValue()",
+      "norm_label": "getorderdiscountvalue()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L308"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "paymenthelpers_getremainingrefundablebalance",
+      "label": "getRemainingRefundableBalance()",
+      "norm_label": "getremainingrefundablebalance()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L207"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "paymenthelpers_isdeliveryfeewaived",
+      "label": "isDeliveryFeeWaived()",
+      "norm_label": "isdeliveryfeewaived()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L110"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "paymenthelpers_normalizedeliveryoption",
+      "label": "normalizeDeliveryOption()",
+      "norm_label": "normalizedeliveryoption()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L80"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "paymenthelpers_resolverefundamount",
+      "label": "resolveRefundAmount()",
+      "norm_label": "resolverefundamount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L218"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "paymenthelpers_resolveserverdeliveryfee",
+      "label": "resolveServerDeliveryFee()",
+      "norm_label": "resolveserverdeliveryfee()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L151"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "paymenthelpers_validatepaymentamount",
+      "label": "validatePaymentAmount()",
+      "norm_label": "validatepaymentamount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L294"
     },
     {
       "community": 1510,
@@ -191904,137 +191928,137 @@
     {
       "community": 152,
       "file_type": "code",
-      "id": "packages_athena_webapp_shared_registersessionlifecyclepolicy_ts",
-      "label": "registerSessionLifecyclePolicy.ts",
-      "norm_label": "registersessionlifecyclepolicy.ts",
-      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
-      "source_location": "L1"
+      "id": "onlineordertracing_buildactorrefs",
+      "label": "buildActorRefs()",
+      "norm_label": "buildactorrefs()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
+      "source_location": "L90"
     },
     {
       "community": 152,
       "file_type": "code",
-      "id": "registersessionlifecyclepolicy_caninspectruntimeclouddrawerauthority",
-      "label": "canInspectRuntimeCloudDrawerAuthority()",
-      "norm_label": "caninspectruntimeclouddrawerauthority()",
-      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
-      "source_location": "L258"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "registersessionlifecyclepolicy_canopenreplacementdrawerforlocalblock",
-      "label": "canOpenReplacementDrawerForLocalBlock()",
-      "norm_label": "canopenreplacementdrawerforlocalblock()",
-      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
-      "source_location": "L233"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "registersessionlifecyclepolicy_canreusecloudregistersessionforlocalopen",
-      "label": "canReuseCloudRegisterSessionForLocalOpen()",
-      "norm_label": "canreusecloudregistersessionforlocalopen()",
-      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
-      "source_location": "L163"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "registersessionlifecyclepolicy_cansupersedereviewedregistersessionforlocalopen",
-      "label": "canSupersedeReviewedRegisterSessionForLocalOpen()",
-      "norm_label": "cansupersedereviewedregistersessionforlocalopen()",
-      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
-      "source_location": "L194"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "registersessionlifecyclepolicy_drawerauthoritymatchesactiveregistersession",
-      "label": "drawerAuthorityMatchesActiveRegisterSession()",
-      "norm_label": "drawerauthoritymatchesactiveregistersession()",
-      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
-      "source_location": "L298"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "registersessionlifecyclepolicy_getregistersessionvoidapplicationstatus",
-      "label": "getRegisterSessionVoidApplicationStatus()",
-      "norm_label": "getregistersessionvoidapplicationstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
-      "source_location": "L79"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "registersessionlifecyclepolicy_getsaleblockingdrawerauthority",
-      "label": "getSaleBlockingDrawerAuthority()",
-      "norm_label": "getsaleblockingdrawerauthority()",
-      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "registersessionlifecyclepolicy_isdrawerauthoritysaleblocking",
-      "label": "isDrawerAuthoritySaleBlocking()",
-      "norm_label": "isdrawerauthoritysaleblocking()",
-      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
-      "source_location": "L156"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "registersessionlifecyclepolicy_isnonblockingregisterlifecyclereviewevent",
-      "label": "isNonBlockingRegisterLifecycleReviewEvent()",
-      "norm_label": "isnonblockingregisterlifecyclereviewevent()",
-      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "registersessionlifecyclepolicy_isregistercloseoutreviewconflict",
-      "label": "isRegisterCloseoutReviewConflict()",
-      "norm_label": "isregistercloseoutreviewconflict()",
-      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
-      "source_location": "L268"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "registersessionlifecyclepolicy_isregistersessionconflictblocking",
-      "label": "isRegisterSessionConflictBlocking()",
-      "norm_label": "isregistersessionconflictblocking()",
-      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
-      "source_location": "L109"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "registersessionlifecyclepolicy_isregistersessionreplacementblocking",
-      "label": "isRegisterSessionReplacementBlocking()",
-      "norm_label": "isregistersessionreplacementblocking()",
-      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "registersessionlifecyclepolicy_isregistersessionsaleusable",
-      "label": "isRegisterSessionSaleUsable()",
-      "norm_label": "isregistersessionsaleusable()",
-      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 152,
-      "file_type": "code",
-      "id": "registersessionlifecyclepolicy_isscopedregistersession",
-      "label": "isScopedRegisterSession()",
-      "norm_label": "isscopedregistersession()",
-      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
+      "id": "onlineordertracing_buildreturnexchangetraceevent",
+      "label": "buildReturnExchangeTraceEvent()",
+      "norm_label": "buildreturnexchangetraceevent()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
       "source_location": "L287"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
+      "id": "onlineordertracing_buildreturnexchangetracerecord",
+      "label": "buildReturnExchangeTraceRecord()",
+      "norm_label": "buildreturnexchangetracerecord()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
+      "source_location": "L283"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
+      "id": "onlineordertracing_buildtraceevent",
+      "label": "buildTraceEvent()",
+      "norm_label": "buildtraceevent()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
+      "source_location": "L149"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
+      "id": "onlineordertracing_buildtracerecord",
+      "label": "buildTraceRecord()",
+      "norm_label": "buildtracerecord()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
+      "source_location": "L105"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
+      "id": "onlineordertracing_compactdetails",
+      "label": "compactDetails()",
+      "norm_label": "compactdetails()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
+      "source_location": "L99"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
+      "id": "onlineordertracing_recordonlineorderreturnexchangetracebesteffort",
+      "label": "recordOnlineOrderReturnExchangeTraceBestEffort()",
+      "norm_label": "recordonlineorderreturnexchangetracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
+      "source_location": "L396"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
+      "id": "onlineordertracing_recordonlineordertracebesteffort",
+      "label": "recordOnlineOrderTraceBestEffort()",
+      "norm_label": "recordonlineordertracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
+      "source_location": "L352"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
+      "id": "onlineordertracing_resolvestoreorganizationid",
+      "label": "resolveStoreOrganizationId()",
+      "norm_label": "resolvestoreorganizationid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
+      "id": "onlineordertracing_returnexchangemessage",
+      "label": "returnExchangeMessage()",
+      "norm_label": "returnexchangemessage()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
+      "source_location": "L260"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
+      "id": "onlineordertracing_returnexchangestep",
+      "label": "returnExchangeStep()",
+      "norm_label": "returnexchangestep()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
+      "source_location": "L237"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
+      "id": "onlineordertracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
+      "source_location": "L344"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
+      "id": "onlineordertracing_statusmessage",
+      "label": "statusMessage()",
+      "norm_label": "statusmessage()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
+      "source_location": "L131"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
+      "id": "onlineordertracing_statusstep",
+      "label": "statusStep()",
+      "norm_label": "statusstep()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
+      "source_location": "L114"
+    },
+    {
+      "community": 152,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_onlineordertracing_ts",
+      "label": "onlineOrderTracing.ts",
+      "norm_label": "onlineordertracing.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
+      "source_location": "L1"
     },
     {
       "community": 1520,
@@ -192219,137 +192243,137 @@
     {
       "community": 153,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productstockinput_ts",
-      "label": "ProductStockInput.ts",
-      "norm_label": "productstockinput.ts",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
+      "id": "packages_athena_webapp_shared_registersessionlifecyclepolicy_ts",
+      "label": "registerSessionLifecyclePolicy.ts",
+      "norm_label": "registersessionlifecyclepolicy.ts",
+      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
       "source_location": "L1"
     },
     {
       "community": 153,
       "file_type": "code",
-      "id": "productstockinput_buildtrustedinventoryfinalizationpayload",
-      "label": "buildTrustedInventoryFinalizationPayload()",
-      "norm_label": "buildtrustedinventoryfinalizationpayload()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
-      "source_location": "L527"
+      "id": "registersessionlifecyclepolicy_caninspectruntimeclouddrawerauthority",
+      "label": "canInspectRuntimeCloudDrawerAuthority()",
+      "norm_label": "caninspectruntimeclouddrawerauthority()",
+      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
+      "source_location": "L258"
     },
     {
       "community": 153,
       "file_type": "code",
-      "id": "productstockinput_buildtrustedinventorymoneypayload",
-      "label": "buildTrustedInventoryMoneyPayload()",
-      "norm_label": "buildtrustedinventorymoneypayload()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
-      "source_location": "L507"
+      "id": "registersessionlifecyclepolicy_canopenreplacementdrawerforlocalblock",
+      "label": "canOpenReplacementDrawerForLocalBlock()",
+      "norm_label": "canopenreplacementdrawerforlocalblock()",
+      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
+      "source_location": "L233"
     },
     {
       "community": 153,
       "file_type": "code",
-      "id": "productstockinput_gettrustedinventoryreviewvalidationmessage",
-      "label": "getTrustedInventoryReviewValidationMessage()",
-      "norm_label": "gettrustedinventoryreviewvalidationmessage()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
-      "source_location": "L317"
+      "id": "registersessionlifecyclepolicy_canreusecloudregistersessionforlocalopen",
+      "label": "canReuseCloudRegisterSessionForLocalOpen()",
+      "norm_label": "canreusecloudregistersessionforlocalopen()",
+      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
+      "source_location": "L163"
     },
     {
       "community": 153,
       "file_type": "code",
-      "id": "productstockinput_isnonnegativeinteger",
-      "label": "isNonNegativeInteger()",
-      "norm_label": "isnonnegativeinteger()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
-      "source_location": "L308"
+      "id": "registersessionlifecyclepolicy_cansupersedereviewedregistersessionforlocalopen",
+      "label": "canSupersedeReviewedRegisterSessionForLocalOpen()",
+      "norm_label": "cansupersedereviewedregistersessionforlocalopen()",
+      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
+      "source_location": "L194"
     },
     {
       "community": 153,
       "file_type": "code",
-      "id": "productstockinput_parsevariantdisplaymoney",
-      "label": "parseVariantDisplayMoney()",
-      "norm_label": "parsevariantdisplaymoney()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
-      "source_location": "L499"
+      "id": "registersessionlifecyclepolicy_drawerauthoritymatchesactiveregistersession",
+      "label": "drawerAuthorityMatchesActiveRegisterSession()",
+      "norm_label": "drawerauthoritymatchesactiveregistersession()",
+      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
+      "source_location": "L298"
     },
     {
       "community": 153,
       "file_type": "code",
-      "id": "productstockinput_parsevariantinputvalue",
-      "label": "parseVariantInputValue()",
-      "norm_label": "parsevariantinputvalue()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
-      "source_location": "L21"
+      "id": "registersessionlifecyclepolicy_getregistersessionvoidapplicationstatus",
+      "label": "getRegisterSessionVoidApplicationStatus()",
+      "norm_label": "getregistersessionvoidapplicationstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
+      "source_location": "L79"
     },
     {
       "community": 153,
       "file_type": "code",
-      "id": "productstockinput_resolvependingcheckoutskulinkpricestate",
-      "label": "resolvePendingCheckoutSkuLinkPriceState()",
-      "norm_label": "resolvependingcheckoutskulinkpricestate()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
-      "source_location": "L171"
+      "id": "registersessionlifecyclepolicy_getsaleblockingdrawerauthority",
+      "label": "getSaleBlockingDrawerAuthority()",
+      "norm_label": "getsaleblockingdrawerauthority()",
+      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
+      "source_location": "L128"
     },
     {
       "community": 153,
       "file_type": "code",
-      "id": "productstockinput_resolvestockinputupdate",
-      "label": "resolveStockInputUpdate()",
-      "norm_label": "resolvestockinputupdate()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
-      "source_location": "L43"
+      "id": "registersessionlifecyclepolicy_isdrawerauthoritysaleblocking",
+      "label": "isDrawerAuthoritySaleBlocking()",
+      "norm_label": "isdrawerauthoritysaleblocking()",
+      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
+      "source_location": "L156"
     },
     {
       "community": 153,
       "file_type": "code",
-      "id": "productstockinput_resolvetrustedinventorycommanderror",
-      "label": "resolveTrustedInventoryCommandError()",
-      "norm_label": "resolvetrustedinventorycommanderror()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
-      "source_location": "L84"
+      "id": "registersessionlifecyclepolicy_isnonblockingregisterlifecyclereviewevent",
+      "label": "isNonBlockingRegisterLifecycleReviewEvent()",
+      "norm_label": "isnonblockingregisterlifecyclereviewevent()",
+      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
+      "source_location": "L51"
     },
     {
       "community": 153,
       "file_type": "code",
-      "id": "productstockinput_resolvetrustedinventoryfinalizationpricingpolicy",
-      "label": "resolveTrustedInventoryFinalizationPricingPolicy()",
-      "norm_label": "resolvetrustedinventoryfinalizationpricingpolicy()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
-      "source_location": "L151"
+      "id": "registersessionlifecyclepolicy_isregistercloseoutreviewconflict",
+      "label": "isRegisterCloseoutReviewConflict()",
+      "norm_label": "isregistercloseoutreviewconflict()",
+      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
+      "source_location": "L268"
     },
     {
       "community": 153,
       "file_type": "code",
-      "id": "productstockinput_resolvetrustedinventoryrefreshreviewstate",
-      "label": "resolveTrustedInventoryRefreshReviewState()",
-      "norm_label": "resolvetrustedinventoryrefreshreviewstate()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
-      "source_location": "L130"
+      "id": "registersessionlifecyclepolicy_isregistersessionconflictblocking",
+      "label": "isRegisterSessionConflictBlocking()",
+      "norm_label": "isregistersessionconflictblocking()",
+      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
+      "source_location": "L109"
     },
     {
       "community": 153,
       "file_type": "code",
-      "id": "productstockinput_resolvetrustedinventoryreviewclickaction",
-      "label": "resolveTrustedInventoryReviewClickAction()",
-      "norm_label": "resolvetrustedinventoryreviewclickaction()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
+      "id": "registersessionlifecyclepolicy_isregistersessionreplacementblocking",
+      "label": "isRegisterSessionReplacementBlocking()",
+      "norm_label": "isregistersessionreplacementblocking()",
+      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 153,
+      "file_type": "code",
+      "id": "registersessionlifecyclepolicy_isregistersessionsaleusable",
+      "label": "isRegisterSessionSaleUsable()",
+      "norm_label": "isregistersessionsaleusable()",
+      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
       "source_location": "L62"
     },
     {
       "community": 153,
       "file_type": "code",
-      "id": "productstockinput_resolvetrustedinventoryreviewstate",
-      "label": "resolveTrustedInventoryReviewState()",
-      "norm_label": "resolvetrustedinventoryreviewstate()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
-      "source_location": "L344"
-    },
-    {
-      "community": 153,
-      "file_type": "code",
-      "id": "productstockinput_resolvevariantnumericinputvalue",
-      "label": "resolveVariantNumericInputValue()",
-      "norm_label": "resolvevariantnumericinputvalue()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
-      "source_location": "L52"
+      "id": "registersessionlifecyclepolicy_isscopedregistersession",
+      "label": "isScopedRegisterSession()",
+      "norm_label": "isscopedregistersession()",
+      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
+      "source_location": "L287"
     },
     {
       "community": 1530,
@@ -192534,137 +192558,137 @@
     {
       "community": 154,
       "file_type": "code",
-      "id": "inventoryimportview_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
-      "source_location": "L1292"
-    },
-    {
-      "community": 154,
-      "file_type": "code",
-      "id": "inventoryimportview_handleapplybulkreviewdecision",
-      "label": "handleApplyBulkReviewDecision()",
-      "norm_label": "handleapplybulkreviewdecision()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
-      "source_location": "L1126"
-    },
-    {
-      "community": 154,
-      "file_type": "code",
-      "id": "inventoryimportview_handleenterreviewmode",
-      "label": "handleEnterReviewMode()",
-      "norm_label": "handleenterreviewmode()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
-      "source_location": "L1092"
-    },
-    {
-      "community": 154,
-      "file_type": "code",
-      "id": "inventoryimportview_handlefilechange",
-      "label": "handleFileChange()",
-      "norm_label": "handlefilechange()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
-      "source_location": "L833"
-    },
-    {
-      "community": 154,
-      "file_type": "code",
-      "id": "inventoryimportview_handleloadlatestreviewversion",
-      "label": "handleLoadLatestReviewVersion()",
-      "norm_label": "handleloadlatestreviewversion()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
-      "source_location": "L1063"
-    },
-    {
-      "community": 154,
-      "file_type": "code",
-      "id": "inventoryimportview_handleoverlaypagechange",
-      "label": "handleOverlayPageChange()",
-      "norm_label": "handleoverlaypagechange()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
-      "source_location": "L1119"
-    },
-    {
-      "community": 154,
-      "file_type": "code",
-      "id": "inventoryimportview_handlesavereviewversion",
-      "label": "handleSaveReviewVersion()",
-      "norm_label": "handlesavereviewversion()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
-      "source_location": "L967"
-    },
-    {
-      "community": 154,
-      "file_type": "code",
-      "id": "inventoryimportview_handlestagereviewrowsforpos",
-      "label": "handleStageReviewRowsForPos()",
-      "norm_label": "handlestagereviewrowsforpos()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
-      "source_location": "L971"
-    },
-    {
-      "community": 154,
-      "file_type": "code",
-      "id": "inventoryimportview_parseinventoryoverlayfilter",
-      "label": "parseInventoryOverlayFilter()",
-      "norm_label": "parseinventoryoverlayfilter()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
-      "source_location": "L207"
-    },
-    {
-      "community": 154,
-      "file_type": "code",
-      "id": "inventoryimportview_parseinventoryoverlaypage",
-      "label": "parseInventoryOverlayPage()",
-      "norm_label": "parseinventoryoverlaypage()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
-      "source_location": "L220"
-    },
-    {
-      "community": 154,
-      "file_type": "code",
-      "id": "inventoryimportview_parseinventoryoverlayquery",
-      "label": "parseInventoryOverlayQuery()",
-      "norm_label": "parseinventoryoverlayquery()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
-      "source_location": "L216"
-    },
-    {
-      "community": 154,
-      "file_type": "code",
-      "id": "inventoryimportview_readinventoryimportroutedraft",
-      "label": "readInventoryImportRouteDraft()",
-      "norm_label": "readinventoryimportroutedraft()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
-      "source_location": "L244"
-    },
-    {
-      "community": 154,
-      "file_type": "code",
-      "id": "inventoryimportview_saveinventoryimportroutedraft",
-      "label": "saveInventoryImportRouteDraft()",
-      "norm_label": "saveinventoryimportroutedraft()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
-      "source_location": "L235"
-    },
-    {
-      "community": 154,
-      "file_type": "code",
-      "id": "inventoryimportview_switch",
-      "label": "switch()",
-      "norm_label": "switch()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
-      "source_location": "L2943"
-    },
-    {
-      "community": 154,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_inventoryimportview_tsx",
-      "label": "InventoryImportView.tsx",
-      "norm_label": "inventoryimportview.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
+      "id": "packages_athena_webapp_src_components_add_product_productstockinput_ts",
+      "label": "ProductStockInput.ts",
+      "norm_label": "productstockinput.ts",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 154,
+      "file_type": "code",
+      "id": "productstockinput_buildtrustedinventoryfinalizationpayload",
+      "label": "buildTrustedInventoryFinalizationPayload()",
+      "norm_label": "buildtrustedinventoryfinalizationpayload()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
+      "source_location": "L527"
+    },
+    {
+      "community": 154,
+      "file_type": "code",
+      "id": "productstockinput_buildtrustedinventorymoneypayload",
+      "label": "buildTrustedInventoryMoneyPayload()",
+      "norm_label": "buildtrustedinventorymoneypayload()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
+      "source_location": "L507"
+    },
+    {
+      "community": 154,
+      "file_type": "code",
+      "id": "productstockinput_gettrustedinventoryreviewvalidationmessage",
+      "label": "getTrustedInventoryReviewValidationMessage()",
+      "norm_label": "gettrustedinventoryreviewvalidationmessage()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
+      "source_location": "L317"
+    },
+    {
+      "community": 154,
+      "file_type": "code",
+      "id": "productstockinput_isnonnegativeinteger",
+      "label": "isNonNegativeInteger()",
+      "norm_label": "isnonnegativeinteger()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
+      "source_location": "L308"
+    },
+    {
+      "community": 154,
+      "file_type": "code",
+      "id": "productstockinput_parsevariantdisplaymoney",
+      "label": "parseVariantDisplayMoney()",
+      "norm_label": "parsevariantdisplaymoney()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
+      "source_location": "L499"
+    },
+    {
+      "community": 154,
+      "file_type": "code",
+      "id": "productstockinput_parsevariantinputvalue",
+      "label": "parseVariantInputValue()",
+      "norm_label": "parsevariantinputvalue()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 154,
+      "file_type": "code",
+      "id": "productstockinput_resolvependingcheckoutskulinkpricestate",
+      "label": "resolvePendingCheckoutSkuLinkPriceState()",
+      "norm_label": "resolvependingcheckoutskulinkpricestate()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
+      "source_location": "L171"
+    },
+    {
+      "community": 154,
+      "file_type": "code",
+      "id": "productstockinput_resolvestockinputupdate",
+      "label": "resolveStockInputUpdate()",
+      "norm_label": "resolvestockinputupdate()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 154,
+      "file_type": "code",
+      "id": "productstockinput_resolvetrustedinventorycommanderror",
+      "label": "resolveTrustedInventoryCommandError()",
+      "norm_label": "resolvetrustedinventorycommanderror()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 154,
+      "file_type": "code",
+      "id": "productstockinput_resolvetrustedinventoryfinalizationpricingpolicy",
+      "label": "resolveTrustedInventoryFinalizationPricingPolicy()",
+      "norm_label": "resolvetrustedinventoryfinalizationpricingpolicy()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
+      "source_location": "L151"
+    },
+    {
+      "community": 154,
+      "file_type": "code",
+      "id": "productstockinput_resolvetrustedinventoryrefreshreviewstate",
+      "label": "resolveTrustedInventoryRefreshReviewState()",
+      "norm_label": "resolvetrustedinventoryrefreshreviewstate()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
+      "source_location": "L130"
+    },
+    {
+      "community": 154,
+      "file_type": "code",
+      "id": "productstockinput_resolvetrustedinventoryreviewclickaction",
+      "label": "resolveTrustedInventoryReviewClickAction()",
+      "norm_label": "resolvetrustedinventoryreviewclickaction()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 154,
+      "file_type": "code",
+      "id": "productstockinput_resolvetrustedinventoryreviewstate",
+      "label": "resolveTrustedInventoryReviewState()",
+      "norm_label": "resolvetrustedinventoryreviewstate()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
+      "source_location": "L344"
+    },
+    {
+      "community": 154,
+      "file_type": "code",
+      "id": "productstockinput_resolvevariantnumericinputvalue",
+      "label": "resolveVariantNumericInputValue()",
+      "norm_label": "resolvevariantnumericinputvalue()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
+      "source_location": "L52"
     },
     {
       "community": 1540,
@@ -192849,137 +192873,137 @@
     {
       "community": 155,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
-      "label": "TransactionsView.tsx",
-      "norm_label": "transactionsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L1"
+      "id": "inventoryimportview_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
+      "source_location": "L1292"
     },
     {
       "community": 155,
       "file_type": "code",
-      "id": "transactionsview_formatoperatingdatefilterlabel",
-      "label": "formatOperatingDateFilterLabel()",
-      "norm_label": "formatoperatingdatefilterlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L109"
+      "id": "inventoryimportview_handleapplybulkreviewdecision",
+      "label": "handleApplyBulkReviewDecision()",
+      "norm_label": "handleapplybulkreviewdecision()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
+      "source_location": "L1126"
     },
     {
       "community": 155,
       "file_type": "code",
-      "id": "transactionsview_formatpaymentmethod",
-      "label": "formatPaymentMethod()",
-      "norm_label": "formatpaymentmethod()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L38"
+      "id": "inventoryimportview_handleenterreviewmode",
+      "label": "handleEnterReviewMode()",
+      "norm_label": "handleenterreviewmode()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
+      "source_location": "L1092"
     },
     {
       "community": 155,
       "file_type": "code",
-      "id": "transactionsview_formatregisterfilterlabel",
-      "label": "formatRegisterFilterLabel()",
-      "norm_label": "formatregisterfilterlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L43"
+      "id": "inventoryimportview_handlefilechange",
+      "label": "handleFileChange()",
+      "norm_label": "handlefilechange()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
+      "source_location": "L833"
     },
     {
       "community": 155,
       "file_type": "code",
-      "id": "transactionsview_getcompletedtransactionlimitforpage",
-      "label": "getCompletedTransactionLimitForPage()",
-      "norm_label": "getcompletedtransactionlimitforpage()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L123"
+      "id": "inventoryimportview_handleloadlatestreviewversion",
+      "label": "handleLoadLatestReviewVersion()",
+      "norm_label": "handleloadlatestreviewversion()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
+      "source_location": "L1063"
     },
     {
       "community": 155,
       "file_type": "code",
-      "id": "transactionsview_getemptytransactiontitle",
-      "label": "getEmptyTransactionTitle()",
-      "norm_label": "getemptytransactiontitle()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "id": "inventoryimportview_handleoverlaypagechange",
+      "label": "handleOverlayPageChange()",
+      "norm_label": "handleoverlaypagechange()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
+      "source_location": "L1119"
+    },
+    {
+      "community": 155,
+      "file_type": "code",
+      "id": "inventoryimportview_handlesavereviewversion",
+      "label": "handleSaveReviewVersion()",
+      "norm_label": "handlesavereviewversion()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
+      "source_location": "L967"
+    },
+    {
+      "community": 155,
+      "file_type": "code",
+      "id": "inventoryimportview_handlestagereviewrowsforpos",
+      "label": "handleStageReviewRowsForPos()",
+      "norm_label": "handlestagereviewrowsforpos()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
+      "source_location": "L971"
+    },
+    {
+      "community": 155,
+      "file_type": "code",
+      "id": "inventoryimportview_parseinventoryoverlayfilter",
+      "label": "parseInventoryOverlayFilter()",
+      "norm_label": "parseinventoryoverlayfilter()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
+      "source_location": "L207"
+    },
+    {
+      "community": 155,
+      "file_type": "code",
+      "id": "inventoryimportview_parseinventoryoverlaypage",
+      "label": "parseInventoryOverlayPage()",
+      "norm_label": "parseinventoryoverlaypage()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
+      "source_location": "L220"
+    },
+    {
+      "community": 155,
+      "file_type": "code",
+      "id": "inventoryimportview_parseinventoryoverlayquery",
+      "label": "parseInventoryOverlayQuery()",
+      "norm_label": "parseinventoryoverlayquery()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
+      "source_location": "L216"
+    },
+    {
+      "community": 155,
+      "file_type": "code",
+      "id": "inventoryimportview_readinventoryimportroutedraft",
+      "label": "readInventoryImportRouteDraft()",
+      "norm_label": "readinventoryimportroutedraft()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
       "source_location": "L244"
     },
     {
       "community": 155,
       "file_type": "code",
-      "id": "transactionsview_getnexttransactionpagesearch",
-      "label": "getNextTransactionPageSearch()",
-      "norm_label": "getnexttransactionpagesearch()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L133"
+      "id": "inventoryimportview_saveinventoryimportroutedraft",
+      "label": "saveInventoryImportRouteDraft()",
+      "norm_label": "saveinventoryimportroutedraft()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
+      "source_location": "L235"
     },
     {
       "community": 155,
       "file_type": "code",
-      "id": "transactionsview_getnexttransactionpaymentfiltersearch",
-      "label": "getNextTransactionPaymentFilterSearch()",
-      "norm_label": "getnexttransactionpaymentfiltersearch()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L187"
+      "id": "inventoryimportview_switch",
+      "label": "switch()",
+      "norm_label": "switch()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
+      "source_location": "L2943"
     },
     {
       "community": 155,
       "file_type": "code",
-      "id": "transactionsview_getnexttransactiontimefiltersearch",
-      "label": "getNextTransactionTimeFilterSearch()",
-      "norm_label": "getnexttransactiontimefiltersearch()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L177"
-    },
-    {
-      "community": 155,
-      "file_type": "code",
-      "id": "transactionsview_getpageindexfromsearch",
-      "label": "getPageIndexFromSearch()",
-      "norm_label": "getpageindexfromsearch()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L117"
-    },
-    {
-      "community": 155,
-      "file_type": "code",
-      "id": "transactionsview_getpaymentmethodicon",
-      "label": "getPaymentMethodIcon()",
-      "norm_label": "getpaymentmethodicon()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L221"
-    },
-    {
-      "community": 155,
-      "file_type": "code",
-      "id": "transactionsview_getstartofoperatingdate",
-      "label": "getStartOfOperatingDate()",
-      "norm_label": "getstartofoperatingdate()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 155,
-      "file_type": "code",
-      "id": "transactionsview_gettransactiontimefilter",
-      "label": "getTransactionTimeFilter()",
-      "norm_label": "gettransactiontimefilter()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L149"
-    },
-    {
-      "community": 155,
-      "file_type": "code",
-      "id": "transactionsview_istoday",
-      "label": "isToday()",
-      "norm_label": "istoday()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L94"
-    },
-    {
-      "community": 155,
-      "file_type": "code",
-      "id": "transactionsview_transactionmobilecard",
-      "label": "TransactionMobileCard()",
-      "norm_label": "transactionmobilecard()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L285"
+      "id": "packages_athena_webapp_src_components_operations_inventoryimportview_tsx",
+      "label": "InventoryImportView.tsx",
+      "norm_label": "inventoryimportview.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
+      "source_location": "L1"
     },
     {
       "community": 1550,
@@ -193164,137 +193188,137 @@
     {
       "community": 156,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_quickaddproductdialog_tsx",
-      "label": "QuickAddProductDialog.tsx",
-      "norm_label": "quickaddproductdialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
+      "label": "TransactionsView.tsx",
+      "norm_label": "transactionsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
       "source_location": "L1"
     },
     {
       "community": 156,
       "file_type": "code",
-      "id": "quickaddproductdialog_addquickaddextravariant",
-      "label": "addQuickAddExtraVariant()",
-      "norm_label": "addquickaddextravariant()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L453"
+      "id": "transactionsview_formatoperatingdatefilterlabel",
+      "label": "formatOperatingDateFilterLabel()",
+      "norm_label": "formatoperatingdatefilterlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L109"
     },
     {
       "community": 156,
       "file_type": "code",
-      "id": "quickaddproductdialog_buildquickaddexistingskuoptionfromsearchresult",
-      "label": "buildQuickAddExistingSkuOptionFromSearchResult()",
-      "norm_label": "buildquickaddexistingskuoptionfromsearchresult()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L169"
+      "id": "transactionsview_formatpaymentmethod",
+      "label": "formatPaymentMethod()",
+      "norm_label": "formatpaymentmethod()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L38"
     },
     {
       "community": 156,
       "file_type": "code",
-      "id": "quickaddproductdialog_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L824"
+      "id": "transactionsview_formatregisterfilterlabel",
+      "label": "formatRegisterFilterLabel()",
+      "norm_label": "formatregisterfilterlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L43"
     },
     {
       "community": 156,
       "file_type": "code",
-      "id": "quickaddproductdialog_formatquickadddialogerror",
-      "label": "formatQuickAddDialogError()",
-      "norm_label": "formatquickadddialogerror()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L118"
+      "id": "transactionsview_getcompletedtransactionlimitforpage",
+      "label": "getCompletedTransactionLimitForPage()",
+      "norm_label": "getcompletedtransactionlimitforpage()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L123"
     },
     {
       "community": 156,
       "file_type": "code",
-      "id": "quickaddproductdialog_getexistingskumetadata",
-      "label": "getExistingSkuMetadata()",
-      "norm_label": "getexistingskumetadata()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L158"
+      "id": "transactionsview_getemptytransactiontitle",
+      "label": "getEmptyTransactionTitle()",
+      "norm_label": "getemptytransactiontitle()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L244"
     },
     {
       "community": 156,
       "file_type": "code",
-      "id": "quickaddproductdialog_handleattachbarcode",
-      "label": "handleAttachBarcode()",
-      "norm_label": "handleattachbarcode()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L681"
+      "id": "transactionsview_getnexttransactionpagesearch",
+      "label": "getNextTransactionPageSearch()",
+      "norm_label": "getnexttransactionpagesearch()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L133"
     },
     {
       "community": 156,
       "file_type": "code",
-      "id": "quickaddproductdialog_handlecancel",
-      "label": "handleCancel()",
-      "norm_label": "handlecancel()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L473"
+      "id": "transactionsview_getnexttransactionpaymentfiltersearch",
+      "label": "getNextTransactionPaymentFilterSearch()",
+      "norm_label": "getnexttransactionpaymentfiltersearch()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L187"
     },
     {
       "community": 156,
       "file_type": "code",
-      "id": "quickaddproductdialog_handleopenchange",
-      "label": "handleOpenChange()",
-      "norm_label": "handleopenchange()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L466"
+      "id": "transactionsview_getnexttransactiontimefiltersearch",
+      "label": "getNextTransactionTimeFilterSearch()",
+      "norm_label": "getnexttransactiontimefiltersearch()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L177"
     },
     {
       "community": 156,
       "file_type": "code",
-      "id": "quickaddproductdialog_handlequickaddmultiplevariantschange",
-      "label": "handleQuickAddMultipleVariantsChange()",
-      "norm_label": "handlequickaddmultiplevariantschange()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L435"
+      "id": "transactionsview_getpageindexfromsearch",
+      "label": "getPageIndexFromSearch()",
+      "norm_label": "getpageindexfromsearch()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L117"
     },
     {
       "community": 156,
       "file_type": "code",
-      "id": "quickaddproductdialog_handlequickaddsubmit",
-      "label": "handleQuickAddSubmit()",
-      "norm_label": "handlequickaddsubmit()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L487"
+      "id": "transactionsview_getpaymentmethodicon",
+      "label": "getPaymentMethodIcon()",
+      "norm_label": "getpaymentmethodicon()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L221"
     },
     {
       "community": 156,
       "file_type": "code",
-      "id": "quickaddproductdialog_preventoutsidedismiss",
-      "label": "preventOutsideDismiss()",
-      "norm_label": "preventoutsidedismiss()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L478"
+      "id": "transactionsview_getstartofoperatingdate",
+      "label": "getStartOfOperatingDate()",
+      "norm_label": "getstartofoperatingdate()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L100"
     },
     {
       "community": 156,
       "file_type": "code",
-      "id": "quickaddproductdialog_removequickaddextravariant",
-      "label": "removeQuickAddExtraVariant()",
-      "norm_label": "removequickaddextravariant()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L460"
+      "id": "transactionsview_gettransactiontimefilter",
+      "label": "getTransactionTimeFilter()",
+      "norm_label": "gettransactiontimefilter()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L149"
     },
     {
       "community": 156,
       "file_type": "code",
-      "id": "quickaddproductdialog_updatequickaddextravariant",
-      "label": "updateQuickAddExtraVariant()",
-      "norm_label": "updatequickaddextravariant()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L442"
+      "id": "transactionsview_istoday",
+      "label": "isToday()",
+      "norm_label": "istoday()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L94"
     },
     {
       "community": 156,
       "file_type": "code",
-      "id": "quickaddproductdialog_validatequickaddlookupcode",
-      "label": "validateQuickAddLookupCode()",
-      "norm_label": "validatequickaddlookupcode()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L136"
+      "id": "transactionsview_transactionmobilecard",
+      "label": "TransactionMobileCard()",
+      "norm_label": "transactionmobilecard()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L285"
     },
     {
       "community": 1560,
@@ -193479,128 +193503,137 @@
     {
       "community": 157,
       "file_type": "code",
-      "id": "dailyclose_test_compareindexedvalue",
-      "label": "compareIndexedValue()",
-      "norm_label": "compareindexedvalue()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 157,
-      "file_type": "code",
-      "id": "dailyclose_test_completeddailycloserow",
-      "label": "completedDailyCloseRow()",
-      "norm_label": "completeddailycloserow()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L464"
-    },
-    {
-      "community": 157,
-      "file_type": "code",
-      "id": "dailyclose_test_completeddailyclosesnapshot",
-      "label": "completedDailyCloseSnapshot()",
-      "norm_label": "completeddailyclosesnapshot()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L410"
-    },
-    {
-      "community": 157,
-      "file_type": "code",
-      "id": "dailyclose_test_createcommandargs",
-      "label": "createCommandArgs()",
-      "norm_label": "createcommandargs()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L5574"
-    },
-    {
-      "community": 157,
-      "file_type": "code",
-      "id": "dailyclose_test_createdb",
-      "label": "createDb()",
-      "norm_label": "createdb()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L82"
-    },
-    {
-      "community": 157,
-      "file_type": "code",
-      "id": "dailyclose_test_dailycloseapprovalproof",
-      "label": "dailyCloseApprovalProof()",
-      "norm_label": "dailycloseapprovalproof()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L354"
-    },
-    {
-      "community": 157,
-      "file_type": "code",
-      "id": "dailyclose_test_dailyclosecarryforwardapprovalproof",
-      "label": "dailyCloseCarryForwardApprovalProof()",
-      "norm_label": "dailyclosecarryforwardapprovalproof()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L390"
-    },
-    {
-      "community": 157,
-      "file_type": "code",
-      "id": "dailyclose_test_dailyclosereopenapprovalproof",
-      "label": "dailyCloseReopenApprovalProof()",
-      "norm_label": "dailyclosereopenapprovalproof()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L372"
-    },
-    {
-      "community": 157,
-      "file_type": "code",
-      "id": "dailyclose_test_dailyclosesummary",
-      "label": "dailyCloseSummary()",
-      "norm_label": "dailyclosesummary()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L329"
-    },
-    {
-      "community": 157,
-      "file_type": "code",
-      "id": "dailyclose_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L69"
-    },
-    {
-      "community": 157,
-      "file_type": "code",
-      "id": "dailyclose_test_mockdailyclosesnapshotaccess",
-      "label": "mockDailyCloseSnapshotAccess()",
-      "norm_label": "mockdailyclosesnapshotaccess()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L497"
-    },
-    {
-      "community": 157,
-      "file_type": "code",
-      "id": "dailyclose_test_openoperationalworkitems",
-      "label": "openOperationalWorkItems()",
-      "norm_label": "openoperationalworkitems()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L311"
-    },
-    {
-      "community": 157,
-      "file_type": "code",
-      "id": "dailyclose_test_syncedreview",
-      "label": "syncedReview()",
-      "norm_label": "syncedreview()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L1914"
-    },
-    {
-      "community": 157,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
-      "label": "dailyClose.test.ts",
-      "norm_label": "dailyclose.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "id": "packages_athena_webapp_src_components_product_quickaddproductdialog_tsx",
+      "label": "QuickAddProductDialog.tsx",
+      "norm_label": "quickaddproductdialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "quickaddproductdialog_addquickaddextravariant",
+      "label": "addQuickAddExtraVariant()",
+      "norm_label": "addquickaddextravariant()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L453"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "quickaddproductdialog_buildquickaddexistingskuoptionfromsearchresult",
+      "label": "buildQuickAddExistingSkuOptionFromSearchResult()",
+      "norm_label": "buildquickaddexistingskuoptionfromsearchresult()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L169"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "quickaddproductdialog_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L824"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "quickaddproductdialog_formatquickadddialogerror",
+      "label": "formatQuickAddDialogError()",
+      "norm_label": "formatquickadddialogerror()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L118"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "quickaddproductdialog_getexistingskumetadata",
+      "label": "getExistingSkuMetadata()",
+      "norm_label": "getexistingskumetadata()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L158"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "quickaddproductdialog_handleattachbarcode",
+      "label": "handleAttachBarcode()",
+      "norm_label": "handleattachbarcode()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L681"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "quickaddproductdialog_handlecancel",
+      "label": "handleCancel()",
+      "norm_label": "handlecancel()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L473"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "quickaddproductdialog_handleopenchange",
+      "label": "handleOpenChange()",
+      "norm_label": "handleopenchange()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L466"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "quickaddproductdialog_handlequickaddmultiplevariantschange",
+      "label": "handleQuickAddMultipleVariantsChange()",
+      "norm_label": "handlequickaddmultiplevariantschange()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L435"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "quickaddproductdialog_handlequickaddsubmit",
+      "label": "handleQuickAddSubmit()",
+      "norm_label": "handlequickaddsubmit()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L487"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "quickaddproductdialog_preventoutsidedismiss",
+      "label": "preventOutsideDismiss()",
+      "norm_label": "preventoutsidedismiss()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L478"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "quickaddproductdialog_removequickaddextravariant",
+      "label": "removeQuickAddExtraVariant()",
+      "norm_label": "removequickaddextravariant()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L460"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "quickaddproductdialog_updatequickaddextravariant",
+      "label": "updateQuickAddExtraVariant()",
+      "norm_label": "updatequickaddextravariant()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L442"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "quickaddproductdialog_validatequickaddlookupcode",
+      "label": "validateQuickAddLookupCode()",
+      "norm_label": "validatequickaddlookupcode()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L136"
     },
     {
       "community": 1570,
@@ -193785,127 +193818,127 @@
     {
       "community": 158,
       "file_type": "code",
-      "id": "operationalworkitems_approvalrequesttransactionid",
-      "label": "approvalRequestTransactionId()",
-      "norm_label": "approvalrequesttransactionid()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L402"
+      "id": "dailyclose_test_compareindexedvalue",
+      "label": "compareIndexedValue()",
+      "norm_label": "compareindexedvalue()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L74"
     },
     {
       "community": 158,
       "file_type": "code",
-      "id": "operationalworkitems_authorizeoperationalworksummaryread",
-      "label": "authorizeOperationalWorkSummaryRead()",
-      "norm_label": "authorizeoperationalworksummaryread()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L64"
+      "id": "dailyclose_test_completeddailycloserow",
+      "label": "completedDailyCloseRow()",
+      "norm_label": "completeddailycloserow()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L464"
     },
     {
       "community": 158,
       "file_type": "code",
-      "id": "operationalworkitems_buildoperationalworkitem",
-      "label": "buildOperationalWorkItem()",
-      "norm_label": "buildoperationalworkitem()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L489"
+      "id": "dailyclose_test_completeddailyclosesnapshot",
+      "label": "completedDailyCloseSnapshot()",
+      "norm_label": "completeddailyclosesnapshot()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L410"
     },
     {
       "community": 158,
       "file_type": "code",
-      "id": "operationalworkitems_createoperationalworkitemwithctx",
-      "label": "createOperationalWorkItemWithCtx()",
-      "norm_label": "createoperationalworkitemwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L516"
+      "id": "dailyclose_test_createcommandargs",
+      "label": "createCommandArgs()",
+      "norm_label": "createcommandargs()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L5574"
     },
     {
       "community": 158,
       "file_type": "code",
-      "id": "operationalworkitems_filterarchivedpendingcheckoutworkitems",
-      "label": "filterArchivedPendingCheckoutWorkItems()",
-      "norm_label": "filterarchivedpendingcheckoutworkitems()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L88"
+      "id": "dailyclose_test_createdb",
+      "label": "createDb()",
+      "norm_label": "createdb()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L82"
     },
     {
       "community": 158,
       "file_type": "code",
-      "id": "operationalworkitems_formatregistersyncreviewtitle",
-      "label": "formatRegisterSyncReviewTitle()",
-      "norm_label": "formatregistersyncreviewtitle()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L483"
+      "id": "dailyclose_test_dailycloseapprovalproof",
+      "label": "dailyCloseApprovalProof()",
+      "norm_label": "dailycloseapprovalproof()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L354"
     },
     {
       "community": 158,
       "file_type": "code",
-      "id": "operationalworkitems_listopensyncedsaleinventoryreviewgroupswithcompleteness",
-      "label": "listOpenSyncedSaleInventoryReviewGroupsWithCompleteness()",
-      "norm_label": "listopensyncedsaleinventoryreviewgroupswithcompleteness()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L614"
+      "id": "dailyclose_test_dailyclosecarryforwardapprovalproof",
+      "label": "dailyCloseCarryForwardApprovalProof()",
+      "norm_label": "dailyclosecarryforwardapprovalproof()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L390"
     },
     {
       "community": 158,
       "file_type": "code",
-      "id": "operationalworkitems_metadataarraycount",
-      "label": "metadataArrayCount()",
-      "norm_label": "metadataarraycount()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L135"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "operationalworkitems_metadatanumber",
-      "label": "metadataNumber()",
-      "norm_label": "metadatanumber()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L127"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "operationalworkitems_projectoperationalworkitemforqueue",
-      "label": "projectOperationalWorkItemForQueue()",
-      "norm_label": "projectoperationalworkitemforqueue()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "id": "dailyclose_test_dailyclosereopenapprovalproof",
+      "label": "dailyCloseReopenApprovalProof()",
+      "norm_label": "dailyclosereopenapprovalproof()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
       "source_location": "L372"
     },
     {
       "community": 158,
       "file_type": "code",
-      "id": "operationalworkitems_sanitizeapprovalrequestmetadata",
-      "label": "sanitizeApprovalRequestMetadata()",
-      "norm_label": "sanitizeapprovalrequestmetadata()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L427"
+      "id": "dailyclose_test_dailyclosesummary",
+      "label": "dailyCloseSummary()",
+      "norm_label": "dailyclosesummary()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L329"
     },
     {
       "community": 158,
       "file_type": "code",
-      "id": "operationalworkitems_sanitizeoperationalworkitemdetails",
-      "label": "sanitizeOperationalWorkItemDetails()",
-      "norm_label": "sanitizeoperationalworkitemdetails()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L295"
+      "id": "dailyclose_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L69"
     },
     {
       "community": 158,
       "file_type": "code",
-      "id": "operationalworkitems_updateoperationalworkitemstatuswithctx",
-      "label": "updateOperationalWorkItemStatusWithCtx()",
-      "norm_label": "updateoperationalworkitemstatuswithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L551"
+      "id": "dailyclose_test_mockdailyclosesnapshotaccess",
+      "label": "mockDailyCloseSnapshotAccess()",
+      "norm_label": "mockdailyclosesnapshotaccess()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L497"
     },
     {
       "community": 158,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_operationalworkitems_ts",
-      "label": "operationalWorkItems.ts",
-      "norm_label": "operationalworkitems.ts",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "id": "dailyclose_test_openoperationalworkitems",
+      "label": "openOperationalWorkItems()",
+      "norm_label": "openoperationalworkitems()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L311"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
+      "id": "dailyclose_test_syncedreview",
+      "label": "syncedReview()",
+      "norm_label": "syncedreview()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L1914"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
+      "label": "dailyClose.test.ts",
+      "norm_label": "dailyclose.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
       "source_location": "L1"
     },
     {
@@ -194091,128 +194124,128 @@
     {
       "community": 159,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_staffprofiles_ts",
-      "label": "staffProfiles.ts",
-      "norm_label": "staffprofiles.ts",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "id": "operationalworkitems_approvalrequesttransactionid",
+      "label": "approvalRequestTransactionId()",
+      "norm_label": "approvalrequesttransactionid()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L402"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "operationalworkitems_authorizeoperationalworksummaryread",
+      "label": "authorizeOperationalWorkSummaryRead()",
+      "norm_label": "authorizeoperationalworksummaryread()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L64"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "operationalworkitems_buildoperationalworkitem",
+      "label": "buildOperationalWorkItem()",
+      "norm_label": "buildoperationalworkitem()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L489"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "operationalworkitems_createoperationalworkitemwithctx",
+      "label": "createOperationalWorkItemWithCtx()",
+      "norm_label": "createoperationalworkitemwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L516"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "operationalworkitems_filterarchivedpendingcheckoutworkitems",
+      "label": "filterArchivedPendingCheckoutWorkItems()",
+      "norm_label": "filterarchivedpendingcheckoutworkitems()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L88"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "operationalworkitems_formatregistersyncreviewtitle",
+      "label": "formatRegisterSyncReviewTitle()",
+      "norm_label": "formatregistersyncreviewtitle()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L483"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "operationalworkitems_listopensyncedsaleinventoryreviewgroupswithcompleteness",
+      "label": "listOpenSyncedSaleInventoryReviewGroupsWithCompleteness()",
+      "norm_label": "listopensyncedsaleinventoryreviewgroupswithcompleteness()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L614"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "operationalworkitems_metadataarraycount",
+      "label": "metadataArrayCount()",
+      "norm_label": "metadataarraycount()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "operationalworkitems_metadatanumber",
+      "label": "metadataNumber()",
+      "norm_label": "metadatanumber()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L127"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "operationalworkitems_projectoperationalworkitemforqueue",
+      "label": "projectOperationalWorkItemForQueue()",
+      "norm_label": "projectoperationalworkitemforqueue()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L372"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "operationalworkitems_sanitizeapprovalrequestmetadata",
+      "label": "sanitizeApprovalRequestMetadata()",
+      "norm_label": "sanitizeapprovalrequestmetadata()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L427"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "operationalworkitems_sanitizeoperationalworkitemdetails",
+      "label": "sanitizeOperationalWorkItemDetails()",
+      "norm_label": "sanitizeoperationalworkitemdetails()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L295"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "operationalworkitems_updateoperationalworkitemstatuswithctx",
+      "label": "updateOperationalWorkItemStatusWithCtx()",
+      "norm_label": "updateoperationalworkitemstatuswithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L551"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_operationalworkitems_ts",
+      "label": "operationalWorkItems.ts",
+      "norm_label": "operationalworkitems.ts",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "staffprofiles_assertroleconfiguration",
-      "label": "assertRoleConfiguration()",
-      "norm_label": "assertroleconfiguration()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L114"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "staffprofiles_buildroleassignmentdrafts",
-      "label": "buildRoleAssignmentDrafts()",
-      "norm_label": "buildroleassignmentdrafts()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L92"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "staffprofiles_buildstafffullname",
-      "label": "buildStaffFullName()",
-      "norm_label": "buildstafffullname()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "staffprofiles_buildstaffprofileresult",
-      "label": "buildStaffProfileResult()",
-      "norm_label": "buildstaffprofileresult()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L197"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "staffprofiles_createstaffprofilewithctx",
-      "label": "createStaffProfileWithCtx()",
-      "norm_label": "createstaffprofilewithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L305"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "staffprofiles_ensurelinkeduseravailable",
-      "label": "ensureLinkedUserAvailable()",
-      "norm_label": "ensurelinkeduseravailable()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "staffprofiles_getstaffprofilebyidwithctx",
-      "label": "getStaffProfileByIdWithCtx()",
-      "norm_label": "getstaffprofilebyidwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L215"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "staffprofiles_liststaffprofileswithctx",
-      "label": "listStaffProfilesWithCtx()",
-      "norm_label": "liststaffprofileswithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L254"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "staffprofiles_normalizeoptionalstring",
-      "label": "normalizeOptionalString()",
-      "norm_label": "normalizeoptionalstring()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L44"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "staffprofiles_normalizestaffprofilepatch",
-      "label": "normalizeStaffProfilePatch()",
-      "norm_label": "normalizestaffprofilepatch()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L179"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "staffprofiles_requirenamesegment",
-      "label": "requireNameSegment()",
-      "norm_label": "requirenamesegment()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "staffprofiles_syncstaffroleassignmentswithctx",
-      "label": "syncStaffRoleAssignmentsWithCtx()",
-      "norm_label": "syncstaffroleassignmentswithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "staffprofiles_updatestaffprofilewithctx",
-      "label": "updateStaffProfileWithCtx()",
-      "norm_label": "updatestaffprofilewithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L381"
     },
     {
       "community": 1590,
@@ -194784,128 +194817,128 @@
     {
       "community": 160,
       "file_type": "code",
-      "id": "cloudrepairpolicy_buildterminalcloudrepairpreconditionhash",
-      "label": "buildTerminalCloudRepairPreconditionHash()",
-      "norm_label": "buildterminalcloudrepairpreconditionhash()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L143"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_buildterminalcloudrepairpreview",
-      "label": "buildTerminalCloudRepairPreview()",
-      "norm_label": "buildterminalcloudrepairpreview()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_canprojectregisteropenforterminalcloudrepair",
-      "label": "canProjectRegisterOpenForTerminalCloudRepair()",
-      "norm_label": "canprojectregisteropenforterminalcloudrepair()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L167"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_classifyterminalcloudrepairconflict",
-      "label": "classifyTerminalCloudRepairConflict()",
-      "norm_label": "classifyterminalcloudrepairconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_containsbusinessfacts",
-      "label": "containsBusinessFacts()",
-      "norm_label": "containsbusinessfacts()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L374"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_getrepairconflictcloseoutreviewboundaryat",
-      "label": "getRepairConflictCloseoutReviewBoundaryAt()",
-      "norm_label": "getrepairconflictcloseoutreviewboundaryat()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L289"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_getrepairopenregistercloseoutreviewstate",
-      "label": "getRepairOpenRegisterCloseoutReviewState()",
-      "norm_label": "getrepairopenregistercloseoutreviewstate()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L261"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_getrepairregistersessioncloseoutboundaryat",
-      "label": "getRepairRegisterSessionCloseoutBoundaryAt()",
-      "norm_label": "getrepairregistersessioncloseoutboundaryat()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L297"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_isduplicateregisteropenconflict",
-      "label": "isDuplicateRegisterOpenConflict()",
-      "norm_label": "isduplicateregisteropenconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L354"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_normalizerepairstring",
-      "label": "normalizeRepairString()",
-      "norm_label": "normalizerepairstring()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L395"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_repairfactmatchesregistersessioncloseoutreview",
-      "label": "repairFactMatchesRegisterSessionCloseoutReview()",
-      "norm_label": "repairfactmatchesregistersessioncloseoutreview()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L326"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_skipped",
-      "label": "skipped()",
-      "norm_label": "skipped()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L343"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_skipterminalcloudrepairconflict",
-      "label": "skipTerminalCloudRepairConflict()",
-      "norm_label": "skipterminalcloudrepairconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L132"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_cloudrepairpolicy_ts",
-      "label": "cloudRepairPolicy.ts",
-      "norm_label": "cloudrepairpolicy.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "id": "packages_athena_webapp_convex_operations_staffprofiles_ts",
+      "label": "staffProfiles.ts",
+      "norm_label": "staffprofiles.ts",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "staffprofiles_assertroleconfiguration",
+      "label": "assertRoleConfiguration()",
+      "norm_label": "assertroleconfiguration()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L114"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "staffprofiles_buildroleassignmentdrafts",
+      "label": "buildRoleAssignmentDrafts()",
+      "norm_label": "buildroleassignmentdrafts()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "staffprofiles_buildstafffullname",
+      "label": "buildStaffFullName()",
+      "norm_label": "buildstafffullname()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "staffprofiles_buildstaffprofileresult",
+      "label": "buildStaffProfileResult()",
+      "norm_label": "buildstaffprofileresult()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L197"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "staffprofiles_createstaffprofilewithctx",
+      "label": "createStaffProfileWithCtx()",
+      "norm_label": "createstaffprofilewithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L305"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "staffprofiles_ensurelinkeduseravailable",
+      "label": "ensureLinkedUserAvailable()",
+      "norm_label": "ensurelinkeduseravailable()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "staffprofiles_getstaffprofilebyidwithctx",
+      "label": "getStaffProfileByIdWithCtx()",
+      "norm_label": "getstaffprofilebyidwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L215"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "staffprofiles_liststaffprofileswithctx",
+      "label": "listStaffProfilesWithCtx()",
+      "norm_label": "liststaffprofileswithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L254"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "staffprofiles_normalizeoptionalstring",
+      "label": "normalizeOptionalString()",
+      "norm_label": "normalizeoptionalstring()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L44"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "staffprofiles_normalizestaffprofilepatch",
+      "label": "normalizeStaffProfilePatch()",
+      "norm_label": "normalizestaffprofilepatch()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L179"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "staffprofiles_requirenamesegment",
+      "label": "requireNameSegment()",
+      "norm_label": "requirenamesegment()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "staffprofiles_syncstaffroleassignmentswithctx",
+      "label": "syncStaffRoleAssignmentsWithCtx()",
+      "norm_label": "syncstaffroleassignmentswithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "staffprofiles_updatestaffprofilewithctx",
+      "label": "updateStaffProfileWithCtx()",
+      "norm_label": "updatestaffprofilewithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L381"
     },
     {
       "community": 1600,
@@ -195090,128 +195123,128 @@
     {
       "community": 161,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_weekly_test_ts",
-      "label": "weekly.test.ts",
-      "norm_label": "weekly.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "id": "cloudrepairpolicy_buildterminalcloudrepairpreconditionhash",
+      "label": "buildTerminalCloudRepairPreconditionHash()",
+      "norm_label": "buildterminalcloudrepairpreconditionhash()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L143"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_buildterminalcloudrepairpreview",
+      "label": "buildTerminalCloudRepairPreview()",
+      "norm_label": "buildterminalcloudrepairpreview()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_canprojectregisteropenforterminalcloudrepair",
+      "label": "canProjectRegisterOpenForTerminalCloudRepair()",
+      "norm_label": "canprojectregisteropenforterminalcloudrepair()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L167"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_classifyterminalcloudrepairconflict",
+      "label": "classifyTerminalCloudRepairConflict()",
+      "norm_label": "classifyterminalcloudrepairconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_containsbusinessfacts",
+      "label": "containsBusinessFacts()",
+      "norm_label": "containsbusinessfacts()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L374"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_getrepairconflictcloseoutreviewboundaryat",
+      "label": "getRepairConflictCloseoutReviewBoundaryAt()",
+      "norm_label": "getrepairconflictcloseoutreviewboundaryat()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L289"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_getrepairopenregistercloseoutreviewstate",
+      "label": "getRepairOpenRegisterCloseoutReviewState()",
+      "norm_label": "getrepairopenregistercloseoutreviewstate()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L261"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_getrepairregistersessioncloseoutboundaryat",
+      "label": "getRepairRegisterSessionCloseoutBoundaryAt()",
+      "norm_label": "getrepairregistersessioncloseoutboundaryat()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L297"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_isduplicateregisteropenconflict",
+      "label": "isDuplicateRegisterOpenConflict()",
+      "norm_label": "isduplicateregisteropenconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L354"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_normalizerepairstring",
+      "label": "normalizeRepairString()",
+      "norm_label": "normalizerepairstring()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L395"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_repairfactmatchesregistersessioncloseoutreview",
+      "label": "repairFactMatchesRegisterSessionCloseoutReview()",
+      "norm_label": "repairfactmatchesregistersessioncloseoutreview()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L326"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_skipped",
+      "label": "skipped()",
+      "norm_label": "skipped()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L343"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_skipterminalcloudrepairconflict",
+      "label": "skipTerminalCloudRepairConflict()",
+      "norm_label": "skipterminalcloudrepairconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L132"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_cloudrepairpolicy_ts",
+      "label": "cloudRepairPolicy.ts",
+      "norm_label": "cloudrepairpolicy.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "weekly_test_day",
-      "label": "day()",
-      "norm_label": "day()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L68"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "weekly_test_fact",
-      "label": "fact()",
-      "norm_label": "fact()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "weekly_test_insertcompletedclose",
-      "label": "insertCompletedClose()",
-      "norm_label": "insertcompletedclose()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L253"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "weekly_test_insertfact",
-      "label": "insertFact()",
-      "norm_label": "insertfact()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L224"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "weekly_test_insertfoldedcloseday",
-      "label": "insertFoldedCloseDay()",
-      "norm_label": "insertfoldedcloseday()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L328"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "weekly_test_inserthistoricalweekdays",
-      "label": "insertHistoricalWeekDays()",
-      "norm_label": "inserthistoricalweekdays()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L355"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "weekly_test_linkclosetoday",
-      "label": "linkCloseToDay()",
-      "norm_label": "linkclosetoday()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L2559"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "weekly_test_patchscheduleexceptions",
-      "label": "patchScheduleExceptions()",
-      "norm_label": "patchscheduleexceptions()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L2538"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "weekly_test_period",
-      "label": "period()",
-      "norm_label": "period()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L50"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "weekly_test_readbaseline",
-      "label": "readBaseline()",
-      "norm_label": "readbaseline()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L2049"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "weekly_test_readweekmark",
-      "label": "readWeekMark()",
-      "norm_label": "readweekmark()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L2040"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "weekly_test_seedstore",
-      "label": "seedStore()",
-      "norm_label": "seedstore()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L185"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "weekly_test_withcloses",
-      "label": "withCloses()",
-      "norm_label": "withcloses()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L380"
     },
     {
       "community": 1610,
@@ -195396,128 +195429,128 @@
     {
       "community": 162,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_tsx",
-      "label": "PaymentsAddedList.tsx",
-      "norm_label": "paymentsaddedlist.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "id": "packages_athena_webapp_convex_reports_weekly_test_ts",
+      "label": "weekly.test.ts",
+      "norm_label": "weekly.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
       "source_location": "L1"
     },
     {
       "community": 162,
       "file_type": "code",
-      "id": "paymentsaddedlist_clearpaymentediting",
-      "label": "clearPaymentEditing()",
-      "norm_label": "clearpaymentediting()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L139"
+      "id": "weekly_test_day",
+      "label": "day()",
+      "norm_label": "day()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L68"
     },
     {
       "community": 162,
       "file_type": "code",
-      "id": "paymentsaddedlist_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L384"
+      "id": "weekly_test_fact",
+      "label": "fact()",
+      "norm_label": "fact()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L101"
     },
     {
       "community": 162,
       "file_type": "code",
-      "id": "paymentsaddedlist_getpaymentmethodicon",
-      "label": "getPaymentMethodIcon()",
-      "norm_label": "getpaymentmethodicon()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L52"
+      "id": "weekly_test_insertcompletedclose",
+      "label": "insertCompletedClose()",
+      "norm_label": "insertcompletedclose()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L253"
     },
     {
       "community": 162,
       "file_type": "code",
-      "id": "paymentsaddedlist_getpaymentmethodlabel",
-      "label": "getPaymentMethodLabel()",
-      "norm_label": "getpaymentmethodlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L63"
+      "id": "weekly_test_insertfact",
+      "label": "insertFact()",
+      "norm_label": "insertfact()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L224"
     },
     {
       "community": 162,
       "file_type": "code",
-      "id": "paymentsaddedlist_handlecanceledit",
-      "label": "handleCancelEdit()",
-      "norm_label": "handlecanceledit()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L180"
+      "id": "weekly_test_insertfoldedcloseday",
+      "label": "insertFoldedCloseDay()",
+      "norm_label": "insertfoldedcloseday()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L328"
     },
     {
       "community": 162,
       "file_type": "code",
-      "id": "paymentsaddedlist_handleclearpayments",
-      "label": "handleClearPayments()",
-      "norm_label": "handleclearpayments()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L198"
+      "id": "weekly_test_inserthistoricalweekdays",
+      "label": "insertHistoricalWeekDays()",
+      "norm_label": "inserthistoricalweekdays()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L355"
     },
     {
       "community": 162,
       "file_type": "code",
-      "id": "paymentsaddedlist_handleremovepayment",
-      "label": "handleRemovePayment()",
-      "norm_label": "handleremovepayment()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L204"
+      "id": "weekly_test_linkclosetoday",
+      "label": "linkCloseToDay()",
+      "norm_label": "linkclosetoday()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L2559"
     },
     {
       "community": 162,
       "file_type": "code",
-      "id": "paymentsaddedlist_handlesaveedit",
-      "label": "handleSaveEdit()",
-      "norm_label": "handlesaveedit()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L145"
+      "id": "weekly_test_patchscheduleexceptions",
+      "label": "patchScheduleExceptions()",
+      "norm_label": "patchscheduleexceptions()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L2538"
     },
     {
       "community": 162,
       "file_type": "code",
-      "id": "paymentsaddedlist_handlestartedit",
-      "label": "handleStartEdit()",
-      "norm_label": "handlestartedit()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L132"
+      "id": "weekly_test_period",
+      "label": "period()",
+      "norm_label": "period()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L50"
     },
     {
       "community": 162,
       "file_type": "code",
-      "id": "paymentsaddedlist_if",
-      "label": "if()",
-      "norm_label": "if()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L315"
+      "id": "weekly_test_readbaseline",
+      "label": "readBaseline()",
+      "norm_label": "readbaseline()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L2049"
     },
     {
       "community": 162,
       "file_type": "code",
-      "id": "paymentsaddedlist_resetpaymentcollectioncontrols",
-      "label": "resetPaymentCollectionControls()",
-      "norm_label": "resetpaymentcollectioncontrols()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L193"
+      "id": "weekly_test_readweekmark",
+      "label": "readWeekMark()",
+      "norm_label": "readweekmark()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L2040"
     },
     {
       "community": 162,
       "file_type": "code",
-      "id": "paymentsaddedlist_setpaymentediting",
-      "label": "setPaymentEditing()",
-      "norm_label": "setpaymentediting()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L123"
+      "id": "weekly_test_seedstore",
+      "label": "seedStore()",
+      "norm_label": "seedstore()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L185"
     },
     {
       "community": 162,
       "file_type": "code",
-      "id": "paymentsaddedlist_setpaymentsexpanded",
-      "label": "setPaymentsExpanded()",
-      "norm_label": "setpaymentsexpanded()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L115"
+      "id": "weekly_test_withcloses",
+      "label": "withCloses()",
+      "norm_label": "withcloses()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L380"
     },
     {
       "community": 1620,
@@ -195702,128 +195735,128 @@
     {
       "community": 163,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_shared_demo_shareddemotransactionsfixture_ts",
-      "label": "sharedDemoTransactionsFixture.ts",
-      "norm_label": "shareddemotransactionsfixture.ts",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
+      "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_tsx",
+      "label": "PaymentsAddedList.tsx",
+      "norm_label": "paymentsaddedlist.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L1"
     },
     {
       "community": 163,
       "file_type": "code",
-      "id": "shareddemotransactionsfixture_builddaytransactions",
-      "label": "buildDayTransactions()",
-      "norm_label": "builddaytransactions()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
-      "source_location": "L360"
+      "id": "paymentsaddedlist_clearpaymentediting",
+      "label": "clearPaymentEditing()",
+      "norm_label": "clearpaymentediting()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L139"
     },
     {
       "community": 163,
       "file_type": "code",
-      "id": "shareddemotransactionsfixture_builditems",
-      "label": "buildItems()",
-      "norm_label": "builditems()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
-      "source_location": "L260"
+      "id": "paymentsaddedlist_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L384"
     },
     {
       "community": 163,
       "file_type": "code",
-      "id": "shareddemotransactionsfixture_buildpaymentproductmixes",
-      "label": "buildPaymentProductMixes()",
-      "norm_label": "buildpaymentproductmixes()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
-      "source_location": "L183"
+      "id": "paymentsaddedlist_getpaymentmethodicon",
+      "label": "getPaymentMethodIcon()",
+      "norm_label": "getpaymentmethodicon()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L52"
     },
     {
       "community": 163,
       "file_type": "code",
-      "id": "shareddemotransactionsfixture_buildtransaction",
-      "label": "buildTransaction()",
-      "norm_label": "buildtransaction()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
-      "source_location": "L289"
+      "id": "paymentsaddedlist_getpaymentmethodlabel",
+      "label": "getPaymentMethodLabel()",
+      "norm_label": "getpaymentmethodlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L63"
     },
     {
       "community": 163,
       "file_type": "code",
-      "id": "shareddemotransactionsfixture_createshareddemotransactionfixtures",
-      "label": "createSharedDemoTransactionFixtures()",
-      "norm_label": "createshareddemotransactionfixtures()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
-      "source_location": "L414"
+      "id": "paymentsaddedlist_handlecanceledit",
+      "label": "handleCancelEdit()",
+      "norm_label": "handlecanceledit()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L180"
     },
     {
       "community": 163,
       "file_type": "code",
-      "id": "shareddemotransactionsfixture_distributeproducts",
-      "label": "distributeProducts()",
-      "norm_label": "distributeproducts()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
-      "source_location": "L236"
+      "id": "paymentsaddedlist_handleclearpayments",
+      "label": "handleClearPayments()",
+      "norm_label": "handleclearpayments()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L198"
     },
     {
       "community": 163,
       "file_type": "code",
-      "id": "shareddemotransactionsfixture_findproductmix",
-      "label": "findProductMix()",
-      "norm_label": "findproductmix()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
-      "source_location": "L134"
+      "id": "paymentsaddedlist_handleremovepayment",
+      "label": "handleRemovePayment()",
+      "norm_label": "handleremovepayment()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L204"
     },
     {
       "community": 163,
       "file_type": "code",
-      "id": "shareddemotransactionsfixture_formatoperatingdate",
-      "label": "formatOperatingDate()",
-      "norm_label": "formatoperatingdate()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
-      "source_location": "L104"
+      "id": "paymentsaddedlist_handlesaveedit",
+      "label": "handleSaveEdit()",
+      "norm_label": "handlesaveedit()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L145"
     },
     {
       "community": 163,
       "file_type": "code",
-      "id": "shareddemotransactionsfixture_getshareddemotransactionfixture",
-      "label": "getSharedDemoTransactionFixture()",
-      "norm_label": "getshareddemotransactionfixture()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
-      "source_location": "L441"
+      "id": "paymentsaddedlist_handlestartedit",
+      "label": "handleStartEdit()",
+      "norm_label": "handlestartedit()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L132"
     },
     {
       "community": 163,
       "file_type": "code",
-      "id": "shareddemotransactionsfixture_isshareddemotransactionfixtureid",
-      "label": "isSharedDemoTransactionFixtureId()",
-      "norm_label": "isshareddemotransactionfixtureid()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
-      "source_location": "L437"
+      "id": "paymentsaddedlist_if",
+      "label": "if()",
+      "norm_label": "if()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L315"
     },
     {
       "community": 163,
       "file_type": "code",
-      "id": "shareddemotransactionsfixture_operatingdatetimestamp",
-      "label": "operatingDateTimestamp()",
-      "norm_label": "operatingdatetimestamp()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
-      "source_location": "L118"
+      "id": "paymentsaddedlist_resetpaymentcollectioncontrols",
+      "label": "resetPaymentCollectionControls()",
+      "norm_label": "resetpaymentcollectioncontrols()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L193"
     },
     {
       "community": 163,
       "file_type": "code",
-      "id": "shareddemotransactionsfixture_ordereditemcountcandidates",
-      "label": "orderedItemCountCandidates()",
-      "norm_label": "ordereditemcountcandidates()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
-      "source_location": "L160"
+      "id": "paymentsaddedlist_setpaymentediting",
+      "label": "setPaymentEditing()",
+      "norm_label": "setpaymentediting()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L123"
     },
     {
       "community": 163,
       "file_type": "code",
-      "id": "shareddemotransactionsfixture_shiftoperatingdate",
-      "label": "shiftOperatingDate()",
-      "norm_label": "shiftoperatingdate()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
-      "source_location": "L111"
+      "id": "paymentsaddedlist_setpaymentsexpanded",
+      "label": "setPaymentsExpanded()",
+      "norm_label": "setpaymentsexpanded()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L115"
     },
     {
       "community": 1630,
@@ -196008,128 +196041,128 @@
     {
       "community": 164,
       "file_type": "code",
-      "id": "mtnmomoview_cleanundefinedfields",
-      "label": "cleanUndefinedFields()",
-      "norm_label": "cleanundefinedfields()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L52"
-    },
-    {
-      "community": 164,
-      "file_type": "code",
-      "id": "mtnmomoview_clonereceivingaccount",
-      "label": "cloneReceivingAccount()",
-      "norm_label": "clonereceivingaccount()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L27"
-    },
-    {
-      "community": 164,
-      "file_type": "code",
-      "id": "mtnmomoview_createemptyreceivingaccount",
-      "label": "createEmptyReceivingAccount()",
-      "norm_label": "createemptyreceivingaccount()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L35"
-    },
-    {
-      "community": 164,
-      "file_type": "code",
-      "id": "mtnmomoview_getstatusbadgevariant",
-      "label": "getStatusBadgeVariant()",
-      "norm_label": "getstatusbadgevariant()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L114"
-    },
-    {
-      "community": 164,
-      "file_type": "code",
-      "id": "mtnmomoview_handleaddaccount",
-      "label": "handleAddAccount()",
-      "norm_label": "handleaddaccount()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L152"
-    },
-    {
-      "community": 164,
-      "file_type": "code",
-      "id": "mtnmomoview_handlemakeprimary",
-      "label": "handleMakePrimary()",
-      "norm_label": "handlemakeprimary()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L159"
-    },
-    {
-      "community": 164,
-      "file_type": "code",
-      "id": "mtnmomoview_handleremoveaccount",
-      "label": "handleRemoveAccount()",
-      "norm_label": "handleremoveaccount()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L168"
-    },
-    {
-      "community": 164,
-      "file_type": "code",
-      "id": "mtnmomoview_handlesave",
-      "label": "handleSave()",
-      "norm_label": "handlesave()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L188"
-    },
-    {
-      "community": 164,
-      "file_type": "code",
-      "id": "mtnmomoview_hasreceivingaccountdetails",
-      "label": "hasReceivingAccountDetails()",
-      "norm_label": "hasreceivingaccountdetails()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L64"
-    },
-    {
-      "community": 164,
-      "file_type": "code",
-      "id": "mtnmomoview_normalizeprimaryaccounts",
-      "label": "normalizePrimaryAccounts()",
-      "norm_label": "normalizeprimaryaccounts()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L77"
-    },
-    {
-      "community": 164,
-      "file_type": "code",
-      "id": "mtnmomoview_topatchreceivingaccounts",
-      "label": "toPatchReceivingAccounts()",
-      "norm_label": "topatchreceivingaccounts()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L93"
-    },
-    {
-      "community": 164,
-      "file_type": "code",
-      "id": "mtnmomoview_trimtoundefined",
-      "label": "trimToUndefined()",
-      "norm_label": "trimtoundefined()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L47"
-    },
-    {
-      "community": 164,
-      "file_type": "code",
-      "id": "mtnmomoview_updateaccount",
-      "label": "updateAccount()",
-      "norm_label": "updateaccount()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L141"
-    },
-    {
-      "community": 164,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_tsx",
-      "label": "MtnMomoView.tsx",
-      "norm_label": "mtnmomoview.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "id": "packages_athena_webapp_src_components_shared_demo_shareddemotransactionsfixture_ts",
+      "label": "sharedDemoTransactionsFixture.ts",
+      "norm_label": "shareddemotransactionsfixture.ts",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 164,
+      "file_type": "code",
+      "id": "shareddemotransactionsfixture_builddaytransactions",
+      "label": "buildDayTransactions()",
+      "norm_label": "builddaytransactions()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
+      "source_location": "L360"
+    },
+    {
+      "community": 164,
+      "file_type": "code",
+      "id": "shareddemotransactionsfixture_builditems",
+      "label": "buildItems()",
+      "norm_label": "builditems()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
+      "source_location": "L260"
+    },
+    {
+      "community": 164,
+      "file_type": "code",
+      "id": "shareddemotransactionsfixture_buildpaymentproductmixes",
+      "label": "buildPaymentProductMixes()",
+      "norm_label": "buildpaymentproductmixes()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
+      "source_location": "L183"
+    },
+    {
+      "community": 164,
+      "file_type": "code",
+      "id": "shareddemotransactionsfixture_buildtransaction",
+      "label": "buildTransaction()",
+      "norm_label": "buildtransaction()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
+      "source_location": "L289"
+    },
+    {
+      "community": 164,
+      "file_type": "code",
+      "id": "shareddemotransactionsfixture_createshareddemotransactionfixtures",
+      "label": "createSharedDemoTransactionFixtures()",
+      "norm_label": "createshareddemotransactionfixtures()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
+      "source_location": "L414"
+    },
+    {
+      "community": 164,
+      "file_type": "code",
+      "id": "shareddemotransactionsfixture_distributeproducts",
+      "label": "distributeProducts()",
+      "norm_label": "distributeproducts()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
+      "source_location": "L236"
+    },
+    {
+      "community": 164,
+      "file_type": "code",
+      "id": "shareddemotransactionsfixture_findproductmix",
+      "label": "findProductMix()",
+      "norm_label": "findproductmix()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
+      "source_location": "L134"
+    },
+    {
+      "community": 164,
+      "file_type": "code",
+      "id": "shareddemotransactionsfixture_formatoperatingdate",
+      "label": "formatOperatingDate()",
+      "norm_label": "formatoperatingdate()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
+      "source_location": "L104"
+    },
+    {
+      "community": 164,
+      "file_type": "code",
+      "id": "shareddemotransactionsfixture_getshareddemotransactionfixture",
+      "label": "getSharedDemoTransactionFixture()",
+      "norm_label": "getshareddemotransactionfixture()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
+      "source_location": "L441"
+    },
+    {
+      "community": 164,
+      "file_type": "code",
+      "id": "shareddemotransactionsfixture_isshareddemotransactionfixtureid",
+      "label": "isSharedDemoTransactionFixtureId()",
+      "norm_label": "isshareddemotransactionfixtureid()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
+      "source_location": "L437"
+    },
+    {
+      "community": 164,
+      "file_type": "code",
+      "id": "shareddemotransactionsfixture_operatingdatetimestamp",
+      "label": "operatingDateTimestamp()",
+      "norm_label": "operatingdatetimestamp()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
+      "source_location": "L118"
+    },
+    {
+      "community": 164,
+      "file_type": "code",
+      "id": "shareddemotransactionsfixture_ordereditemcountcandidates",
+      "label": "orderedItemCountCandidates()",
+      "norm_label": "ordereditemcountcandidates()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
+      "source_location": "L160"
+    },
+    {
+      "community": 164,
+      "file_type": "code",
+      "id": "shareddemotransactionsfixture_shiftoperatingdate",
+      "label": "shiftOperatingDate()",
+      "norm_label": "shiftoperatingdate()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
+      "source_location": "L111"
     },
     {
       "community": 1640,
@@ -196314,128 +196347,128 @@
     {
       "community": 165,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_marketing_walkthroughrequestclient_ts",
-      "label": "walkthroughRequestClient.ts",
-      "norm_label": "walkthroughrequestclient.ts",
-      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 165,
-      "file_type": "code",
-      "id": "walkthroughrequestclient_canonicalizewalkthroughpayload",
-      "label": "canonicalizeWalkthroughPayload()",
-      "norm_label": "canonicalizewalkthroughpayload()",
-      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 165,
-      "file_type": "code",
-      "id": "walkthroughrequestclient_generatesubmissionkey",
-      "label": "generateSubmissionKey()",
-      "norm_label": "generatesubmissionkey()",
-      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
+      "id": "mtnmomoview_cleanundefinedfields",
+      "label": "cleanUndefinedFields()",
+      "norm_label": "cleanundefinedfields()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L52"
     },
     {
       "community": 165,
       "file_type": "code",
-      "id": "walkthroughrequestclient_normalizewalkthroughemail",
-      "label": "normalizeWalkthroughEmail()",
-      "norm_label": "normalizewalkthroughemail()",
-      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
-      "source_location": "L41"
+      "id": "mtnmomoview_clonereceivingaccount",
+      "label": "cloneReceivingAccount()",
+      "norm_label": "clonereceivingaccount()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L27"
     },
     {
       "community": 165,
       "file_type": "code",
-      "id": "walkthroughrequestclient_normalizewalkthroughtext",
-      "label": "normalizeWalkthroughText()",
-      "norm_label": "normalizewalkthroughtext()",
-      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
-      "source_location": "L37"
+      "id": "mtnmomoview_createemptyreceivingaccount",
+      "label": "createEmptyReceivingAccount()",
+      "norm_label": "createemptyreceivingaccount()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L35"
     },
     {
       "community": 165,
       "file_type": "code",
-      "id": "walkthroughrequestclient_readpublicerrorcode",
-      "label": "readPublicErrorCode()",
-      "norm_label": "readpublicerrorcode()",
-      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
-      "source_location": "L160"
+      "id": "mtnmomoview_getstatusbadgevariant",
+      "label": "getStatusBadgeVariant()",
+      "norm_label": "getstatusbadgevariant()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L114"
     },
     {
       "community": 165,
       "file_type": "code",
-      "id": "walkthroughrequestclient_resolvewalkthroughrequesturl",
-      "label": "resolveWalkthroughRequestUrl()",
-      "norm_label": "resolvewalkthroughrequesturl()",
-      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
-      "source_location": "L98"
+      "id": "mtnmomoview_handleaddaccount",
+      "label": "handleAddAccount()",
+      "norm_label": "handleaddaccount()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L152"
     },
     {
       "community": 165,
       "file_type": "code",
-      "id": "walkthroughrequestclient_stripcontrolcharacters",
-      "label": "stripControlCharacters()",
-      "norm_label": "stripcontrolcharacters()",
-      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
-      "source_location": "L45"
+      "id": "mtnmomoview_handlemakeprimary",
+      "label": "handleMakePrimary()",
+      "norm_label": "handlemakeprimary()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L159"
     },
     {
       "community": 165,
       "file_type": "code",
-      "id": "walkthroughrequestclient_submitwalkthroughrequest",
-      "label": "submitWalkthroughRequest()",
-      "norm_label": "submitwalkthroughrequest()",
-      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
-      "source_location": "L106"
+      "id": "mtnmomoview_handleremoveaccount",
+      "label": "handleRemoveAccount()",
+      "norm_label": "handleremoveaccount()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L168"
     },
     {
       "community": 165,
       "file_type": "code",
-      "id": "walkthroughrequestclient_walkthroughsubmissionidentity",
-      "label": "WalkthroughSubmissionIdentity",
-      "norm_label": "walkthroughsubmissionidentity",
-      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
-      "source_location": "L65"
+      "id": "mtnmomoview_handlesave",
+      "label": "handleSave()",
+      "norm_label": "handlesave()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L188"
     },
     {
       "community": 165,
       "file_type": "code",
-      "id": "walkthroughrequestclient_walkthroughsubmissionidentity_beginattempt",
-      "label": ".beginAttempt()",
-      "norm_label": ".beginattempt()",
-      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
-      "source_location": "L85"
+      "id": "mtnmomoview_hasreceivingaccountdetails",
+      "label": "hasReceivingAccountDetails()",
+      "norm_label": "hasreceivingaccountdetails()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L64"
     },
     {
       "community": 165,
       "file_type": "code",
-      "id": "walkthroughrequestclient_walkthroughsubmissionidentity_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
-      "source_location": "L70"
+      "id": "mtnmomoview_normalizeprimaryaccounts",
+      "label": "normalizePrimaryAccounts()",
+      "norm_label": "normalizeprimaryaccounts()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L77"
     },
     {
       "community": 165,
       "file_type": "code",
-      "id": "walkthroughrequestclient_walkthroughsubmissionidentity_notepayloadchange",
-      "label": ".notePayloadChange()",
-      "norm_label": ".notepayloadchange()",
-      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
-      "source_location": "L74"
+      "id": "mtnmomoview_topatchreceivingaccounts",
+      "label": "toPatchReceivingAccounts()",
+      "norm_label": "topatchreceivingaccounts()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L93"
     },
     {
       "community": 165,
       "file_type": "code",
-      "id": "walkthroughrequestclient_walkthroughsubmissionidentity_rotateforretry",
-      "label": ".rotateForRetry()",
-      "norm_label": ".rotateforretry()",
-      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
-      "source_location": "L91"
+      "id": "mtnmomoview_trimtoundefined",
+      "label": "trimToUndefined()",
+      "norm_label": "trimtoundefined()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 165,
+      "file_type": "code",
+      "id": "mtnmomoview_updateaccount",
+      "label": "updateAccount()",
+      "norm_label": "updateaccount()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L141"
+    },
+    {
+      "community": 165,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_tsx",
+      "label": "MtnMomoView.tsx",
+      "norm_label": "mtnmomoview.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L1"
     },
     {
       "community": 1650,
@@ -196611,128 +196644,128 @@
     {
       "community": 166,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_validation_ts",
-      "label": "validation.ts",
-      "norm_label": "validation.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "id": "packages_athena_webapp_src_lib_marketing_walkthroughrequestclient_ts",
+      "label": "walkthroughRequestClient.ts",
+      "norm_label": "walkthroughrequestclient.ts",
+      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
       "source_location": "L1"
     },
     {
       "community": 166,
       "file_type": "code",
-      "id": "validation_cancompletetransaction",
-      "label": "canCompleteTransaction()",
-      "norm_label": "cancompletetransaction()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L404"
+      "id": "walkthroughrequestclient_canonicalizewalkthroughpayload",
+      "label": "canonicalizeWalkthroughPayload()",
+      "norm_label": "canonicalizewalkthroughpayload()",
+      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
+      "source_location": "L25"
     },
     {
       "community": 166,
       "file_type": "code",
-      "id": "validation_isoverpaypaymentmethod",
-      "label": "isOverpayPaymentMethod()",
-      "norm_label": "isoverpaypaymentmethod()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L414"
+      "id": "walkthroughrequestclient_generatesubmissionkey",
+      "label": "generateSubmissionKey()",
+      "norm_label": "generatesubmissionkey()",
+      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
+      "source_location": "L52"
     },
     {
       "community": 166,
       "file_type": "code",
-      "id": "validation_isvalidemail",
-      "label": "isValidEmail()",
-      "norm_label": "isvalidemail()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L246"
+      "id": "walkthroughrequestclient_normalizewalkthroughemail",
+      "label": "normalizeWalkthroughEmail()",
+      "norm_label": "normalizewalkthroughemail()",
+      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
+      "source_location": "L41"
     },
     {
       "community": 166,
       "file_type": "code",
-      "id": "validation_isvalidphone",
-      "label": "isValidPhone()",
-      "norm_label": "isvalidphone()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L304"
+      "id": "walkthroughrequestclient_normalizewalkthroughtext",
+      "label": "normalizeWalkthroughText()",
+      "norm_label": "normalizewalkthroughtext()",
+      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
+      "source_location": "L37"
     },
     {
       "community": 166,
       "file_type": "code",
-      "id": "validation_validatebarcode",
-      "label": "validateBarcode()",
-      "norm_label": "validatebarcode()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L187"
+      "id": "walkthroughrequestclient_readpublicerrorcode",
+      "label": "readPublicErrorCode()",
+      "norm_label": "readpublicerrorcode()",
+      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
+      "source_location": "L160"
     },
     {
       "community": 166,
       "file_type": "code",
-      "id": "validation_validatecart",
-      "label": "validateCart()",
-      "norm_label": "validatecart()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L23"
+      "id": "walkthroughrequestclient_resolvewalkthroughrequesturl",
+      "label": "resolveWalkthroughRequestUrl()",
+      "norm_label": "resolvewalkthroughrequesturl()",
+      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
+      "source_location": "L98"
     },
     {
       "community": 166,
       "file_type": "code",
-      "id": "validation_validatecustomer",
-      "label": "validateCustomer()",
-      "norm_label": "validatecustomer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L110"
+      "id": "walkthroughrequestclient_stripcontrolcharacters",
+      "label": "stripControlCharacters()",
+      "norm_label": "stripcontrolcharacters()",
+      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
+      "source_location": "L45"
     },
     {
       "community": 166,
       "file_type": "code",
-      "id": "validation_validatepayment",
-      "label": "validatePayment()",
-      "norm_label": "validatepayment()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L148"
+      "id": "walkthroughrequestclient_submitwalkthroughrequest",
+      "label": "submitWalkthroughRequest()",
+      "norm_label": "submitwalkthroughrequest()",
+      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
+      "source_location": "L106"
     },
     {
       "community": 166,
       "file_type": "code",
-      "id": "validation_validatepaymentamount",
-      "label": "validatePaymentAmount()",
-      "norm_label": "validatepaymentamount()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L317"
+      "id": "walkthroughrequestclient_walkthroughsubmissionidentity",
+      "label": "WalkthroughSubmissionIdentity",
+      "norm_label": "walkthroughsubmissionidentity",
+      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
+      "source_location": "L65"
     },
     {
       "community": 166,
       "file_type": "code",
-      "id": "validation_validatepayments",
-      "label": "validatePayments()",
-      "norm_label": "validatepayments()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L359"
+      "id": "walkthroughrequestclient_walkthroughsubmissionidentity_beginattempt",
+      "label": ".beginAttempt()",
+      "norm_label": ".beginattempt()",
+      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
+      "source_location": "L85"
     },
     {
       "community": 166,
       "file_type": "code",
-      "id": "validation_validateproduct",
-      "label": "validateProduct()",
-      "norm_label": "validateproduct()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "id": "walkthroughrequestclient_walkthroughsubmissionidentity_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
       "source_location": "L70"
     },
     {
       "community": 166,
       "file_type": "code",
-      "id": "validation_validatequantity",
-      "label": "validateQuantity()",
-      "norm_label": "validatequantity()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L215"
+      "id": "walkthroughrequestclient_walkthroughsubmissionidentity_notepayloadchange",
+      "label": ".notePayloadChange()",
+      "norm_label": ".notepayloadchange()",
+      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
+      "source_location": "L74"
     },
     {
       "community": 166,
       "file_type": "code",
-      "id": "validation_validatesession",
-      "label": "validateSession()",
-      "norm_label": "validatesession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L254"
+      "id": "walkthroughrequestclient_walkthroughsubmissionidentity_rotateforretry",
+      "label": ".rotateForRetry()",
+      "norm_label": ".rotateforretry()",
+      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
+      "source_location": "L91"
     },
     {
       "community": 1660,
@@ -196827,128 +196860,128 @@
     {
       "community": 167,
       "file_type": "code",
-      "id": "livekitremoteassistclient_buildparticipantidentity",
-      "label": "buildParticipantIdentity()",
-      "norm_label": "buildparticipantidentity()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
-      "source_location": "L164"
+      "id": "packages_athena_webapp_src_lib_pos_validation_ts",
+      "label": "validation.ts",
+      "norm_label": "validation.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L1"
     },
     {
       "community": 167,
       "file_type": "code",
-      "id": "livekitremoteassistclient_createlivekitremoteassistclient",
-      "label": "createLiveKitRemoteAssistClient()",
-      "norm_label": "createlivekitremoteassistclient()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
-      "source_location": "L19"
+      "id": "validation_cancompletetransaction",
+      "label": "canCompleteTransaction()",
+      "norm_label": "cancompletetransaction()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L404"
     },
     {
       "community": 167,
       "file_type": "code",
-      "id": "livekitremoteassistclient_getdatapublishrouting",
-      "label": "getDataPublishRouting()",
-      "norm_label": "getdatapublishrouting()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
-      "source_location": "L143"
+      "id": "validation_isoverpaypaymentmethod",
+      "label": "isOverpayPaymentMethod()",
+      "norm_label": "isoverpaypaymentmethod()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L414"
     },
     {
       "community": 167,
       "file_type": "code",
-      "id": "livekitremoteassistclient_getparticipantrole",
-      "label": "getParticipantRole()",
-      "norm_label": "getparticipantrole()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
-      "source_location": "L211"
+      "id": "validation_isvalidemail",
+      "label": "isValidEmail()",
+      "norm_label": "isvalidemail()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L246"
     },
     {
       "community": 167,
       "file_type": "code",
-      "id": "livekitremoteassistclient_isallowedsender",
-      "label": "isAllowedSender()",
-      "norm_label": "isallowedsender()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
-      "source_location": "L179"
+      "id": "validation_isvalidphone",
+      "label": "isValidPhone()",
+      "norm_label": "isvalidphone()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L304"
     },
     {
       "community": 167,
       "file_type": "code",
-      "id": "livekitremoteassistclient_livekitremoteassistclient",
-      "label": "LiveKitRemoteAssistClient",
-      "norm_label": "livekitremoteassistclient",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
+      "id": "validation_validatebarcode",
+      "label": "validateBarcode()",
+      "norm_label": "validatebarcode()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L187"
+    },
+    {
+      "community": 167,
+      "file_type": "code",
+      "id": "validation_validatecart",
+      "label": "validateCart()",
+      "norm_label": "validatecart()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L23"
     },
     {
       "community": 167,
       "file_type": "code",
-      "id": "livekitremoteassistclient_livekitremoteassistclient_connect",
-      "label": ".connect()",
-      "norm_label": ".connect()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
-      "source_location": "L33"
+      "id": "validation_validatecustomer",
+      "label": "validateCustomer()",
+      "norm_label": "validatecustomer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L110"
     },
     {
       "community": 167,
       "file_type": "code",
-      "id": "livekitremoteassistclient_livekitremoteassistclient_disconnect",
-      "label": ".disconnect()",
-      "norm_label": ".disconnect()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
-      "source_location": "L59"
+      "id": "validation_validatepayment",
+      "label": "validatePayment()",
+      "norm_label": "validatepayment()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L148"
     },
     {
       "community": 167,
       "file_type": "code",
-      "id": "livekitremoteassistclient_livekitremoteassistclient_emitstate",
-      "label": ".emitState()",
-      "norm_label": ".emitstate()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
-      "source_location": "L136"
+      "id": "validation_validatepaymentamount",
+      "label": "validatePaymentAmount()",
+      "norm_label": "validatepaymentamount()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L317"
     },
     {
       "community": 167,
       "file_type": "code",
-      "id": "livekitremoteassistclient_livekitremoteassistclient_publish",
-      "label": ".publish()",
-      "norm_label": ".publish()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
-      "source_location": "L71"
+      "id": "validation_validatepayments",
+      "label": "validatePayments()",
+      "norm_label": "validatepayments()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L359"
     },
     {
       "community": 167,
       "file_type": "code",
-      "id": "livekitremoteassistclient_livekitremoteassistclient_subscribe",
-      "label": ".subscribe()",
-      "norm_label": ".subscribe()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
-      "source_location": "L91"
+      "id": "validation_validateproduct",
+      "label": "validateProduct()",
+      "norm_label": "validateproduct()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L70"
     },
     {
       "community": 167,
       "file_type": "code",
-      "id": "livekitremoteassistclient_livekitremoteassistclient_subscribetoconnectionstate",
-      "label": ".subscribeToConnectionState()",
-      "norm_label": ".subscribetoconnectionstate()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
-      "source_location": "L96"
+      "id": "validation_validatequantity",
+      "label": "validateQuantity()",
+      "norm_label": "validatequantity()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L215"
     },
     {
       "community": 167,
       "file_type": "code",
-      "id": "livekitremoteassistclient_parseparticipantrole",
-      "label": "parseParticipantRole()",
-      "norm_label": "parseparticipantrole()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
-      "source_location": "L221"
-    },
-    {
-      "community": 167,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_remote_assist_transport_livekitremoteassistclient_ts",
-      "label": "livekitRemoteAssistClient.ts",
-      "norm_label": "livekitremoteassistclient.ts",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
-      "source_location": "L1"
+      "id": "validation_validatesession",
+      "label": "validateSession()",
+      "norm_label": "validatesession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L254"
     },
     {
       "community": 1670,
@@ -197043,127 +197076,127 @@
     {
       "community": 168,
       "file_type": "code",
-      "id": "fuzzysearch_bestfuzzytokenscore",
-      "label": "bestFuzzyTokenScore()",
-      "norm_label": "bestfuzzytokenscore()",
-      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
-      "source_location": "L168"
-    },
-    {
-      "community": 168,
-      "file_type": "code",
-      "id": "fuzzysearch_compactsearchtext",
-      "label": "compactSearchText()",
-      "norm_label": "compactsearchtext()",
-      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
+      "id": "livekitremoteassistclient_buildparticipantidentity",
+      "label": "buildParticipantIdentity()",
+      "norm_label": "buildparticipantidentity()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
       "source_location": "L164"
     },
     {
       "community": 168,
       "file_type": "code",
-      "id": "fuzzysearch_createfuzzysearchentry",
-      "label": "createFuzzySearchEntry()",
-      "norm_label": "createfuzzysearchentry()",
-      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
-      "source_location": "L9"
+      "id": "livekitremoteassistclient_createlivekitremoteassistclient",
+      "label": "createLiveKitRemoteAssistClient()",
+      "norm_label": "createlivekitremoteassistclient()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
+      "source_location": "L19"
     },
     {
       "community": 168,
       "file_type": "code",
-      "id": "fuzzysearch_isprobablysametoken",
-      "label": "isProbablySameToken()",
-      "norm_label": "isprobablysametoken()",
-      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
-      "source_location": "L216"
+      "id": "livekitremoteassistclient_getdatapublishrouting",
+      "label": "getDataPublishRouting()",
+      "norm_label": "getdatapublishrouting()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
+      "source_location": "L143"
     },
     {
       "community": 168,
       "file_type": "code",
-      "id": "fuzzysearch_levenshteindistance",
-      "label": "levenshteinDistance()",
-      "norm_label": "levenshteindistance()",
-      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
-      "source_location": "L224"
+      "id": "livekitremoteassistclient_getparticipantrole",
+      "label": "getParticipantRole()",
+      "norm_label": "getparticipantrole()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
+      "source_location": "L211"
     },
     {
       "community": 168,
       "file_type": "code",
-      "id": "fuzzysearch_normalizefuzzysearchtext",
-      "label": "normalizeFuzzySearchText()",
-      "norm_label": "normalizefuzzysearchtext()",
-      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
-      "source_location": "L76"
+      "id": "livekitremoteassistclient_isallowedsender",
+      "label": "isAllowedSender()",
+      "norm_label": "isallowedsender()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
+      "source_location": "L179"
     },
     {
       "community": 168,
       "file_type": "code",
-      "id": "fuzzysearch_scorecompactfieldcontains",
-      "label": "scoreCompactFieldContains()",
-      "norm_label": "scorecompactfieldcontains()",
-      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
-      "source_location": "L131"
+      "id": "livekitremoteassistclient_livekitremoteassistclient",
+      "label": "LiveKitRemoteAssistClient",
+      "norm_label": "livekitremoteassistclient",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
+      "source_location": "L23"
     },
     {
       "community": 168,
       "file_type": "code",
-      "id": "fuzzysearch_scorefieldcontains",
-      "label": "scoreFieldContains()",
-      "norm_label": "scorefieldcontains()",
-      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
-      "source_location": "L127"
+      "id": "livekitremoteassistclient_livekitremoteassistclient_connect",
+      "label": ".connect()",
+      "norm_label": ".connect()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
+      "source_location": "L33"
     },
     {
       "community": 168,
       "file_type": "code",
-      "id": "fuzzysearch_scorefuzzysearchentry",
-      "label": "scoreFuzzySearchEntry()",
-      "norm_label": "scorefuzzysearchentry()",
-      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
-      "source_location": "L56"
+      "id": "livekitremoteassistclient_livekitremoteassistclient_disconnect",
+      "label": ".disconnect()",
+      "norm_label": ".disconnect()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
+      "source_location": "L59"
     },
     {
       "community": 168,
       "file_type": "code",
-      "id": "fuzzysearch_scorefuzzytokenmatch",
-      "label": "scoreFuzzyTokenMatch()",
-      "norm_label": "scorefuzzytokenmatch()",
-      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
-      "source_location": "L185"
+      "id": "livekitremoteassistclient_livekitremoteassistclient_emitstate",
+      "label": ".emitState()",
+      "norm_label": ".emitstate()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
+      "source_location": "L136"
     },
     {
       "community": 168,
       "file_type": "code",
-      "id": "fuzzysearch_scorequerytokenforentry",
-      "label": "scoreQueryTokenForEntry()",
-      "norm_label": "scorequerytokenforentry()",
-      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
-      "source_location": "L100"
+      "id": "livekitremoteassistclient_livekitremoteassistclient_publish",
+      "label": ".publish()",
+      "norm_label": ".publish()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
+      "source_location": "L71"
     },
     {
       "community": 168,
       "file_type": "code",
-      "id": "fuzzysearch_searchfuzzyentries",
-      "label": "searchFuzzyEntries()",
-      "norm_label": "searchfuzzyentries()",
-      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
-      "source_location": "L27"
+      "id": "livekitremoteassistclient_livekitremoteassistclient_subscribe",
+      "label": ".subscribe()",
+      "norm_label": ".subscribe()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
+      "source_location": "L91"
     },
     {
       "community": 168,
       "file_type": "code",
-      "id": "fuzzysearch_tokenizefuzzysearchtext",
-      "label": "tokenizeFuzzySearchText()",
-      "norm_label": "tokenizefuzzysearchtext()",
-      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
-      "source_location": "L86"
+      "id": "livekitremoteassistclient_livekitremoteassistclient_subscribetoconnectionstate",
+      "label": ".subscribeToConnectionState()",
+      "norm_label": ".subscribetoconnectionstate()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
+      "source_location": "L96"
     },
     {
       "community": 168,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_search_fuzzysearch_ts",
-      "label": "fuzzySearch.ts",
-      "norm_label": "fuzzysearch.ts",
-      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
+      "id": "livekitremoteassistclient_parseparticipantrole",
+      "label": "parseParticipantRole()",
+      "norm_label": "parseparticipantrole()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
+      "source_location": "L221"
+    },
+    {
+      "community": 168,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_remote_assist_transport_livekitremoteassistclient_ts",
+      "label": "livekitRemoteAssistClient.ts",
+      "norm_label": "livekitremoteassistclient.ts",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
       "source_location": "L1"
     },
     {
@@ -197259,127 +197292,127 @@
     {
       "community": 169,
       "file_type": "code",
-      "id": "authed_layout_getbrowserpathname",
-      "label": "getBrowserPathname()",
-      "norm_label": "getbrowserpathname()",
-      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
-      "source_location": "L133"
+      "id": "fuzzysearch_bestfuzzytokenscore",
+      "label": "bestFuzzyTokenScore()",
+      "norm_label": "bestfuzzytokenscore()",
+      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
+      "source_location": "L168"
     },
     {
       "community": 169,
       "file_type": "code",
-      "id": "authed_layout_getbrowserpathwithsearch",
-      "label": "getBrowserPathWithSearch()",
-      "norm_label": "getbrowserpathwithsearch()",
-      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
-      "source_location": "L137"
+      "id": "fuzzysearch_compactsearchtext",
+      "label": "compactSearchText()",
+      "norm_label": "compactsearchtext()",
+      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
+      "source_location": "L164"
     },
     {
       "community": 169,
       "file_type": "code",
-      "id": "authed_layout_getloginhref",
-      "label": "getLoginHref()",
-      "norm_label": "getloginhref()",
-      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
-      "source_location": "L156"
+      "id": "fuzzysearch_createfuzzysearchentry",
+      "label": "createFuzzySearchEntry()",
+      "norm_label": "createfuzzysearchentry()",
+      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
+      "source_location": "L9"
     },
     {
       "community": 169,
       "file_type": "code",
-      "id": "authed_layout_getposhubrouteparams",
-      "label": "getPosHubRouteParams()",
-      "norm_label": "getposhubrouteparams()",
-      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
-      "source_location": "L98"
+      "id": "fuzzysearch_isprobablysametoken",
+      "label": "isProbablySameToken()",
+      "norm_label": "isprobablysametoken()",
+      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
+      "source_location": "L216"
     },
     {
       "community": 169,
       "file_type": "code",
-      "id": "authed_layout_getredirectpathwithsearch",
-      "label": "getRedirectPathWithSearch()",
-      "norm_label": "getredirectpathwithsearch()",
-      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
-      "source_location": "L145"
+      "id": "fuzzysearch_levenshteindistance",
+      "label": "levenshteinDistance()",
+      "norm_label": "levenshteindistance()",
+      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
+      "source_location": "L224"
     },
     {
       "community": 169,
       "file_type": "code",
-      "id": "authed_layout_getrouteparamsforpattern",
-      "label": "getRouteParamsForPattern()",
-      "norm_label": "getrouteparamsforpattern()",
-      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
-      "source_location": "L106"
+      "id": "fuzzysearch_normalizefuzzysearchtext",
+      "label": "normalizeFuzzySearchText()",
+      "norm_label": "normalizefuzzysearchtext()",
+      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
+      "source_location": "L76"
     },
     {
       "community": 169,
       "file_type": "code",
-      "id": "authed_layout_getstoreworkspacerouteparams",
-      "label": "getStoreWorkspaceRouteParams()",
-      "norm_label": "getstoreworkspacerouteparams()",
-      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
-      "source_location": "L102"
+      "id": "fuzzysearch_scorecompactfieldcontains",
+      "label": "scoreCompactFieldContains()",
+      "norm_label": "scorecompactfieldcontains()",
+      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
+      "source_location": "L131"
     },
     {
       "community": 169,
       "file_type": "code",
-      "id": "authed_layout_handlesignout",
-      "label": "handleSignOut()",
-      "norm_label": "handlesignout()",
-      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
-      "source_location": "L441"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "authed_layout_hasstoredlocalsession",
-      "label": "hasStoredLocalSession()",
-      "norm_label": "hasstoredlocalsession()",
-      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
-      "source_location": "L169"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "authed_layout_isbrowseroffline",
-      "label": "isBrowserOffline()",
-      "norm_label": "isbrowseroffline()",
-      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
-      "source_location": "L184"
-    },
-    {
-      "community": 169,
-      "file_type": "code",
-      "id": "authed_layout_isposterminalfullscreenpath",
-      "label": "isPosTerminalFullscreenPath()",
-      "norm_label": "isposterminalfullscreenpath()",
-      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
+      "id": "fuzzysearch_scorefieldcontains",
+      "label": "scoreFieldContains()",
+      "norm_label": "scorefieldcontains()",
+      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
       "source_location": "L127"
     },
     {
       "community": 169,
       "file_type": "code",
-      "id": "authed_layout_isunknownrouterpath",
-      "label": "isUnknownRouterPath()",
-      "norm_label": "isunknownrouterpath()",
-      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
-      "source_location": "L165"
+      "id": "fuzzysearch_scorefuzzysearchentry",
+      "label": "scoreFuzzySearchEntry()",
+      "norm_label": "scorefuzzysearchentry()",
+      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
+      "source_location": "L56"
     },
     {
       "community": 169,
       "file_type": "code",
-      "id": "authed_layout_usebrowserofflinestatus",
-      "label": "useBrowserOfflineStatus()",
-      "norm_label": "usebrowserofflinestatus()",
-      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
-      "source_location": "L188"
+      "id": "fuzzysearch_scorefuzzytokenmatch",
+      "label": "scoreFuzzyTokenMatch()",
+      "norm_label": "scorefuzzytokenmatch()",
+      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
+      "source_location": "L185"
     },
     {
       "community": 169,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_layout_tsx",
-      "label": "-authed-layout.tsx",
-      "norm_label": "-authed-layout.tsx",
-      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
+      "id": "fuzzysearch_scorequerytokenforentry",
+      "label": "scoreQueryTokenForEntry()",
+      "norm_label": "scorequerytokenforentry()",
+      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
+      "source_location": "L100"
+    },
+    {
+      "community": 169,
+      "file_type": "code",
+      "id": "fuzzysearch_searchfuzzyentries",
+      "label": "searchFuzzyEntries()",
+      "norm_label": "searchfuzzyentries()",
+      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 169,
+      "file_type": "code",
+      "id": "fuzzysearch_tokenizefuzzysearchtext",
+      "label": "tokenizeFuzzySearchText()",
+      "norm_label": "tokenizefuzzysearchtext()",
+      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
+      "source_location": "L86"
+    },
+    {
+      "community": 169,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_search_fuzzysearch_ts",
+      "label": "fuzzySearch.ts",
+      "norm_label": "fuzzysearch.ts",
+      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
       "source_location": "L1"
     },
     {
@@ -197862,127 +197895,127 @@
     {
       "community": 170,
       "file_type": "code",
-      "id": "github_pr_merge_deleteheadbranch",
-      "label": "deleteHeadBranch()",
-      "norm_label": "deleteheadbranch()",
-      "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L207"
+      "id": "authed_layout_getbrowserpathname",
+      "label": "getBrowserPathname()",
+      "norm_label": "getbrowserpathname()",
+      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
+      "source_location": "L133"
     },
     {
       "community": 170,
       "file_type": "code",
-      "id": "github_pr_merge_enablepullrequestautomerge",
-      "label": "enablePullRequestAutoMerge()",
-      "norm_label": "enablepullrequestautomerge()",
-      "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L225"
+      "id": "authed_layout_getbrowserpathwithsearch",
+      "label": "getBrowserPathWithSearch()",
+      "norm_label": "getbrowserpathwithsearch()",
+      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
+      "source_location": "L137"
     },
     {
       "community": 170,
       "file_type": "code",
-      "id": "github_pr_merge_encodegitrefpath",
-      "label": "encodeGitRefPath()",
-      "norm_label": "encodegitrefpath()",
-      "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L268"
+      "id": "authed_layout_getloginhref",
+      "label": "getLoginHref()",
+      "norm_label": "getloginhref()",
+      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
+      "source_location": "L156"
     },
     {
       "community": 170,
       "file_type": "code",
-      "id": "github_pr_merge_ghjson",
-      "label": "ghJson()",
-      "norm_label": "ghjson()",
-      "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L272"
+      "id": "authed_layout_getposhubrouteparams",
+      "label": "getPosHubRouteParams()",
+      "norm_label": "getposhubrouteparams()",
+      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
+      "source_location": "L98"
     },
     {
       "community": 170,
       "file_type": "code",
-      "id": "github_pr_merge_helprequested",
-      "label": "HelpRequested",
-      "norm_label": "helprequested",
-      "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L318"
+      "id": "authed_layout_getredirectpathwithsearch",
+      "label": "getRedirectPathWithSearch()",
+      "norm_label": "getredirectpathwithsearch()",
+      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
+      "source_location": "L145"
     },
     {
       "community": 170,
       "file_type": "code",
-      "id": "github_pr_merge_mergepullrequest",
-      "label": "mergePullRequest()",
-      "norm_label": "mergepullrequest()",
-      "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L65"
+      "id": "authed_layout_getrouteparamsforpattern",
+      "label": "getRouteParamsForPattern()",
+      "norm_label": "getrouteparamsforpattern()",
+      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
+      "source_location": "L106"
     },
     {
       "community": 170,
       "file_type": "code",
-      "id": "github_pr_merge_parseargs",
-      "label": "parseArgs()",
-      "norm_label": "parseargs()",
-      "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L115"
+      "id": "authed_layout_getstoreworkspacerouteparams",
+      "label": "getStoreWorkspaceRouteParams()",
+      "norm_label": "getstoreworkspacerouteparams()",
+      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
+      "source_location": "L102"
     },
     {
       "community": 170,
       "file_type": "code",
-      "id": "github_pr_merge_parsemergemethod",
-      "label": "parseMergeMethod()",
-      "norm_label": "parsemergemethod()",
-      "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L328"
+      "id": "authed_layout_handlesignout",
+      "label": "handleSignOut()",
+      "norm_label": "handlesignout()",
+      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
+      "source_location": "L441"
     },
     {
       "community": 170,
       "file_type": "code",
-      "id": "github_pr_merge_requirevalue",
-      "label": "requireValue()",
-      "norm_label": "requirevalue()",
-      "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L320"
+      "id": "authed_layout_hasstoredlocalsession",
+      "label": "hasStoredLocalSession()",
+      "norm_label": "hasstoredlocalsession()",
+      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
+      "source_location": "L169"
     },
     {
       "community": 170,
       "file_type": "code",
-      "id": "github_pr_merge_resolvecurrentrepo",
-      "label": "resolveCurrentRepo()",
-      "norm_label": "resolvecurrentrepo()",
-      "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L177"
+      "id": "authed_layout_isbrowseroffline",
+      "label": "isBrowserOffline()",
+      "norm_label": "isbrowseroffline()",
+      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
+      "source_location": "L184"
     },
     {
       "community": 170,
       "file_type": "code",
-      "id": "github_pr_merge_runprocess",
-      "label": "runProcess()",
-      "norm_label": "runprocess()",
-      "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L294"
+      "id": "authed_layout_isposterminalfullscreenpath",
+      "label": "isPosTerminalFullscreenPath()",
+      "norm_label": "isposterminalfullscreenpath()",
+      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
+      "source_location": "L127"
     },
     {
       "community": 170,
       "file_type": "code",
-      "id": "github_pr_merge_shoulddeleteheadbranch",
-      "label": "shouldDeleteHeadBranch()",
-      "norm_label": "shoulddeleteheadbranch()",
-      "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L264"
+      "id": "authed_layout_isunknownrouterpath",
+      "label": "isUnknownRouterPath()",
+      "norm_label": "isunknownrouterpath()",
+      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
+      "source_location": "L165"
     },
     {
       "community": 170,
       "file_type": "code",
-      "id": "github_pr_merge_viewpullrequest",
-      "label": "viewPullRequest()",
-      "norm_label": "viewpullrequest()",
-      "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L186"
+      "id": "authed_layout_usebrowserofflinestatus",
+      "label": "useBrowserOfflineStatus()",
+      "norm_label": "usebrowserofflinestatus()",
+      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
+      "source_location": "L188"
     },
     {
       "community": 170,
       "file_type": "code",
-      "id": "scripts_github_pr_merge_ts",
-      "label": "github-pr-merge.ts",
-      "norm_label": "github-pr-merge.ts",
-      "source_file": "scripts/github-pr-merge.ts",
+      "id": "packages_athena_webapp_src_routes_authed_layout_tsx",
+      "label": "-authed-layout.tsx",
+      "norm_label": "-authed-layout.tsx",
+      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
       "source_location": "L1"
     },
     {
@@ -198078,118 +198111,127 @@
     {
       "community": 171,
       "file_type": "code",
-      "id": "backfillstoreschedules_backfillstoreschedulesfromlegacypolicywithctx",
-      "label": "backfillStoreSchedulesFromLegacyPolicyWithCtx()",
-      "norm_label": "backfillstoreschedulesfromlegacypolicywithctx()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L324"
+      "id": "github_pr_merge_deleteheadbranch",
+      "label": "deleteHeadBranch()",
+      "norm_label": "deleteheadbranch()",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L207"
     },
     {
       "community": 171,
       "file_type": "code",
-      "id": "backfillstoreschedules_buildbackfillrow",
-      "label": "buildBackfillRow()",
-      "norm_label": "buildbackfillrow()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L187"
+      "id": "github_pr_merge_enablepullrequestautomerge",
+      "label": "enablePullRequestAutoMerge()",
+      "norm_label": "enablepullrequestautomerge()",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L225"
     },
     {
       "community": 171,
       "file_type": "code",
-      "id": "backfillstoreschedules_buildcandidateweeklywindows",
-      "label": "buildCandidateWeeklyWindows()",
-      "norm_label": "buildcandidateweeklywindows()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L163"
+      "id": "github_pr_merge_encodegitrefpath",
+      "label": "encodeGitRefPath()",
+      "norm_label": "encodegitrefpath()",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L268"
     },
     {
       "community": 171,
       "file_type": "code",
-      "id": "backfillstoreschedules_compatibilitymetadata",
-      "label": "compatibilityMetadata()",
-      "norm_label": "compatibilitymetadata()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L133"
+      "id": "github_pr_merge_ghjson",
+      "label": "ghJson()",
+      "norm_label": "ghjson()",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L272"
     },
     {
       "community": 171,
       "file_type": "code",
-      "id": "backfillstoreschedules_compatibilityonlyrow",
-      "label": "compatibilityOnlyRow()",
-      "norm_label": "compatibilityonlyrow()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L174"
+      "id": "github_pr_merge_helprequested",
+      "label": "HelpRequested",
+      "norm_label": "helprequested",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L318"
     },
     {
       "community": 171,
       "file_type": "code",
-      "id": "backfillstoreschedules_findexistingscheduletoskip",
-      "label": "findExistingScheduleToSkip()",
-      "norm_label": "findexistingscheduletoskip()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L114"
+      "id": "github_pr_merge_mergepullrequest",
+      "label": "mergePullRequest()",
+      "norm_label": "mergepullrequest()",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L65"
     },
     {
       "community": 171,
       "file_type": "code",
-      "id": "backfillstoreschedules_firstpolicy",
-      "label": "firstPolicy()",
-      "norm_label": "firstpolicy()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L75"
+      "id": "github_pr_merge_parseargs",
+      "label": "parseArgs()",
+      "norm_label": "parseargs()",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L115"
     },
     {
       "community": 171,
       "file_type": "code",
-      "id": "backfillstoreschedules_isvalidminute",
-      "label": "isValidMinute()",
-      "norm_label": "isvalidminute()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L66"
+      "id": "github_pr_merge_parsemergemethod",
+      "label": "parseMergeMethod()",
+      "norm_label": "parsemergemethod()",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L328"
     },
     {
       "community": 171,
       "file_type": "code",
-      "id": "backfillstoreschedules_listpoliciesforstoreaction",
-      "label": "listPoliciesForStoreAction()",
-      "norm_label": "listpoliciesforstoreaction()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L81"
+      "id": "github_pr_merge_requirevalue",
+      "label": "requireValue()",
+      "norm_label": "requirevalue()",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L320"
     },
     {
       "community": 171,
       "file_type": "code",
-      "id": "backfillstoreschedules_listschedulesforstorebystatus",
-      "label": "listSchedulesForStoreByStatus()",
-      "norm_label": "listschedulesforstorebystatus()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L99"
+      "id": "github_pr_merge_resolvecurrentrepo",
+      "label": "resolveCurrentRepo()",
+      "norm_label": "resolvecurrentrepo()",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L177"
     },
     {
       "community": 171,
       "file_type": "code",
-      "id": "backfillstoreschedules_normalizelimit",
-      "label": "normalizeLimit()",
-      "norm_label": "normalizelimit()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L58"
+      "id": "github_pr_merge_runprocess",
+      "label": "runProcess()",
+      "norm_label": "runprocess()",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L294"
     },
     {
       "community": 171,
       "file_type": "code",
-      "id": "backfillstoreschedules_trustedtimezoneforstore",
-      "label": "trustedTimezoneForStore()",
-      "norm_label": "trustedtimezoneforstore()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L126"
+      "id": "github_pr_merge_shoulddeleteheadbranch",
+      "label": "shouldDeleteHeadBranch()",
+      "norm_label": "shoulddeleteheadbranch()",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L264"
     },
     {
       "community": 171,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_migrations_backfillstoreschedules_ts",
-      "label": "backfillStoreSchedules.ts",
-      "norm_label": "backfillstoreschedules.ts",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "id": "github_pr_merge_viewpullrequest",
+      "label": "viewPullRequest()",
+      "norm_label": "viewpullrequest()",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L186"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "scripts_github_pr_merge_ts",
+      "label": "github-pr-merge.ts",
+      "norm_label": "github-pr-merge.ts",
+      "source_file": "scripts/github-pr-merge.ts",
       "source_location": "L1"
     },
     {
@@ -198285,119 +198327,119 @@
     {
       "community": 172,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operationadmission_readdefinitions_ts",
-      "label": "readDefinitions.ts",
-      "norm_label": "readdefinitions.ts",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "id": "packages_athena_webapp_convex_inventory_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
       "source_location": "L1"
     },
     {
       "community": 172,
       "file_type": "code",
-      "id": "readdefinitions_definecashcontrolsread",
-      "label": "defineCashControlsRead()",
-      "norm_label": "definecashcontrolsread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L50"
+      "id": "packages_athena_webapp_src_components_orders_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 172,
       "file_type": "code",
-      "id": "readdefinitions_definedailycloseread",
-      "label": "defineDailyCloseRead()",
-      "norm_label": "definedailycloseread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L30"
+      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 172,
       "file_type": "code",
-      "id": "readdefinitions_definedailyoperationsread",
-      "label": "defineDailyOperationsRead()",
-      "norm_label": "definedailyoperationsread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L10"
+      "id": "utils_formatdeliveryaddress",
+      "label": "formatDeliveryAddress()",
+      "norm_label": "formatdeliveryaddress()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L74"
     },
     {
       "community": 172,
       "file_type": "code",
-      "id": "readdefinitions_defineinventorycatalogread",
-      "label": "defineInventoryCatalogRead()",
-      "norm_label": "defineinventorycatalogread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L70"
+      "id": "utils_getamountpaidfororder",
+      "label": "getAmountPaidForOrder()",
+      "norm_label": "getamountpaidfororder()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L191"
     },
     {
       "community": 172,
       "file_type": "code",
-      "id": "readdefinitions_defineinventorycostoverlayread",
-      "label": "defineInventoryCostOverlayRead()",
-      "norm_label": "defineinventorycostoverlayread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L639"
+      "id": "utils_getdiscountvalue",
+      "label": "getDiscountValue()",
+      "norm_label": "getdiscountvalue()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L17"
     },
     {
       "community": 172,
       "file_type": "code",
-      "id": "readdefinitions_defineonlineordersread",
-      "label": "defineOnlineOrdersRead()",
-      "norm_label": "defineonlineordersread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L84"
+      "id": "utils_getonlineorderplacedat",
+      "label": "getOnlineOrderPlacedAt()",
+      "norm_label": "getonlineorderplacedat()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 172,
       "file_type": "code",
-      "id": "readdefinitions_defineoperationalworkread",
-      "label": "defineOperationalWorkRead()",
-      "norm_label": "defineoperationalworkread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L20"
+      "id": "utils_getorderamount",
+      "label": "getOrderAmount()",
+      "norm_label": "getorderamount()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L51"
     },
     {
       "community": 172,
       "file_type": "code",
-      "id": "readdefinitions_defineorganizationread",
-      "label": "defineOrganizationRead()",
-      "norm_label": "defineorganizationread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L94"
-    },
-    {
-      "community": 172,
-      "file_type": "code",
-      "id": "readdefinitions_defineposread",
-      "label": "definePosRead()",
-      "norm_label": "defineposread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "id": "utils_getorderstate",
+      "label": "getOrderState()",
+      "norm_label": "getorderstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
       "source_location": "L40"
     },
     {
       "community": 172,
       "file_type": "code",
-      "id": "readdefinitions_definereadoperation",
-      "label": "defineReadOperation()",
-      "norm_label": "definereadoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L4"
+      "id": "utils_getpickupactionstate",
+      "label": "getPickupActionState()",
+      "norm_label": "getpickupactionstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L102"
     },
     {
       "community": 172,
       "file_type": "code",
-      "id": "readdefinitions_definestockadjustmentsread",
-      "label": "defineStockAdjustmentsRead()",
-      "norm_label": "definestockadjustmentsread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L60"
+      "id": "utils_getpotentialpoints",
+      "label": "getPotentialPoints()",
+      "norm_label": "getpotentialpoints()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L107"
     },
     {
       "community": 172,
       "file_type": "code",
-      "id": "readdefinitions_validatereadoperationdefinition",
-      "label": "validateReadOperationDefinition()",
-      "norm_label": "validatereadoperationdefinition()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L781"
+      "id": "utils_getproductdiscountvalue",
+      "label": "getProductDiscountValue()",
+      "norm_label": "getproductdiscountvalue()",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 172,
+      "file_type": "code",
+      "id": "utils_shouldshowpickupexceptionaction",
+      "label": "shouldShowPickupExceptionAction()",
+      "norm_label": "shouldshowpickupexceptionaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L116"
     },
     {
       "community": 1720,
@@ -198492,118 +198534,118 @@
     {
       "community": 173,
       "file_type": "code",
-      "id": "frozenmetricauthority_closecandidateoperatingrange",
-      "label": "closeCandidateOperatingRange()",
-      "norm_label": "closecandidateoperatingrange()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L199"
+      "id": "backfillstoreschedules_backfillstoreschedulesfromlegacypolicywithctx",
+      "label": "backfillStoreSchedulesFromLegacyPolicyWithCtx()",
+      "norm_label": "backfillstoreschedulesfromlegacypolicywithctx()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L324"
     },
     {
       "community": 173,
       "file_type": "code",
-      "id": "frozenmetricauthority_emptyclosesummary",
-      "label": "emptyCloseSummary()",
-      "norm_label": "emptyclosesummary()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L62"
+      "id": "backfillstoreschedules_buildbackfillrow",
+      "label": "buildBackfillRow()",
+      "norm_label": "buildbackfillrow()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L187"
     },
     {
       "community": 173,
       "file_type": "code",
-      "id": "frozenmetricauthority_exactstatuses",
-      "label": "exactStatuses()",
-      "norm_label": "exactstatuses()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L96"
+      "id": "backfillstoreschedules_buildcandidateweeklywindows",
+      "label": "buildCandidateWeeklyWindows()",
+      "norm_label": "buildcandidateweeklywindows()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L163"
     },
     {
       "community": 173,
       "file_type": "code",
-      "id": "frozenmetricauthority_finitenumber",
-      "label": "finiteNumber()",
-      "norm_label": "finitenumber()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L91"
-    },
-    {
-      "community": 173,
-      "file_type": "code",
-      "id": "frozenmetricauthority_frozenfinancialsourcecounts",
-      "label": "frozenFinancialSourceCounts()",
-      "norm_label": "frozenfinancialsourcecounts()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "id": "backfillstoreschedules_compatibilitymetadata",
+      "label": "compatibilityMetadata()",
+      "norm_label": "compatibilitymetadata()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
       "source_location": "L133"
     },
     {
       "community": 173,
       "file_type": "code",
-      "id": "frozenmetricauthority_frozenweekmetricfordate",
-      "label": "frozenWeekMetricForDate()",
-      "norm_label": "frozenweekmetricfordate()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L481"
+      "id": "backfillstoreschedules_compatibilityonlyrow",
+      "label": "compatibilityOnlyRow()",
+      "norm_label": "compatibilityonlyrow()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L174"
     },
     {
       "community": 173,
       "file_type": "code",
-      "id": "frozenmetricauthority_matchesrequestedoperatingrange",
-      "label": "matchesRequestedOperatingRange()",
-      "norm_label": "matchesrequestedoperatingrange()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L102"
+      "id": "backfillstoreschedules_findexistingscheduletoskip",
+      "label": "findExistingScheduleToSkip()",
+      "norm_label": "findexistingscheduletoskip()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L114"
     },
     {
       "community": 173,
       "file_type": "code",
-      "id": "frozenmetricauthority_normalizefrozenpaymenttotals",
-      "label": "normalizeFrozenPaymentTotals()",
-      "norm_label": "normalizefrozenpaymenttotals()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L241"
+      "id": "backfillstoreschedules_firstpolicy",
+      "label": "firstPolicy()",
+      "norm_label": "firstpolicy()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L75"
     },
     {
       "community": 173,
       "file_type": "code",
-      "id": "frozenmetricauthority_recordvalue",
-      "label": "recordValue()",
-      "norm_label": "recordvalue()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L85"
+      "id": "backfillstoreschedules_isvalidminute",
+      "label": "isValidMinute()",
+      "norm_label": "isvalidminute()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L66"
     },
     {
       "community": 173,
       "file_type": "code",
-      "id": "frozenmetricauthority_resolvefrozendailycloseauthority",
-      "label": "resolveFrozenDailyCloseAuthority()",
-      "norm_label": "resolvefrozendailycloseauthority()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L393"
+      "id": "backfillstoreschedules_listpoliciesforstoreaction",
+      "label": "listPoliciesForStoreAction()",
+      "norm_label": "listpoliciesforstoreaction()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L81"
     },
     {
       "community": 173,
       "file_type": "code",
-      "id": "frozenmetricauthority_samedailycloseid",
-      "label": "sameDailyCloseId()",
-      "norm_label": "samedailycloseid()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L386"
+      "id": "backfillstoreschedules_listschedulesforstorebystatus",
+      "label": "listSchedulesForStoreByStatus()",
+      "norm_label": "listschedulesforstorebystatus()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L99"
     },
     {
       "community": 173,
       "file_type": "code",
-      "id": "frozenmetricauthority_usablefrozenweeksummary",
-      "label": "usableFrozenWeekSummary()",
-      "norm_label": "usablefrozenweeksummary()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L273"
+      "id": "backfillstoreschedules_normalizelimit",
+      "label": "normalizeLimit()",
+      "norm_label": "normalizelimit()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L58"
     },
     {
       "community": 173,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_dailyoperations_frozenmetricauthority_ts",
-      "label": "frozenMetricAuthority.ts",
-      "norm_label": "frozenmetricauthority.ts",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "id": "backfillstoreschedules_trustedtimezoneforstore",
+      "label": "trustedTimezoneForStore()",
+      "norm_label": "trustedtimezoneforstore()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L126"
+    },
+    {
+      "community": 173,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_migrations_backfillstoreschedules_ts",
+      "label": "backfillStoreSchedules.ts",
+      "norm_label": "backfillstoreschedules.ts",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
       "source_location": "L1"
     },
     {
@@ -198699,119 +198741,119 @@
     {
       "community": 174,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildctx",
-      "label": "buildCtx()",
-      "norm_label": "buildctx()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L956"
-    },
-    {
-      "community": 174,
-      "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildinventorymovement",
-      "label": "buildInventoryMovement()",
-      "norm_label": "buildinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1109"
-    },
-    {
-      "community": 174,
-      "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildmapping",
-      "label": "buildMapping()",
-      "norm_label": "buildmapping()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1213"
-    },
-    {
-      "community": 174,
-      "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildproductsku",
-      "label": "buildProductSku()",
-      "norm_label": "buildproductsku()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1130"
-    },
-    {
-      "community": 174,
-      "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1169"
-    },
-    {
-      "community": 174,
-      "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildstaffprofile",
-      "label": "buildStaffProfile()",
-      "norm_label": "buildstaffprofile()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1065"
-    },
-    {
-      "community": 174,
-      "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildstore",
-      "label": "buildStore()",
-      "norm_label": "buildstore()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1052"
-    },
-    {
-      "community": 174,
-      "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildterminal",
-      "label": "buildTerminal()",
-      "norm_label": "buildterminal()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1149"
-    },
-    {
-      "community": 174,
-      "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildtransaction",
-      "label": "buildTransaction()",
-      "norm_label": "buildtransaction()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1189"
-    },
-    {
-      "community": 174,
-      "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildworkitem",
-      "label": "buildWorkItem()",
-      "norm_label": "buildworkitem()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1079"
-    },
-    {
-      "community": 174,
-      "file_type": "code",
-      "id": "openworkinventoryreviews_test_defaultargs",
-      "label": "defaultArgs()",
-      "norm_label": "defaultargs()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L909"
-    },
-    {
-      "community": 174,
-      "file_type": "code",
-      "id": "openworkinventoryreviews_test_expectrejectedcontext",
-      "label": "expectRejectedContext()",
-      "norm_label": "expectrejectedcontext()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L891"
-    },
-    {
-      "community": 174,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_openworkinventoryreviews_test_ts",
-      "label": "openWorkInventoryReviews.test.ts",
-      "norm_label": "openworkinventoryreviews.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "id": "packages_athena_webapp_convex_operationadmission_readdefinitions_ts",
+      "label": "readDefinitions.ts",
+      "norm_label": "readdefinitions.ts",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 174,
+      "file_type": "code",
+      "id": "readdefinitions_definecashcontrolsread",
+      "label": "defineCashControlsRead()",
+      "norm_label": "definecashcontrolsread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 174,
+      "file_type": "code",
+      "id": "readdefinitions_definedailycloseread",
+      "label": "defineDailyCloseRead()",
+      "norm_label": "definedailycloseread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 174,
+      "file_type": "code",
+      "id": "readdefinitions_definedailyoperationsread",
+      "label": "defineDailyOperationsRead()",
+      "norm_label": "definedailyoperationsread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 174,
+      "file_type": "code",
+      "id": "readdefinitions_defineinventorycatalogread",
+      "label": "defineInventoryCatalogRead()",
+      "norm_label": "defineinventorycatalogread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 174,
+      "file_type": "code",
+      "id": "readdefinitions_defineinventorycostoverlayread",
+      "label": "defineInventoryCostOverlayRead()",
+      "norm_label": "defineinventorycostoverlayread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L639"
+    },
+    {
+      "community": 174,
+      "file_type": "code",
+      "id": "readdefinitions_defineonlineordersread",
+      "label": "defineOnlineOrdersRead()",
+      "norm_label": "defineonlineordersread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 174,
+      "file_type": "code",
+      "id": "readdefinitions_defineoperationalworkread",
+      "label": "defineOperationalWorkRead()",
+      "norm_label": "defineoperationalworkread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 174,
+      "file_type": "code",
+      "id": "readdefinitions_defineorganizationread",
+      "label": "defineOrganizationRead()",
+      "norm_label": "defineorganizationread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L94"
+    },
+    {
+      "community": 174,
+      "file_type": "code",
+      "id": "readdefinitions_defineposread",
+      "label": "definePosRead()",
+      "norm_label": "defineposread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 174,
+      "file_type": "code",
+      "id": "readdefinitions_definereadoperation",
+      "label": "defineReadOperation()",
+      "norm_label": "definereadoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 174,
+      "file_type": "code",
+      "id": "readdefinitions_definestockadjustmentsread",
+      "label": "defineStockAdjustmentsRead()",
+      "norm_label": "definestockadjustmentsread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L60"
+    },
+    {
+      "community": 174,
+      "file_type": "code",
+      "id": "readdefinitions_validatereadoperationdefinition",
+      "label": "validateReadOperationDefinition()",
+      "norm_label": "validatereadoperationdefinition()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L781"
     },
     {
       "community": 1740,
@@ -198906,119 +198948,119 @@
     {
       "community": 175,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
-      "label": "paymentAllocations.ts",
-      "norm_label": "paymentallocations.ts",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L1"
+      "id": "frozenmetricauthority_closecandidateoperatingrange",
+      "label": "closeCandidateOperatingRange()",
+      "norm_label": "closecandidateoperatingrange()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L199"
     },
     {
       "community": 175,
       "file_type": "code",
-      "id": "paymentallocations_buildpaymentallocation",
-      "label": "buildPaymentAllocation()",
-      "norm_label": "buildpaymentallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L32"
+      "id": "frozenmetricauthority_emptyclosesummary",
+      "label": "emptyCloseSummary()",
+      "norm_label": "emptyclosesummary()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L62"
     },
     {
       "community": 175,
       "file_type": "code",
-      "id": "paymentallocations_correctsameamountsinglepaymentallocationwithctx",
-      "label": "correctSameAmountSinglePaymentAllocationWithCtx()",
-      "norm_label": "correctsameamountsinglepaymentallocationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L397"
+      "id": "frozenmetricauthority_exactstatuses",
+      "label": "exactStatuses()",
+      "norm_label": "exactstatuses()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L96"
     },
     {
       "community": 175,
       "file_type": "code",
-      "id": "paymentallocations_ensurepaymentallocationreportingwithctx",
-      "label": "ensurePaymentAllocationReportingWithCtx()",
-      "norm_label": "ensurepaymentallocationreportingwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L198"
+      "id": "frozenmetricauthority_finitenumber",
+      "label": "finiteNumber()",
+      "norm_label": "finitenumber()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L91"
     },
     {
       "community": 175,
       "file_type": "code",
-      "id": "paymentallocations_findsameamountsinglepaymentallocation",
-      "label": "findSameAmountSinglePaymentAllocation()",
-      "norm_label": "findsameamountsinglepaymentallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L68"
+      "id": "frozenmetricauthority_frozenfinancialsourcecounts",
+      "label": "frozenFinancialSourceCounts()",
+      "norm_label": "frozenfinancialsourcecounts()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L133"
     },
     {
       "community": 175,
       "file_type": "code",
-      "id": "paymentallocations_listpaymentallocationsfortargetwithctx",
-      "label": "listPaymentAllocationsForTargetWithCtx()",
-      "norm_label": "listpaymentallocationsfortargetwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L377"
+      "id": "frozenmetricauthority_frozenweekmetricfordate",
+      "label": "frozenWeekMetricForDate()",
+      "norm_label": "frozenweekmetricfordate()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L481"
     },
     {
       "community": 175,
       "file_type": "code",
-      "id": "paymentallocations_matchesexistingallocation",
-      "label": "matchesExistingAllocation()",
-      "norm_label": "matchesexistingallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L92"
+      "id": "frozenmetricauthority_matchesrequestedoperatingrange",
+      "label": "matchesRequestedOperatingRange()",
+      "norm_label": "matchesrequestedoperatingrange()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L102"
     },
     {
       "community": 175,
       "file_type": "code",
-      "id": "paymentallocations_matcheskeyedallocation",
-      "label": "matchesKeyedAllocation()",
-      "norm_label": "matcheskeyedallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L139"
+      "id": "frozenmetricauthority_normalizefrozenpaymenttotals",
+      "label": "normalizeFrozenPaymentTotals()",
+      "norm_label": "normalizefrozenpaymenttotals()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L241"
     },
     {
       "community": 175,
       "file_type": "code",
-      "id": "paymentallocations_paymentallocationreportingdimensions",
-      "label": "paymentAllocationReportingDimensions()",
-      "norm_label": "paymentallocationreportingdimensions()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L172"
+      "id": "frozenmetricauthority_recordvalue",
+      "label": "recordValue()",
+      "norm_label": "recordvalue()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L85"
     },
     {
       "community": 175,
       "file_type": "code",
-      "id": "paymentallocations_paymentallocationreportingidentity",
-      "label": "paymentAllocationReportingIdentity()",
-      "norm_label": "paymentallocationreportingidentity()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L162"
+      "id": "frozenmetricauthority_resolvefrozendailycloseauthority",
+      "label": "resolveFrozenDailyCloseAuthority()",
+      "norm_label": "resolvefrozendailycloseauthority()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L393"
     },
     {
       "community": 175,
       "file_type": "code",
-      "id": "paymentallocations_recordpaymentallocationwithctx",
-      "label": "recordPaymentAllocationWithCtx()",
-      "norm_label": "recordpaymentallocationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "id": "frozenmetricauthority_samedailycloseid",
+      "label": "sameDailyCloseId()",
+      "norm_label": "samedailycloseid()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L386"
+    },
+    {
+      "community": 175,
+      "file_type": "code",
+      "id": "frozenmetricauthority_usablefrozenweeksummary",
+      "label": "usableFrozenWeekSummary()",
+      "norm_label": "usablefrozenweeksummary()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
       "source_location": "L273"
     },
     {
       "community": 175,
       "file_type": "code",
-      "id": "paymentallocations_summarizepaymentallocations",
-      "label": "summarizePaymentAllocations()",
-      "norm_label": "summarizepaymentallocations()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 175,
-      "file_type": "code",
-      "id": "paymentallocations_voidpaymentallocationwithctx",
-      "label": "voidPaymentAllocationWithCtx()",
-      "norm_label": "voidpaymentallocationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L255"
+      "id": "packages_athena_webapp_convex_operations_dailyoperations_frozenmetricauthority_ts",
+      "label": "frozenMetricAuthority.ts",
+      "norm_label": "frozenmetricauthority.ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L1"
     },
     {
       "community": 1750,
@@ -199113,118 +199155,118 @@
     {
       "community": 176,
       "file_type": "code",
-      "id": "assigncustomer_createcustomer",
-      "label": "createCustomer()",
-      "norm_label": "createcustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L132"
+      "id": "openworkinventoryreviews_test_buildctx",
+      "label": "buildCtx()",
+      "norm_label": "buildctx()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L956"
     },
     {
       "community": 176,
       "file_type": "code",
-      "id": "assigncustomer_fullnamefromparts",
-      "label": "fullNameFromParts()",
-      "norm_label": "fullnamefromparts()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L58"
+      "id": "openworkinventoryreviews_test_buildinventorymovement",
+      "label": "buildInventoryMovement()",
+      "norm_label": "buildinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1109"
     },
     {
       "community": 176,
       "file_type": "code",
-      "id": "assigncustomer_guestresult",
-      "label": "guestResult()",
-      "norm_label": "guestresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L111"
+      "id": "openworkinventoryreviews_test_buildmapping",
+      "label": "buildMapping()",
+      "norm_label": "buildmapping()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1213"
     },
     {
       "community": 176,
       "file_type": "code",
-      "id": "assigncustomer_linktoguest",
-      "label": "linkToGuest()",
-      "norm_label": "linktoguest()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L348"
+      "id": "openworkinventoryreviews_test_buildproductsku",
+      "label": "buildProductSku()",
+      "norm_label": "buildproductsku()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1130"
     },
     {
       "community": 176,
       "file_type": "code",
-      "id": "assigncustomer_linktostorefrontuser",
-      "label": "linkToStoreFrontUser()",
-      "norm_label": "linktostorefrontuser()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L290"
+      "id": "openworkinventoryreviews_test_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1169"
     },
     {
       "community": 176,
       "file_type": "code",
-      "id": "assigncustomer_poscustomerresult",
-      "label": "posCustomerResult()",
-      "norm_label": "poscustomerresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L71"
+      "id": "openworkinventoryreviews_test_buildstaffprofile",
+      "label": "buildStaffProfile()",
+      "norm_label": "buildstaffprofile()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1065"
     },
     {
       "community": 176,
       "file_type": "code",
-      "id": "assigncustomer_resolveguestmatch",
-      "label": "resolveGuestMatch()",
-      "norm_label": "resolveguestmatch()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L478"
+      "id": "openworkinventoryreviews_test_buildstore",
+      "label": "buildStore()",
+      "norm_label": "buildstore()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1052"
     },
     {
       "community": 176,
       "file_type": "code",
-      "id": "assigncustomer_resolveposcustomerselection",
-      "label": "resolvePosCustomerSelection()",
-      "norm_label": "resolveposcustomerselection()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L267"
+      "id": "openworkinventoryreviews_test_buildterminal",
+      "label": "buildTerminal()",
+      "norm_label": "buildterminal()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1149"
     },
     {
       "community": 176,
       "file_type": "code",
-      "id": "assigncustomer_resolvestorefrontusermatch",
-      "label": "resolveStoreFrontUserMatch()",
-      "norm_label": "resolvestorefrontusermatch()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L384"
+      "id": "openworkinventoryreviews_test_buildtransaction",
+      "label": "buildTransaction()",
+      "norm_label": "buildtransaction()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1189"
     },
     {
       "community": 176,
       "file_type": "code",
-      "id": "assigncustomer_storefrontresult",
-      "label": "storefrontResult()",
-      "norm_label": "storefrontresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L90"
+      "id": "openworkinventoryreviews_test_buildworkitem",
+      "label": "buildWorkItem()",
+      "norm_label": "buildworkitem()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1079"
     },
     {
       "community": 176,
       "file_type": "code",
-      "id": "assigncustomer_updatecustomer",
-      "label": "updateCustomer()",
-      "norm_label": "updatecustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L220"
+      "id": "openworkinventoryreviews_test_defaultargs",
+      "label": "defaultArgs()",
+      "norm_label": "defaultargs()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L909"
     },
     {
       "community": 176,
       "file_type": "code",
-      "id": "assigncustomer_updatecustomerstats",
-      "label": "updateCustomerStats()",
-      "norm_label": "updatecustomerstats()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L251"
+      "id": "openworkinventoryreviews_test_expectrejectedcontext",
+      "label": "expectRejectedContext()",
+      "norm_label": "expectrejectedcontext()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L891"
     },
     {
       "community": 176,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_ts",
-      "label": "assignCustomer.ts",
-      "norm_label": "assigncustomer.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "id": "packages_athena_webapp_convex_operations_openworkinventoryreviews_test_ts",
+      "label": "openWorkInventoryReviews.test.ts",
+      "norm_label": "openworkinventoryreviews.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
       "source_location": "L1"
     },
     {
@@ -199320,119 +199362,119 @@
     {
       "community": 177,
       "file_type": "code",
-      "id": "catalogrepository_findactivependingcheckoutlookupaliasbycode",
-      "label": "findActivePendingCheckoutLookupAliasByCode()",
-      "norm_label": "findactivependingcheckoutlookupaliasbycode()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L97"
+      "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
+      "label": "paymentAllocations.ts",
+      "norm_label": "paymentallocations.ts",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L1"
     },
     {
       "community": 177,
       "file_type": "code",
-      "id": "catalogrepository_findactiveprovisionalimportskuforstoresku",
-      "label": "findActiveProvisionalImportSkuForStoreSku()",
-      "norm_label": "findactiveprovisionalimportskuforstoresku()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L120"
+      "id": "paymentallocations_buildpaymentallocation",
+      "label": "buildPaymentAllocation()",
+      "norm_label": "buildpaymentallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L32"
     },
     {
       "community": 177,
       "file_type": "code",
-      "id": "catalogrepository_findstoreskubybarcode",
-      "label": "findStoreSkuByBarcode()",
-      "norm_label": "findstoreskubybarcode()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L62"
+      "id": "paymentallocations_correctsameamountsinglepaymentallocationwithctx",
+      "label": "correctSameAmountSinglePaymentAllocationWithCtx()",
+      "norm_label": "correctsameamountsinglepaymentallocationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L397"
     },
     {
       "community": 177,
       "file_type": "code",
-      "id": "catalogrepository_findstoreskubysku",
-      "label": "findStoreSkuBySku()",
-      "norm_label": "findstoreskubysku()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L77"
+      "id": "paymentallocations_ensurepaymentallocationreportingwithctx",
+      "label": "ensurePaymentAllocationReportingWithCtx()",
+      "norm_label": "ensurepaymentallocationreportingwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L198"
     },
     {
       "community": 177,
       "file_type": "code",
-      "id": "catalogrepository_getcategorybyid",
-      "label": "getCategoryById()",
-      "norm_label": "getcategorybyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L29"
+      "id": "paymentallocations_findsameamountsinglepaymentallocation",
+      "label": "findSameAmountSinglePaymentAllocation()",
+      "norm_label": "findsameamountsinglepaymentallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L68"
     },
     {
       "community": 177,
       "file_type": "code",
-      "id": "catalogrepository_getcolorbyid",
-      "label": "getColorById()",
-      "norm_label": "getcolorbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L40"
+      "id": "paymentallocations_listpaymentallocationsfortargetwithctx",
+      "label": "listPaymentAllocationsForTargetWithCtx()",
+      "norm_label": "listpaymentallocationsfortargetwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L377"
     },
     {
       "community": 177,
       "file_type": "code",
-      "id": "catalogrepository_getproductbyid",
-      "label": "getProductById()",
-      "norm_label": "getproductbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 177,
-      "file_type": "code",
-      "id": "catalogrepository_isconvexproductid",
-      "label": "isConvexProductId()",
-      "norm_label": "isconvexproductid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 177,
-      "file_type": "code",
-      "id": "catalogrepository_listmatchingstoreskus",
-      "label": "listMatchingStoreSkus()",
-      "norm_label": "listmatchingstoreskus()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L140"
-    },
-    {
-      "community": 177,
-      "file_type": "code",
-      "id": "catalogrepository_listproductskusbyproductid",
-      "label": "listProductSkusByProductId()",
-      "norm_label": "listproductskusbyproductid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 177,
-      "file_type": "code",
-      "id": "catalogrepository_normalizelookupcode",
-      "label": "normalizeLookupCode()",
-      "norm_label": "normalizelookupcode()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "id": "paymentallocations_matchesexistingallocation",
+      "label": "matchesExistingAllocation()",
+      "norm_label": "matchesexistingallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
       "source_location": "L92"
     },
     {
       "community": 177,
       "file_type": "code",
-      "id": "catalogrepository_readallqueryresults",
-      "label": "readAllQueryResults()",
-      "norm_label": "readallqueryresults()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L15"
+      "id": "paymentallocations_matcheskeyedallocation",
+      "label": "matchesKeyedAllocation()",
+      "norm_label": "matcheskeyedallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L139"
     },
     {
       "community": 177,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_catalogrepository_ts",
-      "label": "catalogRepository.ts",
-      "norm_label": "catalogrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L1"
+      "id": "paymentallocations_paymentallocationreportingdimensions",
+      "label": "paymentAllocationReportingDimensions()",
+      "norm_label": "paymentallocationreportingdimensions()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L172"
+    },
+    {
+      "community": 177,
+      "file_type": "code",
+      "id": "paymentallocations_paymentallocationreportingidentity",
+      "label": "paymentAllocationReportingIdentity()",
+      "norm_label": "paymentallocationreportingidentity()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L162"
+    },
+    {
+      "community": 177,
+      "file_type": "code",
+      "id": "paymentallocations_recordpaymentallocationwithctx",
+      "label": "recordPaymentAllocationWithCtx()",
+      "norm_label": "recordpaymentallocationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L273"
+    },
+    {
+      "community": 177,
+      "file_type": "code",
+      "id": "paymentallocations_summarizepaymentallocations",
+      "label": "summarizePaymentAllocations()",
+      "norm_label": "summarizepaymentallocations()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 177,
+      "file_type": "code",
+      "id": "paymentallocations_voidpaymentallocationwithctx",
+      "label": "voidPaymentAllocationWithCtx()",
+      "norm_label": "voidpaymentallocationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L255"
     },
     {
       "community": 1770,
@@ -199527,119 +199569,119 @@
     {
       "community": 178,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_skumovementrange_test_ts",
-      "label": "skuMovementRange.test.ts",
-      "norm_label": "skumovementrange.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "id": "assigncustomer_createcustomer",
+      "label": "createCustomer()",
+      "norm_label": "createcustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L132"
+    },
+    {
+      "community": 178,
+      "file_type": "code",
+      "id": "assigncustomer_fullnamefromparts",
+      "label": "fullNameFromParts()",
+      "norm_label": "fullnamefromparts()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 178,
+      "file_type": "code",
+      "id": "assigncustomer_guestresult",
+      "label": "guestResult()",
+      "norm_label": "guestresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L111"
+    },
+    {
+      "community": 178,
+      "file_type": "code",
+      "id": "assigncustomer_linktoguest",
+      "label": "linkToGuest()",
+      "norm_label": "linktoguest()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L348"
+    },
+    {
+      "community": 178,
+      "file_type": "code",
+      "id": "assigncustomer_linktostorefrontuser",
+      "label": "linkToStoreFrontUser()",
+      "norm_label": "linktostorefrontuser()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L290"
+    },
+    {
+      "community": 178,
+      "file_type": "code",
+      "id": "assigncustomer_poscustomerresult",
+      "label": "posCustomerResult()",
+      "norm_label": "poscustomerresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 178,
+      "file_type": "code",
+      "id": "assigncustomer_resolveguestmatch",
+      "label": "resolveGuestMatch()",
+      "norm_label": "resolveguestmatch()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L478"
+    },
+    {
+      "community": 178,
+      "file_type": "code",
+      "id": "assigncustomer_resolveposcustomerselection",
+      "label": "resolvePosCustomerSelection()",
+      "norm_label": "resolveposcustomerselection()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L267"
+    },
+    {
+      "community": 178,
+      "file_type": "code",
+      "id": "assigncustomer_resolvestorefrontusermatch",
+      "label": "resolveStoreFrontUserMatch()",
+      "norm_label": "resolvestorefrontusermatch()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L384"
+    },
+    {
+      "community": 178,
+      "file_type": "code",
+      "id": "assigncustomer_storefrontresult",
+      "label": "storefrontResult()",
+      "norm_label": "storefrontresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 178,
+      "file_type": "code",
+      "id": "assigncustomer_updatecustomer",
+      "label": "updateCustomer()",
+      "norm_label": "updatecustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L220"
+    },
+    {
+      "community": 178,
+      "file_type": "code",
+      "id": "assigncustomer_updatecustomerstats",
+      "label": "updateCustomerStats()",
+      "norm_label": "updatecustomerstats()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L251"
+    },
+    {
+      "community": 178,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_ts",
+      "label": "assignCustomer.ts",
+      "norm_label": "assigncustomer.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
-      "id": "skumovementrange_test_admitone",
-      "label": "admitOne()",
-      "norm_label": "admitone()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L352"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
-      "id": "skumovementrange_test_allow",
-      "label": "allow()",
-      "norm_label": "allow()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L113"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
-      "id": "skumovementrange_test_certifyday",
-      "label": "certifyDay()",
-      "norm_label": "certifyday()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L238"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
-      "id": "skumovementrange_test_dailyfor",
-      "label": "dailyFor()",
-      "norm_label": "dailyfor()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L656"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
-      "id": "skumovementrange_test_drive",
-      "label": "drive()",
-      "norm_label": "drive()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L322"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
-      "id": "skumovementrange_test_ensure",
-      "label": "ensure()",
-      "norm_label": "ensure()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L283"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
-      "id": "skumovementrange_test_handlerof",
-      "label": "handlerOf()",
-      "norm_label": "handlerof()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L108"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
-      "id": "skumovementrange_test_headerbykey",
-      "label": "headerByKey()",
-      "norm_label": "headerbykey()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L304"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
-      "id": "skumovementrange_test_seedskus",
-      "label": "seedSkus()",
-      "norm_label": "seedskus()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L162"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
-      "id": "skumovementrange_test_seedstore",
-      "label": "seedStore()",
-      "norm_label": "seedstore()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L140"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
-      "id": "skumovementrange_test_step",
-      "label": "step()",
-      "norm_label": "step()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L955"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
-      "id": "skumovementrange_test_twodayfixture",
-      "label": "twoDayFixture()",
-      "norm_label": "twodayfixture()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L939"
     },
     {
       "community": 1780,
@@ -199734,119 +199776,119 @@
     {
       "community": 179,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_sweeper_test_ts",
-      "label": "sweeper.test.ts",
-      "norm_label": "sweeper.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
+      "id": "catalogrepository_findactivependingcheckoutlookupaliasbycode",
+      "label": "findActivePendingCheckoutLookupAliasByCode()",
+      "norm_label": "findactivependingcheckoutlookupaliasbycode()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L97"
+    },
+    {
+      "community": 179,
+      "file_type": "code",
+      "id": "catalogrepository_findactiveprovisionalimportskuforstoresku",
+      "label": "findActiveProvisionalImportSkuForStoreSku()",
+      "norm_label": "findactiveprovisionalimportskuforstoresku()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L120"
+    },
+    {
+      "community": 179,
+      "file_type": "code",
+      "id": "catalogrepository_findstoreskubybarcode",
+      "label": "findStoreSkuByBarcode()",
+      "norm_label": "findstoreskubybarcode()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 179,
+      "file_type": "code",
+      "id": "catalogrepository_findstoreskubysku",
+      "label": "findStoreSkuBySku()",
+      "norm_label": "findstoreskubysku()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 179,
+      "file_type": "code",
+      "id": "catalogrepository_getcategorybyid",
+      "label": "getCategoryById()",
+      "norm_label": "getcategorybyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 179,
+      "file_type": "code",
+      "id": "catalogrepository_getcolorbyid",
+      "label": "getColorById()",
+      "norm_label": "getcolorbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 179,
+      "file_type": "code",
+      "id": "catalogrepository_getproductbyid",
+      "label": "getProductById()",
+      "norm_label": "getproductbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 179,
+      "file_type": "code",
+      "id": "catalogrepository_isconvexproductid",
+      "label": "isConvexProductId()",
+      "norm_label": "isconvexproductid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 179,
+      "file_type": "code",
+      "id": "catalogrepository_listmatchingstoreskus",
+      "label": "listMatchingStoreSkus()",
+      "norm_label": "listmatchingstoreskus()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L140"
+    },
+    {
+      "community": 179,
+      "file_type": "code",
+      "id": "catalogrepository_listproductskusbyproductid",
+      "label": "listProductSkusByProductId()",
+      "norm_label": "listproductskusbyproductid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 179,
+      "file_type": "code",
+      "id": "catalogrepository_normalizelookupcode",
+      "label": "normalizeLookupCode()",
+      "norm_label": "normalizelookupcode()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 179,
+      "file_type": "code",
+      "id": "catalogrepository_readallqueryresults",
+      "label": "readAllQueryResults()",
+      "norm_label": "readallqueryresults()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 179,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_catalogrepository_ts",
+      "label": "catalogRepository.ts",
+      "norm_label": "catalogrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "sweeper_test_allow",
-      "label": "allow()",
-      "norm_label": "allow()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "sweeper_test_close",
-      "label": "close()",
-      "norm_label": "close()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L93"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "sweeper_test_insertmovementheader",
-      "label": "insertMovementHeader()",
-      "norm_label": "insertmovementheader()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L1629"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "sweeper_test_insertsalefact",
-      "label": "insertSaleFact()",
-      "norm_label": "insertsalefact()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L224"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "sweeper_test_insertweeklyclosefixture",
-      "label": "insertWeeklyCloseFixture()",
-      "norm_label": "insertweeklyclosefixture()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L1254"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "sweeper_test_mark",
-      "label": "mark()",
-      "norm_label": "mark()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L265"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "sweeper_test_marksof",
-      "label": "marksOf()",
-      "norm_label": "marksof()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L284"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "sweeper_test_movementconstants",
-      "label": "movementConstants()",
-      "norm_label": "movementconstants()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L1626"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "sweeper_test_readdocs",
-      "label": "readDocs()",
-      "norm_label": "readdocs()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L1328"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "sweeper_test_seedstore",
-      "label": "seedStore()",
-      "norm_label": "seedstore()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L150"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "sweeper_test_sweep",
-      "label": "sweep()",
-      "norm_label": "sweep()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L282"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "sweeper_test_withfrozenscheduler",
-      "label": "withFrozenScheduler()",
-      "norm_label": "withfrozenscheduler()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L1661"
     },
     {
       "community": 1790,
@@ -200310,119 +200352,119 @@
     {
       "community": 180,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productview_tsx",
-      "label": "ProductView.tsx",
-      "norm_label": "productview.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "id": "packages_athena_webapp_convex_reports_skumovementrange_test_ts",
+      "label": "skuMovementRange.test.ts",
+      "norm_label": "skumovementrange.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
       "source_location": "L1"
     },
     {
       "community": 180,
       "file_type": "code",
-      "id": "productview_archivedproductnestedorigin",
-      "label": "archivedProductNestedOrigin()",
-      "norm_label": "archivedproductnestedorigin()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L107"
+      "id": "skumovementrange_test_admitone",
+      "label": "admitOne()",
+      "norm_label": "admitone()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L352"
     },
     {
       "community": 180,
       "file_type": "code",
-      "id": "productview_buildvariantskumoneypayload",
-      "label": "buildVariantSkuMoneyPayload()",
-      "norm_label": "buildvariantskumoneypayload()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L67"
+      "id": "skumovementrange_test_allow",
+      "label": "allow()",
+      "norm_label": "allow()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L113"
     },
     {
       "community": 180,
       "file_type": "code",
-      "id": "productview_createvariantsku",
-      "label": "createVariantSku()",
-      "norm_label": "createvariantsku()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L346"
+      "id": "skumovementrange_test_certifyday",
+      "label": "certifyDay()",
+      "norm_label": "certifyday()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L238"
     },
     {
       "community": 180,
       "file_type": "code",
-      "id": "productview_decodeoriginvalue",
-      "label": "decodeOriginValue()",
-      "norm_label": "decodeoriginvalue()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L93"
+      "id": "skumovementrange_test_dailyfor",
+      "label": "dailyFor()",
+      "norm_label": "dailyfor()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L656"
     },
     {
       "community": 180,
       "file_type": "code",
-      "id": "productview_deleteactiveproduct",
-      "label": "deleteActiveProduct()",
-      "norm_label": "deleteactiveproduct()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L177"
+      "id": "skumovementrange_test_drive",
+      "label": "drive()",
+      "norm_label": "drive()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L322"
     },
     {
       "community": 180,
       "file_type": "code",
-      "id": "productview_getarchivedproductredirect",
-      "label": "getArchivedProductRedirect()",
-      "norm_label": "getarchivedproductredirect()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L74"
+      "id": "skumovementrange_test_ensure",
+      "label": "ensure()",
+      "norm_label": "ensure()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L283"
     },
     {
       "community": 180,
       "file_type": "code",
-      "id": "productview_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L506"
+      "id": "skumovementrange_test_handlerof",
+      "label": "handlerOf()",
+      "norm_label": "handlerof()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L108"
     },
     {
       "community": 180,
       "file_type": "code",
-      "id": "productview_modifyproduct",
-      "label": "modifyProduct()",
-      "norm_label": "modifyproduct()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L271"
+      "id": "skumovementrange_test_headerbykey",
+      "label": "headerByKey()",
+      "norm_label": "headerbykey()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L304"
     },
     {
       "community": 180,
       "file_type": "code",
-      "id": "productview_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L490"
+      "id": "skumovementrange_test_seedskus",
+      "label": "seedSkus()",
+      "norm_label": "seedskus()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L162"
     },
     {
       "community": 180,
       "file_type": "code",
-      "id": "productview_resolvelegacytaxonomysavegate",
-      "label": "resolveLegacyTaxonomySaveGate()",
-      "norm_label": "resolvelegacytaxonomysavegate()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L40"
+      "id": "skumovementrange_test_seedstore",
+      "label": "seedStore()",
+      "norm_label": "seedstore()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L140"
     },
     {
       "community": 180,
       "file_type": "code",
-      "id": "productview_saveproduct",
-      "label": "saveProduct()",
-      "norm_label": "saveproduct()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L217"
+      "id": "skumovementrange_test_step",
+      "label": "step()",
+      "norm_label": "step()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L955"
     },
     {
       "community": 180,
       "file_type": "code",
-      "id": "productview_updatevariantsku",
-      "label": "updateVariantSku()",
-      "norm_label": "updatevariantsku()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L404"
+      "id": "skumovementrange_test_twodayfixture",
+      "label": "twoDayFixture()",
+      "norm_label": "twodayfixture()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L939"
     },
     {
       "community": 1800,
@@ -200517,119 +200559,119 @@
     {
       "community": 181,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "id": "packages_athena_webapp_src_components_add_product_productview_tsx",
+      "label": "ProductView.tsx",
+      "norm_label": "productview.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L1"
     },
     {
       "community": 181,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 181,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 181,
-      "file_type": "code",
-      "id": "utils_formatdeliveryaddress",
-      "label": "formatDeliveryAddress()",
-      "norm_label": "formatdeliveryaddress()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 181,
-      "file_type": "code",
-      "id": "utils_getamountpaidfororder",
-      "label": "getAmountPaidForOrder()",
-      "norm_label": "getamountpaidfororder()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L191"
-    },
-    {
-      "community": 181,
-      "file_type": "code",
-      "id": "utils_getdiscountvalue",
-      "label": "getDiscountValue()",
-      "norm_label": "getdiscountvalue()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 181,
-      "file_type": "code",
-      "id": "utils_getonlineorderplacedat",
-      "label": "getOnlineOrderPlacedAt()",
-      "norm_label": "getonlineorderplacedat()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 181,
-      "file_type": "code",
-      "id": "utils_getorderamount",
-      "label": "getOrderAmount()",
-      "norm_label": "getorderamount()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 181,
-      "file_type": "code",
-      "id": "utils_getorderstate",
-      "label": "getOrderState()",
-      "norm_label": "getorderstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 181,
-      "file_type": "code",
-      "id": "utils_getpickupactionstate",
-      "label": "getPickupActionState()",
-      "norm_label": "getpickupactionstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 181,
-      "file_type": "code",
-      "id": "utils_getpotentialpoints",
-      "label": "getPotentialPoints()",
-      "norm_label": "getpotentialpoints()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "id": "productview_archivedproductnestedorigin",
+      "label": "archivedProductNestedOrigin()",
+      "norm_label": "archivedproductnestedorigin()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L107"
     },
     {
       "community": 181,
       "file_type": "code",
-      "id": "utils_getproductdiscountvalue",
-      "label": "getProductDiscountValue()",
-      "norm_label": "getproductdiscountvalue()",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
-      "source_location": "L75"
+      "id": "productview_buildvariantskumoneypayload",
+      "label": "buildVariantSkuMoneyPayload()",
+      "norm_label": "buildvariantskumoneypayload()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L67"
     },
     {
       "community": 181,
       "file_type": "code",
-      "id": "utils_shouldshowpickupexceptionaction",
-      "label": "shouldShowPickupExceptionAction()",
-      "norm_label": "shouldshowpickupexceptionaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L116"
+      "id": "productview_createvariantsku",
+      "label": "createVariantSku()",
+      "norm_label": "createvariantsku()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L346"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "productview_decodeoriginvalue",
+      "label": "decodeOriginValue()",
+      "norm_label": "decodeoriginvalue()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L93"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "productview_deleteactiveproduct",
+      "label": "deleteActiveProduct()",
+      "norm_label": "deleteactiveproduct()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L177"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "productview_getarchivedproductredirect",
+      "label": "getArchivedProductRedirect()",
+      "norm_label": "getarchivedproductredirect()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L74"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "productview_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L506"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "productview_modifyproduct",
+      "label": "modifyProduct()",
+      "norm_label": "modifyproduct()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L271"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "productview_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L490"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "productview_resolvelegacytaxonomysavegate",
+      "label": "resolveLegacyTaxonomySaveGate()",
+      "norm_label": "resolvelegacytaxonomysavegate()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L40"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "productview_saveproduct",
+      "label": "saveProduct()",
+      "norm_label": "saveproduct()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L217"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "productview_updatevariantsku",
+      "label": "updateVariantSku()",
+      "norm_label": "updatevariantsku()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L404"
     },
     {
       "community": 1810,
@@ -223503,249 +223545,6 @@
     {
       "community": 292,
       "file_type": "code",
-      "id": "applyremoteassistcontrolintent_applyacceptedcontrolresult",
-      "label": "applyAcceptedControlResult()",
-      "norm_label": "applyacceptedcontrolresult()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L84"
-    },
-    {
-      "community": 292,
-      "file_type": "code",
-      "id": "applyremoteassistcontrolintent_applykeyevent",
-      "label": "applyKeyEvent()",
-      "norm_label": "applykeyevent()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L155"
-    },
-    {
-      "community": 292,
-      "file_type": "code",
-      "id": "applyremoteassistcontrolintent_applypointerevent",
-      "label": "applyPointerEvent()",
-      "norm_label": "applypointerevent()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 292,
-      "file_type": "code",
-      "id": "applyremoteassistcontrolintent_applyremoteassistcontrolintent",
-      "label": "applyRemoteAssistControlIntent()",
-      "norm_label": "applyremoteassistcontrolintent()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 292,
-      "file_type": "code",
-      "id": "applyremoteassistcontrolintent_getrecentcontrolresult",
-      "label": "getRecentControlResult()",
-      "norm_label": "getrecentcontrolresult()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 292,
-      "file_type": "code",
-      "id": "applyremoteassistcontrolintent_getremoteassistcontroltarget",
-      "label": "getRemoteAssistControlTarget()",
-      "norm_label": "getremoteassistcontroltarget()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L145"
-    },
-    {
-      "community": 292,
-      "file_type": "code",
-      "id": "applyremoteassistcontrolintent_prepareremoteassistcontrolintent",
-      "label": "prepareRemoteAssistControlIntent()",
-      "norm_label": "prepareremoteassistcontrolintent()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 292,
-      "file_type": "code",
-      "id": "applyremoteassistcontrolintent_remembercontrolresult",
-      "label": "rememberControlResult()",
-      "norm_label": "remembercontrolresult()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 292,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_remote_assist_runtime_applyremoteassistcontrolintent_ts",
-      "label": "applyRemoteAssistControlIntent.ts",
-      "norm_label": "applyremoteassistcontrolintent.ts",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 293,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_offline_posofflinereadiness_ts",
-      "label": "posOfflineReadiness.ts",
-      "norm_label": "posofflinereadiness.ts",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 293,
-      "file_type": "code",
-      "id": "posofflinereadiness_buildposofflinereadinesssummary",
-      "label": "buildPosOfflineReadinessSummary()",
-      "norm_label": "buildposofflinereadinesssummary()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L152"
-    },
-    {
-      "community": 293,
-      "file_type": "code",
-      "id": "posofflinereadiness_buildsignal",
-      "label": "buildSignal()",
-      "norm_label": "buildsignal()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L178"
-    },
-    {
-      "community": 293,
-      "file_type": "code",
-      "id": "posofflinereadiness_formatage",
-      "label": "formatAge()",
-      "norm_label": "formatage()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L290"
-    },
-    {
-      "community": 293,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsignaldescription",
-      "label": "getSignalDescription()",
-      "norm_label": "getsignaldescription()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L221"
-    },
-    {
-      "community": 293,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsignalstatus",
-      "label": "getSignalStatus()",
-      "norm_label": "getsignalstatus()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L201"
-    },
-    {
-      "community": 293,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsummarydescription",
-      "label": "getSummaryDescription()",
-      "norm_label": "getsummarydescription()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L262"
-    },
-    {
-      "community": 293,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsummarytitle",
-      "label": "getSummaryTitle()",
-      "norm_label": "getsummarytitle()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L256"
-    },
-    {
-      "community": 293,
-      "file_type": "code",
-      "id": "posofflinereadiness_isreadylike",
-      "label": "isReadyLike()",
-      "norm_label": "isreadylike()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L286"
-    },
-    {
-      "community": 294,
-      "file_type": "code",
-      "id": "foundations_content_colorrolecard",
-      "label": "ColorRoleCard()",
-      "norm_label": "colorrolecard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L222"
-    },
-    {
-      "community": 294,
-      "file_type": "code",
-      "id": "foundations_content_densitycard",
-      "label": "DensityCard()",
-      "norm_label": "densitycard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L283"
-    },
-    {
-      "community": 294,
-      "file_type": "code",
-      "id": "foundations_content_detailviewrolecard",
-      "label": "DetailViewRoleCard()",
-      "norm_label": "detailviewrolecard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L363"
-    },
-    {
-      "community": 294,
-      "file_type": "code",
-      "id": "foundations_content_hslvar",
-      "label": "hslVar()",
-      "norm_label": "hslvar()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L214"
-    },
-    {
-      "community": 294,
-      "file_type": "code",
-      "id": "foundations_content_motioncard",
-      "label": "MotionCard()",
-      "norm_label": "motioncard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L342"
-    },
-    {
-      "community": 294,
-      "file_type": "code",
-      "id": "foundations_content_spacetokenrow",
-      "label": "SpaceTokenRow()",
-      "norm_label": "spacetokenrow()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L265"
-    },
-    {
-      "community": 294,
-      "file_type": "code",
-      "id": "foundations_content_textvar",
-      "label": "textVar()",
-      "norm_label": "textvar()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L218"
-    },
-    {
-      "community": 294,
-      "file_type": "code",
-      "id": "foundations_content_typespecimencard",
-      "label": "TypeSpecimenCard()",
-      "norm_label": "typespecimencard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L246"
-    },
-    {
-      "community": 294,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_tsx",
-      "label": "foundations-content.tsx",
-      "norm_label": "foundations-content.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 295,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_productutils_ts",
       "label": "productUtils.ts",
       "norm_label": "productutils.ts",
@@ -223753,7 +223552,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 292,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_productutils_ts",
       "label": "productUtils.ts",
@@ -223762,7 +223561,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 292,
       "file_type": "code",
       "id": "productutils_getpreferredsku",
       "label": "getPreferredSku()",
@@ -223771,7 +223570,7 @@
       "source_location": "L78"
     },
     {
-      "community": 295,
+      "community": 292,
       "file_type": "code",
       "id": "productutils_getproductname",
       "label": "getProductName()",
@@ -223780,7 +223579,7 @@
       "source_location": "L18"
     },
     {
-      "community": 295,
+      "community": 292,
       "file_type": "code",
       "id": "productutils_haslowstock",
       "label": "hasLowStock()",
@@ -223789,7 +223588,7 @@
       "source_location": "L52"
     },
     {
-      "community": 295,
+      "community": 292,
       "file_type": "code",
       "id": "productutils_issoldout",
       "label": "isSoldOut()",
@@ -223798,7 +223597,7 @@
       "source_location": "L45"
     },
     {
-      "community": 295,
+      "community": 292,
       "file_type": "code",
       "id": "productutils_sortproduct",
       "label": "sortProduct()",
@@ -223807,7 +223606,7 @@
       "source_location": "L82"
     },
     {
-      "community": 295,
+      "community": 292,
       "file_type": "code",
       "id": "productutils_sortskusbyavailabilitythenlength",
       "label": "sortSkusByAvailabilityThenLength()",
@@ -223816,7 +223615,7 @@
       "source_location": "L63"
     },
     {
-      "community": 295,
+      "community": 292,
       "file_type": "code",
       "id": "productutils_sortskusbylength",
       "label": "sortSkusByLength()",
@@ -223825,88 +223624,250 @@
       "source_location": "L59"
     },
     {
-      "community": 296,
+      "community": 293,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontobservability_ts",
-      "label": "storefrontObservability.ts",
-      "norm_label": "storefrontobservability.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "id": "applyremoteassistcontrolintent_applyacceptedcontrolresult",
+      "label": "applyAcceptedControlResult()",
+      "norm_label": "applyacceptedcontrolresult()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 293,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_applykeyevent",
+      "label": "applyKeyEvent()",
+      "norm_label": "applykeyevent()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L155"
+    },
+    {
+      "community": 293,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_applypointerevent",
+      "label": "applyPointerEvent()",
+      "norm_label": "applypointerevent()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L116"
+    },
+    {
+      "community": 293,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_applyremoteassistcontrolintent",
+      "label": "applyRemoteAssistControlIntent()",
+      "norm_label": "applyremoteassistcontrolintent()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 293,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_getrecentcontrolresult",
+      "label": "getRecentControlResult()",
+      "norm_label": "getrecentcontrolresult()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 293,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_getremoteassistcontroltarget",
+      "label": "getRemoteAssistControlTarget()",
+      "norm_label": "getremoteassistcontroltarget()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L145"
+    },
+    {
+      "community": 293,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_prepareremoteassistcontrolintent",
+      "label": "prepareRemoteAssistControlIntent()",
+      "norm_label": "prepareremoteassistcontrolintent()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 293,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_remembercontrolresult",
+      "label": "rememberControlResult()",
+      "norm_label": "remembercontrolresult()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 293,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_remote_assist_runtime_applyremoteassistcontrolintent_ts",
+      "label": "applyRemoteAssistControlIntent.ts",
+      "norm_label": "applyremoteassistcontrolintent.ts",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 294,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_offline_posofflinereadiness_ts",
+      "label": "posOfflineReadiness.ts",
+      "norm_label": "posofflinereadiness.ts",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 294,
+      "file_type": "code",
+      "id": "posofflinereadiness_buildposofflinereadinesssummary",
+      "label": "buildPosOfflineReadinessSummary()",
+      "norm_label": "buildposofflinereadinesssummary()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L152"
+    },
+    {
+      "community": 294,
+      "file_type": "code",
+      "id": "posofflinereadiness_buildsignal",
+      "label": "buildSignal()",
+      "norm_label": "buildsignal()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L178"
+    },
+    {
+      "community": 294,
+      "file_type": "code",
+      "id": "posofflinereadiness_formatage",
+      "label": "formatAge()",
+      "norm_label": "formatage()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L290"
+    },
+    {
+      "community": 294,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsignaldescription",
+      "label": "getSignalDescription()",
+      "norm_label": "getsignaldescription()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L221"
+    },
+    {
+      "community": 294,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsignalstatus",
+      "label": "getSignalStatus()",
+      "norm_label": "getsignalstatus()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L201"
+    },
+    {
+      "community": 294,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsummarydescription",
+      "label": "getSummaryDescription()",
+      "norm_label": "getsummarydescription()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L262"
+    },
+    {
+      "community": 294,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsummarytitle",
+      "label": "getSummaryTitle()",
+      "norm_label": "getsummarytitle()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L256"
+    },
+    {
+      "community": 294,
+      "file_type": "code",
+      "id": "posofflinereadiness_isreadylike",
+      "label": "isReadyLike()",
+      "norm_label": "isreadylike()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L286"
+    },
+    {
+      "community": 295,
+      "file_type": "code",
+      "id": "foundations_content_colorrolecard",
+      "label": "ColorRoleCard()",
+      "norm_label": "colorrolecard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L222"
+    },
+    {
+      "community": 295,
+      "file_type": "code",
+      "id": "foundations_content_densitycard",
+      "label": "DensityCard()",
+      "norm_label": "densitycard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L283"
+    },
+    {
+      "community": 295,
+      "file_type": "code",
+      "id": "foundations_content_detailviewrolecard",
+      "label": "DetailViewRoleCard()",
+      "norm_label": "detailviewrolecard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L363"
+    },
+    {
+      "community": 295,
+      "file_type": "code",
+      "id": "foundations_content_hslvar",
+      "label": "hslVar()",
+      "norm_label": "hslvar()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L214"
+    },
+    {
+      "community": 295,
+      "file_type": "code",
+      "id": "foundations_content_motioncard",
+      "label": "MotionCard()",
+      "norm_label": "motioncard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L342"
+    },
+    {
+      "community": 295,
+      "file_type": "code",
+      "id": "foundations_content_spacetokenrow",
+      "label": "SpaceTokenRow()",
+      "norm_label": "spacetokenrow()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L265"
+    },
+    {
+      "community": 295,
+      "file_type": "code",
+      "id": "foundations_content_textvar",
+      "label": "textVar()",
+      "norm_label": "textvar()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L218"
+    },
+    {
+      "community": 295,
+      "file_type": "code",
+      "id": "foundations_content_typespecimencard",
+      "label": "TypeSpecimenCard()",
+      "norm_label": "typespecimencard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L246"
+    },
+    {
+      "community": 295,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_tsx",
+      "label": "foundations-content.tsx",
+      "norm_label": "foundations-content.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
       "source_location": "L1"
     },
     {
       "community": 296,
-      "file_type": "code",
-      "id": "storefrontobservability_createstorefrontobservabilitycontext",
-      "label": "createStorefrontObservabilityContext()",
-      "norm_label": "createstorefrontobservabilitycontext()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L182"
-    },
-    {
-      "community": 296,
-      "file_type": "code",
-      "id": "storefrontobservability_createstorefrontobservabilitypayload",
-      "label": "createStorefrontObservabilityPayload()",
-      "norm_label": "createstorefrontobservabilitypayload()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L229"
-    },
-    {
-      "community": 296,
-      "file_type": "code",
-      "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
-      "label": "getOrCreateStorefrontObservabilitySessionId()",
-      "norm_label": "getorcreatestorefrontobservabilitysessionid()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L157"
-    },
-    {
-      "community": 296,
-      "file_type": "code",
-      "id": "storefrontobservability_isbrowserautomationcontext",
-      "label": "isBrowserAutomationContext()",
-      "norm_label": "isbrowserautomationcontext()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L125"
-    },
-    {
-      "community": 296,
-      "file_type": "code",
-      "id": "storefrontobservability_issyntheticmonitororigin",
-      "label": "isSyntheticMonitorOrigin()",
-      "norm_label": "issyntheticmonitororigin()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L121"
-    },
-    {
-      "community": 296,
-      "file_type": "code",
-      "id": "storefrontobservability_resolvestorefrontanalyticsorigin",
-      "label": "resolveStorefrontAnalyticsOrigin()",
-      "norm_label": "resolvestorefrontanalyticsorigin()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L135"
-    },
-    {
-      "community": 296,
-      "file_type": "code",
-      "id": "storefrontobservability_resolveviewportbucket",
-      "label": "resolveViewportBucket()",
-      "norm_label": "resolveviewportbucket()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L211"
-    },
-    {
-      "community": 296,
-      "file_type": "code",
-      "id": "storefrontobservability_trackstorefrontevent",
-      "label": "trackStorefrontEvent()",
-      "norm_label": "trackstorefrontevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L265"
-    },
-    {
-      "community": 297,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -223915,7 +223876,7 @@
       "source_location": "L1"
     },
     {
-      "community": 297,
+      "community": 296,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -223924,7 +223885,7 @@
       "source_location": "L1"
     },
     {
-      "community": 297,
+      "community": 296,
       "file_type": "code",
       "id": "versionchecker_buildidfromscripts",
       "label": "buildIdFromScripts()",
@@ -223933,7 +223894,7 @@
       "source_location": "L192"
     },
     {
-      "community": 297,
+      "community": 296,
       "file_type": "code",
       "id": "versionchecker_createversionchecker",
       "label": "createVersionChecker()",
@@ -223942,7 +223903,7 @@
       "source_location": "L16"
     },
     {
-      "community": 297,
+      "community": 296,
       "file_type": "code",
       "id": "versionchecker_getinitialdeploybuildid",
       "label": "getInitialDeployBuildId()",
@@ -223951,7 +223912,7 @@
       "source_location": "L135"
     },
     {
-      "community": 297,
+      "community": 296,
       "file_type": "code",
       "id": "versionchecker_readdeploybuildid",
       "label": "readDeployBuildId()",
@@ -223960,7 +223921,7 @@
       "source_location": "L141"
     },
     {
-      "community": 297,
+      "community": 296,
       "file_type": "code",
       "id": "versionchecker_readdocumentscriptsources",
       "label": "readDocumentScriptSources()",
@@ -223969,7 +223930,7 @@
       "source_location": "L174"
     },
     {
-      "community": 297,
+      "community": 296,
       "file_type": "code",
       "id": "versionchecker_readentryhtmlscripts",
       "label": "readEntryHtmlScripts()",
@@ -223978,13 +223939,94 @@
       "source_location": "L151"
     },
     {
-      "community": 297,
+      "community": 296,
       "file_type": "code",
       "id": "versionchecker_readscriptsources",
       "label": "readScriptSources()",
       "norm_label": "readscriptsources()",
       "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
       "source_location": "L182"
+    },
+    {
+      "community": 297,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_storefrontobservability_ts",
+      "label": "storefrontObservability.ts",
+      "norm_label": "storefrontobservability.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 297,
+      "file_type": "code",
+      "id": "storefrontobservability_createstorefrontobservabilitycontext",
+      "label": "createStorefrontObservabilityContext()",
+      "norm_label": "createstorefrontobservabilitycontext()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L182"
+    },
+    {
+      "community": 297,
+      "file_type": "code",
+      "id": "storefrontobservability_createstorefrontobservabilitypayload",
+      "label": "createStorefrontObservabilityPayload()",
+      "norm_label": "createstorefrontobservabilitypayload()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L229"
+    },
+    {
+      "community": 297,
+      "file_type": "code",
+      "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
+      "label": "getOrCreateStorefrontObservabilitySessionId()",
+      "norm_label": "getorcreatestorefrontobservabilitysessionid()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L157"
+    },
+    {
+      "community": 297,
+      "file_type": "code",
+      "id": "storefrontobservability_isbrowserautomationcontext",
+      "label": "isBrowserAutomationContext()",
+      "norm_label": "isbrowserautomationcontext()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L125"
+    },
+    {
+      "community": 297,
+      "file_type": "code",
+      "id": "storefrontobservability_issyntheticmonitororigin",
+      "label": "isSyntheticMonitorOrigin()",
+      "norm_label": "issyntheticmonitororigin()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L121"
+    },
+    {
+      "community": 297,
+      "file_type": "code",
+      "id": "storefrontobservability_resolvestorefrontanalyticsorigin",
+      "label": "resolveStorefrontAnalyticsOrigin()",
+      "norm_label": "resolvestorefrontanalyticsorigin()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 297,
+      "file_type": "code",
+      "id": "storefrontobservability_resolveviewportbucket",
+      "label": "resolveViewportBucket()",
+      "norm_label": "resolveviewportbucket()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L211"
+    },
+    {
+      "community": 297,
+      "file_type": "code",
+      "id": "storefrontobservability_trackstorefrontevent",
+      "label": "trackStorefrontEvent()",
+      "norm_label": "trackstorefrontevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L265"
     },
     {
       "community": 298,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2759
-- Graph nodes: 11546
-- Graph edges: 14180
+- Graph nodes: 11548
+- Graph edges: 14182
 - Communities: 2684
 
 ## Graph Hotspots

--- a/packages/athena-webapp/convex/reports/sweeper.test.ts
+++ b/packages/athena-webapp/convex/reports/sweeper.test.ts
@@ -13,7 +13,15 @@ import { REPORTS_FOLD_VERSION } from "../../shared/reportsContract";
  * one thing the sweeper owns and cannot otherwise provoke: what happens when a
  * fold fails mid-sweep.
  */
-const foldControl = vi.hoisted(() => ({ shouldThrow: false }));
+const foldControl = vi.hoisted(() => ({
+  shouldThrow: false,
+  /**
+   * Fail only the day carrying this fact. The batch-rollup tests need ONE day
+   * of a multi-day sweep to fail; `shouldThrow` is all-or-nothing, and the day
+   * is not otherwise identifiable from `foldDay`'s arguments.
+   */
+  throwOnSourceId: null as string | null,
+}));
 
 vi.mock("./foldDay", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./foldDay")>();
@@ -21,7 +29,34 @@ vi.mock("./foldDay", async (importOriginal) => {
     ...actual,
     foldDay: (...args: Parameters<typeof actual.foldDay>) => {
       if (foldControl.shouldThrow) throw new Error("fold exploded");
+      if (
+        foldControl.throwOnSourceId !== null &&
+        args[1].some((fact) => fact.sourceId === foldControl.throwOnSourceId)
+      ) {
+        throw new Error("fold exploded");
+      }
       return actual.foldDay(...args);
+    },
+  };
+});
+
+/**
+ * Records every `rebuildRollupsForDates` call the sweep makes, delegating to
+ * the real implementation. The sweep's rollup cost is per PERIOD, so what these
+ * tests pin is the SHAPE of the call — one batched call carrying every folded
+ * date — not just the rollup rows it ends up producing.
+ */
+const rollupCalls = vi.hoisted(() => [] as string[][]);
+
+vi.mock("./rollups", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./rollups")>();
+  return {
+    ...actual,
+    rebuildRollupsForDates: (
+      ...args: Parameters<typeof actual.rebuildRollupsForDates>
+    ) => {
+      rollupCalls.push([...args[2]]);
+      return actual.rebuildRollupsForDates(...args);
     },
   };
 });
@@ -51,6 +86,7 @@ import {
   MAX_FACTS_PER_DAY,
   REPORTS_SWEEP_STORE_ALLOWLIST_ENV,
   WEEKLY_DIRTY_BATCH,
+  foldAndReplaceDay,
   parseStoreAllowlist,
   selectAcceptedClose,
   sweepWithCtx,
@@ -63,6 +99,8 @@ const modules = import.meta.glob("../**/*.ts");
 
 afterEach(() => {
   foldControl.shouldThrow = false;
+  foldControl.throwOnSourceId = null;
+  rollupCalls.length = 0;
   weeklyControl.shouldThrow = false;
   delete process.env[REPORTS_SWEEP_STORE_ALLOWLIST_ENV];
   vi.restoreAllMocks();
@@ -1284,6 +1322,238 @@ async function insertWeeklyCloseFixture(
     }),
   );
 }
+
+// ---------------------------------------------------------------------------
+// Batch rollups
+//
+// Rollup re-aggregation is per period, not per day: rebuilding `m:2026-07`
+// re-reads that whole month of `reportSkuDay` rows however many of its days
+// changed. Rebuilding once per folded day therefore re-read the same month
+// SWEEP_DIRTY_BATCH times in one mutation — the dominant read cost of a full
+// batch, and the reason a backfill drain ran at ~85% of Convex's per-execution
+// byte ceiling. The sweep defers rollups and rebuilds once over the batch.
+//
+// These pin both halves: that the batching actually happens (a shape a pure
+// output assertion cannot see, since both orders produce the same rows), and
+// that the rows stay correct across the days it now merges.
+// ---------------------------------------------------------------------------
+
+describe("batch rollups", () => {
+  it("rebuilds each touched period once per sweep, not once per folded day", async () => {
+    const t = convexTest(schema, modules);
+    const { storeId, productSkuId } = await seedStore(t, "sweep-batch-rollup");
+    allow(storeId);
+
+    // Six same-month days, all inside one ISO week: folded one-by-one this is
+    // 6 rebuilds of `m:2026-07` and 6 of `w:2026-W29`.
+    const dates = [
+      "2026-07-13",
+      "2026-07-14",
+      "2026-07-15",
+      "2026-07-16",
+      "2026-07-17",
+      "2026-07-18",
+    ];
+    for (const [index, operatingDate] of dates.entries()) {
+      await insertSaleFact(t, {
+        storeId,
+        productSkuId,
+        operatingDate,
+        sourceId: `txn-${operatingDate}`,
+        netAmountMinor: 1_000,
+        quantity: 2,
+      });
+      await mark(t, storeId, operatingDate, "late_fact", 1_000 + index);
+    }
+
+    const result = await sweep(t);
+    expect(result.daysFolded).toBe(6);
+
+    // One call for the store, carrying the whole folded-date set.
+    expect(rollupCalls).toHaveLength(1);
+    expect([...rollupCalls[0]].sort()).toEqual(dates);
+
+    const rollups = await t.run(async (ctx) =>
+      // eslint-disable-next-line @convex-dev/no-collect-in-query -- convex-test fixture read, not a production query
+      ctx.db.query("reportPeriodSkuRollup").collect(),
+    );
+
+    // Every period the six days touch is still present — the batching collapses
+    // repeated rebuilds of a period, never the set of periods.
+    expect(rollups.map((row) => row.periodKey).sort()).toEqual([
+      ...dates.map((date) => `d:${date}`),
+      "m:2026-07",
+      "w:2026-W29",
+    ]);
+
+    // ...and the merged periods carry every day's contribution, not the last
+    // day's alone.
+    const month = rollups.find((row) => row.periodKey === "m:2026-07");
+    expect(month?.netSalesMinor).toBe(6_000);
+    expect(month?.unitsSold).toBe(12);
+    const week = rollups.find((row) => row.periodKey === "w:2026-W29");
+    expect(week?.netSalesMinor).toBe(6_000);
+    expect(week?.unitsSold).toBe(12);
+  });
+
+  it("excludes a day whose fold failed from the batch it rebuilds", async () => {
+    const t = convexTest(schema, modules);
+    const { storeId, productSkuId } = await seedStore(t, "sweep-batch-partial");
+    allow(storeId);
+
+    for (const [index, operatingDate] of [
+      "2026-07-13",
+      "2026-07-14",
+      "2026-07-15",
+    ].entries()) {
+      await insertSaleFact(t, {
+        storeId,
+        productSkuId,
+        operatingDate,
+        sourceId: `txn-${operatingDate}`,
+        netAmountMinor: 1_000,
+        quantity: 2,
+      });
+      await mark(t, storeId, operatingDate, "late_fact", 1_000 + index);
+    }
+
+    foldControl.throwOnSourceId = "txn-2026-07-14";
+    const result = await sweep(t);
+    expect(result.daysFolded).toBe(2);
+    expect(result.foldFailures).toBe(1);
+
+    // The failed day wrote nothing, so it is not in the rebuilt set.
+    expect(rollupCalls).toHaveLength(1);
+    expect([...rollupCalls[0]].sort()).toEqual(["2026-07-13", "2026-07-15"]);
+
+    // Its period siblings still rebuilt, over the two days that did land.
+    const monthOf = async () =>
+      t.run(async (ctx) =>
+        ctx.db
+          .query("reportPeriodSkuRollup")
+          .withIndex("by_storeId_periodKey_productSkuId", (q) =>
+            q.eq("storeId", storeId).eq("periodKey", "m:2026-07"),
+          )
+          .unique(),
+      );
+    expect((await monthOf())?.netSalesMinor).toBe(2_000);
+
+    // The failure went back on the queue; the retry folds it and the month
+    // picks it up — no rollup is stranded by the day it skipped.
+    expect((await marksOf(t)).map((row) => row.operatingDate)).toEqual([
+      "2026-07-14",
+    ]);
+
+    foldControl.throwOnSourceId = null;
+    rollupCalls.length = 0;
+    const healed = await sweep(t);
+    expect(healed.daysFolded).toBe(1);
+    expect(rollupCalls).toEqual([["2026-07-14"]]);
+    expect((await monthOf())?.netSalesMinor).toBe(3_000);
+  });
+
+  it("batches per store, and keeps every period a multi-month batch spans", async () => {
+    const t = convexTest(schema, modules);
+    const first = await seedStore(t, "sweep-batch-store-a");
+    const second = await seedStore(t, "sweep-batch-store-b");
+    allow(first.storeId, second.storeId);
+
+    // Straddles a month AND an ISO-week boundary, so the batched call has to
+    // fan back out to four distinct period keys.
+    const plan = [
+      { store: first, operatingDate: "2026-06-29" },
+      { store: first, operatingDate: "2026-07-01" },
+      { store: second, operatingDate: "2026-07-15" },
+    ];
+    for (const [index, entry] of plan.entries()) {
+      await insertSaleFact(t, {
+        storeId: entry.store.storeId,
+        productSkuId: entry.store.productSkuId,
+        operatingDate: entry.operatingDate,
+        sourceId: `txn-${index}-${entry.operatingDate}`,
+        netAmountMinor: 1_000,
+        quantity: 1,
+      });
+      await mark(
+        t,
+        entry.store.storeId,
+        entry.operatingDate,
+        "late_fact",
+        1_000 + index,
+      );
+    }
+
+    const result = await sweep(t);
+    expect(result.daysFolded).toBe(3);
+    expect(result.storesTouched).toBe(2);
+
+    // One batched call per touched store — never one per day, never one global
+    // call mixing two stores' dates.
+    expect(rollupCalls).toHaveLength(2);
+    expect(rollupCalls.map((dates) => [...dates].sort()).sort()).toEqual([
+      ["2026-06-29", "2026-07-01"],
+      ["2026-07-15"],
+    ]);
+
+    const periodsFor = async (storeId: Id<"store">) =>
+      t.run(async (ctx) =>
+        (
+          await ctx.db
+            .query("reportPeriodSkuRollup")
+            .withIndex("by_storeId_periodKey_productSkuId", (q) =>
+              q.eq("storeId", storeId),
+            )
+            .take(50)
+        )
+          .map((row) => row.periodKey)
+          .sort(),
+      );
+
+    expect(await periodsFor(first.storeId)).toEqual([
+      "d:2026-06-29",
+      "d:2026-07-01",
+      "m:2026-06",
+      "m:2026-07",
+      "w:2026-W27",
+    ]);
+    expect(await periodsFor(second.storeId)).toEqual([
+      "d:2026-07-15",
+      "m:2026-07",
+      "w:2026-W29",
+    ]);
+  });
+
+  it("keeps the inline rebuild for callers that do not opt into batching", async () => {
+    const t = convexTest(schema, modules);
+    const { storeId, productSkuId } = await seedStore(t, "sweep-inline-rollup");
+
+    await insertSaleFact(t, {
+      storeId,
+      productSkuId,
+      operatingDate: "2026-07-15",
+      sourceId: "txn-inline",
+      netAmountMinor: 1_000,
+      quantity: 1,
+    });
+
+    // `deferRollups` is an opt-in: a direct fold still rebuilds its own periods,
+    // so no caller outside the sweep has to learn about the batch.
+    await t.run(async (ctx) =>
+      foldAndReplaceDay(ctx, storeId, "2026-07-15", WEEKLY_NOW),
+    );
+
+    expect(rollupCalls).toEqual([["2026-07-15"]]);
+    const rollups = await t.run(async (ctx) =>
+      // eslint-disable-next-line @convex-dev/no-collect-in-query -- convex-test fixture read, not a production query
+      ctx.db.query("reportPeriodSkuRollup").collect(),
+    );
+    expect(rollups.map((row) => row.periodKey).sort()).toEqual([
+      "d:2026-07-15",
+      "m:2026-07",
+      "w:2026-W29",
+    ]);
+  });
+});
 
 describe("certified fold revisions", () => {
   it("stamps matching revisions on the day and all its SKU rows, and a refold advances them together", async () => {

--- a/packages/athena-webapp/convex/reports/sweeper.ts
+++ b/packages/athena-webapp/convex/reports/sweeper.ts
@@ -51,6 +51,14 @@ import {
  *
  * Every read is bounded. Nothing here scans a table, and any work that does
  * not fit in a tick is left on the queue for the next one.
+ *
+ * "No wedged states" is a claim about FOLD errors, which are caught per day and
+ * re-marked. It does not extend to the mutation's own transaction limits: a
+ * sweep that reads past Convex's per-execution byte ceiling fails before it
+ * returns, so nothing commits (marks included — no day is lost or half-written)
+ * but the next tick reads the same marks and breaches identically. That wedge
+ * is invisible to `SweepResult`, which is why the batch's per-period read cost
+ * is kept flat rather than multiplied by SWEEP_DIRTY_BATCH — see `deferRollups`.
  */
 
 /** Dirty marks folded per tick. */
@@ -304,6 +312,22 @@ export async function foldAndReplaceDay(
      * still-open past day to `provisional`, and a close reconciles.
      */
     openPolicy?: "current-day" | "preserve-existing";
+    /**
+     * Leave the day's calendar rollups to the caller.
+     *
+     * Rollup re-aggregation is per PERIOD, not per day: rebuilding `m:2026-07`
+     * reads that whole month of `reportSkuDay` rows regardless of which day
+     * changed. Folding a batch of days one-by-one therefore re-reads the same
+     * month once per day — the batch's dominant read cost, and quadratic in
+     * `SWEEP_DIRTY_BATCH` for a run of same-month days. The sweep sets this and
+     * rebuilds once over the batch's whole folded-date set instead, where
+     * `affectedPeriodKeys` collapses those repeats into one key.
+     *
+     * Only an optimization: the periods rebuilt are identical either way, so a
+     * caller folding a single day (or one that wants the day self-contained)
+     * leaves this unset and keeps the inline rebuild.
+     */
+    deferRollups?: boolean;
   },
 ): Promise<void> {
   const store = await ctx.db.get("store", storeId);
@@ -447,7 +471,9 @@ export async function foldAndReplaceDay(
   }
 
   // --- rollups: re-aggregate the day's calendar periods ---------------------
-  await rebuildRollupsForDates(ctx, storeId, [operatingDate]);
+  if (opts?.deferRollups !== true) {
+    await rebuildRollupsForDates(ctx, storeId, [operatingDate]);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -648,6 +674,7 @@ export async function sweepWithCtx(ctx: MutationCtx): Promise<SweepResult> {
       // transactions order both hang off that status.
       await foldAndReplaceDay(ctx, mark.storeId, mark.operatingDate, now, {
         openPolicy: openPolicyForReason(mark.reason),
+        deferRollups: true,
       });
       const foldedDates = foldedDatesByStore.get(storeKey) ?? new Set<string>();
       foldedDates.add(mark.operatingDate);
@@ -679,6 +706,17 @@ export async function sweepWithCtx(ctx: MutationCtx): Promise<SweepResult> {
   }
 
   for (const storeId of touchedStores.values()) {
+    // Rollups for the WHOLE batch at once (see `deferRollups`): the folds above
+    // deliberately skipped them so a run of same-month days re-aggregates that
+    // month once instead of once per day.
+    //
+    // Driven by foldedDatesByStore, not by the marks: a day that threw wrote
+    // nothing, and rebuilding its periods here would fold the unchanged rows
+    // back over a rollup the failed day never touched. Failures already went
+    // back on the queue, so their periods rebuild when the fold succeeds.
+    await rebuildRollupsForDates(ctx, storeId, [
+      ...(foldedDatesByStore.get(String(storeId)) ?? []),
+    ]);
     await rebuildStoreOverview(ctx, storeId, now);
     result.rangesComputed += await computePendingRanges(ctx, storeId);
     // A day fold is the sole normal signal for current weekly truth. The


### PR DESCRIPTION
## Problem

The U8 prod backfill (#732) drove ~11 consecutive full-batch `reports/sweeper:sweep` executions on `colorless-cardinal-870`, each emitting:

```
[WARN] Many bytes read in a single function execution (actual: 13491635 bytes, limit: 16777216 bytes)
```

Observed 13,491,635 / 13,877,861 / 14,415,886 bytes — 80–86% of the ceiling. Every sweep still succeeded (`foldFailures=0`, `capExceeded=0`), so this was headroom, not breakage.

## Where the bytes went

Not the facts. Rollup re-aggregation is per **period**, not per day: rebuilding `m:2026-07` re-reads that whole month of `reportSkuDay` rows however many of its days changed. `foldAndReplaceDay` ended with a per-day `rebuildRollupsForDates`, so a batch of ten same-month days re-read the same month **ten times** in one mutation.

Measured by instrumenting `ctx.db` and draining 108 dirty days over a wigclub-shaped fixture (108 days, 30 SKUs/day, ~3,200 sku-day rows). Worst full-batch sweep:

| table | docs read | share |
|---|---|---|
| `reportSkuDay` | 11,850 | 74% |
| `reportPeriodSkuRollup` | 3,480 | 21% |
| `reportFact` | 300 | 2.5% |
| everything else | ~175 | 2.5% |

Only 300 of those `reportSkuDay` reads are the folds' own reconciliation read — **97.5% came from the rollup rebuild**. `MAX_ROLLUP_SKU_DAY_ROWS` was never the binding constraint; the repetition was. Weekly, range and snapshot lanes were under 1% combined.

## Change

`foldAndReplaceDay` gains an opt-in `deferRollups`. The sweep sets it and rebuilds once per store over the batch's folded-date set, where `affectedPeriodKeys` collapses the repeats.

| | peak docs | typical full batch |
|---|---|---|
| before | 15,805 | ~3.0 MB |
| after | 7,985 | ~0.9 MB |

The default is unchanged, so single-day callers keep the inline rebuild.

Driven by `foldedDatesByStore` rather than the marks: a day that threw wrote nothing, so rebuilding its periods would fold unchanged rows back over a rollup that day never touched.

## Scope — what this does not do

It lowers the odds of tripping the ceiling; it does not cap or surface it. Nothing bounds the product of the per-day and per-period caps across a tick, so the limit stays structurally reachable. A breach fails the whole mutation, so nothing commits — marks included, no day lost or half-written — but the retry is deterministic and invisible to `SweepResult`, since the mutation never returns one.

The dedup also only pays off when a batch's dates share periods. Marks drain by `markedAt`, not by date, so ten scattered late facts across ten months have nothing to collapse and the change is close to a no-op there. The ~3.5x is the backfill shape, not a floor.

The module header now records that gap honestly. Making it detectable is tracked separately.

## Tests

Four new cases in `sweeper.test.ts`, using a spy on `rebuildRollupsForDates` that records call shape and delegates to the real implementation — the shape is the point, since both orderings produce identical rollup rows and an output-only assertion would pass against the old code. Verified by reverting the fix:

| test | against unfixed code |
|---|---|
| rebuilds each period once per sweep | fails — 6 calls, expected 1 |
| excludes a failed day from the batch | fails — 2 calls, expected 1 |
| batches per store across month/week boundaries | fails — 3 calls, expected 2 |
| keeps inline rebuild for non-opted callers | passes (pins unchanged default) |

Each also asserts the merged periods carry every folded day's contribution, and the failure case walks the re-queued day through its healing sweep.

Rebased on #733; `openPolicy` and `deferRollups` coexist at the same call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)