### PR TITLE
feat(emails): report units sold for the operating day and sharpen the approvals email

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 11545 nodes · 14178 edges · 2684 communities detected
+- 11546 nodes · 14180 edges · 2684 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -3178,68 +3178,68 @@ Cohesion: 0.19
 Nodes (10): canListRegisterSessionSyncConflicts(), filterPendingCompletedSaleVoidApprovals(), filterPendingTransactionItemAdjustmentApprovals(), getNumberMetadata(), getPendingItemAdjustmentCashDelta(), getStringMetadata(), listPendingCompletedSaleVoidApprovals(), listPendingRegisterSessionApprovalRequests() (+2 more)
 
 ### Community 114 - "Community 114"
+Cohesion: 0.2
+Nodes (13): computePendingRanges(), DayCapExceeded, expireRangeResults(), foldAndReplaceDay(), loadAcceptedClose(), markDayDirty(), openPolicyForReason(), parseStoreAllowlist() (+5 more)
+
+### Community 115 - "Community 115"
 Cohesion: 0.22
 Nodes (15): buildSameElapsedOperatingComparison(), elapsedOperatingTime(), latestEffectiveSchedule(), operatingDuration(), reportingDateAt(), resolveReportingCalendarReferenceWithCtx(), resolveReportingFinancialPeriod(), resolveReportingFinancialPeriodWithCtx() (+7 more)
 
-### Community 115 - "Community 115"
+### Community 116 - "Community 116"
 Cohesion: 0.24
 Nodes (14): arrayLength(), asRecord(), canReportPosRegisterSessionLocalActivityType(), cashDirection(), classifyPosRegisterSessionLocalEventType(), compactMetadata(), finiteNumber(), labelFromToken() (+6 more)
 
-### Community 116 - "Community 116"
+### Community 117 - "Community 117"
 Cohesion: 0.12
 Nodes (1): DataTableViewOptions()
 
-### Community 117 - "Community 117"
+### Community 118 - "Community 118"
 Cohesion: 0.13
 Nodes (4): DailyCloseHistoryView(), getDailyCloseHistoryApi(), getHistoryRecordSnapshot(), normalizeHistorySnapshot()
 
-### Community 118 - "Community 118"
+### Community 119 - "Community 119"
 Cohesion: 0.19
 Nodes (13): compareSnapshots(), fileExists(), formatArtifactList(), formatDetailLines(), formatError(), formatHarnessJanitorReport(), readUtf8OrNull(), runCheckStep() (+5 more)
 
-### Community 119 - "Community 119"
+### Community 120 - "Community 120"
 Cohesion: 0.21
 Nodes (14): buildNumericTrendStats(), buildRegressionWarnings(), buildRuntimeTrendOutput(), buildScenarioTrend(), collectHarnessRuntimeTrends(), formatMs(), formatPercent(), parseHarnessBehaviorReportLines() (+6 more)
 
-### Community 120 - "Community 120"
+### Community 121 - "Community 121"
 Cohesion: 0.23
 Nodes (13): buildAbusePartitionKey(), buildServerContextTrackingEnvelope(), deriveBrowserFamily(), deriveContextEnvironment(), deriveOsFamily(), derivePrimarySubject(), isAcceptedSyntheticContext(), isRecord() (+5 more)
 
-### Community 121 - "Community 121"
+### Community 122 - "Community 122"
 Cohesion: 0.19
 Nodes (10): buildLatestRunDebugPayload(), getBoundedDebugRunsByCapability(), getLatestDebugRunByCapability(), getLatestDebugRunBySubject(), isActiveRunStale(), isActiveRunStatus(), selectLatestDebugRunFromCandidates(), shouldRecoverActiveRun() (+2 more)
 
-### Community 122 - "Community 122"
+### Community 123 - "Community 123"
 Cohesion: 0.19
 Nodes (13): ConstructionScopeError, costOverlayConstructionIdentity(), digest(), heartbeatConstructionOrThrow(), loadAnchors(), loadSource(), materializeCostOverlayRows(), normalizeOutcome() (+5 more)
 
-### Community 123 - "Community 123"
+### Community 124 - "Community 124"
 Cohesion: 0.18
 Nodes (8): buildCtx(), buildFrozenClose(), buildObservedCtx(), createDb(), frozenFinancialCompleteness(), frozenFinancialCompletenessForRange(), frozenFinancialCompletenessWithExpenseOverride(), operatingDateRange()
 
-### Community 124 - "Community 124"
+### Community 125 - "Community 125"
 Cohesion: 0.24
 Nodes (12): canonicalSyncedSaleInventoryReviewSkuId(), compareOperationalWorkItems(), compareStrings(), groupKey(), joinSourceIdentity(), operationalWorkActionableTimestamp(), operationalWorkMetadataString(), priorityBucket() (+4 more)
 
-### Community 125 - "Community 125"
+### Community 126 - "Community 126"
 Cohesion: 0.32
 Nodes (15): adjustRegisterSessionExpectedCashForPaymentCorrection(), applyPaymentMethodCorrection(), buildPaymentMethodCorrectionApprovalRequirement(), consumePaymentMethodCorrectionApprovalProof(), correctTransactionCustomer(), correctTransactionPaymentMethod(), createPaymentMethodCorrectionApprovalRequest(), getPaymentMethodCashContribution() (+7 more)
 
-### Community 126 - "Community 126"
+### Community 127 - "Community 127"
 Cohesion: 0.3
 Nodes (15): buildPosOperatorSnapshot(), buildRecentDayBuckets(), buildSummaryTrendBucket(), buildTransactionDateBuckets(), calculateDeltaPercent(), formatHourLabel(), formatPaymentMethodLabel(), formatShortDate() (+7 more)
 
-### Community 127 - "Community 127"
+### Community 128 - "Community 128"
 Cohesion: 0.18
 Nodes (7): buildPendingCheckoutFinalizationPayloadHash(), buildPendingCheckoutSaleEvidenceFingerprint(), buildTrustedSkuFingerprint(), listPendingCheckoutProductPageBindingWithCtx(), reviewedPosVisibleFor(), stableStringify(), validateReviewedTrustedInventoryFields()
 
-### Community 128 - "Community 128"
+### Community 129 - "Community 129"
 Cohesion: 0.19
 Nodes (9): admitOne(), allow(), completedMix(), drive(), ensure(), headerByKey(), seedSkus(), seedStore() (+1 more)
-
-### Community 129 - "Community 129"
-Cohesion: 0.21
-Nodes (12): computePendingRanges(), DayCapExceeded, expireRangeResults(), foldAndReplaceDay(), loadAcceptedClose(), markDayDirty(), parseStoreAllowlist(), rangeSnapshotKindConfigs() (+4 more)
 
 ### Community 130 - "Community 130"
 Cohesion: 0.18
@@ -3406,48 +3406,48 @@ Cohesion: 0.26
 Nodes (12): deleteHeadBranch(), enablePullRequestAutoMerge(), encodeGitRefPath(), ghJson(), HelpRequested, mergePullRequest(), parseArgs(), parseMergeMethod() (+4 more)
 
 ### Community 171 - "Community 171"
-Cohesion: 0.23
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
-
-### Community 172 - "Community 172"
 Cohesion: 0.31
 Nodes (12): backfillStoreSchedulesFromLegacyPolicyWithCtx(), buildBackfillRow(), buildCandidateWeeklyWindows(), compatibilityMetadata(), compatibilityOnlyRow(), findExistingScheduleToSkip(), firstPolicy(), isValidMinute() (+4 more)
 
-### Community 173 - "Community 173"
+### Community 172 - "Community 172"
 Cohesion: 0.28
 Nodes (11): defineCashControlsRead(), defineDailyCloseRead(), defineDailyOperationsRead(), defineInventoryCatalogRead(), defineInventoryCostOverlayRead(), defineOnlineOrdersRead(), defineOperationalWorkRead(), defineOrganizationRead() (+3 more)
 
-### Community 174 - "Community 174"
+### Community 173 - "Community 173"
 Cohesion: 0.33
 Nodes (11): closeCandidateOperatingRange(), emptyCloseSummary(), exactStatuses(), frozenFinancialSourceCounts(), frozenWeekMetricForDate(), matchesRequestedOperatingRange(), normalizeFrozenPaymentTotals(), recordValue() (+3 more)
 
-### Community 175 - "Community 175"
+### Community 174 - "Community 174"
 Cohesion: 0.29
 Nodes (12): buildCtx(), buildInventoryMovement(), buildMapping(), buildProductSku(), buildRegisterSession(), buildStaffProfile(), buildStore(), buildTerminal() (+4 more)
 
-### Community 176 - "Community 176"
+### Community 175 - "Community 175"
 Cohesion: 0.26
 Nodes (10): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), ensurePaymentAllocationReportingWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), matchesExistingAllocation(), matchesKeyedAllocation(), paymentAllocationReportingDimensions() (+2 more)
 
-### Community 177 - "Community 177"
+### Community 176 - "Community 176"
 Cohesion: 0.26
 Nodes (10): createCustomer(), fullNameFromParts(), guestResult(), linkToGuest(), linkToStoreFrontUser(), posCustomerResult(), resolveGuestMatch(), resolvePosCustomerSelection() (+2 more)
 
-### Community 178 - "Community 178"
+### Community 177 - "Community 177"
 Cohesion: 0.18
 Nodes (4): findActivePendingCheckoutLookupAliasByCode(), listProductSkusByProductId(), normalizeLookupCode(), readAllQueryResults()
 
-### Community 179 - "Community 179"
+### Community 178 - "Community 178"
 Cohesion: 0.23
 Nodes (7): admitOne(), allow(), ensure(), headerByKey(), seedSkus(), seedStore(), twoDayFixture()
 
-### Community 180 - "Community 180"
+### Community 179 - "Community 179"
 Cohesion: 0.15
 Nodes (0):
 
-### Community 181 - "Community 181"
+### Community 180 - "Community 180"
 Cohesion: 0.26
 Nodes (10): archivedProductNestedOrigin(), buildVariantSkuMoneyPayload(), createVariantSku(), decodeOriginValue(), deleteActiveProduct(), getArchivedProductRedirect(), modifyProduct(), onSubmit() (+2 more)
+
+### Community 181 - "Community 181"
+Cohesion: 0.23
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 182 - "Community 182"
 Cohesion: 0.17
@@ -3890,20 +3890,20 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 292 - "Community 292"
-Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
-
-### Community 293 - "Community 293"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 294 - "Community 294"
+### Community 293 - "Community 293"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 295 - "Community 295"
+### Community 294 - "Community 294"
 Cohesion: 0.22
 Nodes (0):
+
+### Community 295 - "Community 295"
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
 ### Community 296 - "Community 296"
 Cohesion: 0.39
@@ -4602,108 +4602,108 @@ Cohesion: 0.4
 Nodes (2): isValidRecipientEmail(), normalizeRecipientEmailInput()
 
 ### Community 470 - "Community 470"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 471 - "Community 471"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 472 - "Community 472"
-Cohesion: 0.73
-Nodes (5): canAccessCashControlsSurface(), canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
-
-### Community 473 - "Community 473"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 473 - "Community 473"
+Cohesion: 0.73
+Nodes (5): canAccessCashControlsSurface(), canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
 ### Community 474 - "Community 474"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 475 - "Community 475"
-Cohesion: 0.4
-Nodes (2): deriveRegisterLifecycleAuthorityCandidates(), mappingCandidate()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 476 - "Community 476"
 Cohesion: 0.4
-Nodes (2): buildRecoveryCommandStore(), storeFactory()
+Nodes (2): deriveRegisterLifecycleAuthorityCandidates(), mappingCandidate()
 
 ### Community 477 - "Community 477"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): buildRecoveryCommandStore(), storeFactory()
 
 ### Community 478 - "Community 478"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 479 - "Community 479"
-Cohesion: 0.47
-Nodes (3): buildAdminSkuSearchOption(), compactJoin(), presentationText()
-
-### Community 480 - "Community 480"
-Cohesion: 0.53
-Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
-
-### Community 481 - "Community 481"
-Cohesion: 0.6
-Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
-
-### Community 482 - "Community 482"
-Cohesion: 0.33
-Nodes (1): MemoryCache
-
-### Community 483 - "Community 483"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 484 - "Community 484"
+### Community 480 - "Community 480"
 Cohesion: 0.47
-Nodes (3): completePendingAuthSync(), navigationTargetForRedirect(), sleep()
+Nodes (3): buildAdminSkuSearchOption(), compactJoin(), presentationText()
+
+### Community 481 - "Community 481"
+Cohesion: 0.53
+Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
+
+### Community 482 - "Community 482"
+Cohesion: 0.6
+Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
+
+### Community 483 - "Community 483"
+Cohesion: 0.33
+Nodes (1): MemoryCache
+
+### Community 484 - "Community 484"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 485 - "Community 485"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.47
+Nodes (3): completePendingAuthSync(), navigationTargetForRedirect(), sleep()
 
 ### Community 486 - "Community 486"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 487 - "Community 487"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
+### Community 488 - "Community 488"
 Cohesion: 0.6
 Nodes (5): useDailyCloseFixture(), useDailyOpeningFixture(), useDailyOperationsFixture(), usePosHubFixture(), useWorkspaceFixture()
 
-### Community 488 - "Community 488"
+### Community 489 - "Community 489"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 489 - "Community 489"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 490 - "Community 490"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 491 - "Community 491"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
 ### Community 492 - "Community 492"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 493 - "Community 493"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
-
-### Community 494 - "Community 494"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 494 - "Community 494"
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
+
 ### Community 495 - "Community 495"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 496 - "Community 496"
 Cohesion: 0.53
@@ -5342,40 +5342,40 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 655 - "Community 655"
-Cohesion: 0.5
-Nodes (1): buildCtx()
-
-### Community 656 - "Community 656"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 657 - "Community 657"
+### Community 656 - "Community 656"
 Cohesion: 0.83
 Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
-### Community 658 - "Community 658"
+### Community 657 - "Community 657"
 Cohesion: 0.83
 Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
-### Community 659 - "Community 659"
+### Community 658 - "Community 658"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 660 - "Community 660"
+### Community 659 - "Community 659"
 Cohesion: 0.67
 Nodes (2): buildActivity(), buildReport()
 
-### Community 661 - "Community 661"
+### Community 660 - "Community 660"
 Cohesion: 0.83
 Nodes (3): advanceRegisterCatalogRevision(), readRegisterCatalogRevision(), readRegisterCatalogRevisionRow()
 
-### Community 662 - "Community 662"
+### Community 661 - "Community 661"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 663 - "Community 663"
+### Community 662 - "Community 662"
 Cohesion: 0.83
 Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
+
+### Community 663 - "Community 663"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 664 - "Community 664"
 Cohesion: 0.5
@@ -5387,7 +5387,7 @@ Nodes (0):
 
 ### Community 666 - "Community 666"
 Cohesion: 0.5
-Nodes (0):
+Nodes (1): buildCtx()
 
 ### Community 667 - "Community 667"
 Cohesion: 0.5

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -72023,7 +72023,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L1532",
+      "source_location": "L1629",
       "target": "sweeper_test_insertmovementheader",
       "weight": 1
     },
@@ -72047,7 +72047,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L1157",
+      "source_location": "L1254",
       "target": "sweeper_test_insertweeklyclosefixture",
       "weight": 1
     },
@@ -72083,7 +72083,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L1529",
+      "source_location": "L1626",
       "target": "sweeper_test_movementconstants",
       "weight": 1
     },
@@ -72095,7 +72095,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L1231",
+      "source_location": "L1328",
       "target": "sweeper_test_readdocs",
       "weight": 1
     },
@@ -72131,7 +72131,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L1564",
+      "source_location": "L1661",
       "target": "sweeper_test_withfrozenscheduler",
       "weight": 1
     },
@@ -72143,7 +72143,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L472",
+      "source_location": "L511",
       "target": "sweeper_computependingranges",
       "weight": 1
     },
@@ -72167,7 +72167,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L510",
+      "source_location": "L549",
       "target": "sweeper_expirerangeresults",
       "weight": 1
     },
@@ -72179,7 +72179,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L455",
+      "source_location": "L494",
       "target": "sweeper_findopenoperatingdate",
       "weight": 1
     },
@@ -72191,7 +72191,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L258",
+      "source_location": "L283",
       "target": "sweeper_foldandreplaceday",
       "weight": 1
     },
@@ -72215,8 +72215,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L419",
+      "source_location": "L458",
       "target": "sweeper_markdaydirty",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_reports_sweeper_ts",
+      "_tgt": "sweeper_openpolicyforreason",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_reports_sweeper_ts",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L256",
+      "target": "sweeper_openpolicyforreason",
       "weight": 1
     },
     {
@@ -72239,7 +72251,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L542",
+      "source_location": "L581",
       "target": "sweeper_rangesnapshotkindconfigs",
       "weight": 1
     },
@@ -72275,7 +72287,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L546",
+      "source_location": "L585",
       "target": "sweeper_sweepwithctx",
       "weight": 1
     },
@@ -160067,7 +160079,7 @@
       "relation": "calls",
       "source": "sweeper_loadacceptedclose",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L309",
+      "source_location": "L345",
       "target": "sweeper_foldandreplaceday",
       "weight": 1
     },
@@ -160079,7 +160091,7 @@
       "relation": "calls",
       "source": "sweeper_tocloseref",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L310",
+      "source_location": "L346",
       "target": "sweeper_foldandreplaceday",
       "weight": 1
     },
@@ -160115,7 +160127,7 @@
       "relation": "calls",
       "source": "sweeper_computependingranges",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L637",
+      "source_location": "L683",
       "target": "sweeper_sweepwithctx",
       "weight": 1
     },
@@ -160127,7 +160139,7 @@
       "relation": "calls",
       "source": "sweeper_expirerangeresults",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L688",
+      "source_location": "L734",
       "target": "sweeper_sweepwithctx",
       "weight": 1
     },
@@ -160139,7 +160151,7 @@
       "relation": "calls",
       "source": "sweeper_foldandreplaceday",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L603",
+      "source_location": "L649",
       "target": "sweeper_sweepwithctx",
       "weight": 1
     },
@@ -160151,7 +160163,19 @@
       "relation": "calls",
       "source": "sweeper_markdaydirty",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L625",
+      "source_location": "L671",
+      "target": "sweeper_sweepwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "sweeper_sweepwithctx",
+      "_tgt": "sweeper_openpolicyforreason",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "sweeper_openpolicyforreason",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L650",
       "target": "sweeper_sweepwithctx",
       "weight": 1
     },
@@ -160163,7 +160187,7 @@
       "relation": "calls",
       "source": "sweeper_rangesnapshotkindconfigs",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L696",
+      "source_location": "L742",
       "target": "sweeper_sweepwithctx",
       "weight": 1
     },
@@ -160175,7 +160199,7 @@
       "relation": "calls",
       "source": "sweeper_readstoreallowlist",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L548",
+      "source_location": "L587",
       "target": "sweeper_sweepwithctx",
       "weight": 1
     },
@@ -177939,155 +177963,155 @@
     {
       "community": 114,
       "file_type": "code",
-      "id": "operatingperiods_buildsameelapsedoperatingcomparison",
-      "label": "buildSameElapsedOperatingComparison()",
-      "norm_label": "buildsameelapsedoperatingcomparison()",
-      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
-      "source_location": "L202"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "operatingperiods_elapsedoperatingtime",
-      "label": "elapsedOperatingTime()",
-      "norm_label": "elapsedoperatingtime()",
-      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
-      "source_location": "L168"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "operatingperiods_latesteffectiveschedule",
-      "label": "latestEffectiveSchedule()",
-      "norm_label": "latesteffectiveschedule()",
-      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
-      "source_location": "L340"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "operatingperiods_operatingduration",
-      "label": "operatingDuration()",
-      "norm_label": "operatingduration()",
-      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
-      "source_location": "L161"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "operatingperiods_reportingdateat",
-      "label": "reportingDateAt()",
-      "norm_label": "reportingdateat()",
-      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "operatingperiods_resolvereportingcalendardaterangewithctx",
-      "label": "resolveReportingCalendarDateRangeWithCtx()",
-      "norm_label": "resolvereportingcalendardaterangewithctx()",
-      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
-      "source_location": "L440"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "operatingperiods_resolvereportingcalendarreferencewithctx",
-      "label": "resolveReportingCalendarReferenceWithCtx()",
-      "norm_label": "resolvereportingcalendarreferencewithctx()",
-      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
-      "source_location": "L414"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "operatingperiods_resolvereportingfinancialperiod",
-      "label": "resolveReportingFinancialPeriod()",
-      "norm_label": "resolvereportingfinancialperiod()",
-      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "operatingperiods_resolvereportingfinancialperiodwithctx",
-      "label": "resolveReportingFinancialPeriodWithCtx()",
-      "norm_label": "resolvereportingfinancialperiodwithctx()",
-      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "operatingperiods_resolvereportingoperatingdaterangewithctx",
-      "label": "resolveReportingOperatingDateRangeWithCtx()",
-      "norm_label": "resolvereportingoperatingdaterangewithctx()",
-      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
-      "source_location": "L475"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "operatingperiods_resolvereportingoperatingperiod",
-      "label": "resolveReportingOperatingPeriod()",
-      "norm_label": "resolvereportingoperatingperiod()",
-      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
-      "source_location": "L258"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "operatingperiods_resolvereportingoperatingperiodwithctx",
-      "label": "resolveReportingOperatingPeriodWithCtx()",
-      "norm_label": "resolvereportingoperatingperiodwithctx()",
-      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
-      "source_location": "L355"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "operatingperiods_resolvereportingreferenceperiod",
-      "label": "resolveReportingReferencePeriod()",
-      "norm_label": "resolvereportingreferenceperiod()",
-      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
-      "source_location": "L307"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "operatingperiods_resolvereportingreferenceperiodwithctx",
-      "label": "resolveReportingReferencePeriodWithCtx()",
-      "norm_label": "resolvereportingreferenceperiodwithctx()",
-      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
-      "source_location": "L379"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "operatingperiods_shiftdate",
-      "label": "shiftDate()",
-      "norm_label": "shiftdate()",
-      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
-      "source_location": "L155"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "operatingperiods_takeoperatingtime",
-      "label": "takeOperatingTime()",
-      "norm_label": "takeoperatingtime()",
-      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
-      "source_location": "L181"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storetime_operatingperiods_ts",
-      "label": "operatingPeriods.ts",
-      "norm_label": "operatingperiods.ts",
-      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
+      "id": "packages_athena_webapp_convex_reports_sweeper_ts",
+      "label": "sweeper.ts",
+      "norm_label": "sweeper.ts",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "sweeper_computependingranges",
+      "label": "computePendingRanges()",
+      "norm_label": "computependingranges()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L511"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "sweeper_daycapexceeded",
+      "label": "DayCapExceeded",
+      "norm_label": "daycapexceeded",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L113"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "sweeper_daycapexceeded_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L114"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "sweeper_expirerangeresults",
+      "label": "expireRangeResults()",
+      "norm_label": "expirerangeresults()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L549"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "sweeper_findopenoperatingdate",
+      "label": "findOpenOperatingDate()",
+      "norm_label": "findopenoperatingdate()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L494"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "sweeper_foldandreplaceday",
+      "label": "foldAndReplaceDay()",
+      "norm_label": "foldandreplaceday()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L283"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "sweeper_loadacceptedclose",
+      "label": "loadAcceptedClose()",
+      "norm_label": "loadacceptedclose()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L232"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "sweeper_markdaydirty",
+      "label": "markDayDirty()",
+      "norm_label": "markdaydirty()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L458"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "sweeper_openpolicyforreason",
+      "label": "openPolicyForReason()",
+      "norm_label": "openpolicyforreason()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L256"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "sweeper_parsestoreallowlist",
+      "label": "parseStoreAllowlist()",
+      "norm_label": "parsestoreallowlist()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L136"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "sweeper_rangesnapshotkindconfigs",
+      "label": "rangeSnapshotKindConfigs()",
+      "norm_label": "rangesnapshotkindconfigs()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L581"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "sweeper_readstoreallowlist",
+      "label": "readStoreAllowlist()",
+      "norm_label": "readstoreallowlist()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L146"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "sweeper_selectacceptedclose",
+      "label": "selectAcceptedClose()",
+      "norm_label": "selectacceptedclose()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L198"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "sweeper_sweepwithctx",
+      "label": "sweepWithCtx()",
+      "norm_label": "sweepwithctx()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L585"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "sweeper_tocloseref",
+      "label": "toCloseRef()",
+      "norm_label": "tocloseref()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L214"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "sweeper_tofoldfact",
+      "label": "toFoldFact()",
+      "norm_label": "tofoldfact()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L154"
     },
     {
       "community": 1140,
@@ -178272,155 +178296,155 @@
     {
       "community": 115,
       "file_type": "code",
-      "id": "packages_athena_webapp_shared_posregistersessionactivitycontract_ts",
-      "label": "posRegisterSessionActivityContract.ts",
-      "norm_label": "posregistersessionactivitycontract.ts",
-      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
+      "id": "operatingperiods_buildsameelapsedoperatingcomparison",
+      "label": "buildSameElapsedOperatingComparison()",
+      "norm_label": "buildsameelapsedoperatingcomparison()",
+      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
+      "source_location": "L202"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "operatingperiods_elapsedoperatingtime",
+      "label": "elapsedOperatingTime()",
+      "norm_label": "elapsedoperatingtime()",
+      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
+      "source_location": "L168"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "operatingperiods_latesteffectiveschedule",
+      "label": "latestEffectiveSchedule()",
+      "norm_label": "latesteffectiveschedule()",
+      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
+      "source_location": "L340"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "operatingperiods_operatingduration",
+      "label": "operatingDuration()",
+      "norm_label": "operatingduration()",
+      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
+      "source_location": "L161"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "operatingperiods_reportingdateat",
+      "label": "reportingDateAt()",
+      "norm_label": "reportingdateat()",
+      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "operatingperiods_resolvereportingcalendardaterangewithctx",
+      "label": "resolveReportingCalendarDateRangeWithCtx()",
+      "norm_label": "resolvereportingcalendardaterangewithctx()",
+      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
+      "source_location": "L440"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "operatingperiods_resolvereportingcalendarreferencewithctx",
+      "label": "resolveReportingCalendarReferenceWithCtx()",
+      "norm_label": "resolvereportingcalendarreferencewithctx()",
+      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
+      "source_location": "L414"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "operatingperiods_resolvereportingfinancialperiod",
+      "label": "resolveReportingFinancialPeriod()",
+      "norm_label": "resolvereportingfinancialperiod()",
+      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "operatingperiods_resolvereportingfinancialperiodwithctx",
+      "label": "resolveReportingFinancialPeriodWithCtx()",
+      "norm_label": "resolvereportingfinancialperiodwithctx()",
+      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "operatingperiods_resolvereportingoperatingdaterangewithctx",
+      "label": "resolveReportingOperatingDateRangeWithCtx()",
+      "norm_label": "resolvereportingoperatingdaterangewithctx()",
+      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
+      "source_location": "L475"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "operatingperiods_resolvereportingoperatingperiod",
+      "label": "resolveReportingOperatingPeriod()",
+      "norm_label": "resolvereportingoperatingperiod()",
+      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
+      "source_location": "L258"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "operatingperiods_resolvereportingoperatingperiodwithctx",
+      "label": "resolveReportingOperatingPeriodWithCtx()",
+      "norm_label": "resolvereportingoperatingperiodwithctx()",
+      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
+      "source_location": "L355"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "operatingperiods_resolvereportingreferenceperiod",
+      "label": "resolveReportingReferencePeriod()",
+      "norm_label": "resolvereportingreferenceperiod()",
+      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
+      "source_location": "L307"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "operatingperiods_resolvereportingreferenceperiodwithctx",
+      "label": "resolveReportingReferencePeriodWithCtx()",
+      "norm_label": "resolvereportingreferenceperiodwithctx()",
+      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
+      "source_location": "L379"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "operatingperiods_shiftdate",
+      "label": "shiftDate()",
+      "norm_label": "shiftdate()",
+      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
+      "source_location": "L155"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "operatingperiods_takeoperatingtime",
+      "label": "takeOperatingTime()",
+      "norm_label": "takeoperatingtime()",
+      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
+      "source_location": "L181"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storetime_operatingperiods_ts",
+      "label": "operatingPeriods.ts",
+      "norm_label": "operatingperiods.ts",
+      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "posregistersessionactivitycontract_arraylength",
-      "label": "arrayLength()",
-      "norm_label": "arraylength()",
-      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
-      "source_location": "L409"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "posregistersessionactivitycontract_asrecord",
-      "label": "asRecord()",
-      "norm_label": "asrecord()",
-      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
-      "source_location": "L397"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "posregistersessionactivitycontract_canreportposregistersessionlocalactivitytype",
-      "label": "canReportPosRegisterSessionLocalActivityType()",
-      "norm_label": "canreportposregistersessionlocalactivitytype()",
-      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
-      "source_location": "L246"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "posregistersessionactivitycontract_cashdirection",
-      "label": "cashDirection()",
-      "norm_label": "cashdirection()",
-      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
-      "source_location": "L462"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "posregistersessionactivitycontract_classifyposregistersessionlocaleventtype",
-      "label": "classifyPosRegisterSessionLocalEventType()",
-      "norm_label": "classifyposregistersessionlocaleventtype()",
-      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
-      "source_location": "L240"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "posregistersessionactivitycontract_compactmetadata",
-      "label": "compactMetadata()",
-      "norm_label": "compactmetadata()",
-      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
-      "source_location": "L389"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "posregistersessionactivitycontract_finitenumber",
-      "label": "finiteNumber()",
-      "norm_label": "finitenumber()",
-      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
-      "source_location": "L403"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "posregistersessionactivitycontract_isposregistersessionactivitystatus",
-      "label": "isPosRegisterSessionActivityStatus()",
-      "norm_label": "isposregistersessionactivitystatus()",
-      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
-      "source_location": "L250"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "posregistersessionactivitycontract_labelfromtoken",
-      "label": "labelFromToken()",
-      "norm_label": "labelfromtoken()",
-      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
-      "source_location": "L438"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "posregistersessionactivitycontract_paymentmethodssummary",
-      "label": "paymentMethodsSummary()",
-      "norm_label": "paymentmethodssummary()",
-      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
-      "source_location": "L448"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "posregistersessionactivitycontract_safelabel",
-      "label": "safeLabel()",
-      "norm_label": "safelabel()",
-      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
-      "source_location": "L426"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "posregistersessionactivitycontract_safetoken",
-      "label": "safeToken()",
-      "norm_label": "safetoken()",
-      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
-      "source_location": "L432"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "posregistersessionactivitycontract_sanitizemetadataforlocalevent",
-      "label": "sanitizeMetadataForLocalEvent()",
-      "norm_label": "sanitizemetadataforlocalevent()",
-      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
-      "source_location": "L314"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "posregistersessionactivitycontract_sanitizeposregistersessionlocalactivity",
-      "label": "sanitizePosRegisterSessionLocalActivity()",
-      "norm_label": "sanitizeposregistersessionlocalactivity()",
-      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
-      "source_location": "L267"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "posregistersessionactivitycontract_sumamountarray",
-      "label": "sumAmountArray()",
-      "norm_label": "sumamountarray()",
-      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
-      "source_location": "L413"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "posregistersessionactivitycontract_toposregistersessionactivitystatuslabel",
-      "label": "toPosRegisterSessionActivityStatusLabel()",
-      "norm_label": "toposregistersessionactivitystatuslabel()",
-      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
-      "source_location": "L261"
     },
     {
       "community": 1150,
@@ -178605,155 +178629,155 @@
     {
       "community": 116,
       "file_type": "code",
-      "id": "data_table_view_options_datatableviewoptions",
-      "label": "DataTableViewOptions()",
-      "norm_label": "datatableviewoptions()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
-      "source_location": "L18"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-view-options.tsx",
+      "id": "packages_athena_webapp_shared_posregistersessionactivitycontract_ts",
+      "label": "posRegisterSessionActivityContract.ts",
+      "norm_label": "posregistersessionactivitycontract.ts",
+      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
       "source_location": "L1"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "posregistersessionactivitycontract_arraylength",
+      "label": "arrayLength()",
+      "norm_label": "arraylength()",
+      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
+      "source_location": "L409"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "posregistersessionactivitycontract_asrecord",
+      "label": "asRecord()",
+      "norm_label": "asrecord()",
+      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
+      "source_location": "L397"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "posregistersessionactivitycontract_canreportposregistersessionlocalactivitytype",
+      "label": "canReportPosRegisterSessionLocalActivityType()",
+      "norm_label": "canreportposregistersessionlocalactivitytype()",
+      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
+      "source_location": "L246"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "posregistersessionactivitycontract_cashdirection",
+      "label": "cashDirection()",
+      "norm_label": "cashdirection()",
+      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
+      "source_location": "L462"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "posregistersessionactivitycontract_classifyposregistersessionlocaleventtype",
+      "label": "classifyPosRegisterSessionLocalEventType()",
+      "norm_label": "classifyposregistersessionlocaleventtype()",
+      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
+      "source_location": "L240"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "posregistersessionactivitycontract_compactmetadata",
+      "label": "compactMetadata()",
+      "norm_label": "compactmetadata()",
+      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
+      "source_location": "L389"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "posregistersessionactivitycontract_finitenumber",
+      "label": "finiteNumber()",
+      "norm_label": "finitenumber()",
+      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
+      "source_location": "L403"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "posregistersessionactivitycontract_isposregistersessionactivitystatus",
+      "label": "isPosRegisterSessionActivityStatus()",
+      "norm_label": "isposregistersessionactivitystatus()",
+      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
+      "source_location": "L250"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "posregistersessionactivitycontract_labelfromtoken",
+      "label": "labelFromToken()",
+      "norm_label": "labelfromtoken()",
+      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
+      "source_location": "L438"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "posregistersessionactivitycontract_paymentmethodssummary",
+      "label": "paymentMethodsSummary()",
+      "norm_label": "paymentmethodssummary()",
+      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
+      "source_location": "L448"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "posregistersessionactivitycontract_safelabel",
+      "label": "safeLabel()",
+      "norm_label": "safelabel()",
+      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
+      "source_location": "L426"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "posregistersessionactivitycontract_safetoken",
+      "label": "safeToken()",
+      "norm_label": "safetoken()",
+      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
+      "source_location": "L432"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "posregistersessionactivitycontract_sanitizemetadataforlocalevent",
+      "label": "sanitizeMetadataForLocalEvent()",
+      "norm_label": "sanitizemetadataforlocalevent()",
+      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
+      "source_location": "L314"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "posregistersessionactivitycontract_sanitizeposregistersessionlocalactivity",
+      "label": "sanitizePosRegisterSessionLocalActivity()",
+      "norm_label": "sanitizeposregistersessionlocalactivity()",
+      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
+      "source_location": "L267"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "posregistersessionactivitycontract_sumamountarray",
+      "label": "sumAmountArray()",
+      "norm_label": "sumamountarray()",
+      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
+      "source_location": "L413"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "posregistersessionactivitycontract_toposregistersessionactivitystatuslabel",
+      "label": "toPosRegisterSessionActivityStatusLabel()",
+      "norm_label": "toposregistersessionactivitystatuslabel()",
+      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
+      "source_location": "L261"
     },
     {
       "community": 1160,
@@ -178938,154 +178962,154 @@
     {
       "community": 117,
       "file_type": "code",
-      "id": "dailyclosehistoryview_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L444"
+      "id": "data_table_view_options_datatableviewoptions",
+      "label": "DataTableViewOptions()",
+      "norm_label": "datatableviewoptions()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
+      "source_location": "L18"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "dailyclosehistoryview_dailyclosehistoryapipendingview",
-      "label": "DailyCloseHistoryApiPendingView()",
-      "norm_label": "dailyclosehistoryapipendingview()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L245"
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "dailyclosehistoryview_dailyclosehistoryview",
-      "label": "DailyCloseHistoryView()",
-      "norm_label": "dailyclosehistoryview()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L270"
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "dailyclosehistoryview_formatcount",
-      "label": "formatCount()",
-      "norm_label": "formatcount()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L228"
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "dailyclosehistoryview_getdailyclosehistoryapi",
-      "label": "getDailyCloseHistoryApi()",
-      "norm_label": "getdailyclosehistoryapi()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L107"
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "dailyclosehistoryview_gethistorylifecyclelabel",
-      "label": "getHistoryLifecycleLabel()",
-      "norm_label": "gethistorylifecyclelabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L156"
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "dailyclosehistoryview_gethistoryrecordcompletedat",
-      "label": "getHistoryRecordCompletedAt()",
-      "norm_label": "gethistoryrecordcompletedat()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L140"
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "dailyclosehistoryview_gethistoryrecordcompletedby",
-      "label": "getHistoryRecordCompletedBy()",
-      "norm_label": "gethistoryrecordcompletedby()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L144"
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "dailyclosehistoryview_gethistoryrecordid",
-      "label": "getHistoryRecordId()",
-      "norm_label": "gethistoryrecordid()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L128"
+      "id": "packages_athena_webapp_src_components_base_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "dailyclosehistoryview_gethistoryrecords",
-      "label": "getHistoryRecords()",
-      "norm_label": "gethistoryrecords()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L117"
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "dailyclosehistoryview_gethistoryrecordsnapshot",
-      "label": "getHistoryRecordSnapshot()",
-      "norm_label": "gethistoryrecordsnapshot()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L210"
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "dailyclosehistoryview_gethistoryrecordsummary",
-      "label": "getHistoryRecordSummary()",
-      "norm_label": "gethistoryrecordsummary()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L152"
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "dailyclosehistoryview_getsearchstring",
-      "label": "getSearchString()",
-      "norm_label": "getsearchstring()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L241"
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "dailyclosehistoryview_iscompletedhistoryrecord",
-      "label": "isCompletedHistoryRecord()",
-      "norm_label": "iscompletedhistoryrecord()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L134"
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "dailyclosehistoryview_normalizehistorysnapshot",
-      "label": "normalizeHistorySnapshot()",
-      "norm_label": "normalizehistorysnapshot()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L168"
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "dailyclosehistoryview_sortnewestfirst",
-      "label": "sortNewestFirst()",
-      "norm_label": "sortnewestfirst()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L234"
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_dailyclosehistoryview_tsx",
-      "label": "DailyCloseHistoryView.tsx",
-      "norm_label": "dailyclosehistoryview.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
       "source_location": "L1"
     },
     {
@@ -179271,154 +179295,154 @@
     {
       "community": 118,
       "file_type": "code",
-      "id": "harness_janitor_buildsummary",
-      "label": "buildSummary()",
-      "norm_label": "buildsummary()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L215"
+      "id": "dailyclosehistoryview_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L444"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "harness_janitor_comparesnapshots",
-      "label": "compareSnapshots()",
-      "norm_label": "comparesnapshots()",
-      "source_file": "scripts/harness-janitor.ts",
+      "id": "dailyclosehistoryview_dailyclosehistoryapipendingview",
+      "label": "DailyCloseHistoryApiPendingView()",
+      "norm_label": "dailyclosehistoryapipendingview()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L245"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "dailyclosehistoryview_dailyclosehistoryview",
+      "label": "DailyCloseHistoryView()",
+      "norm_label": "dailyclosehistoryview()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L270"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "dailyclosehistoryview_formatcount",
+      "label": "formatCount()",
+      "norm_label": "formatcount()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L228"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "dailyclosehistoryview_getdailyclosehistoryapi",
+      "label": "getDailyCloseHistoryApi()",
+      "norm_label": "getdailyclosehistoryapi()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
       "source_location": "L107"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "harness_janitor_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L79"
+      "id": "dailyclosehistoryview_gethistorylifecyclelabel",
+      "label": "getHistoryLifecycleLabel()",
+      "norm_label": "gethistorylifecyclelabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L156"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "harness_janitor_formatartifactlist",
-      "label": "formatArtifactList()",
-      "norm_label": "formatartifactlist()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L131"
+      "id": "dailyclosehistoryview_gethistoryrecordcompletedat",
+      "label": "getHistoryRecordCompletedAt()",
+      "norm_label": "gethistoryrecordcompletedat()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L140"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "harness_janitor_formatdetaillines",
-      "label": "formatDetailLines()",
-      "norm_label": "formatdetaillines()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L124"
+      "id": "dailyclosehistoryview_gethistoryrecordcompletedby",
+      "label": "getHistoryRecordCompletedBy()",
+      "norm_label": "gethistoryrecordcompletedby()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L144"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "harness_janitor_formaterror",
-      "label": "formatError()",
-      "norm_label": "formaterror()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L69"
+      "id": "dailyclosehistoryview_gethistoryrecordid",
+      "label": "getHistoryRecordId()",
+      "norm_label": "gethistoryrecordid()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L128"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "harness_janitor_formatharnessjanitorreport",
-      "label": "formatHarnessJanitorReport()",
-      "norm_label": "formatharnessjanitorreport()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L372"
+      "id": "dailyclosehistoryview_gethistoryrecords",
+      "label": "getHistoryRecords()",
+      "norm_label": "gethistoryrecords()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L117"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "harness_janitor_hasfailures",
-      "label": "hasFailures()",
-      "norm_label": "hasfailures()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L242"
+      "id": "dailyclosehistoryview_gethistoryrecordsnapshot",
+      "label": "getHistoryRecordSnapshot()",
+      "norm_label": "gethistoryrecordsnapshot()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L210"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "harness_janitor_parseharnessjanitorcliargs",
-      "label": "parseHarnessJanitorCliArgs()",
-      "norm_label": "parseharnessjanitorcliargs()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L342"
+      "id": "dailyclosehistoryview_gethistoryrecordsummary",
+      "label": "getHistoryRecordSummary()",
+      "norm_label": "gethistoryrecordsummary()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L152"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "harness_janitor_readutf8ornull",
-      "label": "readUtf8OrNull()",
-      "norm_label": "readutf8ornull()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L88"
+      "id": "dailyclosehistoryview_getsearchstring",
+      "label": "getSearchString()",
+      "norm_label": "getsearchstring()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L241"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "harness_janitor_runcheckstep",
-      "label": "runCheckStep()",
-      "norm_label": "runcheckstep()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L163"
+      "id": "dailyclosehistoryview_iscompletedhistoryrecord",
+      "label": "isCompletedHistoryRecord()",
+      "norm_label": "iscompletedhistoryrecord()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L134"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "harness_janitor_runharnessjanitor",
-      "label": "runHarnessJanitor()",
-      "norm_label": "runharnessjanitor()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L252"
+      "id": "dailyclosehistoryview_normalizehistorysnapshot",
+      "label": "normalizeHistorySnapshot()",
+      "norm_label": "normalizehistorysnapshot()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L168"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "harness_janitor_runrepairstep",
-      "label": "runRepairStep()",
-      "norm_label": "runrepairstep()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L175"
+      "id": "dailyclosehistoryview_sortnewestfirst",
+      "label": "sortNewestFirst()",
+      "norm_label": "sortnewestfirst()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L234"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "harness_janitor_snapshotfiles",
-      "label": "snapshotFiles()",
-      "norm_label": "snapshotfiles()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "harness_janitor_sortuniquepaths",
-      "label": "sortUniquePaths()",
-      "norm_label": "sortuniquepaths()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "harness_janitor_withcapturedconsole",
-      "label": "withCapturedConsole()",
-      "norm_label": "withcapturedconsole()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L139"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "scripts_harness_janitor_ts",
-      "label": "harness-janitor.ts",
-      "norm_label": "harness-janitor.ts",
-      "source_file": "scripts/harness-janitor.ts",
+      "id": "packages_athena_webapp_src_components_operations_dailyclosehistoryview_tsx",
+      "label": "DailyCloseHistoryView.tsx",
+      "norm_label": "dailyclosehistoryview.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
       "source_location": "L1"
     },
     {
@@ -179604,154 +179628,154 @@
     {
       "community": 119,
       "file_type": "code",
-      "id": "harness_runtime_trends_buildnumerictrendstats",
-      "label": "buildNumericTrendStats()",
-      "norm_label": "buildnumerictrendstats()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L202"
+      "id": "harness_janitor_buildsummary",
+      "label": "buildSummary()",
+      "norm_label": "buildsummary()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L215"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "harness_runtime_trends_buildregressionwarnings",
-      "label": "buildRegressionWarnings()",
-      "norm_label": "buildregressionwarnings()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L337"
+      "id": "harness_janitor_comparesnapshots",
+      "label": "compareSnapshots()",
+      "norm_label": "comparesnapshots()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L107"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "harness_runtime_trends_buildruntimetrendoutput",
-      "label": "buildRuntimeTrendOutput()",
-      "norm_label": "buildruntimetrendoutput()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L409"
+      "id": "harness_janitor_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L79"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "harness_runtime_trends_buildscenariotrend",
-      "label": "buildScenarioTrend()",
-      "norm_label": "buildscenariotrend()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L241"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "harness_runtime_trends_collectharnessruntimetrends",
-      "label": "collectHarnessRuntimeTrends()",
-      "norm_label": "collectharnessruntimetrends()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L473"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "harness_runtime_trends_formatms",
-      "label": "formatMs()",
-      "norm_label": "formatms()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L237"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "harness_runtime_trends_formatpercent",
-      "label": "formatPercent()",
-      "norm_label": "formatpercent()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L233"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "harness_runtime_trends_isharnessbehaviorscenarioreport",
-      "label": "isHarnessBehaviorScenarioReport()",
-      "norm_label": "isharnessbehaviorscenarioreport()",
-      "source_file": "scripts/harness-runtime-trends.ts",
+      "id": "harness_janitor_formatartifactlist",
+      "label": "formatArtifactList()",
+      "norm_label": "formatartifactlist()",
+      "source_file": "scripts/harness-janitor.ts",
       "source_location": "L131"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "harness_runtime_trends_parseharnessbehaviorreportlines",
-      "label": "parseHarnessBehaviorReportLines()",
-      "norm_label": "parseharnessbehaviorreportlines()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L149"
+      "id": "harness_janitor_formatdetaillines",
+      "label": "formatDetailLines()",
+      "norm_label": "formatdetaillines()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L124"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "harness_runtime_trends_parseharnessruntimetrendsargs",
-      "label": "parseHarnessRuntimeTrendsArgs()",
-      "norm_label": "parseharnessruntimetrendsargs()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L509"
+      "id": "harness_janitor_formaterror",
+      "label": "formatError()",
+      "norm_label": "formaterror()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L69"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "harness_runtime_trends_percentile",
-      "label": "percentile()",
-      "norm_label": "percentile()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L191"
+      "id": "harness_janitor_formatharnessjanitorreport",
+      "label": "formatHarnessJanitorReport()",
+      "norm_label": "formatharnessjanitorreport()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L372"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "harness_runtime_trends_runharnessruntimetrends",
-      "label": "runHarnessRuntimeTrends()",
-      "norm_label": "runharnessruntimetrends()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L481"
+      "id": "harness_janitor_hasfailures",
+      "label": "hasFailures()",
+      "norm_label": "hasfailures()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L242"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "harness_runtime_trends_sortcountentries",
-      "label": "sortCountEntries()",
-      "norm_label": "sortcountentries()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L227"
+      "id": "harness_janitor_parseharnessjanitorcliargs",
+      "label": "parseHarnessJanitorCliArgs()",
+      "norm_label": "parseharnessjanitorcliargs()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L342"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "harness_runtime_trends_sortunique",
-      "label": "sortUnique()",
-      "norm_label": "sortunique()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L125"
+      "id": "harness_janitor_readutf8ornull",
+      "label": "readUtf8OrNull()",
+      "norm_label": "readutf8ornull()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L88"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "harness_runtime_trends_splitinputlines",
-      "label": "splitInputLines()",
-      "norm_label": "splitinputlines()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L119"
+      "id": "harness_janitor_runcheckstep",
+      "label": "runCheckStep()",
+      "norm_label": "runcheckstep()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L163"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "harness_runtime_trends_tohistoryfilestamp",
-      "label": "toHistoryFileStamp()",
-      "norm_label": "tohistoryfilestamp()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L115"
+      "id": "harness_janitor_runharnessjanitor",
+      "label": "runHarnessJanitor()",
+      "norm_label": "runharnessjanitor()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L252"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "scripts_harness_runtime_trends_ts",
-      "label": "harness-runtime-trends.ts",
-      "norm_label": "harness-runtime-trends.ts",
-      "source_file": "scripts/harness-runtime-trends.ts",
+      "id": "harness_janitor_runrepairstep",
+      "label": "runRepairStep()",
+      "norm_label": "runrepairstep()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L175"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "harness_janitor_snapshotfiles",
+      "label": "snapshotFiles()",
+      "norm_label": "snapshotfiles()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "harness_janitor_sortuniquepaths",
+      "label": "sortUniquePaths()",
+      "norm_label": "sortuniquepaths()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "harness_janitor_withcapturedconsole",
+      "label": "withCapturedConsole()",
+      "norm_label": "withcapturedconsole()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L139"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "scripts_harness_janitor_ts",
+      "label": "harness-janitor.ts",
+      "norm_label": "harness-janitor.ts",
+      "source_file": "scripts/harness-janitor.ts",
       "source_location": "L1"
     },
     {
@@ -180360,146 +180384,155 @@
     {
       "community": 120,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_core_routes_trackingevents_ts",
-      "label": "trackingEvents.ts",
-      "norm_label": "trackingevents.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
+      "id": "harness_runtime_trends_buildnumerictrendstats",
+      "label": "buildNumericTrendStats()",
+      "norm_label": "buildnumerictrendstats()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L202"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "harness_runtime_trends_buildregressionwarnings",
+      "label": "buildRegressionWarnings()",
+      "norm_label": "buildregressionwarnings()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L337"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "harness_runtime_trends_buildruntimetrendoutput",
+      "label": "buildRuntimeTrendOutput()",
+      "norm_label": "buildruntimetrendoutput()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L409"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "harness_runtime_trends_buildscenariotrend",
+      "label": "buildScenarioTrend()",
+      "norm_label": "buildscenariotrend()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L241"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "harness_runtime_trends_collectharnessruntimetrends",
+      "label": "collectHarnessRuntimeTrends()",
+      "norm_label": "collectharnessruntimetrends()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L473"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "harness_runtime_trends_formatms",
+      "label": "formatMs()",
+      "norm_label": "formatms()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L237"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "harness_runtime_trends_formatpercent",
+      "label": "formatPercent()",
+      "norm_label": "formatpercent()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L233"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "harness_runtime_trends_isharnessbehaviorscenarioreport",
+      "label": "isHarnessBehaviorScenarioReport()",
+      "norm_label": "isharnessbehaviorscenarioreport()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L131"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "harness_runtime_trends_parseharnessbehaviorreportlines",
+      "label": "parseHarnessBehaviorReportLines()",
+      "norm_label": "parseharnessbehaviorreportlines()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L149"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "harness_runtime_trends_parseharnessruntimetrendsargs",
+      "label": "parseHarnessRuntimeTrendsArgs()",
+      "norm_label": "parseharnessruntimetrendsargs()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L509"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "harness_runtime_trends_percentile",
+      "label": "percentile()",
+      "norm_label": "percentile()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L191"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "harness_runtime_trends_runharnessruntimetrends",
+      "label": "runHarnessRuntimeTrends()",
+      "norm_label": "runharnessruntimetrends()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L481"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "harness_runtime_trends_sortcountentries",
+      "label": "sortCountEntries()",
+      "norm_label": "sortcountentries()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L227"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "harness_runtime_trends_sortunique",
+      "label": "sortUnique()",
+      "norm_label": "sortunique()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L125"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "harness_runtime_trends_splitinputlines",
+      "label": "splitInputLines()",
+      "norm_label": "splitinputlines()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L119"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "harness_runtime_trends_tohistoryfilestamp",
+      "label": "toHistoryFileStamp()",
+      "norm_label": "tohistoryfilestamp()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "scripts_harness_runtime_trends_ts",
+      "label": "harness-runtime-trends.ts",
+      "norm_label": "harness-runtime-trends.ts",
+      "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "trackingevents_buildabusepartitionkey",
-      "label": "buildAbusePartitionKey()",
-      "norm_label": "buildabusepartitionkey()",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
-      "source_location": "L225"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "trackingevents_buildservercontexttrackingenvelope",
-      "label": "buildServerContextTrackingEnvelope()",
-      "norm_label": "buildservercontexttrackingenvelope()",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "trackingevents_derivebrowserfamily",
-      "label": "deriveBrowserFamily()",
-      "norm_label": "derivebrowserfamily()",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
-      "source_location": "L148"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "trackingevents_derivecontextenvironment",
-      "label": "deriveContextEnvironment()",
-      "norm_label": "derivecontextenvironment()",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
-      "source_location": "L117"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "trackingevents_deriveosfamily",
-      "label": "deriveOsFamily()",
-      "norm_label": "deriveosfamily()",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
-      "source_location": "L159"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "trackingevents_deriveprimarysubject",
-      "label": "derivePrimarySubject()",
-      "norm_label": "deriveprimarysubject()",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
-      "source_location": "L235"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "trackingevents_isacceptedsyntheticcontext",
-      "label": "isAcceptedSyntheticContext()",
-      "norm_label": "isacceptedsyntheticcontext()",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
-      "source_location": "L195"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "trackingevents_isallowedtrackingorigin",
-      "label": "isAllowedTrackingOrigin()",
-      "norm_label": "isallowedtrackingorigin()",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
-      "source_location": "L178"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "trackingevents_isrecord",
-      "label": "isRecord()",
-      "norm_label": "isrecord()",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
-      "source_location": "L265"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "trackingevents_readpayload",
-      "label": "readPayload()",
-      "norm_label": "readpayload()",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
-      "source_location": "L205"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "trackingevents_readrequirednumber",
-      "label": "readRequiredNumber()",
-      "norm_label": "readrequirednumber()",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
-      "source_location": "L213"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "trackingevents_readrequiredstring",
-      "label": "readRequiredString()",
-      "norm_label": "readrequiredstring()",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
-      "source_location": "L209"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "trackingevents_readsubjectref",
-      "label": "readSubjectRef()",
-      "norm_label": "readsubjectref()",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
-      "source_location": "L257"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "trackingevents_readtrackingipaddress",
-      "label": "readTrackingIpAddress()",
-      "norm_label": "readtrackingipaddress()",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
-      "source_location": "L217"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "trackingevents_readviewportbucket",
-      "label": "readViewportBucket()",
-      "norm_label": "readviewportbucket()",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
-      "source_location": "L169"
     },
     {
       "community": 1200,
@@ -180684,146 +180717,146 @@
     {
       "community": 121,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_intelligence_runs_ts",
-      "label": "runs.ts",
-      "norm_label": "runs.ts",
-      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
+      "id": "packages_athena_webapp_convex_http_domains_core_routes_trackingevents_ts",
+      "label": "trackingEvents.ts",
+      "norm_label": "trackingevents.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
       "source_location": "L1"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "runs_buildlatestrundebugpayload",
-      "label": "buildLatestRunDebugPayload()",
-      "norm_label": "buildlatestrundebugpayload()",
-      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
-      "source_location": "L633"
+      "id": "trackingevents_buildabusepartitionkey",
+      "label": "buildAbusePartitionKey()",
+      "norm_label": "buildabusepartitionkey()",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
+      "source_location": "L225"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "runs_getboundeddebugrunsbycapability",
-      "label": "getBoundedDebugRunsByCapability()",
-      "norm_label": "getboundeddebugrunsbycapability()",
-      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
-      "source_location": "L576"
+      "id": "trackingevents_buildservercontexttrackingenvelope",
+      "label": "buildServerContextTrackingEnvelope()",
+      "norm_label": "buildservercontexttrackingenvelope()",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
+      "source_location": "L67"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "runs_getlatestdebugrunbycapability",
-      "label": "getLatestDebugRunByCapability()",
-      "norm_label": "getlatestdebugrunbycapability()",
-      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
-      "source_location": "L567"
+      "id": "trackingevents_derivebrowserfamily",
+      "label": "deriveBrowserFamily()",
+      "norm_label": "derivebrowserfamily()",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
+      "source_location": "L148"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "runs_getlatestdebugrunbysubject",
-      "label": "getLatestDebugRunBySubject()",
-      "norm_label": "getlatestdebugrunbysubject()",
-      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
-      "source_location": "L538"
+      "id": "trackingevents_derivecontextenvironment",
+      "label": "deriveContextEnvironment()",
+      "norm_label": "derivecontextenvironment()",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
+      "source_location": "L117"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "runs_isactiverunstale",
-      "label": "isActiveRunStale()",
-      "norm_label": "isactiverunstale()",
-      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
-      "source_location": "L118"
+      "id": "trackingevents_deriveosfamily",
+      "label": "deriveOsFamily()",
+      "norm_label": "deriveosfamily()",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
+      "source_location": "L159"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "runs_isactiverunstatus",
-      "label": "isActiveRunStatus()",
-      "norm_label": "isactiverunstatus()",
-      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
-      "source_location": "L114"
+      "id": "trackingevents_deriveprimarysubject",
+      "label": "derivePrimarySubject()",
+      "norm_label": "deriveprimarysubject()",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
+      "source_location": "L235"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "runs_marksiblingartifactsstale",
-      "label": "markSiblingArtifactsStale()",
-      "norm_label": "marksiblingartifactsstale()",
-      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
-      "source_location": "L63"
+      "id": "trackingevents_isacceptedsyntheticcontext",
+      "label": "isAcceptedSyntheticContext()",
+      "norm_label": "isacceptedsyntheticcontext()",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
+      "source_location": "L195"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "runs_selectactiverunforidempotency",
-      "label": "selectActiveRunForIdempotency()",
-      "norm_label": "selectactiverunforidempotency()",
-      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
-      "source_location": "L132"
+      "id": "trackingevents_isallowedtrackingorigin",
+      "label": "isAllowedTrackingOrigin()",
+      "norm_label": "isallowedtrackingorigin()",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
+      "source_location": "L178"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "runs_selectlatestdebugrunfromcandidates",
-      "label": "selectLatestDebugRunFromCandidates()",
-      "norm_label": "selectlatestdebugrunfromcandidates()",
-      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
-      "source_location": "L149"
+      "id": "trackingevents_isrecord",
+      "label": "isRecord()",
+      "norm_label": "isrecord()",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
+      "source_location": "L265"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "runs_shouldrecoveractiverun",
-      "label": "shouldRecoverActiveRun()",
-      "norm_label": "shouldrecoveractiverun()",
-      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
-      "source_location": "L142"
+      "id": "trackingevents_readpayload",
+      "label": "readPayload()",
+      "norm_label": "readpayload()",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
+      "source_location": "L205"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "runs_shouldsupersedeartifact",
-      "label": "shouldSupersedeArtifact()",
-      "norm_label": "shouldsupersedeartifact()",
-      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
-      "source_location": "L95"
+      "id": "trackingevents_readrequirednumber",
+      "label": "readRequiredNumber()",
+      "norm_label": "readrequirednumber()",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
+      "source_location": "L213"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "runs_summarizeerror",
-      "label": "summarizeError()",
-      "norm_label": "summarizeerror()",
-      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
-      "source_location": "L598"
+      "id": "trackingevents_readrequiredstring",
+      "label": "readRequiredString()",
+      "norm_label": "readrequiredstring()",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
+      "source_location": "L209"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "runs_summarizepayload",
-      "label": "summarizePayload()",
-      "norm_label": "summarizepayload()",
-      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
-      "source_location": "L609"
+      "id": "trackingevents_readsubjectref",
+      "label": "readSubjectRef()",
+      "norm_label": "readsubjectref()",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
+      "source_location": "L257"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "runs_summarizepayloadvalue",
-      "label": "summarizePayloadValue()",
-      "norm_label": "summarizepayloadvalue()",
-      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
-      "source_location": "L615"
+      "id": "trackingevents_readtrackingipaddress",
+      "label": "readTrackingIpAddress()",
+      "norm_label": "readtrackingipaddress()",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
+      "source_location": "L217"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "runs_transitionrun",
-      "label": "transitionRun()",
-      "norm_label": "transitionrun()",
-      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
-      "source_location": "L40"
+      "id": "trackingevents_readviewportbucket",
+      "label": "readViewportBucket()",
+      "norm_label": "readviewportbucket()",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
+      "source_location": "L169"
     },
     {
       "community": 1210,
@@ -181008,146 +181041,146 @@
     {
       "community": 122,
       "file_type": "code",
-      "id": "inventoryimportcostoverlayconstruction_constructionscopeerror",
-      "label": "ConstructionScopeError",
-      "norm_label": "constructionscopeerror",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
-      "source_location": "L156"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlayconstruction_constructionscopeerror_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
-      "source_location": "L157"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlayconstruction_costoverlayconstructionidentity",
-      "label": "costOverlayConstructionIdentity()",
-      "norm_label": "costoverlayconstructionidentity()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
-      "source_location": "L279"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlayconstruction_digest",
-      "label": "digest()",
-      "norm_label": "digest()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
-      "source_location": "L275"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlayconstruction_heartbeatconstructionorthrow",
-      "label": "heartbeatConstructionOrThrow()",
-      "norm_label": "heartbeatconstructionorthrow()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
-      "source_location": "L262"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlayconstruction_loadanchors",
-      "label": "loadAnchors()",
-      "norm_label": "loadanchors()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
-      "source_location": "L646"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlayconstruction_loadsource",
-      "label": "loadSource()",
-      "norm_label": "loadsource()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
-      "source_location": "L590"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlayconstruction_materializecostoverlayrows",
-      "label": "materializeCostOverlayRows()",
-      "norm_label": "materializecostoverlayrows()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
-      "source_location": "L370"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlayconstruction_normalizeoutcome",
-      "label": "normalizeOutcome()",
-      "norm_label": "normalizeoutcome()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
-      "source_location": "L360"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlayconstruction_rawvaluefor",
-      "label": "rawValueFor()",
-      "norm_label": "rawvaluefor()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
-      "source_location": "L322"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlayconstruction_safemultiply",
-      "label": "safeMultiply()",
-      "norm_label": "safemultiply()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
-      "source_location": "L300"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlayconstruction_selectedcolumnfor",
-      "label": "selectedColumnFor()",
-      "norm_label": "selectedcolumnfor()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
-      "source_location": "L309"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlayconstruction_serializerawvalue",
-      "label": "serializeRawValue()",
-      "norm_label": "serializerawvalue()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
-      "source_location": "L352"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlayconstruction_staleconstructionerror",
-      "label": "StaleConstructionError",
-      "norm_label": "staleconstructionerror",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
-      "source_location": "L162"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlayconstruction_truncateutf8",
-      "label": "truncateUtf8()",
-      "norm_label": "truncateutf8()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
-      "source_location": "L326"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_inventoryimportcostoverlayconstruction_ts",
-      "label": "inventoryImportCostOverlayConstruction.ts",
-      "norm_label": "inventoryimportcostoverlayconstruction.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
+      "id": "packages_athena_webapp_convex_intelligence_runs_ts",
+      "label": "runs.ts",
+      "norm_label": "runs.ts",
+      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "runs_buildlatestrundebugpayload",
+      "label": "buildLatestRunDebugPayload()",
+      "norm_label": "buildlatestrundebugpayload()",
+      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
+      "source_location": "L633"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "runs_getboundeddebugrunsbycapability",
+      "label": "getBoundedDebugRunsByCapability()",
+      "norm_label": "getboundeddebugrunsbycapability()",
+      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
+      "source_location": "L576"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "runs_getlatestdebugrunbycapability",
+      "label": "getLatestDebugRunByCapability()",
+      "norm_label": "getlatestdebugrunbycapability()",
+      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
+      "source_location": "L567"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "runs_getlatestdebugrunbysubject",
+      "label": "getLatestDebugRunBySubject()",
+      "norm_label": "getlatestdebugrunbysubject()",
+      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
+      "source_location": "L538"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "runs_isactiverunstale",
+      "label": "isActiveRunStale()",
+      "norm_label": "isactiverunstale()",
+      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
+      "source_location": "L118"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "runs_isactiverunstatus",
+      "label": "isActiveRunStatus()",
+      "norm_label": "isactiverunstatus()",
+      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
+      "source_location": "L114"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "runs_marksiblingartifactsstale",
+      "label": "markSiblingArtifactsStale()",
+      "norm_label": "marksiblingartifactsstale()",
+      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "runs_selectactiverunforidempotency",
+      "label": "selectActiveRunForIdempotency()",
+      "norm_label": "selectactiverunforidempotency()",
+      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
+      "source_location": "L132"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "runs_selectlatestdebugrunfromcandidates",
+      "label": "selectLatestDebugRunFromCandidates()",
+      "norm_label": "selectlatestdebugrunfromcandidates()",
+      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
+      "source_location": "L149"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "runs_shouldrecoveractiverun",
+      "label": "shouldRecoverActiveRun()",
+      "norm_label": "shouldrecoveractiverun()",
+      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
+      "source_location": "L142"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "runs_shouldsupersedeartifact",
+      "label": "shouldSupersedeArtifact()",
+      "norm_label": "shouldsupersedeartifact()",
+      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "runs_summarizeerror",
+      "label": "summarizeError()",
+      "norm_label": "summarizeerror()",
+      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
+      "source_location": "L598"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "runs_summarizepayload",
+      "label": "summarizePayload()",
+      "norm_label": "summarizepayload()",
+      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
+      "source_location": "L609"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "runs_summarizepayloadvalue",
+      "label": "summarizePayloadValue()",
+      "norm_label": "summarizepayloadvalue()",
+      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
+      "source_location": "L615"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "runs_transitionrun",
+      "label": "transitionRun()",
+      "norm_label": "transitionrun()",
+      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
+      "source_location": "L40"
     },
     {
       "community": 1220,
@@ -181332,145 +181365,145 @@
     {
       "community": 123,
       "file_type": "code",
-      "id": "dailyoperations_test_buildcompletedpostransaction",
-      "label": "buildCompletedPosTransaction()",
-      "norm_label": "buildcompletedpostransaction()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
-      "source_location": "L512"
+      "id": "inventoryimportcostoverlayconstruction_constructionscopeerror",
+      "label": "ConstructionScopeError",
+      "norm_label": "constructionscopeerror",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
+      "source_location": "L156"
     },
     {
       "community": 123,
       "file_type": "code",
-      "id": "dailyoperations_test_buildctx",
-      "label": "buildCtx()",
-      "norm_label": "buildctx()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
-      "source_location": "L407"
+      "id": "inventoryimportcostoverlayconstruction_constructionscopeerror_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
+      "source_location": "L157"
     },
     {
       "community": 123,
       "file_type": "code",
-      "id": "dailyoperations_test_buildfrozenclose",
-      "label": "buildFrozenClose()",
-      "norm_label": "buildfrozenclose()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
-      "source_location": "L532"
+      "id": "inventoryimportcostoverlayconstruction_costoverlayconstructionidentity",
+      "label": "costOverlayConstructionIdentity()",
+      "norm_label": "costoverlayconstructionidentity()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
+      "source_location": "L279"
     },
     {
       "community": 123,
       "file_type": "code",
-      "id": "dailyoperations_test_buildobservedctx",
-      "label": "buildObservedCtx()",
-      "norm_label": "buildobservedctx()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
-      "source_location": "L412"
+      "id": "inventoryimportcostoverlayconstruction_digest",
+      "label": "digest()",
+      "norm_label": "digest()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
+      "source_location": "L275"
     },
     {
       "community": 123,
       "file_type": "code",
-      "id": "dailyoperations_test_buildpendingregistercountseed",
-      "label": "buildPendingRegisterCountSeed()",
-      "norm_label": "buildpendingregistercountseed()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
+      "id": "inventoryimportcostoverlayconstruction_heartbeatconstructionorthrow",
+      "label": "heartbeatConstructionOrThrow()",
+      "norm_label": "heartbeatconstructionorthrow()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
+      "source_location": "L262"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "inventoryimportcostoverlayconstruction_loadanchors",
+      "label": "loadAnchors()",
+      "norm_label": "loadanchors()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
+      "source_location": "L646"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "inventoryimportcostoverlayconstruction_loadsource",
+      "label": "loadSource()",
+      "norm_label": "loadsource()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
+      "source_location": "L590"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "inventoryimportcostoverlayconstruction_materializecostoverlayrows",
+      "label": "materializeCostOverlayRows()",
+      "norm_label": "materializecostoverlayrows()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
+      "source_location": "L370"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "inventoryimportcostoverlayconstruction_normalizeoutcome",
+      "label": "normalizeOutcome()",
+      "norm_label": "normalizeoutcome()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
+      "source_location": "L360"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "inventoryimportcostoverlayconstruction_rawvaluefor",
+      "label": "rawValueFor()",
+      "norm_label": "rawvaluefor()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
+      "source_location": "L322"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "inventoryimportcostoverlayconstruction_safemultiply",
+      "label": "safeMultiply()",
+      "norm_label": "safemultiply()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
+      "source_location": "L300"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "inventoryimportcostoverlayconstruction_selectedcolumnfor",
+      "label": "selectedColumnFor()",
+      "norm_label": "selectedcolumnfor()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
+      "source_location": "L309"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "inventoryimportcostoverlayconstruction_serializerawvalue",
+      "label": "serializeRawValue()",
+      "norm_label": "serializerawvalue()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
+      "source_location": "L352"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "inventoryimportcostoverlayconstruction_staleconstructionerror",
+      "label": "StaleConstructionError",
+      "norm_label": "staleconstructionerror",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
+      "source_location": "L162"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "inventoryimportcostoverlayconstruction_truncateutf8",
+      "label": "truncateUtf8()",
+      "norm_label": "truncateutf8()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
       "source_location": "L326"
     },
     {
       "community": 123,
       "file_type": "code",
-      "id": "dailyoperations_test_createdb",
-      "label": "createDb()",
-      "norm_label": "createdb()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "dailyoperations_test_frozenfinancialcompleteness",
-      "label": "frozenFinancialCompleteness()",
-      "norm_label": "frozenfinancialcompleteness()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
-      "source_location": "L434"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "dailyoperations_test_frozenfinancialcompletenessforrange",
-      "label": "frozenFinancialCompletenessForRange()",
-      "norm_label": "frozenfinancialcompletenessforrange()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
-      "source_location": "L485"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "dailyoperations_test_frozenfinancialcompletenesswithexpenseoverride",
-      "label": "frozenFinancialCompletenessWithExpenseOverride()",
-      "norm_label": "frozenfinancialcompletenesswithexpenseoverride()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
-      "source_location": "L496"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "dailyoperations_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
-      "source_location": "L420"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "dailyoperations_test_metricsourceobservations",
-      "label": "metricSourceObservations()",
-      "norm_label": "metricsourceobservations()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
-      "source_location": "L677"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "dailyoperations_test_mockdailyoperationsrole",
-      "label": "mockDailyOperationsRole()",
-      "norm_label": "mockdailyoperationsrole()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
-      "source_location": "L651"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "dailyoperations_test_operatingdaterange",
-      "label": "operatingDateRange()",
-      "norm_label": "operatingdaterange()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
-      "source_location": "L424"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "dailyoperations_test_review",
-      "label": "review()",
-      "norm_label": "review()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
-      "source_location": "L3535"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "dailyoperations_test_syncedsalereview",
-      "label": "syncedSaleReview()",
-      "norm_label": "syncedsalereview()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
-      "source_location": "L3440"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_dailyoperations_test_ts",
-      "label": "dailyOperations.test.ts",
-      "norm_label": "dailyoperations.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
+      "id": "packages_athena_webapp_convex_inventory_inventoryimportcostoverlayconstruction_ts",
+      "label": "inventoryImportCostOverlayConstruction.ts",
+      "norm_label": "inventoryimportcostoverlayconstruction.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
       "source_location": "L1"
     },
     {
@@ -181656,145 +181689,145 @@
     {
       "community": 124,
       "file_type": "code",
-      "id": "logicaloperationalwork_aggregateoperationalstatus",
-      "label": "aggregateOperationalStatus()",
-      "norm_label": "aggregateoperationalstatus()",
-      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
-      "source_location": "L227"
+      "id": "dailyoperations_test_buildcompletedpostransaction",
+      "label": "buildCompletedPosTransaction()",
+      "norm_label": "buildcompletedpostransaction()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
+      "source_location": "L512"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "logicaloperationalwork_canonicalsyncedsaleinventoryreviewskuid",
-      "label": "canonicalSyncedSaleInventoryReviewSkuId()",
-      "norm_label": "canonicalsyncedsaleinventoryreviewskuid()",
-      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
-      "source_location": "L167"
+      "id": "dailyoperations_test_buildctx",
+      "label": "buildCtx()",
+      "norm_label": "buildctx()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
+      "source_location": "L407"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "logicaloperationalwork_compareoperationalworkitems",
-      "label": "compareOperationalWorkItems()",
-      "norm_label": "compareoperationalworkitems()",
-      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
-      "source_location": "L252"
+      "id": "dailyoperations_test_buildfrozenclose",
+      "label": "buildFrozenClose()",
+      "norm_label": "buildfrozenclose()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
+      "source_location": "L532"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "logicaloperationalwork_comparestrings",
-      "label": "compareStrings()",
-      "norm_label": "comparestrings()",
-      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
-      "source_location": "L248"
+      "id": "dailyoperations_test_buildobservedctx",
+      "label": "buildObservedCtx()",
+      "norm_label": "buildobservedctx()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
+      "source_location": "L412"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "logicaloperationalwork_groupkey",
-      "label": "groupKey()",
-      "norm_label": "groupkey()",
-      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
-      "source_location": "L270"
+      "id": "dailyoperations_test_buildpendingregistercountseed",
+      "label": "buildPendingRegisterCountSeed()",
+      "norm_label": "buildpendingregistercountseed()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
+      "source_location": "L326"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "logicaloperationalwork_joinsourceidentity",
-      "label": "joinSourceIdentity()",
-      "norm_label": "joinsourceidentity()",
-      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
-      "source_location": "L40"
+      "id": "dailyoperations_test_createdb",
+      "label": "createDb()",
+      "norm_label": "createdb()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
+      "source_location": "L73"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "logicaloperationalwork_operationalpriorityurgency",
-      "label": "operationalPriorityUrgency()",
-      "norm_label": "operationalpriorityurgency()",
-      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
-      "source_location": "L210"
+      "id": "dailyoperations_test_frozenfinancialcompleteness",
+      "label": "frozenFinancialCompleteness()",
+      "norm_label": "frozenfinancialcompleteness()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
+      "source_location": "L434"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "logicaloperationalwork_operationalworkactionabletimestamp",
-      "label": "operationalWorkActionableTimestamp()",
-      "norm_label": "operationalworkactionabletimestamp()",
-      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
-      "source_location": "L235"
+      "id": "dailyoperations_test_frozenfinancialcompletenessforrange",
+      "label": "frozenFinancialCompletenessForRange()",
+      "norm_label": "frozenfinancialcompletenessforrange()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
+      "source_location": "L485"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "logicaloperationalwork_operationalworkmetadatastring",
-      "label": "operationalWorkMetadataString()",
-      "norm_label": "operationalworkmetadatastring()",
-      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
-      "source_location": "L32"
+      "id": "dailyoperations_test_frozenfinancialcompletenesswithexpenseoverride",
+      "label": "frozenFinancialCompletenessWithExpenseOverride()",
+      "norm_label": "frozenfinancialcompletenesswithexpenseoverride()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
+      "source_location": "L496"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "logicaloperationalwork_prioritybucket",
-      "label": "priorityBucket()",
-      "norm_label": "prioritybucket()",
-      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
-      "source_location": "L180"
+      "id": "dailyoperations_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
+      "source_location": "L420"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "logicaloperationalwork_projectlogicaloperationalwork",
-      "label": "projectLogicalOperationalWork()",
-      "norm_label": "projectlogicaloperationalwork()",
-      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
-      "source_location": "L280"
+      "id": "dailyoperations_test_metricsourceobservations",
+      "label": "metricSourceObservations()",
+      "norm_label": "metricsourceobservations()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
+      "source_location": "L677"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "logicaloperationalwork_resolvercompletenessbucket",
-      "label": "resolverCompletenessBucket()",
-      "norm_label": "resolvercompletenessbucket()",
-      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
-      "source_location": "L241"
+      "id": "dailyoperations_test_mockdailyoperationsrole",
+      "label": "mockDailyOperationsRole()",
+      "norm_label": "mockdailyoperationsrole()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
+      "source_location": "L651"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "logicaloperationalwork_stableoperationalworkitemsourceidentity",
-      "label": "stableOperationalWorkItemSourceIdentity()",
-      "norm_label": "stableoperationalworkitemsourceidentity()",
-      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
-      "source_location": "L44"
+      "id": "dailyoperations_test_operatingdaterange",
+      "label": "operatingDateRange()",
+      "norm_label": "operatingdaterange()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
+      "source_location": "L424"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "logicaloperationalwork_statusurgency",
-      "label": "statusUrgency()",
-      "norm_label": "statusurgency()",
-      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
-      "source_location": "L206"
+      "id": "dailyoperations_test_review",
+      "label": "review()",
+      "norm_label": "review()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
+      "source_location": "L3535"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "logicaloperationalwork_strongestoperationalpriority",
-      "label": "strongestOperationalPriority()",
-      "norm_label": "strongestoperationalpriority()",
-      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
-      "source_location": "L214"
+      "id": "dailyoperations_test_syncedsalereview",
+      "label": "syncedSaleReview()",
+      "norm_label": "syncedsalereview()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
+      "source_location": "L3440"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_logicaloperationalwork_ts",
-      "label": "logicalOperationalWork.ts",
-      "norm_label": "logicaloperationalwork.ts",
-      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
+      "id": "packages_athena_webapp_convex_operations_dailyoperations_test_ts",
+      "label": "dailyOperations.test.ts",
+      "norm_label": "dailyoperations.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
       "source_location": "L1"
     },
     {
@@ -181980,145 +182013,145 @@
     {
       "community": 125,
       "file_type": "code",
-      "id": "correcttransaction_adjustregistersessionexpectedcashforpaymentcorrection",
-      "label": "adjustRegisterSessionExpectedCashForPaymentCorrection()",
-      "norm_label": "adjustregistersessionexpectedcashforpaymentcorrection()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L260"
+      "id": "logicaloperationalwork_aggregateoperationalstatus",
+      "label": "aggregateOperationalStatus()",
+      "norm_label": "aggregateoperationalstatus()",
+      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
+      "source_location": "L227"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "correcttransaction_applypaymentmethodcorrection",
-      "label": "applyPaymentMethodCorrection()",
-      "norm_label": "applypaymentmethodcorrection()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L341"
+      "id": "logicaloperationalwork_canonicalsyncedsaleinventoryreviewskuid",
+      "label": "canonicalSyncedSaleInventoryReviewSkuId()",
+      "norm_label": "canonicalsyncedsaleinventoryreviewskuid()",
+      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
+      "source_location": "L167"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "correcttransaction_buildpaymentmethodcorrectionapprovalrequirement",
-      "label": "buildPaymentMethodCorrectionApprovalRequirement()",
-      "norm_label": "buildpaymentmethodcorrectionapprovalrequirement()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L66"
+      "id": "logicaloperationalwork_compareoperationalworkitems",
+      "label": "compareOperationalWorkItems()",
+      "norm_label": "compareoperationalworkitems()",
+      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
+      "source_location": "L252"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "correcttransaction_consumepaymentmethodcorrectionapprovalproof",
-      "label": "consumePaymentMethodCorrectionApprovalProof()",
-      "norm_label": "consumepaymentmethodcorrectionapprovalproof()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L310"
+      "id": "logicaloperationalwork_comparestrings",
+      "label": "compareStrings()",
+      "norm_label": "comparestrings()",
+      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
+      "source_location": "L248"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "correcttransaction_correcttransactioncustomer",
-      "label": "correctTransactionCustomer()",
-      "norm_label": "correcttransactioncustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L482"
+      "id": "logicaloperationalwork_groupkey",
+      "label": "groupKey()",
+      "norm_label": "groupkey()",
+      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
+      "source_location": "L270"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "correcttransaction_correcttransactionpaymentmethod",
-      "label": "correctTransactionPaymentMethod()",
-      "norm_label": "correcttransactionpaymentmethod()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L551"
+      "id": "logicaloperationalwork_joinsourceidentity",
+      "label": "joinSourceIdentity()",
+      "norm_label": "joinsourceidentity()",
+      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
+      "source_location": "L40"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "correcttransaction_createpaymentmethodcorrectionapprovalrequest",
-      "label": "createPaymentMethodCorrectionApprovalRequest()",
-      "norm_label": "createpaymentmethodcorrectionapprovalrequest()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L119"
+      "id": "logicaloperationalwork_operationalpriorityurgency",
+      "label": "operationalPriorityUrgency()",
+      "norm_label": "operationalpriorityurgency()",
+      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
+      "source_location": "L210"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "correcttransaction_getpaymentmethodcashcontribution",
-      "label": "getPaymentMethodCashContribution()",
-      "norm_label": "getpaymentmethodcashcontribution()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L225"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "correcttransaction_getstringmetadata",
-      "label": "getStringMetadata()",
-      "norm_label": "getstringmetadata()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L683"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "correcttransaction_requirecompletedtransaction",
-      "label": "requireCompletedTransaction()",
-      "norm_label": "requirecompletedtransaction()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L208"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "correcttransaction_requirematchingpendingpaymentmethodcorrectionapprovalrequest",
-      "label": "requireMatchingPendingPaymentMethodCorrectionApprovalRequest()",
-      "norm_label": "requirematchingpendingpaymentmethodcorrectionapprovalrequest()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L691"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "correcttransaction_requireregistersessionallowspaymentcorrection",
-      "label": "requireRegisterSessionAllowsPaymentCorrection()",
-      "norm_label": "requireregistersessionallowspaymentcorrection()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "id": "logicaloperationalwork_operationalworkactionabletimestamp",
+      "label": "operationalWorkActionableTimestamp()",
+      "norm_label": "operationalworkactionabletimestamp()",
+      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
       "source_location": "L235"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "correcttransaction_resolvepaymentmethodcorrectionapprovaldecisionwithctx",
-      "label": "resolvePaymentMethodCorrectionApprovalDecisionWithCtx()",
-      "norm_label": "resolvepaymentmethodcorrectionapprovaldecisionwithctx()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L752"
+      "id": "logicaloperationalwork_operationalworkmetadatastring",
+      "label": "operationalWorkMetadataString()",
+      "norm_label": "operationalworkmetadatastring()",
+      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
+      "source_location": "L32"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "correcttransaction_transactionlabel",
-      "label": "transactionLabel()",
-      "norm_label": "transactionlabel()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L39"
+      "id": "logicaloperationalwork_prioritybucket",
+      "label": "priorityBucket()",
+      "norm_label": "prioritybucket()",
+      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
+      "source_location": "L180"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "correcttransaction_transactionlabelfromapprovalrequest",
-      "label": "transactionLabelFromApprovalRequest()",
-      "norm_label": "transactionlabelfromapprovalrequest()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L43"
+      "id": "logicaloperationalwork_projectlogicaloperationalwork",
+      "label": "projectLogicalOperationalWork()",
+      "norm_label": "projectlogicaloperationalwork()",
+      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
+      "source_location": "L280"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_correcttransaction_ts",
-      "label": "correctTransaction.ts",
-      "norm_label": "correcttransaction.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "id": "logicaloperationalwork_resolvercompletenessbucket",
+      "label": "resolverCompletenessBucket()",
+      "norm_label": "resolvercompletenessbucket()",
+      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
+      "source_location": "L241"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "logicaloperationalwork_stableoperationalworkitemsourceidentity",
+      "label": "stableOperationalWorkItemSourceIdentity()",
+      "norm_label": "stableoperationalworkitemsourceidentity()",
+      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
+      "source_location": "L44"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "logicaloperationalwork_statusurgency",
+      "label": "statusUrgency()",
+      "norm_label": "statusurgency()",
+      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
+      "source_location": "L206"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "logicaloperationalwork_strongestoperationalpriority",
+      "label": "strongestOperationalPriority()",
+      "norm_label": "strongestoperationalpriority()",
+      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
+      "source_location": "L214"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_logicaloperationalwork_ts",
+      "label": "logicalOperationalWork.ts",
+      "norm_label": "logicaloperationalwork.ts",
+      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
       "source_location": "L1"
     },
     {
@@ -182304,146 +182337,146 @@
     {
       "community": 126,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_queries_storepulse_ts",
-      "label": "storePulse.ts",
-      "norm_label": "storepulse.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
+      "id": "correcttransaction_adjustregistersessionexpectedcashforpaymentcorrection",
+      "label": "adjustRegisterSessionExpectedCashForPaymentCorrection()",
+      "norm_label": "adjustregistersessionexpectedcashforpaymentcorrection()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L260"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "correcttransaction_applypaymentmethodcorrection",
+      "label": "applyPaymentMethodCorrection()",
+      "norm_label": "applypaymentmethodcorrection()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L341"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "correcttransaction_buildpaymentmethodcorrectionapprovalrequirement",
+      "label": "buildPaymentMethodCorrectionApprovalRequirement()",
+      "norm_label": "buildpaymentmethodcorrectionapprovalrequirement()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "correcttransaction_consumepaymentmethodcorrectionapprovalproof",
+      "label": "consumePaymentMethodCorrectionApprovalProof()",
+      "norm_label": "consumepaymentmethodcorrectionapprovalproof()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L310"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "correcttransaction_correcttransactioncustomer",
+      "label": "correctTransactionCustomer()",
+      "norm_label": "correcttransactioncustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L482"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "correcttransaction_correcttransactionpaymentmethod",
+      "label": "correctTransactionPaymentMethod()",
+      "norm_label": "correcttransactionpaymentmethod()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L551"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "correcttransaction_createpaymentmethodcorrectionapprovalrequest",
+      "label": "createPaymentMethodCorrectionApprovalRequest()",
+      "norm_label": "createpaymentmethodcorrectionapprovalrequest()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L119"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "correcttransaction_getpaymentmethodcashcontribution",
+      "label": "getPaymentMethodCashContribution()",
+      "norm_label": "getpaymentmethodcashcontribution()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L225"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "correcttransaction_getstringmetadata",
+      "label": "getStringMetadata()",
+      "norm_label": "getstringmetadata()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L683"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "correcttransaction_requirecompletedtransaction",
+      "label": "requireCompletedTransaction()",
+      "norm_label": "requirecompletedtransaction()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L208"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "correcttransaction_requirematchingpendingpaymentmethodcorrectionapprovalrequest",
+      "label": "requireMatchingPendingPaymentMethodCorrectionApprovalRequest()",
+      "norm_label": "requirematchingpendingpaymentmethodcorrectionapprovalrequest()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L691"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "correcttransaction_requireregistersessionallowspaymentcorrection",
+      "label": "requireRegisterSessionAllowsPaymentCorrection()",
+      "norm_label": "requireregistersessionallowspaymentcorrection()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L235"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "correcttransaction_resolvepaymentmethodcorrectionapprovaldecisionwithctx",
+      "label": "resolvePaymentMethodCorrectionApprovalDecisionWithCtx()",
+      "norm_label": "resolvepaymentmethodcorrectionapprovaldecisionwithctx()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L752"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "correcttransaction_transactionlabel",
+      "label": "transactionLabel()",
+      "norm_label": "transactionlabel()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "correcttransaction_transactionlabelfromapprovalrequest",
+      "label": "transactionLabelFromApprovalRequest()",
+      "norm_label": "transactionlabelfromapprovalrequest()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_correcttransaction_ts",
+      "label": "correctTransaction.ts",
+      "norm_label": "correcttransaction.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "storepulse_buildposoperatorsnapshot",
-      "label": "buildPosOperatorSnapshot()",
-      "norm_label": "buildposoperatorsnapshot()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
-      "source_location": "L355"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "storepulse_buildrecentdaybuckets",
-      "label": "buildRecentDayBuckets()",
-      "norm_label": "buildrecentdaybuckets()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
-      "source_location": "L719"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "storepulse_buildsummarytrendbucket",
-      "label": "buildSummaryTrendBucket()",
-      "norm_label": "buildsummarytrendbucket()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
-      "source_location": "L734"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "storepulse_buildtransactiondatebuckets",
-      "label": "buildTransactionDateBuckets()",
-      "norm_label": "buildtransactiondatebuckets()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
-      "source_location": "L754"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "storepulse_calculatedeltapercent",
-      "label": "calculateDeltaPercent()",
-      "norm_label": "calculatedeltapercent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "storepulse_formathourlabel",
-      "label": "formatHourLabel()",
-      "norm_label": "formathourlabel()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
-      "source_location": "L821"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "storepulse_formatpaymentmethodlabel",
-      "label": "formatPaymentMethodLabel()",
-      "norm_label": "formatpaymentmethodlabel()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
-      "source_location": "L828"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "storepulse_formatshortdate",
-      "label": "formatShortDate()",
-      "norm_label": "formatshortdate()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
-      "source_location": "L800"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "storepulse_getfixedhistorybucketdate",
-      "label": "getFixedHistoryBucketDate()",
-      "norm_label": "getfixedhistorybucketdate()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
-      "source_location": "L787"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "storepulse_getstorepulsesummariesforoperatingdateranges",
-      "label": "getStorePulseSummariesForOperatingDateRanges()",
-      "norm_label": "getstorepulsesummariesforoperatingdateranges()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
-      "source_location": "L151"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "storepulse_getstorepulsesummaryforwindow",
-      "label": "getStorePulseSummaryForWindow()",
-      "norm_label": "getstorepulsesummaryforwindow()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "storepulse_parseoperatingdatestart",
-      "label": "parseOperatingDateStart()",
-      "norm_label": "parseoperatingdatestart()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
-      "source_location": "L712"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "storepulse_resolvepospulsewindow",
-      "label": "resolvePosPulseWindow()",
-      "norm_label": "resolvepospulsewindow()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
-      "source_location": "L583"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "storepulse_summarizepospulsetransactions",
-      "label": "summarizePosPulseTransactions()",
-      "norm_label": "summarizepospulsetransactions()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
-      "source_location": "L334"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "storepulse_toisodate",
-      "label": "toIsoDate()",
-      "norm_label": "toisodate()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
-      "source_location": "L796"
     },
     {
       "community": 1260,
@@ -182628,146 +182661,146 @@
     {
       "community": 127,
       "file_type": "code",
-      "id": "catalog_buildpendingcheckoutfinalizationpayloadhash",
-      "label": "buildPendingCheckoutFinalizationPayloadHash()",
-      "norm_label": "buildpendingcheckoutfinalizationpayloadhash()",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
-      "source_location": "L431"
+      "id": "packages_athena_webapp_convex_pos_application_queries_storepulse_ts",
+      "label": "storePulse.ts",
+      "norm_label": "storepulse.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
+      "source_location": "L1"
     },
     {
       "community": 127,
       "file_type": "code",
-      "id": "catalog_buildpendingcheckoutsaleevidencefingerprint",
-      "label": "buildPendingCheckoutSaleEvidenceFingerprint()",
-      "norm_label": "buildpendingcheckoutsaleevidencefingerprint()",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
-      "source_location": "L322"
+      "id": "storepulse_buildposoperatorsnapshot",
+      "label": "buildPosOperatorSnapshot()",
+      "norm_label": "buildposoperatorsnapshot()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
+      "source_location": "L355"
     },
     {
       "community": 127,
       "file_type": "code",
-      "id": "catalog_buildtrustedskufingerprint",
-      "label": "buildTrustedSkuFingerprint()",
-      "norm_label": "buildtrustedskufingerprint()",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
-      "source_location": "L335"
+      "id": "storepulse_buildrecentdaybuckets",
+      "label": "buildRecentDayBuckets()",
+      "norm_label": "buildrecentdaybuckets()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
+      "source_location": "L719"
     },
     {
       "community": 127,
       "file_type": "code",
-      "id": "catalog_islinkedpendingcheckoutaliasvisible",
-      "label": "isLinkedPendingCheckoutAliasVisible()",
-      "norm_label": "islinkedpendingcheckoutaliasvisible()",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
-      "source_location": "L234"
+      "id": "storepulse_buildsummarytrendbucket",
+      "label": "buildSummaryTrendBucket()",
+      "norm_label": "buildsummarytrendbucket()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
+      "source_location": "L734"
     },
     {
       "community": 127,
       "file_type": "code",
-      "id": "catalog_listpendingcheckoutproductpagebindingwithctx",
-      "label": "listPendingCheckoutProductPageBindingWithCtx()",
-      "norm_label": "listpendingcheckoutproductpagebindingwithctx()",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
+      "id": "storepulse_buildtransactiondatebuckets",
+      "label": "buildTransactionDateBuckets()",
+      "norm_label": "buildtransactiondatebuckets()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
+      "source_location": "L754"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "storepulse_calculatedeltapercent",
+      "label": "calculateDeltaPercent()",
+      "norm_label": "calculatedeltapercent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "storepulse_formathourlabel",
+      "label": "formatHourLabel()",
+      "norm_label": "formathourlabel()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
+      "source_location": "L821"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "storepulse_formatpaymentmethodlabel",
+      "label": "formatPaymentMethodLabel()",
+      "norm_label": "formatpaymentmethodlabel()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
+      "source_location": "L828"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "storepulse_formatshortdate",
+      "label": "formatShortDate()",
+      "norm_label": "formatshortdate()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
+      "source_location": "L800"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "storepulse_getfixedhistorybucketdate",
+      "label": "getFixedHistoryBucketDate()",
+      "norm_label": "getfixedhistorybucketdate()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
+      "source_location": "L787"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "storepulse_getstorepulsesummariesforoperatingdateranges",
+      "label": "getStorePulseSummariesForOperatingDateRanges()",
+      "norm_label": "getstorepulsesummariesforoperatingdateranges()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
+      "source_location": "L151"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "storepulse_getstorepulsesummaryforwindow",
+      "label": "getStorePulseSummaryForWindow()",
+      "norm_label": "getstorepulsesummaryforwindow()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "storepulse_parseoperatingdatestart",
+      "label": "parseOperatingDateStart()",
+      "norm_label": "parseoperatingdatestart()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
+      "source_location": "L712"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "storepulse_resolvepospulsewindow",
+      "label": "resolvePosPulseWindow()",
+      "norm_label": "resolvepospulsewindow()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
       "source_location": "L583"
     },
     {
       "community": 127,
       "file_type": "code",
-      "id": "catalog_mappendingcheckoutreviewstatustoworkitempatch",
-      "label": "mapPendingCheckoutReviewStatusToWorkItemPatch()",
-      "norm_label": "mappendingcheckoutreviewstatustoworkitempatch()",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
-      "source_location": "L305"
+      "id": "storepulse_summarizepospulsetransactions",
+      "label": "summarizePosPulseTransactions()",
+      "norm_label": "summarizepospulsetransactions()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
+      "source_location": "L334"
     },
     {
       "community": 127,
       "file_type": "code",
-      "id": "catalog_omitundefined",
-      "label": "omitUndefined()",
-      "norm_label": "omitundefined()",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
-      "source_location": "L452"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "catalog_pendingcheckoutlinkpricesmatch",
-      "label": "pendingCheckoutLinkPricesMatch()",
-      "norm_label": "pendingcheckoutlinkpricesmatch()",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
-      "source_location": "L347"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "catalog_requirependingcheckoutreviewaccess",
-      "label": "requirePendingCheckoutReviewAccess()",
-      "norm_label": "requirependingcheckoutreviewaccess()",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
-      "source_location": "L563"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "catalog_requirependingcheckoutsalecontext",
-      "label": "requirePendingCheckoutSaleContext()",
-      "norm_label": "requirependingcheckoutsalecontext()",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
-      "source_location": "L504"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "catalog_requireregistercatalogstoreaccess",
-      "label": "requireRegisterCatalogStoreAccess()",
-      "norm_label": "requireregistercatalogstoreaccess()",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
-      "source_location": "L474"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "catalog_reviewedposvisiblefor",
-      "label": "reviewedPosVisibleFor()",
-      "norm_label": "reviewedposvisiblefor()",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
-      "source_location": "L354"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "catalog_stablestringify",
-      "label": "stableStringify()",
-      "norm_label": "stablestringify()",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
-      "source_location": "L458"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "catalog_topendingcheckoutreviewitem",
-      "label": "toPendingCheckoutReviewItem()",
-      "norm_label": "topendingcheckoutreviewitem()",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
-      "source_location": "L290"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "catalog_validatereviewedtrustedinventoryfields",
-      "label": "validateReviewedTrustedInventoryFields()",
-      "norm_label": "validatereviewedtrustedinventoryfields()",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
-      "source_location": "L363"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_public_catalog_ts",
-      "label": "catalog.ts",
-      "norm_label": "catalog.ts",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
-      "source_location": "L1"
+      "id": "storepulse_toisodate",
+      "label": "toIsoDate()",
+      "norm_label": "toisodate()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
+      "source_location": "L796"
     },
     {
       "community": 1270,
@@ -182952,146 +182985,146 @@
     {
       "community": 128,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_skumixrange_test_ts",
-      "label": "skuMixRange.test.ts",
-      "norm_label": "skumixrange.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
-      "source_location": "L1"
+      "id": "catalog_buildpendingcheckoutfinalizationpayloadhash",
+      "label": "buildPendingCheckoutFinalizationPayloadHash()",
+      "norm_label": "buildpendingcheckoutfinalizationpayloadhash()",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
+      "source_location": "L431"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "skumixrange_test_admitone",
-      "label": "admitOne()",
-      "norm_label": "admitone()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
-      "source_location": "L365"
+      "id": "catalog_buildpendingcheckoutsaleevidencefingerprint",
+      "label": "buildPendingCheckoutSaleEvidenceFingerprint()",
+      "norm_label": "buildpendingcheckoutsaleevidencefingerprint()",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
+      "source_location": "L322"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "skumixrange_test_allow",
-      "label": "allow()",
-      "norm_label": "allow()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "skumixrange_test_certifyday",
-      "label": "certifyDay()",
-      "norm_label": "certifyday()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
-      "source_location": "L253"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "skumixrange_test_completedmix",
-      "label": "completedMix()",
-      "norm_label": "completedmix()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
-      "source_location": "L959"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "skumixrange_test_drive",
-      "label": "drive()",
-      "norm_label": "drive()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
+      "id": "catalog_buildtrustedskufingerprint",
+      "label": "buildTrustedSkuFingerprint()",
+      "norm_label": "buildtrustedskufingerprint()",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
       "source_location": "L335"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "skumixrange_test_ensure",
-      "label": "ensure()",
-      "norm_label": "ensure()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
-      "source_location": "L298"
+      "id": "catalog_islinkedpendingcheckoutaliasvisible",
+      "label": "isLinkedPendingCheckoutAliasVisible()",
+      "norm_label": "islinkedpendingcheckoutaliasvisible()",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
+      "source_location": "L234"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "skumixrange_test_handlerof",
-      "label": "handlerOf()",
-      "norm_label": "handlerof()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
-      "source_location": "L123"
+      "id": "catalog_listpendingcheckoutproductpagebindingwithctx",
+      "label": "listPendingCheckoutProductPageBindingWithCtx()",
+      "norm_label": "listpendingcheckoutproductpagebindingwithctx()",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
+      "source_location": "L583"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "skumixrange_test_headerbykey",
-      "label": "headerByKey()",
-      "norm_label": "headerbykey()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
-      "source_location": "L319"
+      "id": "catalog_mappendingcheckoutreviewstatustoworkitempatch",
+      "label": "mapPendingCheckoutReviewStatusToWorkItemPatch()",
+      "norm_label": "mappendingcheckoutreviewstatustoworkitempatch()",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
+      "source_location": "L305"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "skumixrange_test_isodateoffset",
-      "label": "isoDateOffset()",
-      "norm_label": "isodateoffset()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
-      "source_location": "L113"
+      "id": "catalog_omitundefined",
+      "label": "omitUndefined()",
+      "norm_label": "omitundefined()",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
+      "source_location": "L452"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "skumixrange_test_mixchildren",
-      "label": "mixChildren()",
-      "norm_label": "mixchildren()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
-      "source_location": "L377"
+      "id": "catalog_pendingcheckoutlinkpricesmatch",
+      "label": "pendingCheckoutLinkPricesMatch()",
+      "norm_label": "pendingcheckoutlinkpricesmatch()",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
+      "source_location": "L347"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "skumixrange_test_seedskus",
-      "label": "seedSkus()",
-      "norm_label": "seedskus()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
-      "source_location": "L177"
+      "id": "catalog_requirependingcheckoutreviewaccess",
+      "label": "requirePendingCheckoutReviewAccess()",
+      "norm_label": "requirependingcheckoutreviewaccess()",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
+      "source_location": "L563"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "skumixrange_test_seedstore",
-      "label": "seedStore()",
-      "norm_label": "seedstore()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
-      "source_location": "L155"
+      "id": "catalog_requirependingcheckoutsalecontext",
+      "label": "requirePendingCheckoutSaleContext()",
+      "norm_label": "requirependingcheckoutsalecontext()",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
+      "source_location": "L504"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "skumixrange_test_step",
-      "label": "step()",
-      "norm_label": "step()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
-      "source_location": "L1082"
+      "id": "catalog_requireregistercatalogstoreaccess",
+      "label": "requireRegisterCatalogStoreAccess()",
+      "norm_label": "requireregistercatalogstoreaccess()",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
+      "source_location": "L474"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "skumixrange_test_twodayfixture",
-      "label": "twoDayFixture()",
-      "norm_label": "twodayfixture()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
-      "source_location": "L1066"
+      "id": "catalog_reviewedposvisiblefor",
+      "label": "reviewedPosVisibleFor()",
+      "norm_label": "reviewedposvisiblefor()",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
+      "source_location": "L354"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "skumixrange_test_visible",
-      "label": "visible()",
-      "norm_label": "visible()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
-      "source_location": "L393"
+      "id": "catalog_stablestringify",
+      "label": "stableStringify()",
+      "norm_label": "stablestringify()",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
+      "source_location": "L458"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "catalog_topendingcheckoutreviewitem",
+      "label": "toPendingCheckoutReviewItem()",
+      "norm_label": "topendingcheckoutreviewitem()",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
+      "source_location": "L290"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "catalog_validatereviewedtrustedinventoryfields",
+      "label": "validateReviewedTrustedInventoryFields()",
+      "norm_label": "validatereviewedtrustedinventoryfields()",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
+      "source_location": "L363"
+    },
+    {
+      "community": 128,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_public_catalog_ts",
+      "label": "catalog.ts",
+      "norm_label": "catalog.ts",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
+      "source_location": "L1"
     },
     {
       "community": 1280,
@@ -183276,146 +183309,146 @@
     {
       "community": 129,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_sweeper_ts",
-      "label": "sweeper.ts",
-      "norm_label": "sweeper.ts",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "id": "packages_athena_webapp_convex_reports_skumixrange_test_ts",
+      "label": "skuMixRange.test.ts",
+      "norm_label": "skumixrange.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
       "source_location": "L1"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "sweeper_computependingranges",
-      "label": "computePendingRanges()",
-      "norm_label": "computependingranges()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L472"
+      "id": "skumixrange_test_admitone",
+      "label": "admitOne()",
+      "norm_label": "admitone()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
+      "source_location": "L365"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "sweeper_daycapexceeded",
-      "label": "DayCapExceeded",
-      "norm_label": "daycapexceeded",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "id": "skumixrange_test_allow",
+      "label": "allow()",
+      "norm_label": "allow()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "skumixrange_test_certifyday",
+      "label": "certifyDay()",
+      "norm_label": "certifyday()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
+      "source_location": "L253"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "skumixrange_test_completedmix",
+      "label": "completedMix()",
+      "norm_label": "completedmix()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
+      "source_location": "L959"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "skumixrange_test_drive",
+      "label": "drive()",
+      "norm_label": "drive()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
+      "source_location": "L335"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "skumixrange_test_ensure",
+      "label": "ensure()",
+      "norm_label": "ensure()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
+      "source_location": "L298"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "skumixrange_test_handlerof",
+      "label": "handlerOf()",
+      "norm_label": "handlerof()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
+      "source_location": "L123"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "skumixrange_test_headerbykey",
+      "label": "headerByKey()",
+      "norm_label": "headerbykey()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
+      "source_location": "L319"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "skumixrange_test_isodateoffset",
+      "label": "isoDateOffset()",
+      "norm_label": "isodateoffset()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
       "source_location": "L113"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "sweeper_daycapexceeded_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L114"
+      "id": "skumixrange_test_mixchildren",
+      "label": "mixChildren()",
+      "norm_label": "mixchildren()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
+      "source_location": "L377"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "sweeper_expirerangeresults",
-      "label": "expireRangeResults()",
-      "norm_label": "expirerangeresults()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L510"
+      "id": "skumixrange_test_seedskus",
+      "label": "seedSkus()",
+      "norm_label": "seedskus()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
+      "source_location": "L177"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "sweeper_findopenoperatingdate",
-      "label": "findOpenOperatingDate()",
-      "norm_label": "findopenoperatingdate()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L455"
+      "id": "skumixrange_test_seedstore",
+      "label": "seedStore()",
+      "norm_label": "seedstore()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
+      "source_location": "L155"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "sweeper_foldandreplaceday",
-      "label": "foldAndReplaceDay()",
-      "norm_label": "foldandreplaceday()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L258"
+      "id": "skumixrange_test_step",
+      "label": "step()",
+      "norm_label": "step()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
+      "source_location": "L1082"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "sweeper_loadacceptedclose",
-      "label": "loadAcceptedClose()",
-      "norm_label": "loadacceptedclose()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L232"
+      "id": "skumixrange_test_twodayfixture",
+      "label": "twoDayFixture()",
+      "norm_label": "twodayfixture()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
+      "source_location": "L1066"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "sweeper_markdaydirty",
-      "label": "markDayDirty()",
-      "norm_label": "markdaydirty()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L419"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "sweeper_parsestoreallowlist",
-      "label": "parseStoreAllowlist()",
-      "norm_label": "parsestoreallowlist()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L136"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "sweeper_rangesnapshotkindconfigs",
-      "label": "rangeSnapshotKindConfigs()",
-      "norm_label": "rangesnapshotkindconfigs()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L542"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "sweeper_readstoreallowlist",
-      "label": "readStoreAllowlist()",
-      "norm_label": "readstoreallowlist()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L146"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "sweeper_selectacceptedclose",
-      "label": "selectAcceptedClose()",
-      "norm_label": "selectacceptedclose()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L198"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "sweeper_sweepwithctx",
-      "label": "sweepWithCtx()",
-      "norm_label": "sweepwithctx()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L546"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "sweeper_tocloseref",
-      "label": "toCloseRef()",
-      "norm_label": "tocloseref()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L214"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "sweeper_tofoldfact",
-      "label": "toFoldFact()",
-      "norm_label": "tofoldfact()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L154"
+      "id": "skumixrange_test_visible",
+      "label": "visible()",
+      "norm_label": "visible()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
+      "source_location": "L393"
     },
     {
       "community": 1290,
@@ -198045,119 +198078,119 @@
     {
       "community": 171,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
-      "source_location": "L1"
+      "id": "backfillstoreschedules_backfillstoreschedulesfromlegacypolicywithctx",
+      "label": "backfillStoreSchedulesFromLegacyPolicyWithCtx()",
+      "norm_label": "backfillstoreschedulesfromlegacypolicywithctx()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L324"
     },
     {
       "community": 171,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
+      "id": "backfillstoreschedules_buildbackfillrow",
+      "label": "buildBackfillRow()",
+      "norm_label": "buildbackfillrow()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L187"
     },
     {
       "community": 171,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L1"
+      "id": "backfillstoreschedules_buildcandidateweeklywindows",
+      "label": "buildCandidateWeeklyWindows()",
+      "norm_label": "buildcandidateweeklywindows()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L163"
     },
     {
       "community": 171,
       "file_type": "code",
-      "id": "utils_formatdeliveryaddress",
-      "label": "formatDeliveryAddress()",
-      "norm_label": "formatdeliveryaddress()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L74"
+      "id": "backfillstoreschedules_compatibilitymetadata",
+      "label": "compatibilityMetadata()",
+      "norm_label": "compatibilitymetadata()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L133"
     },
     {
       "community": 171,
       "file_type": "code",
-      "id": "utils_getamountpaidfororder",
-      "label": "getAmountPaidForOrder()",
-      "norm_label": "getamountpaidfororder()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L191"
+      "id": "backfillstoreschedules_compatibilityonlyrow",
+      "label": "compatibilityOnlyRow()",
+      "norm_label": "compatibilityonlyrow()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L174"
     },
     {
       "community": 171,
       "file_type": "code",
-      "id": "utils_getdiscountvalue",
-      "label": "getDiscountValue()",
-      "norm_label": "getdiscountvalue()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L17"
+      "id": "backfillstoreschedules_findexistingscheduletoskip",
+      "label": "findExistingScheduleToSkip()",
+      "norm_label": "findexistingscheduletoskip()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L114"
     },
     {
       "community": 171,
       "file_type": "code",
-      "id": "utils_getonlineorderplacedat",
-      "label": "getOnlineOrderPlacedAt()",
-      "norm_label": "getonlineorderplacedat()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 171,
-      "file_type": "code",
-      "id": "utils_getorderamount",
-      "label": "getOrderAmount()",
-      "norm_label": "getorderamount()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 171,
-      "file_type": "code",
-      "id": "utils_getorderstate",
-      "label": "getOrderState()",
-      "norm_label": "getorderstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 171,
-      "file_type": "code",
-      "id": "utils_getpickupactionstate",
-      "label": "getPickupActionState()",
-      "norm_label": "getpickupactionstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 171,
-      "file_type": "code",
-      "id": "utils_getpotentialpoints",
-      "label": "getPotentialPoints()",
-      "norm_label": "getpotentialpoints()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 171,
-      "file_type": "code",
-      "id": "utils_getproductdiscountvalue",
-      "label": "getProductDiscountValue()",
-      "norm_label": "getproductdiscountvalue()",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "id": "backfillstoreschedules_firstpolicy",
+      "label": "firstPolicy()",
+      "norm_label": "firstpolicy()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
       "source_location": "L75"
     },
     {
       "community": 171,
       "file_type": "code",
-      "id": "utils_shouldshowpickupexceptionaction",
-      "label": "shouldShowPickupExceptionAction()",
-      "norm_label": "shouldshowpickupexceptionaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L116"
+      "id": "backfillstoreschedules_isvalidminute",
+      "label": "isValidMinute()",
+      "norm_label": "isvalidminute()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "backfillstoreschedules_listpoliciesforstoreaction",
+      "label": "listPoliciesForStoreAction()",
+      "norm_label": "listpoliciesforstoreaction()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L81"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "backfillstoreschedules_listschedulesforstorebystatus",
+      "label": "listSchedulesForStoreByStatus()",
+      "norm_label": "listschedulesforstorebystatus()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L99"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "backfillstoreschedules_normalizelimit",
+      "label": "normalizeLimit()",
+      "norm_label": "normalizelimit()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "backfillstoreschedules_trustedtimezoneforstore",
+      "label": "trustedTimezoneForStore()",
+      "norm_label": "trustedtimezoneforstore()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L126"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_migrations_backfillstoreschedules_ts",
+      "label": "backfillStoreSchedules.ts",
+      "norm_label": "backfillstoreschedules.ts",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L1"
     },
     {
       "community": 1710,
@@ -198252,119 +198285,119 @@
     {
       "community": 172,
       "file_type": "code",
-      "id": "backfillstoreschedules_backfillstoreschedulesfromlegacypolicywithctx",
-      "label": "backfillStoreSchedulesFromLegacyPolicyWithCtx()",
-      "norm_label": "backfillstoreschedulesfromlegacypolicywithctx()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L324"
-    },
-    {
-      "community": 172,
-      "file_type": "code",
-      "id": "backfillstoreschedules_buildbackfillrow",
-      "label": "buildBackfillRow()",
-      "norm_label": "buildbackfillrow()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L187"
-    },
-    {
-      "community": 172,
-      "file_type": "code",
-      "id": "backfillstoreschedules_buildcandidateweeklywindows",
-      "label": "buildCandidateWeeklyWindows()",
-      "norm_label": "buildcandidateweeklywindows()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L163"
-    },
-    {
-      "community": 172,
-      "file_type": "code",
-      "id": "backfillstoreschedules_compatibilitymetadata",
-      "label": "compatibilityMetadata()",
-      "norm_label": "compatibilitymetadata()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L133"
-    },
-    {
-      "community": 172,
-      "file_type": "code",
-      "id": "backfillstoreschedules_compatibilityonlyrow",
-      "label": "compatibilityOnlyRow()",
-      "norm_label": "compatibilityonlyrow()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L174"
-    },
-    {
-      "community": 172,
-      "file_type": "code",
-      "id": "backfillstoreschedules_findexistingscheduletoskip",
-      "label": "findExistingScheduleToSkip()",
-      "norm_label": "findexistingscheduletoskip()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L114"
-    },
-    {
-      "community": 172,
-      "file_type": "code",
-      "id": "backfillstoreschedules_firstpolicy",
-      "label": "firstPolicy()",
-      "norm_label": "firstpolicy()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 172,
-      "file_type": "code",
-      "id": "backfillstoreschedules_isvalidminute",
-      "label": "isValidMinute()",
-      "norm_label": "isvalidminute()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 172,
-      "file_type": "code",
-      "id": "backfillstoreschedules_listpoliciesforstoreaction",
-      "label": "listPoliciesForStoreAction()",
-      "norm_label": "listpoliciesforstoreaction()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L81"
-    },
-    {
-      "community": 172,
-      "file_type": "code",
-      "id": "backfillstoreschedules_listschedulesforstorebystatus",
-      "label": "listSchedulesForStoreByStatus()",
-      "norm_label": "listschedulesforstorebystatus()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L99"
-    },
-    {
-      "community": 172,
-      "file_type": "code",
-      "id": "backfillstoreschedules_normalizelimit",
-      "label": "normalizeLimit()",
-      "norm_label": "normalizelimit()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 172,
-      "file_type": "code",
-      "id": "backfillstoreschedules_trustedtimezoneforstore",
-      "label": "trustedTimezoneForStore()",
-      "norm_label": "trustedtimezoneforstore()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L126"
-    },
-    {
-      "community": 172,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_migrations_backfillstoreschedules_ts",
-      "label": "backfillStoreSchedules.ts",
-      "norm_label": "backfillstoreschedules.ts",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "id": "packages_athena_webapp_convex_operationadmission_readdefinitions_ts",
+      "label": "readDefinitions.ts",
+      "norm_label": "readdefinitions.ts",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 172,
+      "file_type": "code",
+      "id": "readdefinitions_definecashcontrolsread",
+      "label": "defineCashControlsRead()",
+      "norm_label": "definecashcontrolsread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 172,
+      "file_type": "code",
+      "id": "readdefinitions_definedailycloseread",
+      "label": "defineDailyCloseRead()",
+      "norm_label": "definedailycloseread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 172,
+      "file_type": "code",
+      "id": "readdefinitions_definedailyoperationsread",
+      "label": "defineDailyOperationsRead()",
+      "norm_label": "definedailyoperationsread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 172,
+      "file_type": "code",
+      "id": "readdefinitions_defineinventorycatalogread",
+      "label": "defineInventoryCatalogRead()",
+      "norm_label": "defineinventorycatalogread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 172,
+      "file_type": "code",
+      "id": "readdefinitions_defineinventorycostoverlayread",
+      "label": "defineInventoryCostOverlayRead()",
+      "norm_label": "defineinventorycostoverlayread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L639"
+    },
+    {
+      "community": 172,
+      "file_type": "code",
+      "id": "readdefinitions_defineonlineordersread",
+      "label": "defineOnlineOrdersRead()",
+      "norm_label": "defineonlineordersread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 172,
+      "file_type": "code",
+      "id": "readdefinitions_defineoperationalworkread",
+      "label": "defineOperationalWorkRead()",
+      "norm_label": "defineoperationalworkread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 172,
+      "file_type": "code",
+      "id": "readdefinitions_defineorganizationread",
+      "label": "defineOrganizationRead()",
+      "norm_label": "defineorganizationread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L94"
+    },
+    {
+      "community": 172,
+      "file_type": "code",
+      "id": "readdefinitions_defineposread",
+      "label": "definePosRead()",
+      "norm_label": "defineposread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 172,
+      "file_type": "code",
+      "id": "readdefinitions_definereadoperation",
+      "label": "defineReadOperation()",
+      "norm_label": "definereadoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 172,
+      "file_type": "code",
+      "id": "readdefinitions_definestockadjustmentsread",
+      "label": "defineStockAdjustmentsRead()",
+      "norm_label": "definestockadjustmentsread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L60"
+    },
+    {
+      "community": 172,
+      "file_type": "code",
+      "id": "readdefinitions_validatereadoperationdefinition",
+      "label": "validateReadOperationDefinition()",
+      "norm_label": "validatereadoperationdefinition()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L781"
     },
     {
       "community": 1720,
@@ -198459,119 +198492,119 @@
     {
       "community": 173,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operationadmission_readdefinitions_ts",
-      "label": "readDefinitions.ts",
-      "norm_label": "readdefinitions.ts",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "id": "frozenmetricauthority_closecandidateoperatingrange",
+      "label": "closeCandidateOperatingRange()",
+      "norm_label": "closecandidateoperatingrange()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L199"
+    },
+    {
+      "community": 173,
+      "file_type": "code",
+      "id": "frozenmetricauthority_emptyclosesummary",
+      "label": "emptyCloseSummary()",
+      "norm_label": "emptyclosesummary()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 173,
+      "file_type": "code",
+      "id": "frozenmetricauthority_exactstatuses",
+      "label": "exactStatuses()",
+      "norm_label": "exactstatuses()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 173,
+      "file_type": "code",
+      "id": "frozenmetricauthority_finitenumber",
+      "label": "finiteNumber()",
+      "norm_label": "finitenumber()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L91"
+    },
+    {
+      "community": 173,
+      "file_type": "code",
+      "id": "frozenmetricauthority_frozenfinancialsourcecounts",
+      "label": "frozenFinancialSourceCounts()",
+      "norm_label": "frozenfinancialsourcecounts()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L133"
+    },
+    {
+      "community": 173,
+      "file_type": "code",
+      "id": "frozenmetricauthority_frozenweekmetricfordate",
+      "label": "frozenWeekMetricForDate()",
+      "norm_label": "frozenweekmetricfordate()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L481"
+    },
+    {
+      "community": 173,
+      "file_type": "code",
+      "id": "frozenmetricauthority_matchesrequestedoperatingrange",
+      "label": "matchesRequestedOperatingRange()",
+      "norm_label": "matchesrequestedoperatingrange()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L102"
+    },
+    {
+      "community": 173,
+      "file_type": "code",
+      "id": "frozenmetricauthority_normalizefrozenpaymenttotals",
+      "label": "normalizeFrozenPaymentTotals()",
+      "norm_label": "normalizefrozenpaymenttotals()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L241"
+    },
+    {
+      "community": 173,
+      "file_type": "code",
+      "id": "frozenmetricauthority_recordvalue",
+      "label": "recordValue()",
+      "norm_label": "recordvalue()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 173,
+      "file_type": "code",
+      "id": "frozenmetricauthority_resolvefrozendailycloseauthority",
+      "label": "resolveFrozenDailyCloseAuthority()",
+      "norm_label": "resolvefrozendailycloseauthority()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L393"
+    },
+    {
+      "community": 173,
+      "file_type": "code",
+      "id": "frozenmetricauthority_samedailycloseid",
+      "label": "sameDailyCloseId()",
+      "norm_label": "samedailycloseid()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L386"
+    },
+    {
+      "community": 173,
+      "file_type": "code",
+      "id": "frozenmetricauthority_usablefrozenweeksummary",
+      "label": "usableFrozenWeekSummary()",
+      "norm_label": "usablefrozenweeksummary()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L273"
+    },
+    {
+      "community": 173,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_dailyoperations_frozenmetricauthority_ts",
+      "label": "frozenMetricAuthority.ts",
+      "norm_label": "frozenmetricauthority.ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 173,
-      "file_type": "code",
-      "id": "readdefinitions_definecashcontrolsread",
-      "label": "defineCashControlsRead()",
-      "norm_label": "definecashcontrolsread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L50"
-    },
-    {
-      "community": 173,
-      "file_type": "code",
-      "id": "readdefinitions_definedailycloseread",
-      "label": "defineDailyCloseRead()",
-      "norm_label": "definedailycloseread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 173,
-      "file_type": "code",
-      "id": "readdefinitions_definedailyoperationsread",
-      "label": "defineDailyOperationsRead()",
-      "norm_label": "definedailyoperationsread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 173,
-      "file_type": "code",
-      "id": "readdefinitions_defineinventorycatalogread",
-      "label": "defineInventoryCatalogRead()",
-      "norm_label": "defineinventorycatalogread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 173,
-      "file_type": "code",
-      "id": "readdefinitions_defineinventorycostoverlayread",
-      "label": "defineInventoryCostOverlayRead()",
-      "norm_label": "defineinventorycostoverlayread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L639"
-    },
-    {
-      "community": 173,
-      "file_type": "code",
-      "id": "readdefinitions_defineonlineordersread",
-      "label": "defineOnlineOrdersRead()",
-      "norm_label": "defineonlineordersread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L84"
-    },
-    {
-      "community": 173,
-      "file_type": "code",
-      "id": "readdefinitions_defineoperationalworkread",
-      "label": "defineOperationalWorkRead()",
-      "norm_label": "defineoperationalworkread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 173,
-      "file_type": "code",
-      "id": "readdefinitions_defineorganizationread",
-      "label": "defineOrganizationRead()",
-      "norm_label": "defineorganizationread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L94"
-    },
-    {
-      "community": 173,
-      "file_type": "code",
-      "id": "readdefinitions_defineposread",
-      "label": "definePosRead()",
-      "norm_label": "defineposread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 173,
-      "file_type": "code",
-      "id": "readdefinitions_definereadoperation",
-      "label": "defineReadOperation()",
-      "norm_label": "definereadoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 173,
-      "file_type": "code",
-      "id": "readdefinitions_definestockadjustmentsread",
-      "label": "defineStockAdjustmentsRead()",
-      "norm_label": "definestockadjustmentsread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L60"
-    },
-    {
-      "community": 173,
-      "file_type": "code",
-      "id": "readdefinitions_validatereadoperationdefinition",
-      "label": "validateReadOperationDefinition()",
-      "norm_label": "validatereadoperationdefinition()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L781"
     },
     {
       "community": 1730,
@@ -198666,118 +198699,118 @@
     {
       "community": 174,
       "file_type": "code",
-      "id": "frozenmetricauthority_closecandidateoperatingrange",
-      "label": "closeCandidateOperatingRange()",
-      "norm_label": "closecandidateoperatingrange()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L199"
+      "id": "openworkinventoryreviews_test_buildctx",
+      "label": "buildCtx()",
+      "norm_label": "buildctx()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L956"
     },
     {
       "community": 174,
       "file_type": "code",
-      "id": "frozenmetricauthority_emptyclosesummary",
-      "label": "emptyCloseSummary()",
-      "norm_label": "emptyclosesummary()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L62"
+      "id": "openworkinventoryreviews_test_buildinventorymovement",
+      "label": "buildInventoryMovement()",
+      "norm_label": "buildinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1109"
     },
     {
       "community": 174,
       "file_type": "code",
-      "id": "frozenmetricauthority_exactstatuses",
-      "label": "exactStatuses()",
-      "norm_label": "exactstatuses()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L96"
+      "id": "openworkinventoryreviews_test_buildmapping",
+      "label": "buildMapping()",
+      "norm_label": "buildmapping()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1213"
     },
     {
       "community": 174,
       "file_type": "code",
-      "id": "frozenmetricauthority_finitenumber",
-      "label": "finiteNumber()",
-      "norm_label": "finitenumber()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L91"
+      "id": "openworkinventoryreviews_test_buildproductsku",
+      "label": "buildProductSku()",
+      "norm_label": "buildproductsku()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1130"
     },
     {
       "community": 174,
       "file_type": "code",
-      "id": "frozenmetricauthority_frozenfinancialsourcecounts",
-      "label": "frozenFinancialSourceCounts()",
-      "norm_label": "frozenfinancialsourcecounts()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L133"
+      "id": "openworkinventoryreviews_test_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1169"
     },
     {
       "community": 174,
       "file_type": "code",
-      "id": "frozenmetricauthority_frozenweekmetricfordate",
-      "label": "frozenWeekMetricForDate()",
-      "norm_label": "frozenweekmetricfordate()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L481"
+      "id": "openworkinventoryreviews_test_buildstaffprofile",
+      "label": "buildStaffProfile()",
+      "norm_label": "buildstaffprofile()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1065"
     },
     {
       "community": 174,
       "file_type": "code",
-      "id": "frozenmetricauthority_matchesrequestedoperatingrange",
-      "label": "matchesRequestedOperatingRange()",
-      "norm_label": "matchesrequestedoperatingrange()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L102"
+      "id": "openworkinventoryreviews_test_buildstore",
+      "label": "buildStore()",
+      "norm_label": "buildstore()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1052"
     },
     {
       "community": 174,
       "file_type": "code",
-      "id": "frozenmetricauthority_normalizefrozenpaymenttotals",
-      "label": "normalizeFrozenPaymentTotals()",
-      "norm_label": "normalizefrozenpaymenttotals()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L241"
+      "id": "openworkinventoryreviews_test_buildterminal",
+      "label": "buildTerminal()",
+      "norm_label": "buildterminal()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1149"
     },
     {
       "community": 174,
       "file_type": "code",
-      "id": "frozenmetricauthority_recordvalue",
-      "label": "recordValue()",
-      "norm_label": "recordvalue()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L85"
+      "id": "openworkinventoryreviews_test_buildtransaction",
+      "label": "buildTransaction()",
+      "norm_label": "buildtransaction()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1189"
     },
     {
       "community": 174,
       "file_type": "code",
-      "id": "frozenmetricauthority_resolvefrozendailycloseauthority",
-      "label": "resolveFrozenDailyCloseAuthority()",
-      "norm_label": "resolvefrozendailycloseauthority()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L393"
+      "id": "openworkinventoryreviews_test_buildworkitem",
+      "label": "buildWorkItem()",
+      "norm_label": "buildworkitem()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1079"
     },
     {
       "community": 174,
       "file_type": "code",
-      "id": "frozenmetricauthority_samedailycloseid",
-      "label": "sameDailyCloseId()",
-      "norm_label": "samedailycloseid()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L386"
+      "id": "openworkinventoryreviews_test_defaultargs",
+      "label": "defaultArgs()",
+      "norm_label": "defaultargs()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L909"
     },
     {
       "community": 174,
       "file_type": "code",
-      "id": "frozenmetricauthority_usablefrozenweeksummary",
-      "label": "usableFrozenWeekSummary()",
-      "norm_label": "usablefrozenweeksummary()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L273"
+      "id": "openworkinventoryreviews_test_expectrejectedcontext",
+      "label": "expectRejectedContext()",
+      "norm_label": "expectrejectedcontext()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L891"
     },
     {
       "community": 174,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_dailyoperations_frozenmetricauthority_ts",
-      "label": "frozenMetricAuthority.ts",
-      "norm_label": "frozenmetricauthority.ts",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "id": "packages_athena_webapp_convex_operations_openworkinventoryreviews_test_ts",
+      "label": "openWorkInventoryReviews.test.ts",
+      "norm_label": "openworkinventoryreviews.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
       "source_location": "L1"
     },
     {
@@ -198873,119 +198906,119 @@
     {
       "community": 175,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildctx",
-      "label": "buildCtx()",
-      "norm_label": "buildctx()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L956"
-    },
-    {
-      "community": 175,
-      "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildinventorymovement",
-      "label": "buildInventoryMovement()",
-      "norm_label": "buildinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1109"
-    },
-    {
-      "community": 175,
-      "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildmapping",
-      "label": "buildMapping()",
-      "norm_label": "buildmapping()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1213"
-    },
-    {
-      "community": 175,
-      "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildproductsku",
-      "label": "buildProductSku()",
-      "norm_label": "buildproductsku()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1130"
-    },
-    {
-      "community": 175,
-      "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1169"
-    },
-    {
-      "community": 175,
-      "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildstaffprofile",
-      "label": "buildStaffProfile()",
-      "norm_label": "buildstaffprofile()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1065"
-    },
-    {
-      "community": 175,
-      "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildstore",
-      "label": "buildStore()",
-      "norm_label": "buildstore()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1052"
-    },
-    {
-      "community": 175,
-      "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildterminal",
-      "label": "buildTerminal()",
-      "norm_label": "buildterminal()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1149"
-    },
-    {
-      "community": 175,
-      "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildtransaction",
-      "label": "buildTransaction()",
-      "norm_label": "buildtransaction()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1189"
-    },
-    {
-      "community": 175,
-      "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildworkitem",
-      "label": "buildWorkItem()",
-      "norm_label": "buildworkitem()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1079"
-    },
-    {
-      "community": 175,
-      "file_type": "code",
-      "id": "openworkinventoryreviews_test_defaultargs",
-      "label": "defaultArgs()",
-      "norm_label": "defaultargs()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L909"
-    },
-    {
-      "community": 175,
-      "file_type": "code",
-      "id": "openworkinventoryreviews_test_expectrejectedcontext",
-      "label": "expectRejectedContext()",
-      "norm_label": "expectrejectedcontext()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L891"
-    },
-    {
-      "community": 175,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_openworkinventoryreviews_test_ts",
-      "label": "openWorkInventoryReviews.test.ts",
-      "norm_label": "openworkinventoryreviews.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
+      "label": "paymentAllocations.ts",
+      "norm_label": "paymentallocations.ts",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 175,
+      "file_type": "code",
+      "id": "paymentallocations_buildpaymentallocation",
+      "label": "buildPaymentAllocation()",
+      "norm_label": "buildpaymentallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 175,
+      "file_type": "code",
+      "id": "paymentallocations_correctsameamountsinglepaymentallocationwithctx",
+      "label": "correctSameAmountSinglePaymentAllocationWithCtx()",
+      "norm_label": "correctsameamountsinglepaymentallocationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L397"
+    },
+    {
+      "community": 175,
+      "file_type": "code",
+      "id": "paymentallocations_ensurepaymentallocationreportingwithctx",
+      "label": "ensurePaymentAllocationReportingWithCtx()",
+      "norm_label": "ensurepaymentallocationreportingwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L198"
+    },
+    {
+      "community": 175,
+      "file_type": "code",
+      "id": "paymentallocations_findsameamountsinglepaymentallocation",
+      "label": "findSameAmountSinglePaymentAllocation()",
+      "norm_label": "findsameamountsinglepaymentallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L68"
+    },
+    {
+      "community": 175,
+      "file_type": "code",
+      "id": "paymentallocations_listpaymentallocationsfortargetwithctx",
+      "label": "listPaymentAllocationsForTargetWithCtx()",
+      "norm_label": "listpaymentallocationsfortargetwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L377"
+    },
+    {
+      "community": 175,
+      "file_type": "code",
+      "id": "paymentallocations_matchesexistingallocation",
+      "label": "matchesExistingAllocation()",
+      "norm_label": "matchesexistingallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 175,
+      "file_type": "code",
+      "id": "paymentallocations_matcheskeyedallocation",
+      "label": "matchesKeyedAllocation()",
+      "norm_label": "matcheskeyedallocation()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L139"
+    },
+    {
+      "community": 175,
+      "file_type": "code",
+      "id": "paymentallocations_paymentallocationreportingdimensions",
+      "label": "paymentAllocationReportingDimensions()",
+      "norm_label": "paymentallocationreportingdimensions()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L172"
+    },
+    {
+      "community": 175,
+      "file_type": "code",
+      "id": "paymentallocations_paymentallocationreportingidentity",
+      "label": "paymentAllocationReportingIdentity()",
+      "norm_label": "paymentallocationreportingidentity()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L162"
+    },
+    {
+      "community": 175,
+      "file_type": "code",
+      "id": "paymentallocations_recordpaymentallocationwithctx",
+      "label": "recordPaymentAllocationWithCtx()",
+      "norm_label": "recordpaymentallocationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L273"
+    },
+    {
+      "community": 175,
+      "file_type": "code",
+      "id": "paymentallocations_summarizepaymentallocations",
+      "label": "summarizePaymentAllocations()",
+      "norm_label": "summarizepaymentallocations()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 175,
+      "file_type": "code",
+      "id": "paymentallocations_voidpaymentallocationwithctx",
+      "label": "voidPaymentAllocationWithCtx()",
+      "norm_label": "voidpaymentallocationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "source_location": "L255"
     },
     {
       "community": 1750,
@@ -199080,119 +199113,119 @@
     {
       "community": 176,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_paymentallocations_ts",
-      "label": "paymentAllocations.ts",
-      "norm_label": "paymentallocations.ts",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
+      "id": "assigncustomer_createcustomer",
+      "label": "createCustomer()",
+      "norm_label": "createcustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L132"
+    },
+    {
+      "community": 176,
+      "file_type": "code",
+      "id": "assigncustomer_fullnamefromparts",
+      "label": "fullNameFromParts()",
+      "norm_label": "fullnamefromparts()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 176,
+      "file_type": "code",
+      "id": "assigncustomer_guestresult",
+      "label": "guestResult()",
+      "norm_label": "guestresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L111"
+    },
+    {
+      "community": 176,
+      "file_type": "code",
+      "id": "assigncustomer_linktoguest",
+      "label": "linkToGuest()",
+      "norm_label": "linktoguest()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L348"
+    },
+    {
+      "community": 176,
+      "file_type": "code",
+      "id": "assigncustomer_linktostorefrontuser",
+      "label": "linkToStoreFrontUser()",
+      "norm_label": "linktostorefrontuser()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L290"
+    },
+    {
+      "community": 176,
+      "file_type": "code",
+      "id": "assigncustomer_poscustomerresult",
+      "label": "posCustomerResult()",
+      "norm_label": "poscustomerresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 176,
+      "file_type": "code",
+      "id": "assigncustomer_resolveguestmatch",
+      "label": "resolveGuestMatch()",
+      "norm_label": "resolveguestmatch()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L478"
+    },
+    {
+      "community": 176,
+      "file_type": "code",
+      "id": "assigncustomer_resolveposcustomerselection",
+      "label": "resolvePosCustomerSelection()",
+      "norm_label": "resolveposcustomerselection()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L267"
+    },
+    {
+      "community": 176,
+      "file_type": "code",
+      "id": "assigncustomer_resolvestorefrontusermatch",
+      "label": "resolveStoreFrontUserMatch()",
+      "norm_label": "resolvestorefrontusermatch()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L384"
+    },
+    {
+      "community": 176,
+      "file_type": "code",
+      "id": "assigncustomer_storefrontresult",
+      "label": "storefrontResult()",
+      "norm_label": "storefrontresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 176,
+      "file_type": "code",
+      "id": "assigncustomer_updatecustomer",
+      "label": "updateCustomer()",
+      "norm_label": "updatecustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L220"
+    },
+    {
+      "community": 176,
+      "file_type": "code",
+      "id": "assigncustomer_updatecustomerstats",
+      "label": "updateCustomerStats()",
+      "norm_label": "updatecustomerstats()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L251"
+    },
+    {
+      "community": 176,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_ts",
+      "label": "assignCustomer.ts",
+      "norm_label": "assigncustomer.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 176,
-      "file_type": "code",
-      "id": "paymentallocations_buildpaymentallocation",
-      "label": "buildPaymentAllocation()",
-      "norm_label": "buildpaymentallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 176,
-      "file_type": "code",
-      "id": "paymentallocations_correctsameamountsinglepaymentallocationwithctx",
-      "label": "correctSameAmountSinglePaymentAllocationWithCtx()",
-      "norm_label": "correctsameamountsinglepaymentallocationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L397"
-    },
-    {
-      "community": 176,
-      "file_type": "code",
-      "id": "paymentallocations_ensurepaymentallocationreportingwithctx",
-      "label": "ensurePaymentAllocationReportingWithCtx()",
-      "norm_label": "ensurepaymentallocationreportingwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L198"
-    },
-    {
-      "community": 176,
-      "file_type": "code",
-      "id": "paymentallocations_findsameamountsinglepaymentallocation",
-      "label": "findSameAmountSinglePaymentAllocation()",
-      "norm_label": "findsameamountsinglepaymentallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L68"
-    },
-    {
-      "community": 176,
-      "file_type": "code",
-      "id": "paymentallocations_listpaymentallocationsfortargetwithctx",
-      "label": "listPaymentAllocationsForTargetWithCtx()",
-      "norm_label": "listpaymentallocationsfortargetwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L377"
-    },
-    {
-      "community": 176,
-      "file_type": "code",
-      "id": "paymentallocations_matchesexistingallocation",
-      "label": "matchesExistingAllocation()",
-      "norm_label": "matchesexistingallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L92"
-    },
-    {
-      "community": 176,
-      "file_type": "code",
-      "id": "paymentallocations_matcheskeyedallocation",
-      "label": "matchesKeyedAllocation()",
-      "norm_label": "matcheskeyedallocation()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L139"
-    },
-    {
-      "community": 176,
-      "file_type": "code",
-      "id": "paymentallocations_paymentallocationreportingdimensions",
-      "label": "paymentAllocationReportingDimensions()",
-      "norm_label": "paymentallocationreportingdimensions()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L172"
-    },
-    {
-      "community": 176,
-      "file_type": "code",
-      "id": "paymentallocations_paymentallocationreportingidentity",
-      "label": "paymentAllocationReportingIdentity()",
-      "norm_label": "paymentallocationreportingidentity()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L162"
-    },
-    {
-      "community": 176,
-      "file_type": "code",
-      "id": "paymentallocations_recordpaymentallocationwithctx",
-      "label": "recordPaymentAllocationWithCtx()",
-      "norm_label": "recordpaymentallocationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L273"
-    },
-    {
-      "community": 176,
-      "file_type": "code",
-      "id": "paymentallocations_summarizepaymentallocations",
-      "label": "summarizePaymentAllocations()",
-      "norm_label": "summarizepaymentallocations()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 176,
-      "file_type": "code",
-      "id": "paymentallocations_voidpaymentallocationwithctx",
-      "label": "voidPaymentAllocationWithCtx()",
-      "norm_label": "voidpaymentallocationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocations.ts",
-      "source_location": "L255"
     },
     {
       "community": 1760,
@@ -199287,118 +199320,118 @@
     {
       "community": 177,
       "file_type": "code",
-      "id": "assigncustomer_createcustomer",
-      "label": "createCustomer()",
-      "norm_label": "createcustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L132"
+      "id": "catalogrepository_findactivependingcheckoutlookupaliasbycode",
+      "label": "findActivePendingCheckoutLookupAliasByCode()",
+      "norm_label": "findactivependingcheckoutlookupaliasbycode()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L97"
     },
     {
       "community": 177,
       "file_type": "code",
-      "id": "assigncustomer_fullnamefromparts",
-      "label": "fullNameFromParts()",
-      "norm_label": "fullnamefromparts()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L58"
+      "id": "catalogrepository_findactiveprovisionalimportskuforstoresku",
+      "label": "findActiveProvisionalImportSkuForStoreSku()",
+      "norm_label": "findactiveprovisionalimportskuforstoresku()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L120"
     },
     {
       "community": 177,
       "file_type": "code",
-      "id": "assigncustomer_guestresult",
-      "label": "guestResult()",
-      "norm_label": "guestresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L111"
+      "id": "catalogrepository_findstoreskubybarcode",
+      "label": "findStoreSkuByBarcode()",
+      "norm_label": "findstoreskubybarcode()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L62"
     },
     {
       "community": 177,
       "file_type": "code",
-      "id": "assigncustomer_linktoguest",
-      "label": "linkToGuest()",
-      "norm_label": "linktoguest()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L348"
+      "id": "catalogrepository_findstoreskubysku",
+      "label": "findStoreSkuBySku()",
+      "norm_label": "findstoreskubysku()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L77"
     },
     {
       "community": 177,
       "file_type": "code",
-      "id": "assigncustomer_linktostorefrontuser",
-      "label": "linkToStoreFrontUser()",
-      "norm_label": "linktostorefrontuser()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L290"
+      "id": "catalogrepository_getcategorybyid",
+      "label": "getCategoryById()",
+      "norm_label": "getcategorybyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L29"
     },
     {
       "community": 177,
       "file_type": "code",
-      "id": "assigncustomer_poscustomerresult",
-      "label": "posCustomerResult()",
-      "norm_label": "poscustomerresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L71"
+      "id": "catalogrepository_getcolorbyid",
+      "label": "getColorById()",
+      "norm_label": "getcolorbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L40"
     },
     {
       "community": 177,
       "file_type": "code",
-      "id": "assigncustomer_resolveguestmatch",
-      "label": "resolveGuestMatch()",
-      "norm_label": "resolveguestmatch()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L478"
+      "id": "catalogrepository_getproductbyid",
+      "label": "getProductById()",
+      "norm_label": "getproductbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L25"
     },
     {
       "community": 177,
       "file_type": "code",
-      "id": "assigncustomer_resolveposcustomerselection",
-      "label": "resolvePosCustomerSelection()",
-      "norm_label": "resolveposcustomerselection()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L267"
+      "id": "catalogrepository_isconvexproductid",
+      "label": "isConvexProductId()",
+      "norm_label": "isconvexproductid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L11"
     },
     {
       "community": 177,
       "file_type": "code",
-      "id": "assigncustomer_resolvestorefrontusermatch",
-      "label": "resolveStoreFrontUserMatch()",
-      "norm_label": "resolvestorefrontusermatch()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L384"
+      "id": "catalogrepository_listmatchingstoreskus",
+      "label": "listMatchingStoreSkus()",
+      "norm_label": "listmatchingstoreskus()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L140"
     },
     {
       "community": 177,
       "file_type": "code",
-      "id": "assigncustomer_storefrontresult",
-      "label": "storefrontResult()",
-      "norm_label": "storefrontresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L90"
+      "id": "catalogrepository_listproductskusbyproductid",
+      "label": "listProductSkusByProductId()",
+      "norm_label": "listproductskusbyproductid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L51"
     },
     {
       "community": 177,
       "file_type": "code",
-      "id": "assigncustomer_updatecustomer",
-      "label": "updateCustomer()",
-      "norm_label": "updatecustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L220"
+      "id": "catalogrepository_normalizelookupcode",
+      "label": "normalizeLookupCode()",
+      "norm_label": "normalizelookupcode()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L92"
     },
     {
       "community": 177,
       "file_type": "code",
-      "id": "assigncustomer_updatecustomerstats",
-      "label": "updateCustomerStats()",
-      "norm_label": "updatecustomerstats()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L251"
+      "id": "catalogrepository_readallqueryresults",
+      "label": "readAllQueryResults()",
+      "norm_label": "readallqueryresults()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L15"
     },
     {
       "community": 177,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_ts",
-      "label": "assignCustomer.ts",
-      "norm_label": "assigncustomer.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_catalogrepository_ts",
+      "label": "catalogRepository.ts",
+      "norm_label": "catalogrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
       "source_location": "L1"
     },
     {
@@ -199494,119 +199527,119 @@
     {
       "community": 178,
       "file_type": "code",
-      "id": "catalogrepository_findactivependingcheckoutlookupaliasbycode",
-      "label": "findActivePendingCheckoutLookupAliasByCode()",
-      "norm_label": "findactivependingcheckoutlookupaliasbycode()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L97"
+      "id": "packages_athena_webapp_convex_reports_skumovementrange_test_ts",
+      "label": "skuMovementRange.test.ts",
+      "norm_label": "skumovementrange.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L1"
     },
     {
       "community": 178,
       "file_type": "code",
-      "id": "catalogrepository_findactiveprovisionalimportskuforstoresku",
-      "label": "findActiveProvisionalImportSkuForStoreSku()",
-      "norm_label": "findactiveprovisionalimportskuforstoresku()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L120"
+      "id": "skumovementrange_test_admitone",
+      "label": "admitOne()",
+      "norm_label": "admitone()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L352"
     },
     {
       "community": 178,
       "file_type": "code",
-      "id": "catalogrepository_findstoreskubybarcode",
-      "label": "findStoreSkuByBarcode()",
-      "norm_label": "findstoreskubybarcode()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L62"
+      "id": "skumovementrange_test_allow",
+      "label": "allow()",
+      "norm_label": "allow()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L113"
     },
     {
       "community": 178,
       "file_type": "code",
-      "id": "catalogrepository_findstoreskubysku",
-      "label": "findStoreSkuBySku()",
-      "norm_label": "findstoreskubysku()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L77"
+      "id": "skumovementrange_test_certifyday",
+      "label": "certifyDay()",
+      "norm_label": "certifyday()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L238"
     },
     {
       "community": 178,
       "file_type": "code",
-      "id": "catalogrepository_getcategorybyid",
-      "label": "getCategoryById()",
-      "norm_label": "getcategorybyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L29"
+      "id": "skumovementrange_test_dailyfor",
+      "label": "dailyFor()",
+      "norm_label": "dailyfor()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L656"
     },
     {
       "community": 178,
       "file_type": "code",
-      "id": "catalogrepository_getcolorbyid",
-      "label": "getColorById()",
-      "norm_label": "getcolorbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L40"
+      "id": "skumovementrange_test_drive",
+      "label": "drive()",
+      "norm_label": "drive()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L322"
     },
     {
       "community": 178,
       "file_type": "code",
-      "id": "catalogrepository_getproductbyid",
-      "label": "getProductById()",
-      "norm_label": "getproductbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L25"
+      "id": "skumovementrange_test_ensure",
+      "label": "ensure()",
+      "norm_label": "ensure()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L283"
     },
     {
       "community": 178,
       "file_type": "code",
-      "id": "catalogrepository_isconvexproductid",
-      "label": "isConvexProductId()",
-      "norm_label": "isconvexproductid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L11"
+      "id": "skumovementrange_test_handlerof",
+      "label": "handlerOf()",
+      "norm_label": "handlerof()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L108"
     },
     {
       "community": 178,
       "file_type": "code",
-      "id": "catalogrepository_listmatchingstoreskus",
-      "label": "listMatchingStoreSkus()",
-      "norm_label": "listmatchingstoreskus()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "id": "skumovementrange_test_headerbykey",
+      "label": "headerByKey()",
+      "norm_label": "headerbykey()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L304"
+    },
+    {
+      "community": 178,
+      "file_type": "code",
+      "id": "skumovementrange_test_seedskus",
+      "label": "seedSkus()",
+      "norm_label": "seedskus()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L162"
+    },
+    {
+      "community": 178,
+      "file_type": "code",
+      "id": "skumovementrange_test_seedstore",
+      "label": "seedStore()",
+      "norm_label": "seedstore()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
       "source_location": "L140"
     },
     {
       "community": 178,
       "file_type": "code",
-      "id": "catalogrepository_listproductskusbyproductid",
-      "label": "listProductSkusByProductId()",
-      "norm_label": "listproductskusbyproductid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L51"
+      "id": "skumovementrange_test_step",
+      "label": "step()",
+      "norm_label": "step()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L955"
     },
     {
       "community": 178,
       "file_type": "code",
-      "id": "catalogrepository_normalizelookupcode",
-      "label": "normalizeLookupCode()",
-      "norm_label": "normalizelookupcode()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L92"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
-      "id": "catalogrepository_readallqueryresults",
-      "label": "readAllQueryResults()",
-      "norm_label": "readallqueryresults()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 178,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_catalogrepository_ts",
-      "label": "catalogRepository.ts",
-      "norm_label": "catalogrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L1"
+      "id": "skumovementrange_test_twodayfixture",
+      "label": "twoDayFixture()",
+      "norm_label": "twodayfixture()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L939"
     },
     {
       "community": 1780,
@@ -199701,119 +199734,119 @@
     {
       "community": 179,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_skumovementrange_test_ts",
-      "label": "skuMovementRange.test.ts",
-      "norm_label": "skumovementrange.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "id": "packages_athena_webapp_convex_reports_sweeper_test_ts",
+      "label": "sweeper.test.ts",
+      "norm_label": "sweeper.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
       "source_location": "L1"
     },
     {
       "community": 179,
       "file_type": "code",
-      "id": "skumovementrange_test_admitone",
-      "label": "admitOne()",
-      "norm_label": "admitone()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L352"
-    },
-    {
-      "community": 179,
-      "file_type": "code",
-      "id": "skumovementrange_test_allow",
+      "id": "sweeper_test_allow",
       "label": "allow()",
       "norm_label": "allow()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L113"
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
+      "source_location": "L71"
     },
     {
       "community": 179,
       "file_type": "code",
-      "id": "skumovementrange_test_certifyday",
-      "label": "certifyDay()",
-      "norm_label": "certifyday()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L238"
+      "id": "sweeper_test_close",
+      "label": "close()",
+      "norm_label": "close()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
+      "source_location": "L93"
     },
     {
       "community": 179,
       "file_type": "code",
-      "id": "skumovementrange_test_dailyfor",
-      "label": "dailyFor()",
-      "norm_label": "dailyfor()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L656"
+      "id": "sweeper_test_insertmovementheader",
+      "label": "insertMovementHeader()",
+      "norm_label": "insertmovementheader()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
+      "source_location": "L1629"
     },
     {
       "community": 179,
       "file_type": "code",
-      "id": "skumovementrange_test_drive",
-      "label": "drive()",
-      "norm_label": "drive()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L322"
+      "id": "sweeper_test_insertsalefact",
+      "label": "insertSaleFact()",
+      "norm_label": "insertsalefact()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
+      "source_location": "L224"
     },
     {
       "community": 179,
       "file_type": "code",
-      "id": "skumovementrange_test_ensure",
-      "label": "ensure()",
-      "norm_label": "ensure()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L283"
+      "id": "sweeper_test_insertweeklyclosefixture",
+      "label": "insertWeeklyCloseFixture()",
+      "norm_label": "insertweeklyclosefixture()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
+      "source_location": "L1254"
     },
     {
       "community": 179,
       "file_type": "code",
-      "id": "skumovementrange_test_handlerof",
-      "label": "handlerOf()",
-      "norm_label": "handlerof()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L108"
+      "id": "sweeper_test_mark",
+      "label": "mark()",
+      "norm_label": "mark()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
+      "source_location": "L265"
     },
     {
       "community": 179,
       "file_type": "code",
-      "id": "skumovementrange_test_headerbykey",
-      "label": "headerByKey()",
-      "norm_label": "headerbykey()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L304"
+      "id": "sweeper_test_marksof",
+      "label": "marksOf()",
+      "norm_label": "marksof()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
+      "source_location": "L284"
     },
     {
       "community": 179,
       "file_type": "code",
-      "id": "skumovementrange_test_seedskus",
-      "label": "seedSkus()",
-      "norm_label": "seedskus()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L162"
+      "id": "sweeper_test_movementconstants",
+      "label": "movementConstants()",
+      "norm_label": "movementconstants()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
+      "source_location": "L1626"
     },
     {
       "community": 179,
       "file_type": "code",
-      "id": "skumovementrange_test_seedstore",
+      "id": "sweeper_test_readdocs",
+      "label": "readDocs()",
+      "norm_label": "readdocs()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
+      "source_location": "L1328"
+    },
+    {
+      "community": 179,
+      "file_type": "code",
+      "id": "sweeper_test_seedstore",
       "label": "seedStore()",
       "norm_label": "seedstore()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L140"
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
+      "source_location": "L150"
     },
     {
       "community": 179,
       "file_type": "code",
-      "id": "skumovementrange_test_step",
-      "label": "step()",
-      "norm_label": "step()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L955"
+      "id": "sweeper_test_sweep",
+      "label": "sweep()",
+      "norm_label": "sweep()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
+      "source_location": "L282"
     },
     {
       "community": 179,
       "file_type": "code",
-      "id": "skumovementrange_test_twodayfixture",
-      "label": "twoDayFixture()",
-      "norm_label": "twodayfixture()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L939"
+      "id": "sweeper_test_withfrozenscheduler",
+      "label": "withFrozenScheduler()",
+      "norm_label": "withfrozenscheduler()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
+      "source_location": "L1661"
     },
     {
       "community": 1790,
@@ -200277,119 +200310,119 @@
     {
       "community": 180,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_sweeper_test_ts",
-      "label": "sweeper.test.ts",
-      "norm_label": "sweeper.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
+      "id": "packages_athena_webapp_src_components_add_product_productview_tsx",
+      "label": "ProductView.tsx",
+      "norm_label": "productview.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L1"
     },
     {
       "community": 180,
       "file_type": "code",
-      "id": "sweeper_test_allow",
-      "label": "allow()",
-      "norm_label": "allow()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L71"
+      "id": "productview_archivedproductnestedorigin",
+      "label": "archivedProductNestedOrigin()",
+      "norm_label": "archivedproductnestedorigin()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L107"
     },
     {
       "community": 180,
       "file_type": "code",
-      "id": "sweeper_test_close",
-      "label": "close()",
-      "norm_label": "close()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
+      "id": "productview_buildvariantskumoneypayload",
+      "label": "buildVariantSkuMoneyPayload()",
+      "norm_label": "buildvariantskumoneypayload()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L67"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "productview_createvariantsku",
+      "label": "createVariantSku()",
+      "norm_label": "createvariantsku()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L346"
+    },
+    {
+      "community": 180,
+      "file_type": "code",
+      "id": "productview_decodeoriginvalue",
+      "label": "decodeOriginValue()",
+      "norm_label": "decodeoriginvalue()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L93"
     },
     {
       "community": 180,
       "file_type": "code",
-      "id": "sweeper_test_insertmovementheader",
-      "label": "insertMovementHeader()",
-      "norm_label": "insertmovementheader()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L1532"
+      "id": "productview_deleteactiveproduct",
+      "label": "deleteActiveProduct()",
+      "norm_label": "deleteactiveproduct()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L177"
     },
     {
       "community": 180,
       "file_type": "code",
-      "id": "sweeper_test_insertsalefact",
-      "label": "insertSaleFact()",
-      "norm_label": "insertsalefact()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L224"
+      "id": "productview_getarchivedproductredirect",
+      "label": "getArchivedProductRedirect()",
+      "norm_label": "getarchivedproductredirect()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L74"
     },
     {
       "community": 180,
       "file_type": "code",
-      "id": "sweeper_test_insertweeklyclosefixture",
-      "label": "insertWeeklyCloseFixture()",
-      "norm_label": "insertweeklyclosefixture()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L1157"
+      "id": "productview_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L506"
     },
     {
       "community": 180,
       "file_type": "code",
-      "id": "sweeper_test_mark",
-      "label": "mark()",
-      "norm_label": "mark()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L265"
+      "id": "productview_modifyproduct",
+      "label": "modifyProduct()",
+      "norm_label": "modifyproduct()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L271"
     },
     {
       "community": 180,
       "file_type": "code",
-      "id": "sweeper_test_marksof",
-      "label": "marksOf()",
-      "norm_label": "marksof()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L284"
+      "id": "productview_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L490"
     },
     {
       "community": 180,
       "file_type": "code",
-      "id": "sweeper_test_movementconstants",
-      "label": "movementConstants()",
-      "norm_label": "movementconstants()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L1529"
+      "id": "productview_resolvelegacytaxonomysavegate",
+      "label": "resolveLegacyTaxonomySaveGate()",
+      "norm_label": "resolvelegacytaxonomysavegate()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L40"
     },
     {
       "community": 180,
       "file_type": "code",
-      "id": "sweeper_test_readdocs",
-      "label": "readDocs()",
-      "norm_label": "readdocs()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L1231"
+      "id": "productview_saveproduct",
+      "label": "saveProduct()",
+      "norm_label": "saveproduct()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L217"
     },
     {
       "community": 180,
       "file_type": "code",
-      "id": "sweeper_test_seedstore",
-      "label": "seedStore()",
-      "norm_label": "seedstore()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L150"
-    },
-    {
-      "community": 180,
-      "file_type": "code",
-      "id": "sweeper_test_sweep",
-      "label": "sweep()",
-      "norm_label": "sweep()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L282"
-    },
-    {
-      "community": 180,
-      "file_type": "code",
-      "id": "sweeper_test_withfrozenscheduler",
-      "label": "withFrozenScheduler()",
-      "norm_label": "withfrozenscheduler()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L1564"
+      "id": "productview_updatevariantsku",
+      "label": "updateVariantSku()",
+      "norm_label": "updatevariantsku()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L404"
     },
     {
       "community": 1800,
@@ -200484,119 +200517,119 @@
     {
       "community": 181,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productview_tsx",
-      "label": "ProductView.tsx",
-      "norm_label": "productview.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "id": "packages_athena_webapp_convex_inventory_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
       "source_location": "L1"
     },
     {
       "community": 181,
       "file_type": "code",
-      "id": "productview_archivedproductnestedorigin",
-      "label": "archivedProductNestedOrigin()",
-      "norm_label": "archivedproductnestedorigin()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L107"
+      "id": "packages_athena_webapp_src_components_orders_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 181,
       "file_type": "code",
-      "id": "productview_buildvariantskumoneypayload",
-      "label": "buildVariantSkuMoneyPayload()",
-      "norm_label": "buildvariantskumoneypayload()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L67"
+      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 181,
       "file_type": "code",
-      "id": "productview_createvariantsku",
-      "label": "createVariantSku()",
-      "norm_label": "createvariantsku()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L346"
-    },
-    {
-      "community": 181,
-      "file_type": "code",
-      "id": "productview_decodeoriginvalue",
-      "label": "decodeOriginValue()",
-      "norm_label": "decodeoriginvalue()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L93"
-    },
-    {
-      "community": 181,
-      "file_type": "code",
-      "id": "productview_deleteactiveproduct",
-      "label": "deleteActiveProduct()",
-      "norm_label": "deleteactiveproduct()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L177"
-    },
-    {
-      "community": 181,
-      "file_type": "code",
-      "id": "productview_getarchivedproductredirect",
-      "label": "getArchivedProductRedirect()",
-      "norm_label": "getarchivedproductredirect()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "id": "utils_formatdeliveryaddress",
+      "label": "formatDeliveryAddress()",
+      "norm_label": "formatdeliveryaddress()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L74"
     },
     {
       "community": 181,
       "file_type": "code",
-      "id": "productview_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L506"
+      "id": "utils_getamountpaidfororder",
+      "label": "getAmountPaidForOrder()",
+      "norm_label": "getamountpaidfororder()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L191"
     },
     {
       "community": 181,
       "file_type": "code",
-      "id": "productview_modifyproduct",
-      "label": "modifyProduct()",
-      "norm_label": "modifyproduct()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L271"
+      "id": "utils_getdiscountvalue",
+      "label": "getDiscountValue()",
+      "norm_label": "getdiscountvalue()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L17"
     },
     {
       "community": 181,
       "file_type": "code",
-      "id": "productview_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L490"
+      "id": "utils_getonlineorderplacedat",
+      "label": "getOnlineOrderPlacedAt()",
+      "norm_label": "getonlineorderplacedat()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 181,
       "file_type": "code",
-      "id": "productview_resolvelegacytaxonomysavegate",
-      "label": "resolveLegacyTaxonomySaveGate()",
-      "norm_label": "resolvelegacytaxonomysavegate()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "id": "utils_getorderamount",
+      "label": "getOrderAmount()",
+      "norm_label": "getorderamount()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "utils_getorderstate",
+      "label": "getOrderState()",
+      "norm_label": "getorderstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
       "source_location": "L40"
     },
     {
       "community": 181,
       "file_type": "code",
-      "id": "productview_saveproduct",
-      "label": "saveProduct()",
-      "norm_label": "saveproduct()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L217"
+      "id": "utils_getpickupactionstate",
+      "label": "getPickupActionState()",
+      "norm_label": "getpickupactionstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L102"
     },
     {
       "community": 181,
       "file_type": "code",
-      "id": "productview_updatevariantsku",
-      "label": "updateVariantSku()",
-      "norm_label": "updatevariantsku()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L404"
+      "id": "utils_getpotentialpoints",
+      "label": "getPotentialPoints()",
+      "norm_label": "getpotentialpoints()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "utils_getproductdiscountvalue",
+      "label": "getProductDiscountValue()",
+      "norm_label": "getproductdiscountvalue()",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 181,
+      "file_type": "code",
+      "id": "utils_shouldshowpickupexceptionaction",
+      "label": "shouldShowPickupExceptionAction()",
+      "norm_label": "shouldshowpickupexceptionaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L116"
     },
     {
       "community": 1810,
@@ -223470,87 +223503,6 @@
     {
       "community": 292,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 292,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 292,
-      "file_type": "code",
-      "id": "productutils_getpreferredsku",
-      "label": "getPreferredSku()",
-      "norm_label": "getpreferredsku()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 292,
-      "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 292,
-      "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 292,
-      "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 292,
-      "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L82"
-    },
-    {
-      "community": 292,
-      "file_type": "code",
-      "id": "productutils_sortskusbyavailabilitythenlength",
-      "label": "sortSkusByAvailabilityThenLength()",
-      "norm_label": "sortskusbyavailabilitythenlength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 292,
-      "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 293,
-      "file_type": "code",
       "id": "applyremoteassistcontrolintent_applyacceptedcontrolresult",
       "label": "applyAcceptedControlResult()",
       "norm_label": "applyacceptedcontrolresult()",
@@ -223558,7 +223510,7 @@
       "source_location": "L84"
     },
     {
-      "community": 293,
+      "community": 292,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_applykeyevent",
       "label": "applyKeyEvent()",
@@ -223567,7 +223519,7 @@
       "source_location": "L155"
     },
     {
-      "community": 293,
+      "community": 292,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_applypointerevent",
       "label": "applyPointerEvent()",
@@ -223576,7 +223528,7 @@
       "source_location": "L116"
     },
     {
-      "community": 293,
+      "community": 292,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_applyremoteassistcontrolintent",
       "label": "applyRemoteAssistControlIntent()",
@@ -223585,7 +223537,7 @@
       "source_location": "L17"
     },
     {
-      "community": 293,
+      "community": 292,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_getrecentcontrolresult",
       "label": "getRecentControlResult()",
@@ -223594,7 +223546,7 @@
       "source_location": "L95"
     },
     {
-      "community": 293,
+      "community": 292,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_getremoteassistcontroltarget",
       "label": "getRemoteAssistControlTarget()",
@@ -223603,7 +223555,7 @@
       "source_location": "L145"
     },
     {
-      "community": 293,
+      "community": 292,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_prepareremoteassistcontrolintent",
       "label": "prepareRemoteAssistControlIntent()",
@@ -223612,7 +223564,7 @@
       "source_location": "L27"
     },
     {
-      "community": 293,
+      "community": 292,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_remembercontrolresult",
       "label": "rememberControlResult()",
@@ -223621,7 +223573,7 @@
       "source_location": "L101"
     },
     {
-      "community": 293,
+      "community": 292,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_remote_assist_runtime_applyremoteassistcontrolintent_ts",
       "label": "applyRemoteAssistControlIntent.ts",
@@ -223630,7 +223582,7 @@
       "source_location": "L1"
     },
     {
-      "community": 294,
+      "community": 293,
       "file_type": "code",
       "id": "packages_athena_webapp_src_offline_posofflinereadiness_ts",
       "label": "posOfflineReadiness.ts",
@@ -223639,7 +223591,7 @@
       "source_location": "L1"
     },
     {
-      "community": 294,
+      "community": 293,
       "file_type": "code",
       "id": "posofflinereadiness_buildposofflinereadinesssummary",
       "label": "buildPosOfflineReadinessSummary()",
@@ -223648,7 +223600,7 @@
       "source_location": "L152"
     },
     {
-      "community": 294,
+      "community": 293,
       "file_type": "code",
       "id": "posofflinereadiness_buildsignal",
       "label": "buildSignal()",
@@ -223657,7 +223609,7 @@
       "source_location": "L178"
     },
     {
-      "community": 294,
+      "community": 293,
       "file_type": "code",
       "id": "posofflinereadiness_formatage",
       "label": "formatAge()",
@@ -223666,7 +223618,7 @@
       "source_location": "L290"
     },
     {
-      "community": 294,
+      "community": 293,
       "file_type": "code",
       "id": "posofflinereadiness_getsignaldescription",
       "label": "getSignalDescription()",
@@ -223675,7 +223627,7 @@
       "source_location": "L221"
     },
     {
-      "community": 294,
+      "community": 293,
       "file_type": "code",
       "id": "posofflinereadiness_getsignalstatus",
       "label": "getSignalStatus()",
@@ -223684,7 +223636,7 @@
       "source_location": "L201"
     },
     {
-      "community": 294,
+      "community": 293,
       "file_type": "code",
       "id": "posofflinereadiness_getsummarydescription",
       "label": "getSummaryDescription()",
@@ -223693,7 +223645,7 @@
       "source_location": "L262"
     },
     {
-      "community": 294,
+      "community": 293,
       "file_type": "code",
       "id": "posofflinereadiness_getsummarytitle",
       "label": "getSummaryTitle()",
@@ -223702,7 +223654,7 @@
       "source_location": "L256"
     },
     {
-      "community": 294,
+      "community": 293,
       "file_type": "code",
       "id": "posofflinereadiness_isreadylike",
       "label": "isReadyLike()",
@@ -223711,7 +223663,7 @@
       "source_location": "L286"
     },
     {
-      "community": 295,
+      "community": 294,
       "file_type": "code",
       "id": "foundations_content_colorrolecard",
       "label": "ColorRoleCard()",
@@ -223720,7 +223672,7 @@
       "source_location": "L222"
     },
     {
-      "community": 295,
+      "community": 294,
       "file_type": "code",
       "id": "foundations_content_densitycard",
       "label": "DensityCard()",
@@ -223729,7 +223681,7 @@
       "source_location": "L283"
     },
     {
-      "community": 295,
+      "community": 294,
       "file_type": "code",
       "id": "foundations_content_detailviewrolecard",
       "label": "DetailViewRoleCard()",
@@ -223738,7 +223690,7 @@
       "source_location": "L363"
     },
     {
-      "community": 295,
+      "community": 294,
       "file_type": "code",
       "id": "foundations_content_hslvar",
       "label": "hslVar()",
@@ -223747,7 +223699,7 @@
       "source_location": "L214"
     },
     {
-      "community": 295,
+      "community": 294,
       "file_type": "code",
       "id": "foundations_content_motioncard",
       "label": "MotionCard()",
@@ -223756,7 +223708,7 @@
       "source_location": "L342"
     },
     {
-      "community": 295,
+      "community": 294,
       "file_type": "code",
       "id": "foundations_content_spacetokenrow",
       "label": "SpaceTokenRow()",
@@ -223765,7 +223717,7 @@
       "source_location": "L265"
     },
     {
-      "community": 295,
+      "community": 294,
       "file_type": "code",
       "id": "foundations_content_textvar",
       "label": "textVar()",
@@ -223774,7 +223726,7 @@
       "source_location": "L218"
     },
     {
-      "community": 295,
+      "community": 294,
       "file_type": "code",
       "id": "foundations_content_typespecimencard",
       "label": "TypeSpecimenCard()",
@@ -223783,13 +223735,94 @@
       "source_location": "L246"
     },
     {
-      "community": 295,
+      "community": 294,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_foundations_content_tsx",
       "label": "foundations-content.tsx",
       "norm_label": "foundations-content.tsx",
       "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 295,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 295,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 295,
+      "file_type": "code",
+      "id": "productutils_getpreferredsku",
+      "label": "getPreferredSku()",
+      "norm_label": "getpreferredsku()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 295,
+      "file_type": "code",
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 295,
+      "file_type": "code",
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 295,
+      "file_type": "code",
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 295,
+      "file_type": "code",
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L82"
+    },
+    {
+      "community": 295,
+      "file_type": "code",
+      "id": "productutils_sortskusbyavailabilitythenlength",
+      "label": "sortSkusByAvailabilityThenLength()",
+      "norm_label": "sortskusbyavailabilitythenlength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 295,
+      "file_type": "code",
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L59"
     },
     {
       "community": 296,
@@ -241173,6 +241206,60 @@
     {
       "community": 470,
       "file_type": "code",
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L101"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
       "id": "managerelevationcontext_getstaffdisplayname",
       "label": "getStaffDisplayName()",
       "norm_label": "getstaffdisplayname()",
@@ -241180,7 +241267,7 @@
       "source_location": "L64"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "managerelevationcontext_managerelevationprovider",
       "label": "ManagerElevationProvider()",
@@ -241189,7 +241276,7 @@
       "source_location": "L87"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "managerelevationcontext_tostaffauthenticationresult",
       "label": "toStaffAuthenticationResult()",
@@ -241198,7 +241285,7 @@
       "source_location": "L74"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "managerelevationcontext_usemanagerelevation",
       "label": "useManagerElevation()",
@@ -241207,7 +241294,7 @@
       "source_location": "L242"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "managerelevationcontext_useoptionalmanagerelevation",
       "label": "useOptionalManagerElevation()",
@@ -241216,7 +241303,7 @@
       "source_location": "L251"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_managerelevationcontext_tsx",
       "label": "ManagerElevationContext.tsx",
@@ -241225,7 +241312,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
       "label": "useExpenseSessions.ts",
@@ -241234,7 +241321,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "useexpensesessions_useexpenseactivesession",
       "label": "useExpenseActiveSession()",
@@ -241243,7 +241330,7 @@
       "source_location": "L42"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesession",
       "label": "useExpenseSession()",
@@ -241252,7 +241339,7 @@
       "source_location": "L32"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessioncreate",
       "label": "useExpenseSessionCreate()",
@@ -241261,7 +241348,7 @@
       "source_location": "L62"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessionupdate",
       "label": "useExpenseSessionUpdate()",
@@ -241270,7 +241357,7 @@
       "source_location": "L101"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "useexpensesessions_useexpensestoresessions",
       "label": "useExpenseStoreSessions()",
@@ -241279,7 +241366,7 @@
       "source_location": "L10"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "capabilities_canaccesscashcontrolssurface",
       "label": "canAccessCashControlsSurface()",
@@ -241288,7 +241375,7 @@
       "source_location": "L54"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "capabilities_canaccessfulladminsurface",
       "label": "canAccessFullAdminSurface()",
@@ -241297,7 +241384,7 @@
       "source_location": "L41"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "capabilities_canaccessstoredaysurface",
       "label": "canAccessStoreDaySurface()",
@@ -241306,7 +241393,7 @@
       "source_location": "L47"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "capabilities_canviewfinancialdetails",
       "label": "canViewFinancialDetails()",
@@ -241315,7 +241402,7 @@
       "source_location": "L61"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "capabilities_getsurfaceaccess",
       "label": "getSurfaceAccess()",
@@ -241324,7 +241411,7 @@
       "source_location": "L68"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_access_capabilities_ts",
       "label": "capabilities.ts",
@@ -241333,7 +241420,7 @@
       "source_location": "L1"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "behaviorutils_calculateengagementmetrics",
       "label": "calculateEngagementMetrics()",
@@ -241342,7 +241429,7 @@
       "source_location": "L173"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "behaviorutils_calculateriskindicators",
       "label": "calculateRiskIndicators()",
@@ -241351,7 +241438,7 @@
       "source_location": "L71"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "behaviorutils_getactivitypriority",
       "label": "getActivityPriority()",
@@ -241360,7 +241447,7 @@
       "source_location": "L251"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "behaviorutils_getcustomerjourneystage",
       "label": "getCustomerJourneyStage()",
@@ -241369,7 +241456,7 @@
       "source_location": "L36"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "behaviorutils_getjourneystageinfo",
       "label": "getJourneyStageInfo()",
@@ -241378,7 +241465,7 @@
       "source_location": "L277"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
       "label": "behaviorUtils.ts",
@@ -241387,7 +241474,7 @@
       "source_location": "L1"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
       "label": "results.ts",
@@ -241396,7 +241483,7 @@
       "source_location": "L1"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "results_isposusecasesuccess",
       "label": "isPosUseCaseSuccess()",
@@ -241405,7 +241492,7 @@
       "source_location": "L134"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "results_mapcommandoutcome",
       "label": "mapCommandOutcome()",
@@ -241414,7 +241501,7 @@
       "source_location": "L69"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "results_mapcommandresult",
       "label": "mapCommandResult()",
@@ -241423,7 +241510,7 @@
       "source_location": "L86"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "results_maplegacymutationresult",
       "label": "mapLegacyMutationResult()",
@@ -241432,7 +241519,7 @@
       "source_location": "L52"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "results_mapthrownerror",
       "label": "mapThrownError()",
@@ -241441,7 +241528,7 @@
       "source_location": "L103"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registerlifecycleauthoritycandidates_ts",
       "label": "registerLifecycleAuthorityCandidates.ts",
@@ -241450,7 +241537,7 @@
       "source_location": "L1"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_deriveregisterlifecycleauthoritycandidates",
       "label": "deriveRegisterLifecycleAuthorityCandidates()",
@@ -241459,7 +241546,7 @@
       "source_location": "L45"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_isboundedidentifier",
       "label": "isBoundedIdentifier()",
@@ -241468,7 +241555,7 @@
       "source_location": "L220"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_iseligibleregistermapping",
       "label": "isEligibleRegisterMapping()",
@@ -241477,7 +241564,7 @@
       "source_location": "L167"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_legacymappingmatchesactivesession",
       "label": "legacyMappingMatchesActiveSession()",
@@ -241486,7 +241573,7 @@
       "source_location": "L182"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_mappingcandidate",
       "label": "mappingCandidate()",
@@ -241495,7 +241582,7 @@
       "source_location": "L194"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_useposlocalsyncruntime_test_ts",
       "label": "usePosLocalSyncRuntime.test.ts",
@@ -241504,7 +241591,7 @@
       "source_location": "L1"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_buildlocalevent",
       "label": "buildLocalEvent()",
@@ -241513,7 +241600,7 @@
       "source_location": "L7332"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_buildrecoverycommand",
       "label": "buildRecoveryCommand()",
@@ -241522,7 +241609,7 @@
       "source_location": "L7355"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_buildrecoverycommandstore",
       "label": "buildRecoveryCommandStore()",
@@ -241531,7 +241618,7 @@
       "source_location": "L7374"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_deferred",
       "label": "deferred()",
@@ -241540,7 +241627,7 @@
       "source_location": "L103"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_storefactory",
       "label": "storeFactory()",
@@ -241549,7 +241636,7 @@
       "source_location": "L347"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
       "label": "selectors.ts",
@@ -241558,7 +241645,7 @@
       "source_location": "L1"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "selectors_buildregisterheaderstate",
       "label": "buildRegisterHeaderState()",
@@ -241567,7 +241654,7 @@
       "source_location": "L28"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "selectors_buildregisterinfostate",
       "label": "buildRegisterInfoState()",
@@ -241576,7 +241663,7 @@
       "source_location": "L37"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "selectors_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -241585,7 +241672,7 @@
       "source_location": "L12"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "selectors_getregistercustomerinfo",
       "label": "getRegisterCustomerInfo()",
@@ -241594,7 +241681,7 @@
       "source_location": "L6"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "selectors_isregistersessionactive",
       "label": "isRegisterSessionActive()",
@@ -241603,7 +241690,7 @@
       "source_location": "L49"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
       "label": "toastService.ts",
@@ -241612,7 +241699,7 @@
       "source_location": "L1"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "toastservice_handleposoperation",
       "label": "handlePOSOperation()",
@@ -241621,7 +241708,7 @@
       "source_location": "L171"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "toastservice_showinventoryerror",
       "label": "showInventoryError()",
@@ -241630,7 +241717,7 @@
       "source_location": "L302"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "toastservice_shownoactivesessionerror",
       "label": "showNoActiveSessionError()",
@@ -241639,7 +241726,7 @@
       "source_location": "L319"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "toastservice_showsessionexpirederror",
       "label": "showSessionExpiredError()",
@@ -241648,67 +241735,13 @@
       "source_location": "L312"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "toastservice_showvalidationerror",
       "label": "showValidationError()",
       "norm_label": "showvalidationerror()",
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L293"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_skusearch_productskusearchadapters_ts",
-      "label": "productSkuSearchAdapters.ts",
-      "norm_label": "productskusearchadapters.ts",
-      "source_file": "packages/athena-webapp/src/lib/skuSearch/productSkuSearchAdapters.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "productskusearchadapters_buildadminskusearchoption",
-      "label": "buildAdminSkuSearchOption()",
-      "norm_label": "buildadminskusearchoption()",
-      "source_file": "packages/athena-webapp/src/lib/skuSearch/productSkuSearchAdapters.ts",
-      "source_location": "L80"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "productskusearchadapters_buildadminskusearchoptions",
-      "label": "buildAdminSkuSearchOptions()",
-      "norm_label": "buildadminskusearchoptions()",
-      "source_file": "packages/athena-webapp/src/lib/skuSearch/productSkuSearchAdapters.ts",
-      "source_location": "L132"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "productskusearchadapters_compactjoin",
-      "label": "compactJoin()",
-      "norm_label": "compactjoin()",
-      "source_file": "packages/athena-webapp/src/lib/skuSearch/productSkuSearchAdapters.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "productskusearchadapters_groupadminskusearchoptionsbyproduct",
-      "label": "groupAdminSkuSearchOptionsByProduct()",
-      "norm_label": "groupadminskusearchoptionsbyproduct()",
-      "source_file": "packages/athena-webapp/src/lib/skuSearch/productSkuSearchAdapters.ts",
-      "source_location": "L138"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "productskusearchadapters_presentationtext",
-      "label": "presentationText()",
-      "norm_label": "presentationtext()",
-      "source_file": "packages/athena-webapp/src/lib/skuSearch/productSkuSearchAdapters.ts",
-      "source_location": "L66"
     },
     {
       "community": 48,
@@ -241974,6 +242007,60 @@
     {
       "community": 480,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_skusearch_productskusearchadapters_ts",
+      "label": "productSkuSearchAdapters.ts",
+      "norm_label": "productskusearchadapters.ts",
+      "source_file": "packages/athena-webapp/src/lib/skuSearch/productSkuSearchAdapters.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "productskusearchadapters_buildadminskusearchoption",
+      "label": "buildAdminSkuSearchOption()",
+      "norm_label": "buildadminskusearchoption()",
+      "source_file": "packages/athena-webapp/src/lib/skuSearch/productSkuSearchAdapters.ts",
+      "source_location": "L80"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "productskusearchadapters_buildadminskusearchoptions",
+      "label": "buildAdminSkuSearchOptions()",
+      "norm_label": "buildadminskusearchoptions()",
+      "source_file": "packages/athena-webapp/src/lib/skuSearch/productSkuSearchAdapters.ts",
+      "source_location": "L132"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "productskusearchadapters_compactjoin",
+      "label": "compactJoin()",
+      "norm_label": "compactjoin()",
+      "source_file": "packages/athena-webapp/src/lib/skuSearch/productSkuSearchAdapters.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "productskusearchadapters_groupadminskusearchoptionsbyproduct",
+      "label": "groupAdminSkuSearchOptionsByProduct()",
+      "norm_label": "groupadminskusearchoptionsbyproduct()",
+      "source_file": "packages/athena-webapp/src/lib/skuSearch/productSkuSearchAdapters.ts",
+      "source_location": "L138"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "productskusearchadapters_presentationtext",
+      "label": "presentationText()",
+      "norm_label": "presentationtext()",
+      "source_file": "packages/athena-webapp/src/lib/skuSearch/productSkuSearchAdapters.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_stockops_skusearch_ts",
       "label": "skuSearch.ts",
       "norm_label": "skusearch.ts",
@@ -241981,7 +242068,7 @@
       "source_location": "L1"
     },
     {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "skusearch_isbarcodeshapedsearchquery",
       "label": "isBarcodeShapedSearchQuery()",
@@ -241990,7 +242077,7 @@
       "source_location": "L49"
     },
     {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "skusearch_matchesskusearchterms",
       "label": "matchesSkuSearchTerms()",
@@ -241999,7 +242086,7 @@
       "source_location": "L11"
     },
     {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "skusearch_normalizeidentifier",
       "label": "normalizeIdentifier()",
@@ -242008,7 +242095,7 @@
       "source_location": "L53"
     },
     {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "skusearch_normalizeskusearchquery",
       "label": "normalizeSkuSearchQuery()",
@@ -242017,7 +242104,7 @@
       "source_location": "L7"
     },
     {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "skusearch_scoreskusearchterms",
       "label": "scoreSkuSearchTerms()",
@@ -242026,7 +242113,7 @@
       "source_location": "L18"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "packages_athena_webapp_src_offline_posappshellroutes_ts",
       "label": "posAppShellRoutes.ts",
@@ -242035,7 +242122,7 @@
       "source_location": "L1"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "posappshellroutes_isexcludedfromposappshellcache",
       "label": "isExcludedFromPosAppShellCache()",
@@ -242044,7 +242131,7 @@
       "source_location": "L53"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "posappshellroutes_isposappshellnavigationrequest",
       "label": "isPosAppShellNavigationRequest()",
@@ -242053,7 +242140,7 @@
       "source_location": "L71"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "posappshellroutes_isposappshellroutepath",
       "label": "isPosAppShellRoutePath()",
@@ -242062,7 +242149,7 @@
       "source_location": "L48"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "posappshellroutes_isposappshellstaticassetrequest",
       "label": "isPosAppShellStaticAssetRequest()",
@@ -242071,7 +242158,7 @@
       "source_location": "L88"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "posappshellroutes_readheader",
       "label": "readHeader()",
@@ -242080,7 +242167,7 @@
       "source_location": "L107"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "packages_athena_webapp_src_offline_posappshellserviceworkerstaging_test_ts",
       "label": "posAppShellServiceWorkerStaging.test.ts",
@@ -242089,7 +242176,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_createserviceworkerfixture",
       "label": "createServiceWorkerFixture()",
@@ -242098,7 +242185,7 @@
       "source_location": "L32"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_memorycache",
       "label": "MemoryCache",
@@ -242107,7 +242194,7 @@
       "source_location": "L14"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_memorycache_keys",
       "label": ".keys()",
@@ -242116,7 +242203,7 @@
       "source_location": "L27"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_memorycache_match",
       "label": ".match()",
@@ -242125,7 +242212,7 @@
       "source_location": "L17"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_memorycache_put",
       "label": ".put()",
@@ -242134,7 +242221,7 @@
       "source_location": "L22"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
       "label": "procurement.index.tsx",
@@ -242143,7 +242230,7 @@
       "source_location": "L1"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementmodesearch",
       "label": "getNextProcurementModeSearch()",
@@ -242152,7 +242239,7 @@
       "source_location": "L19"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementpagesearch",
       "label": "getNextProcurementPageSearch()",
@@ -242161,7 +242248,7 @@
       "source_location": "L37"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementquerysearch",
       "label": "getNextProcurementQuerySearch()",
@@ -242170,7 +242257,7 @@
       "source_location": "L47"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementselectedskusearch",
       "label": "getNextProcurementSelectedSkuSearch()",
@@ -242179,7 +242266,7 @@
       "source_location": "L62"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "procurement_index_procurementroute",
       "label": "ProcurementRoute()",
@@ -242188,7 +242275,7 @@
       "source_location": "L88"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "login_layout_completependingauthsync",
       "label": "completePendingAuthSync()",
@@ -242197,7 +242284,7 @@
       "source_location": "L145"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "login_layout_handlependingauthsync",
       "label": "handlePendingAuthSync()",
@@ -242206,7 +242293,7 @@
       "source_location": "L95"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "login_layout_navigationtargetforredirect",
       "label": "navigationTargetForRedirect()",
@@ -242215,7 +242302,7 @@
       "source_location": "L33"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "login_layout_sleep",
       "label": "sleep()",
@@ -242224,7 +242311,7 @@
       "source_location": "L29"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "login_layout_usedocumentscrolllock",
       "label": "useDocumentScrollLock()",
@@ -242233,7 +242320,7 @@
       "source_location": "L45"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_login_layout_tsx",
       "label": "-login-layout.tsx",
@@ -242242,7 +242329,7 @@
       "source_location": "L1"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "organizationsettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -242251,7 +242338,7 @@
       "source_location": "L155"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "organizationsettingsview_navigation",
       "label": "Navigation()",
@@ -242260,7 +242347,7 @@
       "source_location": "L197"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "organizationsettingsview_onsubmit",
       "label": "onSubmit()",
@@ -242269,7 +242356,7 @@
       "source_location": "L104"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "organizationsettingsview_organizationsettings",
       "label": "OrganizationSettings()",
@@ -242278,7 +242365,7 @@
       "source_location": "L25"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "organizationsettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -242287,7 +242374,7 @@
       "source_location": "L72"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
       "label": "OrganizationSettingsView.tsx",
@@ -242296,7 +242383,7 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
       "label": "StoreSettingsView.tsx",
@@ -242305,7 +242392,7 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "storesettingsview_handledeleteallproductsinstore",
       "label": "handleDeleteAllProductsInStore()",
@@ -242314,7 +242401,7 @@
       "source_location": "L231"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "storesettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -242323,7 +242410,7 @@
       "source_location": "L167"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "storesettingsview_onsubmit",
       "label": "onSubmit()",
@@ -242332,7 +242419,7 @@
       "source_location": "L116"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "storesettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -242341,7 +242428,7 @@
       "source_location": "L83"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "storesettingsview_storesettings",
       "label": "StoreSettings()",
@@ -242350,7 +242437,7 @@
       "source_location": "L29"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "devfixtureactivation_usedailyclosefixture",
       "label": "useDailyCloseFixture()",
@@ -242359,7 +242446,7 @@
       "source_location": "L102"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "devfixtureactivation_usedailyopeningfixture",
       "label": "useDailyOpeningFixture()",
@@ -242368,7 +242455,7 @@
       "source_location": "L96"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "devfixtureactivation_usedailyoperationsfixture",
       "label": "useDailyOperationsFixture()",
@@ -242377,7 +242464,7 @@
       "source_location": "L90"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "devfixtureactivation_useposhubfixture",
       "label": "usePosHubFixture()",
@@ -242386,7 +242473,7 @@
       "source_location": "L108"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "devfixtureactivation_useworkspacefixture",
       "label": "useWorkspaceFixture()",
@@ -242395,7 +242482,7 @@
       "source_location": "L46"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_operations_devfixtureactivation_ts",
       "label": "devFixtureActivation.ts",
@@ -242404,7 +242491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
       "label": "storybook-shell.tsx",
@@ -242413,7 +242500,7 @@
       "source_location": "L1"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "storybook_shell_storybookcallout",
       "label": "StorybookCallout()",
@@ -242422,7 +242509,7 @@
       "source_location": "L76"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "storybook_shell_storybooklist",
       "label": "StorybookList()",
@@ -242431,7 +242518,7 @@
       "source_location": "L55"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "storybook_shell_storybookpillrow",
       "label": "StorybookPillRow()",
@@ -242440,7 +242527,7 @@
       "source_location": "L88"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "storybook_shell_storybooksection",
       "label": "StorybookSection()",
@@ -242449,67 +242536,13 @@
       "source_location": "L34"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "storybook_shell_storybookshell",
       "label": "StorybookShell()",
       "norm_label": "storybookshell()",
       "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
       "source_location": "L13"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_postransaction_ts",
-      "label": "posTransaction.ts",
-      "norm_label": "postransaction.ts",
-      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "postransaction_fetchpostransaction",
-      "label": "fetchPosTransaction()",
-      "norm_label": "fetchpostransaction()",
-      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
-      "source_location": "L69"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "postransaction_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "postransaction_getpostransactionbyreceipttoken",
-      "label": "getPosTransactionByReceiptToken()",
-      "norm_label": "getpostransactionbyreceipttoken()",
-      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "postransaction_postransactionreceipterror",
-      "label": "PosTransactionReceiptError",
-      "norm_label": "postransactionreceipterror",
-      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "postransaction_postransactionreceipterror_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
-      "source_location": "L62"
     },
     {
       "community": 49,
@@ -242775,6 +242808,60 @@
     {
       "community": 490,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_postransaction_ts",
+      "label": "posTransaction.ts",
+      "norm_label": "postransaction.ts",
+      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "postransaction_fetchpostransaction",
+      "label": "fetchPosTransaction()",
+      "norm_label": "fetchpostransaction()",
+      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
+      "source_location": "L69"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "postransaction_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "postransaction_getpostransactionbyreceipttoken",
+      "label": "getPosTransactionByReceiptToken()",
+      "norm_label": "getpostransactionbyreceipttoken()",
+      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "postransaction_postransactionreceipterror",
+      "label": "PosTransactionReceiptError",
+      "norm_label": "postransactionreceipterror",
+      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "postransaction_postransactionreceipterror_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_promocodes_ts",
       "label": "promoCodes.ts",
       "norm_label": "promocodes.ts",
@@ -242782,7 +242869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 490,
+      "community": 491,
       "file_type": "code",
       "id": "promocodes_getbaseurl",
       "label": "getBaseUrl()",
@@ -242791,7 +242878,7 @@
       "source_location": "L4"
     },
     {
-      "community": 490,
+      "community": 491,
       "file_type": "code",
       "id": "promocodes_getpromocodeitems",
       "label": "getPromoCodeItems()",
@@ -242800,7 +242887,7 @@
       "source_location": "L49"
     },
     {
-      "community": 490,
+      "community": 491,
       "file_type": "code",
       "id": "promocodes_getpromocodes",
       "label": "getPromoCodes()",
@@ -242809,7 +242896,7 @@
       "source_location": "L34"
     },
     {
-      "community": 490,
+      "community": 491,
       "file_type": "code",
       "id": "promocodes_getredeemedpromocodes",
       "label": "getRedeemedPromoCodes()",
@@ -242818,7 +242905,7 @@
       "source_location": "L74"
     },
     {
-      "community": 490,
+      "community": 491,
       "file_type": "code",
       "id": "promocodes_redeempromocode",
       "label": "redeemPromoCode()",
@@ -242827,7 +242914,7 @@
       "source_location": "L6"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "billingdetails_clearform",
       "label": "clearForm()",
@@ -242836,7 +242923,7 @@
       "source_location": "L173"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "billingdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -242845,7 +242932,7 @@
       "source_location": "L102"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "billingdetails_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -242854,7 +242941,7 @@
       "source_location": "L201"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "billingdetails_onsubmit",
       "label": "onSubmit()",
@@ -242863,7 +242950,7 @@
       "source_location": "L150"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "billingdetails_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -242872,7 +242959,7 @@
       "source_location": "L155"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
       "label": "BillingDetails.tsx",
@@ -242881,7 +242968,7 @@
       "source_location": "L1"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "homehero_test_attachmedia",
       "label": "attachMedia()",
@@ -242890,7 +242977,7 @@
       "source_location": "L22"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "homehero_test_destroy",
       "label": "destroy()",
@@ -242899,7 +242986,7 @@
       "source_location": "L24"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "homehero_test_issupported",
       "label": "isSupported()",
@@ -242908,7 +242995,7 @@
       "source_location": "L18"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "homehero_test_loadsource",
       "label": "loadSource()",
@@ -242917,7 +243004,7 @@
       "source_location": "L21"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "homehero_test_on",
       "label": "on()",
@@ -242926,7 +243013,7 @@
       "source_location": "L23"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homehero_test_tsx",
       "label": "HomeHero.test.tsx",
@@ -242935,7 +243022,7 @@
       "source_location": "L1"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "mobileproductactions_collapseonpageclick",
       "label": "collapseOnPageClick()",
@@ -242944,7 +243031,7 @@
       "source_location": "L76"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "mobileproductactions_handleconfirm",
       "label": "handleConfirm()",
@@ -242953,7 +243040,7 @@
       "source_location": "L120"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "mobileproductactions_handleprimaryaction",
       "label": "handlePrimaryAction()",
@@ -242962,7 +243049,7 @@
       "source_location": "L129"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "mobileproductactions_handlesecondaryaction",
       "label": "handleSecondaryAction()",
@@ -242971,7 +243058,7 @@
       "source_location": "L133"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "mobileproductactions_updateposition",
       "label": "updatePosition()",
@@ -242980,7 +243067,7 @@
       "source_location": "L44"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
       "label": "MobileProductActions.tsx",
@@ -242989,7 +243076,7 @@
       "source_location": "L1"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "checkoutexpired_checkoutexpired",
       "label": "CheckoutExpired()",
@@ -242998,7 +243085,7 @@
       "source_location": "L9"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessiongeneric",
       "label": "CheckoutSessionGeneric()",
@@ -243007,7 +243094,7 @@
       "source_location": "L73"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessionnotfound",
       "label": "CheckoutSessionNotFound()",
@@ -243016,7 +243103,7 @@
       "source_location": "L54"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "checkoutexpired_handlesendemail",
       "label": "handleSendEmail()",
@@ -243025,7 +243112,7 @@
       "source_location": "L98"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "checkoutexpired_nocheckoutsession",
       "label": "NoCheckoutSession()",
@@ -243034,66 +243121,12 @@
       "source_location": "L33"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
       "label": "CheckoutExpired.tsx",
       "norm_label": "checkoutexpired.tsx",
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 495,
-      "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L101"
-    },
-    {
-      "community": 495,
-      "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 495,
-      "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 495,
-      "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 495,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 495,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1"
     },
     {
@@ -255051,42 +255084,6 @@
     {
       "community": 655,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_register_test_ts",
-      "label": "register.test.ts",
-      "norm_label": "register.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 655,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_public_register_test_ts",
-      "label": "register.test.ts",
-      "norm_label": "register.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 655,
-      "file_type": "code",
-      "id": "register_test_buildctx",
-      "label": "buildCtx()",
-      "norm_label": "buildctx()",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 655,
-      "file_type": "code",
-      "id": "register_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 656,
-      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
       "label": "register.ts",
       "norm_label": "register.ts",
@@ -255094,7 +255091,7 @@
       "source_location": "L1"
     },
     {
-      "community": 656,
+      "community": 655,
       "file_type": "code",
       "id": "register_mapopendrawerusererror",
       "label": "mapOpenDrawerUserError()",
@@ -255103,7 +255100,7 @@
       "source_location": "L34"
     },
     {
-      "community": 656,
+      "community": 655,
       "file_type": "code",
       "id": "register_normalizeregisternumber",
       "label": "normalizeRegisterNumber()",
@@ -255112,7 +255109,7 @@
       "source_location": "L29"
     },
     {
-      "community": 656,
+      "community": 655,
       "file_type": "code",
       "id": "register_opendrawer",
       "label": "openDrawer()",
@@ -255121,7 +255118,7 @@
       "source_location": "L56"
     },
     {
-      "community": 657,
+      "community": 656,
       "file_type": "code",
       "id": "opendrawer_test_createdbgetmock",
       "label": "createDbGetMock()",
@@ -255130,7 +255127,7 @@
       "source_location": "L39"
     },
     {
-      "community": 657,
+      "community": 656,
       "file_type": "code",
       "id": "opendrawer_test_createdbmock",
       "label": "createDbMock()",
@@ -255139,7 +255136,7 @@
       "source_location": "L99"
     },
     {
-      "community": 657,
+      "community": 656,
       "file_type": "code",
       "id": "opendrawer_test_createdbquerymock",
       "label": "createDbQueryMock()",
@@ -255148,7 +255145,7 @@
       "source_location": "L74"
     },
     {
-      "community": 657,
+      "community": 656,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_opendrawer_test_ts",
       "label": "openDrawer.test.ts",
@@ -255157,7 +255154,7 @@
       "source_location": "L1"
     },
     {
-      "community": 658,
+      "community": 657,
       "file_type": "code",
       "id": "getregisterstate_buildregisterstate",
       "label": "buildRegisterState()",
@@ -255166,7 +255163,7 @@
       "source_location": "L21"
     },
     {
-      "community": 658,
+      "community": 657,
       "file_type": "code",
       "id": "getregisterstate_getactivesessionconflictforregisterstate",
       "label": "getActiveSessionConflictForRegisterState()",
@@ -255175,7 +255172,7 @@
       "source_location": "L42"
     },
     {
-      "community": 658,
+      "community": 657,
       "file_type": "code",
       "id": "getregisterstate_getregisterstate",
       "label": "getRegisterState()",
@@ -255184,7 +255181,7 @@
       "source_location": "L80"
     },
     {
-      "community": 658,
+      "community": 657,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
       "label": "getRegisterState.ts",
@@ -255193,7 +255190,7 @@
       "source_location": "L1"
     },
     {
-      "community": 659,
+      "community": 658,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_storepulse_test_ts",
       "label": "storePulse.test.ts",
@@ -255202,7 +255199,7 @@
       "source_location": "L1"
     },
     {
-      "community": 659,
+      "community": 658,
       "file_type": "code",
       "id": "storepulse_test_createdb",
       "label": "createDb()",
@@ -255211,7 +255208,7 @@
       "source_location": "L12"
     },
     {
-      "community": 659,
+      "community": 658,
       "file_type": "code",
       "id": "storepulse_test_item",
       "label": "item()",
@@ -255220,13 +255217,49 @@
       "source_location": "L127"
     },
     {
-      "community": 659,
+      "community": 658,
       "file_type": "code",
       "id": "storepulse_test_transaction",
       "label": "transaction()",
       "norm_label": "transaction()",
       "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.test.ts",
       "source_location": "L99"
+    },
+    {
+      "community": 659,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_sync_posregistersessionactivity_test_ts",
+      "label": "posRegisterSessionActivity.test.ts",
+      "norm_label": "posregistersessionactivity.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 659,
+      "file_type": "code",
+      "id": "posregistersessionactivity_test_buildactivity",
+      "label": "buildActivity()",
+      "norm_label": "buildactivity()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
+      "source_location": "L457"
+    },
+    {
+      "community": 659,
+      "file_type": "code",
+      "id": "posregistersessionactivity_test_buildreport",
+      "label": "buildReport()",
+      "norm_label": "buildreport()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
+      "source_location": "L436"
+    },
+    {
+      "community": 659,
+      "file_type": "code",
+      "id": "posregistersessionactivity_test_createfakerepository",
+      "label": "createFakeRepository()",
+      "norm_label": "createfakerepository()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
+      "source_location": "L476"
     },
     {
       "community": 66,
@@ -255456,42 +255489,6 @@
     {
       "community": 660,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sync_posregistersessionactivity_test_ts",
-      "label": "posRegisterSessionActivity.test.ts",
-      "norm_label": "posregistersessionactivity.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 660,
-      "file_type": "code",
-      "id": "posregistersessionactivity_test_buildactivity",
-      "label": "buildActivity()",
-      "norm_label": "buildactivity()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
-      "source_location": "L457"
-    },
-    {
-      "community": 660,
-      "file_type": "code",
-      "id": "posregistersessionactivity_test_buildreport",
-      "label": "buildReport()",
-      "norm_label": "buildreport()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
-      "source_location": "L436"
-    },
-    {
-      "community": 660,
-      "file_type": "code",
-      "id": "posregistersessionactivity_test_createfakerepository",
-      "label": "createFakeRepository()",
-      "norm_label": "createfakerepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
-      "source_location": "L476"
-    },
-    {
-      "community": 661,
-      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_registercatalogrevision_ts",
       "label": "registerCatalogRevision.ts",
       "norm_label": "registercatalogrevision.ts",
@@ -255499,7 +255496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 661,
+      "community": 660,
       "file_type": "code",
       "id": "registercatalogrevision_advanceregistercatalogrevision",
       "label": "advanceRegisterCatalogRevision()",
@@ -255508,7 +255505,7 @@
       "source_location": "L24"
     },
     {
-      "community": 661,
+      "community": 660,
       "file_type": "code",
       "id": "registercatalogrevision_readregistercatalogrevision",
       "label": "readRegisterCatalogRevision()",
@@ -255517,7 +255514,7 @@
       "source_location": "L16"
     },
     {
-      "community": 661,
+      "community": 660,
       "file_type": "code",
       "id": "registercatalogrevision_readregistercatalogrevisionrow",
       "label": "readRegisterCatalogRevisionRow()",
@@ -255526,7 +255523,7 @@
       "source_location": "L6"
     },
     {
-      "community": 662,
+      "community": 661,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_sequencegappolicy_ts",
       "label": "sequenceGapPolicy.ts",
@@ -255535,7 +255532,7 @@
       "source_location": "L1"
     },
     {
-      "community": 662,
+      "community": 661,
       "file_type": "code",
       "id": "sequencegappolicy_decidesequencegapaction",
       "label": "decideSequenceGapAction()",
@@ -255544,7 +255541,7 @@
       "source_location": "L115"
     },
     {
-      "community": 662,
+      "community": 661,
       "file_type": "code",
       "id": "sequencegappolicy_issequencegapresolved",
       "label": "isSequenceGapResolved()",
@@ -255553,7 +255550,7 @@
       "source_location": "L219"
     },
     {
-      "community": 662,
+      "community": 661,
       "file_type": "code",
       "id": "sequencegappolicy_recordsequencegapobservation",
       "label": "recordSequenceGapObservation()",
@@ -255562,7 +255559,7 @@
       "source_location": "L190"
     },
     {
-      "community": 663,
+      "community": 662,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_staffproof_ts",
       "label": "staffProof.ts",
@@ -255571,7 +255568,7 @@
       "source_location": "L1"
     },
     {
-      "community": 663,
+      "community": 662,
       "file_type": "code",
       "id": "staffproof_createposlocalstaffprooftoken",
       "label": "createPosLocalStaffProofToken()",
@@ -255580,7 +255577,7 @@
       "source_location": "L10"
     },
     {
-      "community": 663,
+      "community": 662,
       "file_type": "code",
       "id": "staffproof_hashposlocalstaffprooftoken",
       "label": "hashPosLocalStaffProofToken()",
@@ -255589,7 +255586,7 @@
       "source_location": "L16"
     },
     {
-      "community": 663,
+      "community": 662,
       "file_type": "code",
       "id": "staffproof_tohex",
       "label": "toHex()",
@@ -255598,7 +255595,7 @@
       "source_location": "L4"
     },
     {
-      "community": 664,
+      "community": 663,
       "file_type": "code",
       "id": "cloudrepairpolicy_test_buildconflict",
       "label": "buildConflict()",
@@ -255607,7 +255604,7 @@
       "source_location": "L387"
     },
     {
-      "community": 664,
+      "community": 663,
       "file_type": "code",
       "id": "cloudrepairpolicy_test_buildevent",
       "label": "buildEvent()",
@@ -255616,7 +255613,7 @@
       "source_location": "L407"
     },
     {
-      "community": 664,
+      "community": 663,
       "file_type": "code",
       "id": "cloudrepairpolicy_test_createrepairprojectionrepository",
       "label": "createRepairProjectionRepository()",
@@ -255625,7 +255622,7 @@
       "source_location": "L282"
     },
     {
-      "community": 664,
+      "community": 663,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_cloudrepairpolicy_test_ts",
       "label": "cloudRepairPolicy.test.ts",
@@ -255634,7 +255631,7 @@
       "source_location": "L1"
     },
     {
-      "community": 665,
+      "community": 664,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_terminalcommandservice_test_ts",
       "label": "terminalCommandService.test.ts",
@@ -255643,7 +255640,7 @@
       "source_location": "L1"
     },
     {
-      "community": 665,
+      "community": 664,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildcommand",
       "label": "buildCommand()",
@@ -255652,7 +255649,7 @@
       "source_location": "L1731"
     },
     {
-      "community": 665,
+      "community": 664,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildrepository",
       "label": "buildRepository()",
@@ -255661,7 +255658,7 @@
       "source_location": "L1666"
     },
     {
-      "community": 665,
+      "community": 664,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildruntimestatus",
       "label": "buildRuntimeStatus()",
@@ -255670,7 +255667,7 @@
       "source_location": "L1755"
     },
     {
-      "community": 666,
+      "community": 665,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
       "label": "sessionCommandRepository.ts",
@@ -255679,7 +255676,7 @@
       "source_location": "L1"
     },
     {
-      "community": 666,
+      "community": 665,
       "file_type": "code",
       "id": "sessioncommandrepository_collectsessionitemsfrompages",
       "label": "collectSessionItemsFromPages()",
@@ -255688,7 +255685,7 @@
       "source_location": "L177"
     },
     {
-      "community": 666,
+      "community": 665,
       "file_type": "code",
       "id": "sessioncommandrepository_createsessioncommandrepository",
       "label": "createSessionCommandRepository()",
@@ -255697,13 +255694,49 @@
       "source_location": "L68"
     },
     {
-      "community": 666,
+      "community": 665,
       "file_type": "code",
       "id": "sessioncommandrepository_scansessionitembyskuinpages",
       "label": "scanSessionItemBySkuInPages()",
       "norm_label": "scansessionitembyskuinpages()",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
       "source_location": "L195"
+    },
+    {
+      "community": 666,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_register_test_ts",
+      "label": "register.test.ts",
+      "norm_label": "register.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 666,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_public_register_test_ts",
+      "label": "register.test.ts",
+      "norm_label": "register.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 666,
+      "file_type": "code",
+      "id": "register_test_buildctx",
+      "label": "buildCtx()",
+      "norm_label": "buildctx()",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 666,
+      "file_type": "code",
+      "id": "register_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L38"
     },
     {
       "community": 667,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2759
-- Graph nodes: 11545
-- Graph edges: 14178
+- Graph nodes: 11546
+- Graph edges: 14180
 - Communities: 2684
 
 ## Graph Hotspots

--- a/packages/athena-webapp/convex/reports/sweeper.test.ts
+++ b/packages/athena-webapp/convex/reports/sweeper.test.ts
@@ -690,6 +690,103 @@ describe("dirty-mark lifecycle", () => {
     expect(day?.foldedAt).toBeDefined();
   });
 
+  it("keeps the day in progress when a maintenance mark refolds it", async () => {
+    const t = convexTest(schema, modules);
+    const { storeId } = await seedStore(t, "sweep-repair-open-day");
+    allow(storeId);
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("reportDay", {
+        storeId,
+        operatingDate: "2026-07-28",
+        currency: "GHS",
+        status: "open",
+        grossSalesMinor: 0,
+        netSalesMinor: 0,
+        refundsMinor: 0,
+        unitsSold: 0,
+        unitsReturned: 0,
+        uncostedRevenueMinor: 0,
+        grossProfitMinor: 0,
+        paymentsCollectedMinor: 0,
+        paymentsRefundedMinor: 0,
+        paymentAllocatedMinor: 0,
+        foldVersion: REPORTS_FOLD_VERSION,
+        factCount: 0,
+        lastFactRecordedAt: 0,
+        flags: {
+          mixedCurrency: false,
+          hasUncostedRevenue: false,
+          quarantinedFactCount: 0,
+        },
+      });
+    });
+    // A version repair queues the store's current day like any other: the day
+    // lacks `skuDayRowCount`, which is exactly what the backfill looks for.
+    await mark(t, storeId, "2026-07-28", "fold_version_bump");
+
+    await sweep(t);
+
+    const day = await t.run(async (ctx) =>
+      ctx.db
+        .query("reportDay")
+        .withIndex("by_storeId_operatingDate", (q) =>
+          q.eq("storeId", storeId).eq("operatingDate", "2026-07-28"),
+        )
+        .unique(),
+    );
+    // The fold ran, but a maintenance refold has no lifecycle authority: it
+    // must not close the day the Overview is still calling "In progress".
+    expect(day?.foldedAt).toBeDefined();
+    expect(day?.status).toBe("open");
+  });
+
+  it("does not open a settled day when a maintenance mark refolds it", async () => {
+    const t = convexTest(schema, modules);
+    const { storeId } = await seedStore(t, "sweep-repair-past-day");
+    allow(storeId);
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("reportDay", {
+        storeId,
+        operatingDate: "2026-07-20",
+        currency: "GHS",
+        status: "provisional",
+        grossSalesMinor: 0,
+        netSalesMinor: 0,
+        refundsMinor: 0,
+        unitsSold: 0,
+        unitsReturned: 0,
+        uncostedRevenueMinor: 0,
+        grossProfitMinor: 0,
+        paymentsCollectedMinor: 0,
+        paymentsRefundedMinor: 0,
+        paymentAllocatedMinor: 0,
+        foldVersion: REPORTS_FOLD_VERSION,
+        factCount: 0,
+        lastFactRecordedAt: 0,
+        flags: {
+          mixedCurrency: false,
+          hasUncostedRevenue: false,
+          quarantinedFactCount: 0,
+        },
+      });
+    });
+    await mark(t, storeId, "2026-07-20", "fold_version_bump");
+
+    await sweep(t);
+
+    const day = await t.run(async (ctx) =>
+      ctx.db
+        .query("reportDay")
+        .withIndex("by_storeId_operatingDate", (q) =>
+          q.eq("storeId", storeId).eq("operatingDate", "2026-07-20"),
+        )
+        .unique(),
+    );
+    expect(day?.status).toBe("provisional");
+  });
+
   it("re-queues a day whose fold failed, under write_failure, and heals next tick", async () => {
     const t = convexTest(schema, modules);
     const { storeId, productSkuId } = await seedStore(t, "sweep-failure");

--- a/packages/athena-webapp/convex/reports/sweeper.ts
+++ b/packages/athena-webapp/convex/reports/sweeper.ts
@@ -249,6 +249,31 @@ async function loadAcceptedClose(
 // ---------------------------------------------------------------------------
 
 /**
+ * Map a dirty-day reason to the authority its fold carries over `open`.
+ * Exhaustive on purpose: a new reason must state its lifecycle intent rather
+ * than inherit "the fold decides", which silently closes a day in progress.
+ */
+export function openPolicyForReason(
+  reason: Doc<"reportDirtyDay">["reason"],
+): "current-day" | "preserve-existing" | undefined {
+  switch (reason) {
+    // Ingestion asserts this is the store's day in progress.
+    case "day_open":
+      return "current-day";
+    // Maintenance and retries: recompute, change nothing about lifecycle.
+    case "fold_version_bump":
+    case "reseed":
+    case "write_failure":
+    case "fact_cap_exceeded":
+      return "preserve-existing";
+    // Lifecycle-bearing: rollover demotes a past open day, a close reconciles.
+    case "late_fact":
+    case "close_accepted":
+      return undefined;
+  }
+}
+
+/**
  * Replace every derived doc for one (store, operating day) from its facts.
  *
  * Wholesale replacement — not an adjustment — is what makes re-running the
@@ -262,12 +287,23 @@ export async function foldAndReplaceDay(
   now: number,
   opts?: {
     /**
-     * Keep the day's status `open` when the fold would say `provisional`.
-     * Used for `day_open`-reason folds: the store's current day is refolded
-     * for accuracy but is still in progress — only a close (fold returns
-     * `reconciled`/`amended`) or rollover moves it out of `open`.
+     * What this fold is allowed to say about the day's `open` status. The fold
+     * itself never returns `open` — it only knows `provisional`, `reconciled`
+     * and `amended` — so `open` survives a refold only by policy here.
+     *
+     * - `"current-day"`: the mark asserts this IS the store's day in progress
+     *   (`day_open`), so a `provisional` fold becomes `open` unconditionally.
+     *   That also re-opens a day some earlier lifecycle-free refold demoted.
+     * - `"preserve-existing"`: the mark carries no lifecycle meaning — a
+     *   version repair, a reseed, a retry of a fold that failed to write. It
+     *   recomputes metrics and must leave the lifecycle exactly as it found
+     *   it, so an `open` day stays `open` and nothing else is opened.
+     *
+     * Omitted for lifecycle-bearing marks (`late_fact`, `close_accepted`),
+     * where the fold's own answer is the authority: rollover demotes a
+     * still-open past day to `provisional`, and a close reconciles.
      */
-    preserveOpen?: boolean;
+    openPolicy?: "current-day" | "preserve-existing";
   },
 ): Promise<void> {
   const store = await ctx.db.get("store", storeId);
@@ -334,7 +370,10 @@ export async function foldAndReplaceDay(
     operatingDate,
     currency: storeCurrency,
     status:
-      opts?.preserveOpen === true && result.day.status === "provisional"
+      result.day.status === "provisional" &&
+      (opts?.openPolicy === "current-day" ||
+        (opts?.openPolicy === "preserve-existing" &&
+          existingDay?.status === "open"))
         ? ("open" as const)
         : result.day.status,
     grossSalesMinor: result.day.grossSalesMinor,
@@ -600,8 +639,15 @@ export async function sweepWithCtx(ctx: MutationCtx): Promise<SweepResult> {
       // The sweeper does NOT re-mark the open day itself: ingestion upserts a
       // fresh `day_open` mark with every current-day fact, so a quiet day
       // stops being refolded instead of looping one fold per tick forever.
+      //
+      // Maintenance reasons recompute metrics with no lifecycle authority, so
+      // they must not silently close the day in progress. They used to: the
+      // fold only ever answers `provisional`, so a version repair over a quiet
+      // store's current day demoted it out of `open` and the Overview lost
+      // "In progress" — the Daily Operations link and the newest-first
+      // transactions order both hang off that status.
       await foldAndReplaceDay(ctx, mark.storeId, mark.operatingDate, now, {
-        preserveOpen: mark.reason === "day_open",
+        openPolicy: openPolicyForReason(mark.reason),
       });
       const foldedDates = foldedDatesByStore.get(storeKey) ?? new Set<string>();
       foldedDates.add(mark.operatingDate);


### PR DESCRIPTION
## Daily manager report: units sold

The EOD report email carried Sales, Expenses and Voids but no units, so a manager closing the day had no read on volume without opening Reports.

**Units sold comes from the reports lane's `reportDay`, not the close snapshot.** Closing a day does not guarantee it is folded: the close records a `close_snapshot` fact that *marks the day dirty* for the next sweeper tick, so the arrow runs close → dirty → fold and nothing awaits the fold. Timing is benign for units (sale facts fold hours earlier, and the close fact carries `quantity: 0`), but the sweeper's store allowlist is **fail-closed** — a store that isn't switched over has no `reportDay` rows at all. Absence is a normal render path, not an edge case.

**Existence of the row is the whole gate.** `certifiedFoldRevision` is the *movement* trust boundary — it proves a day's SKU rows and its header share a fold — and a day total off the header makes no cross-row claim. Requiring it only dropped pre-stamping legacy days for nothing.

**Unknown is not zero.** The comparison is built from the two numbers rather than routed through `priorDaySummary`, whose accessor coerces a missing key to `0` and would render an unfolded prior day as "No activity on prior day". Metric and comparison drop independently. The prior day is the prior *completed close*, matching what Sales and Expenses compare against.

**Gross, and labelled "Units sold."** The reports UI's "Units moved" is net (`unitsSold - unitsReturned`); reusing that label would have put two different numbers behind one name.

Wired into the closed-day payloads only — the automatic EOD send plus manual/date-range sends. The prepared/skipped/failed open-day email is untouched, since the fold is incomplete before close.

## Approvals email

- Transaction numbers prefixed with `#`, applied once in the builder so the subject line, header subtitle, and detail row cannot disagree. Existing `#` is not doubled.
- Payment methods reuse the daily report's `formatPaymentMethod`, so `mobile_money` reads "Mobile Money" in both emails rather than drifting.
- The requester's note — the server-validated `notes` column, not producer-controlled metadata — is surfaced above Reason, which is the same policy sentence on every request of a type.

Note: the approvals **subject line** changes shape (`… - #TXN-1048`).

## Verification

- `bun run pr:athena` — pass, proof recorded, 0 failed commands.
- 845 tests across `convex/operations`, `convex/emails`, `convex/notifications`; `tsc --noEmit` clean.
- New [approvalRequestEmail.test.ts](packages/athena-webapp/convex/operations/approvalRequestEmail.test.ts) drives the real payload query; units tests drive the real `getDailyManagerReportPayloadsForDateRange` against seeded `dailyClose` + `reportDay` rows, seeding `unitsReturned: 40` so the assertion fails if the metric ever silently becomes net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)