### PR TITLE
fix(operations): surface archival and session context

### DIFF
--- a/docs/solutions/design-patterns/athena-operational-state-context-across-surfaces-2026-08-08.md
+++ b/docs/solutions/design-patterns/athena-operational-state-context-across-surfaces-2026-08-08.md
@@ -1,0 +1,68 @@
+---
+title: Expose operational state consistently across catalog, POS, and EOD alerts
+date: 2026-08-08
+category: design-patterns
+module: athena-webapp operational workspaces
+problem_type: design_pattern
+component: frontend_stimulus
+resolution_type: code_fix
+severity: medium
+applies_when:
+  - "An archived catalog item appears in a search result or report detail"
+  - "A POS-only session needs a different launcher order from a manager session"
+  - "An EOD notification identifies an open register session"
+tags: [operational-state, archived-products, pos, eod-email, catalog]
+related_components: [reports, products, procurement, quick-add, daily-close]
+delivery_diff_fingerprint: 2ee48ae435000623a1bbd6857481905761ea6659fb97e2dad295cbdaa5e75eb2
+---
+
+# Expose operational state consistently across catalog, POS, and EOD alerts
+
+## Problem
+
+Operator surfaces had the data needed to explain exceptional state, but did not
+always present it where a decision was made. Archived products could look live
+in search results, POS-only users saw launchers in a less useful order, and the
+EOD alert named an open register session without identifying its terminal or
+register.
+
+## Solution
+
+Carry the existing operational context to the boundary that renders the
+operator-facing message.
+
+- Search-result rows use an archived badge and a low-emphasis row treatment;
+  report SKU details receive the catalog availability in their identity payload.
+- The POS launcher list changes order only when financial-detail access is
+  absent, leaving the manager layout unchanged.
+- The email adapter reads the already-projected `terminal` and `register`
+  metadata for register-session blockers and prefixes the normal next action:
+
+```ts
+const location = [terminal, register].filter(Boolean).join(" · ");
+return location ? `${location}. ${item.message}` : item.message;
+```
+
+## Why This Matters
+
+Keeping the workflow state and its human context together lets operators act
+without opening another page or inferring why a row is visually different. The
+underlying status, authorization, and closeout behavior remain unchanged.
+
+## Prevention
+
+- When adding an operational-state presentation, test both the state-specific
+  rendering and the unchanged default behavior.
+- Prefer existing report-item metadata over a new query when the notification
+  already has the required terminal or register context.
+
+## Examples
+
+- An archived product result keeps its normal selection behavior but dims its
+  labels and carries an explicit Archived badge.
+- An EOD blocker reads `Front Counter · Register 3. Close the register
+  session before completing the end of day review.`
+
+## Related
+
+- [Register Closeout Variance Alerts and Operations IA](register-closeout-variance-alerts-and-operations-ia-2026-07-08.md)

--- a/docs/solutions/design-patterns/athena-operational-state-context-across-surfaces-2026-08-08.md
+++ b/docs/solutions/design-patterns/athena-operational-state-context-across-surfaces-2026-08-08.md
@@ -65,4 +65,4 @@ underlying status, authorization, and closeout behavior remain unchanged.
 
 ## Related
 
-- [Register Closeout Variance Alerts and Operations IA](register-closeout-variance-alerts-and-operations-ia-2026-07-08.md)
+- [Register Closeout Variance Alerts and Operations IA](athena-register-closeout-variance-alerts-and-ops-ia-2026-07-08.md)

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 2828 files · ~0 words
+- 2829 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 11814 nodes · 14440 edges · 2753 communities detected
+- 11816 nodes · 14442 edges · 2754 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2763,6 +2763,7 @@
 - [[_COMMUNITY_Community 2750|Community 2750]]
 - [[_COMMUNITY_Community 2751|Community 2751]]
 - [[_COMMUNITY_Community 2752|Community 2752]]
+- [[_COMMUNITY_Community 2753|Community 2753]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -2907,16 +2908,16 @@ Cohesion: 0.1
 Nodes (24): addLocalAvailabilityConsumption(), addLocalAvailabilityDeltaConsumption(), buildCatalogRepresentedPendingCheckoutProductSignatures(), buildLocalAvailabilityEventIndex(), buildLocalPendingCheckoutDefinitionEventIdsByItemId(), cartItemLineEventKey(), cartItemLineKey(), cartItemsFromLocalRegisterModel() (+16 more)
 
 ### Community 29 - "Community 29"
+Cohesion: 0.12
+Nodes (28): buildBlockers(), buildCarryForwardItems(), buildCashMetrics(), buildDailyManagerReportPayload(), buildOpenDailyManagerReportPayload(), buildPaymentTotals(), buildPreparedBlockers(), buildPreparedCarryForwardItems() (+20 more)
+
+### Community 30 - "Community 30"
 Cohesion: 0.1
 Nodes (31): applyStockAdjustmentBatchWithCtx(), assertDistinctStockAdjustmentLineItems(), buildInventorySnapshotRowsForProductSkusWithCtx(), buildResolvedStockAdjustmentStatus(), buildStockAdjustmentDecisionEventType(), buildStockAdjustmentOperationalEventMessage(), buildStockAdjustmentSourceId(), buildStockAdjustmentTitle() (+23 more)
 
-### Community 30 - "Community 30"
+### Community 31 - "Community 31"
 Cohesion: 0.08
 Nodes (17): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatOperationalWorkTypeLabel(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue() (+9 more)
-
-### Community 31 - "Community 31"
-Cohesion: 0.13
-Nodes (26): buildBlockers(), buildCarryForwardItems(), buildCashMetrics(), buildDailyManagerReportPayload(), buildOpenDailyManagerReportPayload(), buildPaymentTotals(), buildPreparedBlockers(), buildPreparedCarryForwardItems() (+18 more)
 
 ### Community 32 - "Community 32"
 Cohesion: 0.12
@@ -3415,36 +3416,36 @@ Cohesion: 0.17
 Nodes (6): formatOperatingDateFilterLabel(), formatPaymentMethod(), getEmptyTransactionTitle(), getNextTransactionPageSearch(), getNextTransactionPaymentFilterSearch(), getNextTransactionTimeFilterSearch()
 
 ### Community 156 - "Community 156"
-Cohesion: 0.17
-Nodes (4): formatQuickAddDialogError(), handleAttachBarcode(), handleQuickAddSubmit(), validateQuickAddLookupCode()
-
-### Community 157 - "Community 157"
 Cohesion: 0.15
 Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
 
-### Community 158 - "Community 158"
+### Community 157 - "Community 157"
 Cohesion: 0.19
 Nodes (6): buildOperationalWorkItem(), createOperationalWorkItemWithCtx(), metadataArrayCount(), metadataNumber(), projectOperationalWorkItemForQueue(), sanitizeOperationalWorkItemDetails()
 
-### Community 159 - "Community 159"
+### Community 158 - "Community 158"
 Cohesion: 0.35
 Nodes (12): assertRoleConfiguration(), buildRoleAssignmentDrafts(), buildStaffFullName(), buildStaffProfileResult(), createStaffProfileWithCtx(), ensureLinkedUserAvailable(), getStaffProfileByIdWithCtx(), normalizeOptionalString() (+4 more)
 
-### Community 160 - "Community 160"
+### Community 159 - "Community 159"
 Cohesion: 0.22
 Nodes (10): buildTerminalCloudRepairPreconditionHash(), buildTerminalCloudRepairPreview(), canProjectRegisterOpenForTerminalCloudRepair(), classifyTerminalCloudRepairConflict(), containsBusinessFacts(), getRepairOpenRegisterCloseoutReviewState(), getRepairRegisterSessionCloseoutBoundaryAt(), isDuplicateRegisterOpenConflict() (+2 more)
 
-### Community 161 - "Community 161"
+### Community 160 - "Community 160"
 Cohesion: 0.15
 Nodes (2): period(), withCloses()
 
-### Community 162 - "Community 162"
+### Community 161 - "Community 161"
 Cohesion: 0.25
 Nodes (12): captureBaselineDocumentsWithCtx(), countMutableDemoStoreRowsWithCtx(), isDerivedRestoreTable(), listStoreRows(), planBaselineDocumentPromotion(), promoteBaselineDocumentsWithCtx(), remapDocumentIds(), requireBoundedBatch() (+4 more)
 
-### Community 163 - "Community 163"
+### Community 162 - "Community 162"
 Cohesion: 0.26
 Nodes (9): clearPaymentEditing(), handleCancelEdit(), handleClearPayments(), handleRemovePayment(), handleSaveEdit(), handleStartEdit(), resetPaymentCollectionControls(), setPaymentEditing() (+1 more)
+
+### Community 163 - "Community 163"
+Cohesion: 0.19
+Nodes (4): formatQuickAddDialogError(), handleAttachBarcode(), handleQuickAddSubmit(), validateQuickAddLookupCode()
 
 ### Community 164 - "Community 164"
 Cohesion: 0.23
@@ -3519,40 +3520,40 @@ Cohesion: 0.26
 Nodes (10): archivedProductNestedOrigin(), buildVariantSkuMoneyPayload(), createVariantSku(), decodeOriginValue(), deleteActiveProduct(), getArchivedProductRedirect(), modifyProduct(), onSubmit() (+2 more)
 
 ### Community 182 - "Community 182"
+Cohesion: 0.23
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
+
+### Community 183 - "Community 183"
 Cohesion: 0.17
 Nodes (2): formatRegisterLabel(), getRegisterLabel()
 
-### Community 183 - "Community 183"
+### Community 184 - "Community 184"
 Cohesion: 0.22
 Nodes (6): blocked(), evaluateLocalPosReadiness(), hasSettledLocalCloseout(), localReadinessMatchesInput(), localReadinessRecordFromSnapshots(), refreshLocalPosReadinessFromSnapshots()
 
-### Community 184 - "Community 184"
+### Community 185 - "Community 185"
 Cohesion: 0.31
 Nodes (12): captureRegisterCatalogRuntimePin(), chooseRegisterCatalogRuntimeOwnerId(), clearRegisterCatalogRuntimeActionGuard(), clearRegisterCatalogRuntimeSelection(), getRegisterCatalogRuntimeOwnerId(), hasRegisterCatalogRuntimeActionGuard(), keyForScope(), maintainOwnerClaim() (+4 more)
 
-### Community 185 - "Community 185"
+### Community 186 - "Community 186"
 Cohesion: 0.32
 Nodes (11): clearPosClientTelemetryBuffer(), enqueuePosClientEvent(), mintClientEventId(), normalizePosTelemetryError(), peekPosClientEventBatch(), posClientTelemetryBufferSize(), readBuffer(), removePosClientEvents() (+3 more)
 
-### Community 186 - "Community 186"
+### Community 187 - "Community 187"
 Cohesion: 0.19
 Nodes (5): buildCompletedSalePayload(), completedCustomerInfo(), hasCustomerDetails(), isPosPaymentMethod(), mapLocalPaymentToPayment()
 
-### Community 187 - "Community 187"
+### Community 188 - "Community 188"
 Cohesion: 0.22
 Nodes (9): findRegisterCloseoutReviewItem(), formatCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionId(), getLatestLocalRegisterLifecycleEvent(), getPendingLocalCashVoidApprovals(), getPendingLocalCloseoutRegisterSession(), readLocalSyncStatus() (+1 more)
 
-### Community 188 - "Community 188"
+### Community 189 - "Community 189"
 Cohesion: 0.38
 Nodes (12): base64ToBytes(), bytesToBase64(), createLocalPinVerifier(), cryptoRefDecrypt(), derivePinHash(), deriveWrappingKey(), getCrypto(), isLocalPinVerifierMetadata() (+4 more)
 
-### Community 189 - "Community 189"
+### Community 190 - "Community 190"
 Cohesion: 0.29
 Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
-
-### Community 190 - "Community 190"
-Cohesion: 0.23
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 191 - "Community 191"
 Cohesion: 0.28
@@ -13802,6 +13803,10 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 2753 - "Community 2753"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **3 isolated node(s):** `StaleConstructionError`, `FakeMessageChannel`, `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
@@ -16345,835 +16350,837 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 2337`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2338`** (1 nodes): `input.tsx`
+- **Thin community `Community 2338`** (1 nodes): `input.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2339`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 2339`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2340`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 2340`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2341`** (1 nodes): `popover.tsx`
+- **Thin community `Community 2341`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2342`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 2342`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2343`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 2343`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2344`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 2344`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2345`** (1 nodes): `select.tsx`
+- **Thin community `Community 2345`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2346`** (1 nodes): `separator.tsx`
+- **Thin community `Community 2346`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2347`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 2347`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2348`** (1 nodes): `switch.tsx`
+- **Thin community `Community 2348`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2349`** (1 nodes): `table.test.tsx`
+- **Thin community `Community 2349`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2350`** (1 nodes): `table.tsx`
+- **Thin community `Community 2350`** (1 nodes): `table.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2351`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 2351`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2352`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 2352`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2353`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 2353`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2354`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 2354`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2355`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 2355`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2356`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 2356`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2357`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 2357`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2358`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2358`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2359`** (1 nodes): `constants.ts`
+- **Thin community `Community 2359`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2360`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2360`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2361`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2361`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2362`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2362`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2363`** (1 nodes): `data.ts`
+- **Thin community `Community 2363`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2364`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 2364`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2365`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 2365`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2366`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2366`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2367`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2367`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2368`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2368`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2369`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2369`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2370`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2370`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2371`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 2371`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2372`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 2372`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2373`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 2373`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2374`** (1 nodes): `index.ts`
+- **Thin community `Community 2374`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2375`** (1 nodes): `config.test.ts`
+- **Thin community `Community 2375`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2376`** (1 nodes): `docsWorkspaceTracking.test.ts`
+- **Thin community `Community 2376`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2377`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 2377`** (1 nodes): `docsWorkspaceTracking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2378`** (1 nodes): `onlineOrderSessionOverlay.test.ts`
+- **Thin community `Community 2378`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2379`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 2379`** (1 nodes): `onlineOrderSessionOverlay.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2380`** (1 nodes): `use-pagination-persistence.test.ts`
+- **Thin community `Community 2380`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2381`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 2381`** (1 nodes): `use-pagination-persistence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2382`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 2382`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2383`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 2383`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2384`** (1 nodes): `useGetActiveStore.test.ts`
+- **Thin community `Community 2384`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2385`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 2385`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2386`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 2386`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2387`** (1 nodes): `usePOSProducts.test.ts`
+- **Thin community `Community 2387`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2388`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 2388`** (1 nodes): `usePOSProducts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2389`** (1 nodes): `useSharedDemoContext.test.ts`
+- **Thin community `Community 2389`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2390`** (1 nodes): `useStoreOperatingClock.test.tsx`
+- **Thin community `Community 2390`** (1 nodes): `useSharedDemoContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2391`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 2391`** (1 nodes): `useStoreOperatingClock.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2392`** (1 nodes): `AppMessagesContext.ts`
+- **Thin community `Community 2392`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2393`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
+- **Thin community `Community 2393`** (1 nodes): `AppMessagesContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2394`** (1 nodes): `index.ts`
+- **Thin community `Community 2394`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2395`** (1 nodes): `appUpdateActions.ts`
+- **Thin community `Community 2395`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2396`** (1 nodes): `index.ts`
+- **Thin community `Community 2396`** (1 nodes): `appUpdateActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2397`** (1 nodes): `updateCommunicationPreferenceContext.ts`
+- **Thin community `Community 2397`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2398`** (1 nodes): `updateCoordinator.test.ts`
+- **Thin community `Community 2398`** (1 nodes): `updateCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2399`** (1 nodes): `aws.ts`
+- **Thin community `Community 2399`** (1 nodes): `updateCoordinator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2400`** (1 nodes): `constants.ts`
+- **Thin community `Community 2400`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2401`** (1 nodes): `countries.ts`
+- **Thin community `Community 2401`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2402`** (1 nodes): `access.test.ts`
+- **Thin community `Community 2402`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2403`** (1 nodes): `content.test.ts`
+- **Thin community `Community 2403`** (1 nodes): `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2404`** (1 nodes): `navigation.test.ts`
+- **Thin community `Community 2404`** (1 nodes): `content.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2405`** (1 nodes): `parsing.test.ts`
+- **Thin community `Community 2405`** (1 nodes): `navigation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2406`** (1 nodes): `reportContract.test.ts`
+- **Thin community `Community 2406`** (1 nodes): `parsing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2407`** (1 nodes): `scrollProgress.test.ts`
+- **Thin community `Community 2407`** (1 nodes): `reportContract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2408`** (1 nodes): `virtual-docs-index.d.ts`
+- **Thin community `Community 2408`** (1 nodes): `scrollProgress.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2409`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 2409`** (1 nodes): `virtual-docs-index.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2410`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 2410`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2411`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 2411`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2412`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 2412`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2413`** (1 nodes): `ghana.ts`
+- **Thin community `Community 2413`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2414`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 2414`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2415`** (1 nodes): `inventoryImportParser.test.ts`
+- **Thin community `Community 2415`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2416`** (1 nodes): `landingFunnelClient.test.ts`
+- **Thin community `Community 2416`** (1 nodes): `inventoryImportParser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2417`** (1 nodes): `walkthroughPrivacy.ts`
+- **Thin community `Community 2417`** (1 nodes): `landingFunnelClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2418`** (1 nodes): `walkthroughRequestClient.test.ts`
+- **Thin community `Community 2418`** (1 nodes): `walkthroughPrivacy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2419`** (1 nodes): `appEntryRoutes.test.ts`
+- **Thin community `Community 2419`** (1 nodes): `walkthroughRequestClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2420`** (1 nodes): `storeEntryRoute.test.ts`
+- **Thin community `Community 2420`** (1 nodes): `appEntryRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2421`** (1 nodes): `operatingDate.test.ts`
+- **Thin community `Community 2421`** (1 nodes): `storeEntryRoute.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2422`** (1 nodes): `dto.ts`
+- **Thin community `Community 2422`** (1 nodes): `operatingDate.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2423`** (1 nodes): `ports.ts`
+- **Thin community `Community 2423`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2424`** (1 nodes): `posLocalStorePort.ts`
+- **Thin community `Community 2424`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2425`** (1 nodes): `results.test.ts`
+- **Thin community `Community 2425`** (1 nodes): `posLocalStorePort.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2426`** (1 nodes): `constants.ts`
+- **Thin community `Community 2426`** (1 nodes): `results.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2427`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 2427`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2428`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 2428`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2429`** (1 nodes): `index.ts`
+- **Thin community `Community 2429`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2430`** (1 nodes): `session.test.ts`
+- **Thin community `Community 2430`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2431`** (1 nodes): `types.ts`
+- **Thin community `Community 2431`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2432`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 2432`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2433`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 2433`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2434`** (1 nodes): `registerLifecycleAuthorityGateway.test.ts`
+- **Thin community `Community 2434`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2435`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 2435`** (1 nodes): `registerLifecycleAuthorityGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2436`** (1 nodes): `drawerAuthorityReconciliation.test.ts`
+- **Thin community `Community 2436`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2437`** (1 nodes): `indexedDbPosLocalStorageEngine.test.ts`
+- **Thin community `Community 2437`** (1 nodes): `drawerAuthorityReconciliation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2438`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 2438`** (1 nodes): `indexedDbPosLocalStorageEngine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2439`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 2439`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2440`** (1 nodes): `posLocalLedgerPolicy.test.ts`
+- **Thin community `Community 2440`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2441`** (1 nodes): `posLocalStorageHealth.test.ts`
+- **Thin community `Community 2441`** (1 nodes): `posLocalLedgerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2442`** (1 nodes): `posLocalStorageRuntime.test.ts`
+- **Thin community `Community 2442`** (1 nodes): `posLocalStorageHealth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2443`** (1 nodes): `posLocalStoreInitialization.test.ts`
+- **Thin community `Community 2443`** (1 nodes): `posLocalStorageRuntime.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2444`** (1 nodes): `posLocalStoreMaintenance.test.ts`
+- **Thin community `Community 2444`** (1 nodes): `posLocalStoreInitialization.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2445`** (1 nodes): `posLocalStoreMigrations.test.ts`
+- **Thin community `Community 2445`** (1 nodes): `posLocalStoreMaintenance.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2446`** (1 nodes): `posLocalStoreSnapshot.test.ts`
+- **Thin community `Community 2446`** (1 nodes): `posLocalStoreMigrations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2447`** (1 nodes): `registerCatalogPinRuntime.test.ts`
+- **Thin community `Community 2447`** (1 nodes): `posLocalStoreSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2448`** (1 nodes): `registerLifecycleAuthorityRollout.test.ts`
+- **Thin community `Community 2448`** (1 nodes): `registerCatalogPinRuntime.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2449`** (1 nodes): `registerSessionAuthorityBootstrap.test.ts`
+- **Thin community `Community 2449`** (1 nodes): `registerLifecycleAuthorityRollout.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2450`** (1 nodes): `saleBlockerPolicy.test.ts`
+- **Thin community `Community 2450`** (1 nodes): `registerSessionAuthorityBootstrap.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2451`** (1 nodes): `syncGapDiagnosis.test.ts`
+- **Thin community `Community 2451`** (1 nodes): `saleBlockerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2452`** (1 nodes): `runtimeCounters.test.ts`
+- **Thin community `Community 2452`** (1 nodes): `syncGapDiagnosis.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2453`** (1 nodes): `telemetryBuffer.test.ts`
+- **Thin community `Community 2453`** (1 nodes): `runtimeCounters.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2454`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 2454`** (1 nodes): `telemetryBuffer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2455`** (1 nodes): `catalogSearchPresentation.test.ts`
+- **Thin community `Community 2455`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2456`** (1 nodes): `registerCashierPresence.test.ts`
+- **Thin community `Community 2456`** (1 nodes): `catalogSearchPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2457`** (1 nodes): `registerCheckoutProjection.test.ts`
+- **Thin community `Community 2457`** (1 nodes): `registerCashierPresence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2458`** (1 nodes): `registerUiState.test.ts`
+- **Thin community `Community 2458`** (1 nodes): `registerCheckoutProjection.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2459`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
+- **Thin community `Community 2459`** (1 nodes): `registerUiState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2460`** (1 nodes): `registerSessionCode.test.ts`
+- **Thin community `Community 2460`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2461`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 2461`** (1 nodes): `registerSessionCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2462`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 2462`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2463`** (1 nodes): `contract.test.ts`
+- **Thin community `Community 2463`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2464`** (1 nodes): `guardrails.test.ts`
+- **Thin community `Community 2464`** (1 nodes): `contract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2465`** (1 nodes): `index.ts`
+- **Thin community `Community 2465`** (1 nodes): `guardrails.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2466`** (1 nodes): `runtimeBuildMetadata.test.ts`
+- **Thin community `Community 2466`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2467`** (1 nodes): `category.ts`
+- **Thin community `Community 2467`** (1 nodes): `runtimeBuildMetadata.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2468`** (1 nodes): `product.ts`
+- **Thin community `Community 2468`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2469`** (1 nodes): `store.ts`
+- **Thin community `Community 2469`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2470`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 2470`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2471`** (1 nodes): `user.ts`
+- **Thin community `Community 2471`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2472`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 2472`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2473`** (1 nodes): `sheetReturn.test.ts`
+- **Thin community `Community 2473`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2474`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 2474`** (1 nodes): `sheetReturn.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2475`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 2475`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2476`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 2476`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2477`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2477`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2478`** (1 nodes): `main.tsx`
+- **Thin community `Community 2478`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2479`** (1 nodes): `posAppShellReadiness.test.ts`
+- **Thin community `Community 2479`** (1 nodes): `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2480`** (1 nodes): `posAppShellRoutes.test.ts`
+- **Thin community `Community 2480`** (1 nodes): `posAppShellReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2481`** (1 nodes): `posOfflineReadiness.test.ts`
+- **Thin community `Community 2481`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2482`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
+- **Thin community `Community 2482`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2483`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 2483`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2484`** (1 nodes): `-app-entry-route.tsx`
+- **Thin community `Community 2484`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2485`** (1 nodes): `-privacy-page.tsx`
+- **Thin community `Community 2485`** (1 nodes): `-app-entry-route.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2486`** (1 nodes): `-root-page-search.ts`
+- **Thin community `Community 2486`** (1 nodes): `-privacy-page.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2487`** (1 nodes): `-shared-demo-entry.tsx`
+- **Thin community `Community 2487`** (1 nodes): `-root-page-search.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2488`** (1 nodes): `-walkthrough-page.tsx`
+- **Thin community `Community 2488`** (1 nodes): `-shared-demo-entry.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2489`** (1 nodes): `__root.test.ts`
+- **Thin community `Community 2489`** (1 nodes): `-walkthrough-page.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2490`** (1 nodes): `index.tsx`
+- **Thin community `Community 2490`** (1 nodes): `__root.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 2491`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 2492`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2493`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 2493`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2494`** (1 nodes): `app-settings.tsx`
+- **Thin community `Community 2494`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2495`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 2495`** (1 nodes): `app-settings.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2496`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 2496`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2497`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 2497`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2498`** (1 nodes): `index.tsx`
+- **Thin community `Community 2498`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2499`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 2499`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2500`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 2500`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2501`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 2501`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2502`** (1 nodes): `home.tsx`
+- **Thin community `Community 2502`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2503`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 2503`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2504`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 2504`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2505`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 2505`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2506`** (1 nodes): `index.test.ts`
+- **Thin community `Community 2506`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2507`** (1 nodes): `-cost-overlay-search.ts`
+- **Thin community `Community 2507`** (1 nodes): `index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2508`** (1 nodes): `cost-overlay.test.ts`
+- **Thin community `Community 2508`** (1 nodes): `-cost-overlay-search.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2509`** (1 nodes): `cost-overlay.tsx`
+- **Thin community `Community 2509`** (1 nodes): `cost-overlay.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2510`** (1 nodes): `review.tsx`
+- **Thin community `Community 2510`** (1 nodes): `cost-overlay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2511`** (1 nodes): `inventory-import.test.tsx`
+- **Thin community `Community 2511`** (1 nodes): `review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2512`** (1 nodes): `inventory-import.tsx`
+- **Thin community `Community 2512`** (1 nodes): `inventory-import.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2513`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 2513`** (1 nodes): `inventory-import.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2514`** (1 nodes): `index.tsx`
+- **Thin community `Community 2514`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2515`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 2515`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2516`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 2516`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2517`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 2517`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2518`** (1 nodes): `index.tsx`
+- **Thin community `Community 2518`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2519`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 2519`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2520`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 2520`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2521`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 2521`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2522`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 2522`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2523`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 2523`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2524`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 2524`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2525`** (1 nodes): `expense.index.test.tsx`
+- **Thin community `Community 2525`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2526`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 2526`** (1 nodes): `expense.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2527`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 2527`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2528`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 2528`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2529`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 2529`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2530`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 2530`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2531`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 2531`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2532`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 2532`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2533`** (1 nodes): `edit.tsx`
+- **Thin community `Community 2533`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2534`** (1 nodes): `index.tsx`
+- **Thin community `Community 2534`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2535`** (1 nodes): `archived.tsx`
+- **Thin community `Community 2535`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2536`** (1 nodes): `new.tsx`
+- **Thin community `Community 2536`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 2537`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2538`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 2538`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2539`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 2539`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2540`** (1 nodes): `index.tsx`
+- **Thin community `Community 2540`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2541`** (1 nodes): `new.tsx`
+- **Thin community `Community 2541`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2542`** (1 nodes): `$productSkuId.test.ts`
+- **Thin community `Community 2542`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2543`** (1 nodes): `index.test.ts`
+- **Thin community `Community 2543`** (1 nodes): `$productSkuId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2544`** (1 nodes): `items.tsx`
+- **Thin community `Community 2544`** (1 nodes): `index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2545`** (1 nodes): `weekly.test.ts`
+- **Thin community `Community 2545`** (1 nodes): `items.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2546`** (1 nodes): `reports.tsx`
+- **Thin community `Community 2546`** (1 nodes): `weekly.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2547`** (1 nodes): `index.tsx`
+- **Thin community `Community 2547`** (1 nodes): `reports.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2548`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 2548`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2549`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 2549`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2550`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 2550`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2551`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 2551`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2552`** (1 nodes): `index.tsx`
+- **Thin community `Community 2552`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2553`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 2553`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2554`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 2554`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2555`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 2555`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2556`** (1 nodes): `index.tsx`
+- **Thin community `Community 2556`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2557`** (1 nodes): `_authed-shell.test.tsx`
+- **Thin community `Community 2557`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2558`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 2558`** (1 nodes): `_authed-shell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2559`** (1 nodes): `app.route.test.tsx`
+- **Thin community `Community 2559`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2560`** (1 nodes): `app.test.tsx`
+- **Thin community `Community 2560`** (1 nodes): `app.route.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2561`** (1 nodes): `app.tsx`
+- **Thin community `Community 2561`** (1 nodes): `app.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2562`** (1 nodes): `demo.test.tsx`
+- **Thin community `Community 2562`** (1 nodes): `app.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2563`** (1 nodes): `demo.tsx`
+- **Thin community `Community 2563`** (1 nodes): `demo.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2564`** (1 nodes): `docs.index.tsx`
+- **Thin community `Community 2564`** (1 nodes): `demo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2565`** (1 nodes): `docs.reports.$slug.tsx`
+- **Thin community `Community 2565`** (1 nodes): `docs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2566`** (1 nodes): `docs.solutions.$category.$slug.test.tsx`
+- **Thin community `Community 2566`** (1 nodes): `docs.reports.$slug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2567`** (1 nodes): `docs.tsx`
+- **Thin community `Community 2567`** (1 nodes): `docs.solutions.$category.$slug.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2568`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 2568`** (1 nodes): `docs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2569`** (1 nodes): `index.tsx`
+- **Thin community `Community 2569`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2570`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 2570`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2571`** (1 nodes): `landing.tsx`
+- **Thin community `Community 2571`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2572`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 2572`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2573`** (1 nodes): `_layout.index.tsx`
+- **Thin community `Community 2573`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2574`** (1 nodes): `_layout.tsx`
+- **Thin community `Community 2574`** (1 nodes): `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2575`** (1 nodes): `privacy.test.tsx`
+- **Thin community `Community 2575`** (1 nodes): `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2576`** (1 nodes): `privacy.tsx`
+- **Thin community `Community 2576`** (1 nodes): `privacy.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2577`** (1 nodes): `register-interest.tsx`
+- **Thin community `Community 2577`** (1 nodes): `privacy.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2578`** (1 nodes): `walkthrough.test.tsx`
+- **Thin community `Community 2578`** (1 nodes): `register-interest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2579`** (1 nodes): `walkthrough.tsx`
+- **Thin community `Community 2579`** (1 nodes): `walkthrough.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2580`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 2580`** (1 nodes): `walkthrough.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2581`** (1 nodes): `expenseStore.test.ts`
+- **Thin community `Community 2581`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2582`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 2582`** (1 nodes): `expenseStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2583`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 2583`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2584`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 2584`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2585`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 2585`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2586`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 2586`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2587`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 2587`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2588`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 2588`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2589`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 2589`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2590`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 2590`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2591`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 2591`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2592`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 2592`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2593`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 2593`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2594`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 2594`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2595`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 2595`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2596`** (1 nodes): `eodReviewFixtures.ts`
+- **Thin community `Community 2596`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2597`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 2597`** (1 nodes): `eodReviewFixtures.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2598`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 2598`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2599`** (1 nodes): `setup.ts`
+- **Thin community `Community 2599`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2600`** (1 nodes): `vite-env.d.ts`
+- **Thin community `Community 2600`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2601`** (1 nodes): `viteConfig.test.ts`
+- **Thin community `Community 2601`** (1 nodes): `vite-env.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2602`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 2602`** (1 nodes): `viteConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2603`** (1 nodes): `types.ts`
+- **Thin community `Community 2603`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2604`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 2604`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2605`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 2605`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2606`** (1 nodes): `global.d.ts`
+- **Thin community `Community 2606`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2607`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 2607`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2608`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 2608`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2609`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 2609`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2610`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 2610`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2611`** (1 nodes): `types.ts`
+- **Thin community `Community 2611`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2612`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 2612`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2613`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 2613`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2614`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 2614`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2615`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 2615`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2616`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 2616`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2617`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 2617`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2618`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 2618`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2619`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 2619`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2620`** (1 nodes): `schema.ts`
+- **Thin community `Community 2620`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2621`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 2621`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2622`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 2622`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2623`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 2623`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2624`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 2624`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2625`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 2625`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2626`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 2626`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2627`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 2627`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2628`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 2628`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2629`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 2629`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2630`** (1 nodes): `types.ts`
+- **Thin community `Community 2630`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2631`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2631`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2632`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 2632`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2633`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 2633`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2634`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 2634`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2635`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 2635`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2636`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 2636`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2637`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 2637`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2638`** (1 nodes): `constants.ts`
+- **Thin community `Community 2638`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2639`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 2639`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2640`** (1 nodes): `About.tsx`
+- **Thin community `Community 2640`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2641`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 2641`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2642`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 2642`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2643`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 2643`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2644`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 2644`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2645`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 2645`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2646`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 2646`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2647`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 2647`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2648`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 2648`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2649`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 2649`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2650`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 2650`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2651`** (1 nodes): `types.ts`
+- **Thin community `Community 2651`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2652`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 2652`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2653`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 2653`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2654`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 2654`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2655`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 2655`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2656`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 2656`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2657`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 2657`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2658`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 2658`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2659`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 2659`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2660`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 2660`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2661`** (1 nodes): `alert.tsx`
+- **Thin community `Community 2661`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2662`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 2662`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2663`** (1 nodes): `button.tsx`
+- **Thin community `Community 2663`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2664`** (1 nodes): `card.tsx`
+- **Thin community `Community 2664`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2665`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 2665`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2666`** (1 nodes): `command.tsx`
+- **Thin community `Community 2666`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2667`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 2667`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2668`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 2668`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2669`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 2669`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2670`** (1 nodes): `form.tsx`
+- **Thin community `Community 2670`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2671`** (1 nodes): `icons.tsx`
+- **Thin community `Community 2671`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2672`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 2672`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2673`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 2673`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2674`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 2674`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2675`** (1 nodes): `input.tsx`
+- **Thin community `Community 2675`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2676`** (1 nodes): `label.tsx`
+- **Thin community `Community 2676`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2677`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 2677`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2678`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 2678`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2679`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 2679`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2680`** (1 nodes): `index.ts`
+- **Thin community `Community 2680`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2681`** (1 nodes): `types.ts`
+- **Thin community `Community 2681`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2682`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 2682`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2683`** (1 nodes): `popover.tsx`
+- **Thin community `Community 2683`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2684`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 2684`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2685`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 2685`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2686`** (1 nodes): `select.tsx`
+- **Thin community `Community 2686`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2687`** (1 nodes): `separator.tsx`
+- **Thin community `Community 2687`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2688`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 2688`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2689`** (1 nodes): `table.tsx`
+- **Thin community `Community 2689`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2690`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 2690`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2691`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 2691`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2692`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 2692`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2693`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 2693`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2694`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 2694`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2695`** (1 nodes): `config.ts`
+- **Thin community `Community 2695`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2696`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
+- **Thin community `Community 2696`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2697`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 2697`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2698`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 2698`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2699`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 2699`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2700`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 2700`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2701`** (1 nodes): `constants.ts`
+- **Thin community `Community 2701`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2702`** (1 nodes): `countries.ts`
+- **Thin community `Community 2702`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2703`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 2703`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2704`** (1 nodes): `ghana.ts`
+- **Thin community `Community 2704`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2705`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 2705`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2706`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 2706`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2707`** (1 nodes): `index.ts`
+- **Thin community `Community 2707`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2708`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 2708`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2709`** (1 nodes): `store.ts`
+- **Thin community `Community 2709`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2710`** (1 nodes): `bag.ts`
+- **Thin community `Community 2710`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2711`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 2711`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2712`** (1 nodes): `category.ts`
+- **Thin community `Community 2712`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2713`** (1 nodes): `organization.ts`
+- **Thin community `Community 2713`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2714`** (1 nodes): `product.ts`
+- **Thin community `Community 2714`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2715`** (1 nodes): `store.ts`
+- **Thin community `Community 2715`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2716`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 2716`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2717`** (1 nodes): `user.ts`
+- **Thin community `Community 2717`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2718`** (1 nodes): `states.ts`
+- **Thin community `Community 2718`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2719`** (1 nodes): `storefrontContextEvents.test.ts`
+- **Thin community `Community 2719`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2720`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 2720`** (1 nodes): `storefrontContextEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2721`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 2721`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2722`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2722`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2723`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 2723`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2724`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 2724`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2725`** (1 nodes): `__root.tsx`
+- **Thin community `Community 2725`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2726`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 2726`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2727`** (1 nodes): `index.tsx`
+- **Thin community `Community 2727`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2728`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 2728`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2729`** (1 nodes): `index.tsx`
+- **Thin community `Community 2729`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2730`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 2730`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2731`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 2731`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2732`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 2732`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2733`** (1 nodes): `complete.tsx`
+- **Thin community `Community 2733`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2734`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 2734`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2735`** (1 nodes): `index.tsx`
+- **Thin community `Community 2735`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2736`** (1 nodes): `pending.tsx`
+- **Thin community `Community 2736`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2737`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 2737`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2738`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 2738`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2739`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 2739`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2740`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 2740`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2741`** (1 nodes): `index.js`
+- **Thin community `Community 2741`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2742`** (1 nodes): `check-register-session-authority-writers.test.ts`
+- **Thin community `Community 2742`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2743`** (1 nodes): `delivery-documentation-check.test.ts`
+- **Thin community `Community 2743`** (1 nodes): `check-register-session-authority-writers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2744`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 2744`** (1 nodes): `delivery-documentation-check.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2745`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 2745`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2746`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 2746`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2747`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 2747`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2748`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 2748`** (1 nodes): `valkey-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2749`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 2749`** (1 nodes): `harness-behavior-scenarios.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2750`** (1 nodes): `operational-work-repair.test.ts`
+- **Thin community `Community 2750`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2751`** (1 nodes): `background.js`
+- **Thin community `Community 2751`** (1 nodes): `operational-work-repair.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2752`** (1 nodes): `popup.js`
+- **Thin community `Community 2752`** (1 nodes): `background.js`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2753`** (1 nodes): `popup.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -11687,7 +11687,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildcashmetrics",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L955",
+      "source_location": "L975",
       "target": "dailymanagerreportemail_comparisonfromsummary",
       "weight": 1
     },
@@ -11699,7 +11699,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildcashmetrics",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L943",
+      "source_location": "L963",
       "target": "dailymanagerreportemail_numberfromsummary",
       "weight": 1
     },
@@ -11711,7 +11711,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildcashmetrics",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L945",
+      "source_location": "L965",
       "target": "dailymanagerreportemail_numberfromsummarywithfallback",
       "weight": 1
     },
@@ -12035,7 +12035,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildsummarymetrics",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L871",
+      "source_location": "L891",
       "target": "dailymanagerreportemail_comparisonfromsummary",
       "weight": 1
     },
@@ -12047,7 +12047,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildsummarymetrics",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L876",
+      "source_location": "L896",
       "target": "dailymanagerreportemail_countlabel",
       "weight": 1
     },
@@ -12059,7 +12059,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildsummarymetrics",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L896",
+      "source_location": "L916",
       "target": "dailymanagerreportemail_formatpriordaycomparison",
       "weight": 1
     },
@@ -12071,7 +12071,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildsummarymetrics",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L893",
+      "source_location": "L913",
       "target": "dailymanagerreportemail_formatunitcount",
       "weight": 1
     },
@@ -12083,7 +12083,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildsummarymetrics",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L862",
+      "source_location": "L882",
       "target": "dailymanagerreportemail_numberfromsummary",
       "weight": 1
     },
@@ -12107,7 +12107,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_comparisonfromsummary",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1024",
+      "source_location": "L1044",
       "target": "dailymanagerreportemail_formatpriordaycomparison",
       "weight": 1
     },
@@ -12119,8 +12119,20 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_numberfromsummary",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1026",
+      "source_location": "L1046",
       "target": "dailymanagerreportemail_comparisonfromsummary",
+      "weight": 1
+    },
+    {
+      "_src": "dailymanagerreportemail_formatblockermessage",
+      "_tgt": "dailymanagerreportemail_optionalmetadatalabel",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailymanagerreportemail_formatblockermessage",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L821",
+      "target": "dailymanagerreportemail_optionalmetadatalabel",
       "weight": 1
     },
     {
@@ -12131,7 +12143,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_resolveappurl",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1109",
+      "source_location": "L1129",
       "target": "dailymanagerreportemail_trimtrailingslash",
       "weight": 1
     },
@@ -48911,7 +48923,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L396",
+      "source_location": "L424",
       "target": "dailymanagerreportemail_test_ask",
       "weight": 1
     },
@@ -48923,7 +48935,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L549",
+      "source_location": "L577",
       "target": "dailymanagerreportemail_test_askforday",
       "weight": 1
     },
@@ -48935,7 +48947,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L456",
+      "source_location": "L484",
       "target": "dailymanagerreportemail_test_insertcompletedclose",
       "weight": 1
     },
@@ -48947,7 +48959,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L367",
+      "source_location": "L395",
       "target": "dailymanagerreportemail_test_insertlegacydelivery",
       "weight": 1
     },
@@ -48959,7 +48971,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L506",
+      "source_location": "L534",
       "target": "dailymanagerreportemail_test_insertreportday",
       "weight": 1
     },
@@ -48971,7 +48983,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L300",
+      "source_location": "L328",
       "target": "dailymanagerreportemail_test_money",
       "weight": 1
     },
@@ -48983,7 +48995,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L436",
+      "source_location": "L464",
       "target": "dailymanagerreportemail_test_seedstore",
       "weight": 1
     },
@@ -48995,7 +49007,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L329",
+      "source_location": "L357",
       "target": "dailymanagerreportemail_test_seedstoreandrun",
       "weight": 1
     },
@@ -49007,7 +49019,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L540",
+      "source_location": "L568",
       "target": "dailymanagerreportemail_test_unitsmetric",
       "weight": 1
     },
@@ -49043,7 +49055,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L938",
+      "source_location": "L958",
       "target": "dailymanagerreportemail_buildcashmetrics",
       "weight": 1
     },
@@ -49079,7 +49091,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L816",
+      "source_location": "L836",
       "target": "dailymanagerreportemail_buildpaymenttotals",
       "weight": 1
     },
@@ -49163,7 +49175,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L856",
+      "source_location": "L876",
       "target": "dailymanagerreportemail_buildsummarymetrics",
       "weight": 1
     },
@@ -49187,7 +49199,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1016",
+      "source_location": "L1036",
       "target": "dailymanagerreportemail_comparisonfromsummary",
       "weight": 1
     },
@@ -49199,8 +49211,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1052",
+      "source_location": "L1072",
       "target": "dailymanagerreportemail_countlabel",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
+      "_tgt": "dailymanagerreportemail_formatblockermessage",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L816",
+      "target": "dailymanagerreportemail_formatblockermessage",
       "weight": 1
     },
     {
@@ -49211,7 +49235,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1096",
+      "source_location": "L1116",
       "target": "dailymanagerreportemail_formatcompletedat",
       "weight": 1
     },
@@ -49223,7 +49247,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1075",
+      "source_location": "L1095",
       "target": "dailymanagerreportemail_formatoperatingdate",
       "weight": 1
     },
@@ -49235,7 +49259,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1062",
+      "source_location": "L1082",
       "target": "dailymanagerreportemail_formatpaymentmethod",
       "weight": 1
     },
@@ -49247,7 +49271,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1031",
+      "source_location": "L1051",
       "target": "dailymanagerreportemail_formatpriordaycomparison",
       "weight": 1
     },
@@ -49259,7 +49283,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1048",
+      "source_location": "L1068",
       "target": "dailymanagerreportemail_formatunitcount",
       "weight": 1
     },
@@ -49271,7 +49295,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L983",
+      "source_location": "L1003",
       "target": "dailymanagerreportemail_ispaymenttotal",
       "weight": 1
     },
@@ -49283,7 +49307,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L996",
+      "source_location": "L1016",
       "target": "dailymanagerreportemail_moneyformatter",
       "weight": 1
     },
@@ -49295,7 +49319,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1056",
+      "source_location": "L1076",
       "target": "dailymanagerreportemail_normalizecurrency",
       "weight": 1
     },
@@ -49307,7 +49331,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1068",
+      "source_location": "L1088",
       "target": "dailymanagerreportemail_normalizepaymentmethod",
       "weight": 1
     },
@@ -49319,7 +49343,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1002",
+      "source_location": "L1022",
       "target": "dailymanagerreportemail_numberfromsummary",
       "weight": 1
     },
@@ -49331,8 +49355,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1007",
+      "source_location": "L1027",
       "target": "dailymanagerreportemail_numberfromsummarywithfallback",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
+      "_tgt": "dailymanagerreportemail_optionalmetadatalabel",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L828",
+      "target": "dailymanagerreportemail_optionalmetadatalabel",
       "weight": 1
     },
     {
@@ -49355,7 +49391,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1104",
+      "source_location": "L1124",
       "target": "dailymanagerreportemail_resolveappurl",
       "weight": 1
     },
@@ -49391,7 +49427,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1088",
+      "source_location": "L1108",
       "target": "dailymanagerreportemail_resolvestorescheduletimezoneforat",
       "weight": 1
     },
@@ -49403,7 +49439,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1117",
+      "source_location": "L1137",
       "target": "dailymanagerreportemail_trimtrailingslash",
       "weight": 1
     },
@@ -70847,7 +70883,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L2015",
+      "source_location": "L2037",
       "target": "queries_test_closedday",
       "weight": 1
     },
@@ -70883,7 +70919,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L2125",
+      "source_location": "L2147",
       "target": "queries_test_legacy",
       "weight": 1
     },
@@ -70895,7 +70931,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L2037",
+      "source_location": "L2059",
       "target": "queries_test_ownerroutesfor",
       "weight": 1
     },
@@ -70907,7 +70943,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L2948",
+      "source_location": "L2970",
       "target": "queries_test_readall",
       "weight": 1
     },
@@ -70919,7 +70955,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L1674",
+      "source_location": "L1696",
       "target": "queries_test_seedacceptedweek",
       "weight": 1
     },
@@ -70943,7 +70979,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L2914",
+      "source_location": "L2936",
       "target": "queries_test_seedmember",
       "weight": 1
     },
@@ -70955,7 +70991,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L1588",
+      "source_location": "L1610",
       "target": "queries_test_seedrange",
       "weight": 1
     },
@@ -71027,7 +71063,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L2936",
+      "source_location": "L2958",
       "target": "queries_test_signin",
       "weight": 1
     },
@@ -71039,7 +71075,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L2942",
+      "source_location": "L2964",
       "target": "queries_test_signout",
       "weight": 1
     },
@@ -71051,7 +71087,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L2024",
+      "source_location": "L2046",
       "target": "queries_test_unclosedday",
       "weight": 1
     },
@@ -71183,7 +71219,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L1500",
+      "source_location": "L1503",
       "target": "queries_precedingequalrange",
       "weight": 1
     },
@@ -71267,7 +71303,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L1509",
+      "source_location": "L1512",
       "target": "queries_skurangetotals",
       "weight": 1
     },
@@ -71279,7 +71315,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L1747",
+      "source_location": "L1750",
       "target": "queries_sum",
       "weight": 1
     },
@@ -71411,7 +71447,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L1481",
+      "source_location": "L1484",
       "target": "queries_withskuidentity",
       "weight": 1
     },
@@ -82991,7 +83027,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_shared_reportscontract_ts",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1385",
+      "source_location": "L1387",
       "target": "reportscontract_admissiblemovementdayrevision",
       "weight": 1
     },
@@ -83015,7 +83051,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_shared_reportscontract_ts",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1581",
+      "source_location": "L1583",
       "target": "reportscontract_computemixrequestkey",
       "weight": 1
     },
@@ -83027,7 +83063,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_shared_reportscontract_ts",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1362",
+      "source_location": "L1364",
       "target": "reportscontract_computemovementrequestkey",
       "weight": 1
     },
@@ -83051,7 +83087,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_shared_reportscontract_ts",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1628",
+      "source_location": "L1630",
       "target": "reportscontract_derivemixrequestlifecycle",
       "weight": 1
     },
@@ -83063,7 +83099,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_shared_reportscontract_ts",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1492",
+      "source_location": "L1494",
       "target": "reportscontract_derivemovementrequestlifecycle",
       "weight": 1
     },
@@ -83099,7 +83135,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_shared_reportscontract_ts",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1277",
+      "source_location": "L1279",
       "target": "reportscontract_inclusiveoperatingdayspan",
       "weight": 1
     },
@@ -83123,7 +83159,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_shared_reportscontract_ts",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1265",
+      "source_location": "L1267",
       "target": "reportscontract_isvalidoperatingdatelabel",
       "weight": 1
     },
@@ -83135,7 +83171,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_shared_reportscontract_ts",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1566",
+      "source_location": "L1568",
       "target": "reportscontract_mixrequestkeyidentity",
       "weight": 1
     },
@@ -83147,7 +83183,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_shared_reportscontract_ts",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1596",
+      "source_location": "L1598",
       "target": "reportscontract_mixunitssoldsortkey",
       "weight": 1
     },
@@ -83171,7 +83207,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_shared_reportscontract_ts",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1428",
+      "source_location": "L1430",
       "target": "reportscontract_movementabsnetunitssortkey",
       "weight": 1
     },
@@ -83183,7 +83219,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_shared_reportscontract_ts",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1478",
+      "source_location": "L1480",
       "target": "reportscontract_movementpagecount",
       "weight": 1
     },
@@ -83195,7 +83231,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_shared_reportscontract_ts",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1342",
+      "source_location": "L1344",
       "target": "reportscontract_movementrequestkeyidentity",
       "weight": 1
     },
@@ -83207,7 +83243,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_shared_reportscontract_ts",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1407",
+      "source_location": "L1409",
       "target": "reportscontract_movementsourcerowmatchesrevision",
       "weight": 1
     },
@@ -83267,7 +83303,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_shared_reportscontract_ts",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1203",
+      "source_location": "L1205",
       "target": "reportscontract_skumixsyncrowprobe",
       "weight": 1
     },
@@ -83315,7 +83351,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_shared_reportscontract_ts",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1292",
+      "source_location": "L1294",
       "target": "reportscontract_validatereportrangerequest",
       "weight": 1
     },
@@ -97307,7 +97343,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L1804",
+      "source_location": "L1813",
       "target": "procurementview_cn",
       "weight": 1
     },
@@ -97331,7 +97367,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_procurement_procurementview_tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.tsx",
-      "source_location": "L1831",
+      "source_location": "L1840",
       "target": "procurementview_formatlinecount",
       "weight": 1
     },
@@ -98039,7 +98075,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_product_quickaddproductdialog_tsx",
       "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L453",
+      "source_location": "L455",
       "target": "quickaddproductdialog_addquickaddextravariant",
       "weight": 1
     },
@@ -98051,20 +98087,8 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_product_quickaddproductdialog_tsx",
       "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L169",
+      "source_location": "L170",
       "target": "quickaddproductdialog_buildquickaddexistingskuoptionfromsearchresult",
-      "weight": 1
-    },
-    {
-      "_src": "packages_athena_webapp_src_components_product_quickaddproductdialog_tsx",
-      "_tgt": "quickaddproductdialog_cn",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "contains",
-      "source": "packages_athena_webapp_src_components_product_quickaddproductdialog_tsx",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L824",
-      "target": "quickaddproductdialog_cn",
       "weight": 1
     },
     {
@@ -98075,7 +98099,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_product_quickaddproductdialog_tsx",
       "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L118",
+      "source_location": "L119",
       "target": "quickaddproductdialog_formatquickadddialogerror",
       "weight": 1
     },
@@ -98087,7 +98111,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_product_quickaddproductdialog_tsx",
       "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L158",
+      "source_location": "L159",
       "target": "quickaddproductdialog_getexistingskumetadata",
       "weight": 1
     },
@@ -98099,7 +98123,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_product_quickaddproductdialog_tsx",
       "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L681",
+      "source_location": "L683",
       "target": "quickaddproductdialog_handleattachbarcode",
       "weight": 1
     },
@@ -98111,7 +98135,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_product_quickaddproductdialog_tsx",
       "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L473",
+      "source_location": "L475",
       "target": "quickaddproductdialog_handlecancel",
       "weight": 1
     },
@@ -98123,7 +98147,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_product_quickaddproductdialog_tsx",
       "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L466",
+      "source_location": "L468",
       "target": "quickaddproductdialog_handleopenchange",
       "weight": 1
     },
@@ -98135,7 +98159,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_product_quickaddproductdialog_tsx",
       "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L435",
+      "source_location": "L437",
       "target": "quickaddproductdialog_handlequickaddmultiplevariantschange",
       "weight": 1
     },
@@ -98147,7 +98171,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_product_quickaddproductdialog_tsx",
       "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L487",
+      "source_location": "L489",
       "target": "quickaddproductdialog_handlequickaddsubmit",
       "weight": 1
     },
@@ -98159,7 +98183,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_product_quickaddproductdialog_tsx",
       "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L478",
+      "source_location": "L480",
       "target": "quickaddproductdialog_preventoutsidedismiss",
       "weight": 1
     },
@@ -98171,7 +98195,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_product_quickaddproductdialog_tsx",
       "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L460",
+      "source_location": "L462",
       "target": "quickaddproductdialog_removequickaddextravariant",
       "weight": 1
     },
@@ -98183,7 +98207,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_product_quickaddproductdialog_tsx",
       "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L442",
+      "source_location": "L444",
       "target": "quickaddproductdialog_updatequickaddextravariant",
       "weight": 1
     },
@@ -98195,7 +98219,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_product_quickaddproductdialog_tsx",
       "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L136",
+      "source_location": "L137",
       "target": "quickaddproductdialog_validatequickaddlookupcode",
       "weight": 1
     },
@@ -98435,7 +98459,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_products_products_test_tsx",
       "source_file": "packages/athena-webapp/src/components/products/Products.test.tsx",
-      "source_location": "L830",
+      "source_location": "L863",
       "target": "products_test_makeproduct",
       "weight": 1
     },
@@ -98447,7 +98471,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_products_products_test_tsx",
       "source_file": "packages/athena-webapp/src/components/products/Products.test.tsx",
-      "source_location": "L903",
+      "source_location": "L936",
       "target": "products_test_makeskusearchresult",
       "weight": 1
     },
@@ -98471,7 +98495,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_products_products_tsx",
       "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
-      "source_location": "L467",
+      "source_location": "L472",
       "target": "products_cn",
       "weight": 1
     },
@@ -99959,7 +99983,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportscataloglookup_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsCatalogLookup.tsx",
-      "source_location": "L32",
+      "source_location": "L33",
       "target": "reportscataloglookup_capitalizeproductname",
       "weight": 1
     },
@@ -99971,7 +99995,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportscataloglookup_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsCatalogLookup.tsx",
-      "source_location": "L134",
+      "source_location": "L135",
       "target": "reportscataloglookup_clearquery",
       "weight": 1
     },
@@ -99983,7 +100007,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportscataloglookup_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsCatalogLookup.tsx",
-      "source_location": "L139",
+      "source_location": "L140",
       "target": "reportscataloglookup_inspectsku",
       "weight": 1
     },
@@ -100259,7 +100283,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportsskudetailview_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsSkuDetailView.tsx",
-      "source_location": "L470",
+      "source_location": "L484",
       "target": "reportsskudetailview_cn",
       "weight": 1
     },
@@ -135983,7 +136007,7 @@
       "relation": "calls",
       "source": "products_formatcatalogmetric",
       "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
-      "source_location": "L474",
+      "source_location": "L479",
       "target": "products_cn",
       "weight": 1
     },
@@ -138407,7 +138431,7 @@
       "relation": "calls",
       "source": "queries_inclusivedayspan",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L1501",
+      "source_location": "L1504",
       "target": "queries_precedingequalrange",
       "weight": 1
     },
@@ -138467,7 +138491,7 @@
       "relation": "calls",
       "source": "queries_skurangetotals",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L1520",
+      "source_location": "L1523",
       "target": "queries_sum",
       "weight": 1
     },
@@ -138479,7 +138503,7 @@
       "relation": "calls",
       "source": "queries_test_closedday",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L2129",
+      "source_location": "L2151",
       "target": "queries_test_legacy",
       "weight": 1
     },
@@ -138491,7 +138515,7 @@
       "relation": "calls",
       "source": "queries_test_seedstore",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L2041",
+      "source_location": "L2063",
       "target": "queries_test_ownerroutesfor",
       "weight": 1
     },
@@ -138815,7 +138839,7 @@
       "relation": "calls",
       "source": "quickaddproductdialog_formatquickadddialogerror",
       "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L717",
+      "source_location": "L719",
       "target": "quickaddproductdialog_handleattachbarcode",
       "weight": 1
     },
@@ -138827,7 +138851,7 @@
       "relation": "calls",
       "source": "quickaddproductdialog_validatequickaddlookupcode",
       "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L686",
+      "source_location": "L688",
       "target": "quickaddproductdialog_handleattachbarcode",
       "weight": 1
     },
@@ -138839,7 +138863,7 @@
       "relation": "calls",
       "source": "quickaddproductdialog_formatquickadddialogerror",
       "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L606",
+      "source_location": "L608",
       "target": "quickaddproductdialog_handlequickaddsubmit",
       "weight": 1
     },
@@ -138851,7 +138875,7 @@
       "relation": "calls",
       "source": "quickaddproductdialog_validatequickaddlookupcode",
       "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L514",
+      "source_location": "L516",
       "target": "quickaddproductdialog_handlequickaddsubmit",
       "weight": 1
     },
@@ -143663,7 +143687,7 @@
       "relation": "calls",
       "source": "reportscontract_mixrequestkeyidentity",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1586",
+      "source_location": "L1588",
       "target": "reportscontract_computemixrequestkey",
       "weight": 1
     },
@@ -143675,7 +143699,7 @@
       "relation": "calls",
       "source": "reportscontract_movementrequestkeyidentity",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1367",
+      "source_location": "L1369",
       "target": "reportscontract_computemovementrequestkey",
       "weight": 1
     },
@@ -143687,7 +143711,7 @@
       "relation": "calls",
       "source": "reportscontract_movementpagecount",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1511",
+      "source_location": "L1513",
       "target": "reportscontract_derivemovementrequestlifecycle",
       "weight": 1
     },
@@ -143747,7 +143771,7 @@
       "relation": "calls",
       "source": "reportscontract_inclusiveoperatingdayspan",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1307",
+      "source_location": "L1309",
       "target": "reportscontract_validatereportrangerequest",
       "weight": 1
     },
@@ -143759,7 +143783,7 @@
       "relation": "calls",
       "source": "reportscontract_isvalidoperatingdatelabel",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1297",
+      "source_location": "L1299",
       "target": "reportscontract_validatereportrangerequest",
       "weight": 1
     },
@@ -175894,7 +175918,7 @@
       "label": "closedDay()",
       "norm_label": "closedday()",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L2015"
+      "source_location": "L2037"
     },
     {
       "community": 101,
@@ -175921,7 +175945,7 @@
       "label": "legacy()",
       "norm_label": "legacy()",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L2125"
+      "source_location": "L2147"
     },
     {
       "community": 101,
@@ -175930,7 +175954,7 @@
       "label": "ownerRoutesFor()",
       "norm_label": "ownerroutesfor()",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L2037"
+      "source_location": "L2059"
     },
     {
       "community": 101,
@@ -175939,7 +175963,7 @@
       "label": "readAll()",
       "norm_label": "readall()",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L2948"
+      "source_location": "L2970"
     },
     {
       "community": 101,
@@ -175948,7 +175972,7 @@
       "label": "seedAcceptedWeek()",
       "norm_label": "seedacceptedweek()",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L1674"
+      "source_location": "L1696"
     },
     {
       "community": 101,
@@ -175966,7 +175990,7 @@
       "label": "seedMember()",
       "norm_label": "seedmember()",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L2914"
+      "source_location": "L2936"
     },
     {
       "community": 101,
@@ -175975,7 +175999,7 @@
       "label": "seedRange()",
       "norm_label": "seedrange()",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L1588"
+      "source_location": "L1610"
     },
     {
       "community": 101,
@@ -176029,7 +176053,7 @@
       "label": "signIn()",
       "norm_label": "signin()",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L2936"
+      "source_location": "L2958"
     },
     {
       "community": 101,
@@ -176038,7 +176062,7 @@
       "label": "signOut()",
       "norm_label": "signout()",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L2942"
+      "source_location": "L2964"
     },
     {
       "community": 101,
@@ -176047,7 +176071,7 @@
       "label": "unclosedDay()",
       "norm_label": "unclosedday()",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L2024"
+      "source_location": "L2046"
     },
     {
       "community": 1010,
@@ -190474,7 +190498,7 @@
       "label": "cn()",
       "norm_label": "cn()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsSkuDetailView.tsx",
-      "source_location": "L470"
+      "source_location": "L484"
     },
     {
       "community": 1389,
@@ -196698,137 +196722,128 @@
     {
       "community": 156,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_quickaddproductdialog_tsx",
-      "label": "QuickAddProductDialog.tsx",
-      "norm_label": "quickaddproductdialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "id": "dailyclose_test_compareindexedvalue",
+      "label": "compareIndexedValue()",
+      "norm_label": "compareindexedvalue()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 156,
+      "file_type": "code",
+      "id": "dailyclose_test_completeddailycloserow",
+      "label": "completedDailyCloseRow()",
+      "norm_label": "completeddailycloserow()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L464"
+    },
+    {
+      "community": 156,
+      "file_type": "code",
+      "id": "dailyclose_test_completeddailyclosesnapshot",
+      "label": "completedDailyCloseSnapshot()",
+      "norm_label": "completeddailyclosesnapshot()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L410"
+    },
+    {
+      "community": 156,
+      "file_type": "code",
+      "id": "dailyclose_test_createcommandargs",
+      "label": "createCommandArgs()",
+      "norm_label": "createcommandargs()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L5574"
+    },
+    {
+      "community": 156,
+      "file_type": "code",
+      "id": "dailyclose_test_createdb",
+      "label": "createDb()",
+      "norm_label": "createdb()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L82"
+    },
+    {
+      "community": 156,
+      "file_type": "code",
+      "id": "dailyclose_test_dailycloseapprovalproof",
+      "label": "dailyCloseApprovalProof()",
+      "norm_label": "dailycloseapprovalproof()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L354"
+    },
+    {
+      "community": 156,
+      "file_type": "code",
+      "id": "dailyclose_test_dailyclosecarryforwardapprovalproof",
+      "label": "dailyCloseCarryForwardApprovalProof()",
+      "norm_label": "dailyclosecarryforwardapprovalproof()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L390"
+    },
+    {
+      "community": 156,
+      "file_type": "code",
+      "id": "dailyclose_test_dailyclosereopenapprovalproof",
+      "label": "dailyCloseReopenApprovalProof()",
+      "norm_label": "dailyclosereopenapprovalproof()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L372"
+    },
+    {
+      "community": 156,
+      "file_type": "code",
+      "id": "dailyclose_test_dailyclosesummary",
+      "label": "dailyCloseSummary()",
+      "norm_label": "dailyclosesummary()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L329"
+    },
+    {
+      "community": 156,
+      "file_type": "code",
+      "id": "dailyclose_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L69"
+    },
+    {
+      "community": 156,
+      "file_type": "code",
+      "id": "dailyclose_test_mockdailyclosesnapshotaccess",
+      "label": "mockDailyCloseSnapshotAccess()",
+      "norm_label": "mockdailyclosesnapshotaccess()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L497"
+    },
+    {
+      "community": 156,
+      "file_type": "code",
+      "id": "dailyclose_test_openoperationalworkitems",
+      "label": "openOperationalWorkItems()",
+      "norm_label": "openoperationalworkitems()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L311"
+    },
+    {
+      "community": 156,
+      "file_type": "code",
+      "id": "dailyclose_test_syncedreview",
+      "label": "syncedReview()",
+      "norm_label": "syncedreview()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L1914"
+    },
+    {
+      "community": 156,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
+      "label": "dailyClose.test.ts",
+      "norm_label": "dailyclose.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 156,
-      "file_type": "code",
-      "id": "quickaddproductdialog_addquickaddextravariant",
-      "label": "addQuickAddExtraVariant()",
-      "norm_label": "addquickaddextravariant()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L453"
-    },
-    {
-      "community": 156,
-      "file_type": "code",
-      "id": "quickaddproductdialog_buildquickaddexistingskuoptionfromsearchresult",
-      "label": "buildQuickAddExistingSkuOptionFromSearchResult()",
-      "norm_label": "buildquickaddexistingskuoptionfromsearchresult()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L169"
-    },
-    {
-      "community": 156,
-      "file_type": "code",
-      "id": "quickaddproductdialog_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L824"
-    },
-    {
-      "community": 156,
-      "file_type": "code",
-      "id": "quickaddproductdialog_formatquickadddialogerror",
-      "label": "formatQuickAddDialogError()",
-      "norm_label": "formatquickadddialogerror()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L118"
-    },
-    {
-      "community": 156,
-      "file_type": "code",
-      "id": "quickaddproductdialog_getexistingskumetadata",
-      "label": "getExistingSkuMetadata()",
-      "norm_label": "getexistingskumetadata()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L158"
-    },
-    {
-      "community": 156,
-      "file_type": "code",
-      "id": "quickaddproductdialog_handleattachbarcode",
-      "label": "handleAttachBarcode()",
-      "norm_label": "handleattachbarcode()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L681"
-    },
-    {
-      "community": 156,
-      "file_type": "code",
-      "id": "quickaddproductdialog_handlecancel",
-      "label": "handleCancel()",
-      "norm_label": "handlecancel()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L473"
-    },
-    {
-      "community": 156,
-      "file_type": "code",
-      "id": "quickaddproductdialog_handleopenchange",
-      "label": "handleOpenChange()",
-      "norm_label": "handleopenchange()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L466"
-    },
-    {
-      "community": 156,
-      "file_type": "code",
-      "id": "quickaddproductdialog_handlequickaddmultiplevariantschange",
-      "label": "handleQuickAddMultipleVariantsChange()",
-      "norm_label": "handlequickaddmultiplevariantschange()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L435"
-    },
-    {
-      "community": 156,
-      "file_type": "code",
-      "id": "quickaddproductdialog_handlequickaddsubmit",
-      "label": "handleQuickAddSubmit()",
-      "norm_label": "handlequickaddsubmit()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L487"
-    },
-    {
-      "community": 156,
-      "file_type": "code",
-      "id": "quickaddproductdialog_preventoutsidedismiss",
-      "label": "preventOutsideDismiss()",
-      "norm_label": "preventoutsidedismiss()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L478"
-    },
-    {
-      "community": 156,
-      "file_type": "code",
-      "id": "quickaddproductdialog_removequickaddextravariant",
-      "label": "removeQuickAddExtraVariant()",
-      "norm_label": "removequickaddextravariant()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L460"
-    },
-    {
-      "community": 156,
-      "file_type": "code",
-      "id": "quickaddproductdialog_updatequickaddextravariant",
-      "label": "updateQuickAddExtraVariant()",
-      "norm_label": "updatequickaddextravariant()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L442"
-    },
-    {
-      "community": 156,
-      "file_type": "code",
-      "id": "quickaddproductdialog_validatequickaddlookupcode",
-      "label": "validateQuickAddLookupCode()",
-      "norm_label": "validatequickaddlookupcode()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L136"
     },
     {
       "community": 1560,
@@ -197013,127 +197028,127 @@
     {
       "community": 157,
       "file_type": "code",
-      "id": "dailyclose_test_compareindexedvalue",
-      "label": "compareIndexedValue()",
-      "norm_label": "compareindexedvalue()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L74"
+      "id": "operationalworkitems_approvalrequesttransactionid",
+      "label": "approvalRequestTransactionId()",
+      "norm_label": "approvalrequesttransactionid()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L402"
     },
     {
       "community": 157,
       "file_type": "code",
-      "id": "dailyclose_test_completeddailycloserow",
-      "label": "completedDailyCloseRow()",
-      "norm_label": "completeddailycloserow()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L464"
+      "id": "operationalworkitems_authorizeoperationalworksummaryread",
+      "label": "authorizeOperationalWorkSummaryRead()",
+      "norm_label": "authorizeoperationalworksummaryread()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L64"
     },
     {
       "community": 157,
       "file_type": "code",
-      "id": "dailyclose_test_completeddailyclosesnapshot",
-      "label": "completedDailyCloseSnapshot()",
-      "norm_label": "completeddailyclosesnapshot()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L410"
+      "id": "operationalworkitems_buildoperationalworkitem",
+      "label": "buildOperationalWorkItem()",
+      "norm_label": "buildoperationalworkitem()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L489"
     },
     {
       "community": 157,
       "file_type": "code",
-      "id": "dailyclose_test_createcommandargs",
-      "label": "createCommandArgs()",
-      "norm_label": "createcommandargs()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L5574"
+      "id": "operationalworkitems_createoperationalworkitemwithctx",
+      "label": "createOperationalWorkItemWithCtx()",
+      "norm_label": "createoperationalworkitemwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L516"
     },
     {
       "community": 157,
       "file_type": "code",
-      "id": "dailyclose_test_createdb",
-      "label": "createDb()",
-      "norm_label": "createdb()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L82"
+      "id": "operationalworkitems_filterarchivedpendingcheckoutworkitems",
+      "label": "filterArchivedPendingCheckoutWorkItems()",
+      "norm_label": "filterarchivedpendingcheckoutworkitems()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L88"
     },
     {
       "community": 157,
       "file_type": "code",
-      "id": "dailyclose_test_dailycloseapprovalproof",
-      "label": "dailyCloseApprovalProof()",
-      "norm_label": "dailycloseapprovalproof()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L354"
+      "id": "operationalworkitems_formatregistersyncreviewtitle",
+      "label": "formatRegisterSyncReviewTitle()",
+      "norm_label": "formatregistersyncreviewtitle()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L483"
     },
     {
       "community": 157,
       "file_type": "code",
-      "id": "dailyclose_test_dailyclosecarryforwardapprovalproof",
-      "label": "dailyCloseCarryForwardApprovalProof()",
-      "norm_label": "dailyclosecarryforwardapprovalproof()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L390"
+      "id": "operationalworkitems_listopensyncedsaleinventoryreviewgroupswithcompleteness",
+      "label": "listOpenSyncedSaleInventoryReviewGroupsWithCompleteness()",
+      "norm_label": "listopensyncedsaleinventoryreviewgroupswithcompleteness()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L614"
     },
     {
       "community": 157,
       "file_type": "code",
-      "id": "dailyclose_test_dailyclosereopenapprovalproof",
-      "label": "dailyCloseReopenApprovalProof()",
-      "norm_label": "dailyclosereopenapprovalproof()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "id": "operationalworkitems_metadataarraycount",
+      "label": "metadataArrayCount()",
+      "norm_label": "metadataarraycount()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "operationalworkitems_metadatanumber",
+      "label": "metadataNumber()",
+      "norm_label": "metadatanumber()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L127"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "operationalworkitems_projectoperationalworkitemforqueue",
+      "label": "projectOperationalWorkItemForQueue()",
+      "norm_label": "projectoperationalworkitemforqueue()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
       "source_location": "L372"
     },
     {
       "community": 157,
       "file_type": "code",
-      "id": "dailyclose_test_dailyclosesummary",
-      "label": "dailyCloseSummary()",
-      "norm_label": "dailyclosesummary()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L329"
+      "id": "operationalworkitems_sanitizeapprovalrequestmetadata",
+      "label": "sanitizeApprovalRequestMetadata()",
+      "norm_label": "sanitizeapprovalrequestmetadata()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L427"
     },
     {
       "community": 157,
       "file_type": "code",
-      "id": "dailyclose_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L69"
+      "id": "operationalworkitems_sanitizeoperationalworkitemdetails",
+      "label": "sanitizeOperationalWorkItemDetails()",
+      "norm_label": "sanitizeoperationalworkitemdetails()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L295"
     },
     {
       "community": 157,
       "file_type": "code",
-      "id": "dailyclose_test_mockdailyclosesnapshotaccess",
-      "label": "mockDailyCloseSnapshotAccess()",
-      "norm_label": "mockdailyclosesnapshotaccess()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L497"
+      "id": "operationalworkitems_updateoperationalworkitemstatuswithctx",
+      "label": "updateOperationalWorkItemStatusWithCtx()",
+      "norm_label": "updateoperationalworkitemstatuswithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L551"
     },
     {
       "community": 157,
       "file_type": "code",
-      "id": "dailyclose_test_openoperationalworkitems",
-      "label": "openOperationalWorkItems()",
-      "norm_label": "openoperationalworkitems()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L311"
-    },
-    {
-      "community": 157,
-      "file_type": "code",
-      "id": "dailyclose_test_syncedreview",
-      "label": "syncedReview()",
-      "norm_label": "syncedreview()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L1914"
-    },
-    {
-      "community": 157,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
-      "label": "dailyClose.test.ts",
-      "norm_label": "dailyclose.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "id": "packages_athena_webapp_convex_operations_operationalworkitems_ts",
+      "label": "operationalWorkItems.ts",
+      "norm_label": "operationalworkitems.ts",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
       "source_location": "L1"
     },
     {
@@ -197319,128 +197334,128 @@
     {
       "community": 158,
       "file_type": "code",
-      "id": "operationalworkitems_approvalrequesttransactionid",
-      "label": "approvalRequestTransactionId()",
-      "norm_label": "approvalrequesttransactionid()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L402"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "operationalworkitems_authorizeoperationalworksummaryread",
-      "label": "authorizeOperationalWorkSummaryRead()",
-      "norm_label": "authorizeoperationalworksummaryread()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L64"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "operationalworkitems_buildoperationalworkitem",
-      "label": "buildOperationalWorkItem()",
-      "norm_label": "buildoperationalworkitem()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L489"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "operationalworkitems_createoperationalworkitemwithctx",
-      "label": "createOperationalWorkItemWithCtx()",
-      "norm_label": "createoperationalworkitemwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L516"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "operationalworkitems_filterarchivedpendingcheckoutworkitems",
-      "label": "filterArchivedPendingCheckoutWorkItems()",
-      "norm_label": "filterarchivedpendingcheckoutworkitems()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L88"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "operationalworkitems_formatregistersyncreviewtitle",
-      "label": "formatRegisterSyncReviewTitle()",
-      "norm_label": "formatregistersyncreviewtitle()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L483"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "operationalworkitems_listopensyncedsaleinventoryreviewgroupswithcompleteness",
-      "label": "listOpenSyncedSaleInventoryReviewGroupsWithCompleteness()",
-      "norm_label": "listopensyncedsaleinventoryreviewgroupswithcompleteness()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L614"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "operationalworkitems_metadataarraycount",
-      "label": "metadataArrayCount()",
-      "norm_label": "metadataarraycount()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L135"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "operationalworkitems_metadatanumber",
-      "label": "metadataNumber()",
-      "norm_label": "metadatanumber()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L127"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "operationalworkitems_projectoperationalworkitemforqueue",
-      "label": "projectOperationalWorkItemForQueue()",
-      "norm_label": "projectoperationalworkitemforqueue()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L372"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "operationalworkitems_sanitizeapprovalrequestmetadata",
-      "label": "sanitizeApprovalRequestMetadata()",
-      "norm_label": "sanitizeapprovalrequestmetadata()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L427"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "operationalworkitems_sanitizeoperationalworkitemdetails",
-      "label": "sanitizeOperationalWorkItemDetails()",
-      "norm_label": "sanitizeoperationalworkitemdetails()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L295"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "operationalworkitems_updateoperationalworkitemstatuswithctx",
-      "label": "updateOperationalWorkItemStatusWithCtx()",
-      "norm_label": "updateoperationalworkitemstatuswithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L551"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_operationalworkitems_ts",
-      "label": "operationalWorkItems.ts",
-      "norm_label": "operationalworkitems.ts",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "id": "packages_athena_webapp_convex_operations_staffprofiles_ts",
+      "label": "staffProfiles.ts",
+      "norm_label": "staffprofiles.ts",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
+      "id": "staffprofiles_assertroleconfiguration",
+      "label": "assertRoleConfiguration()",
+      "norm_label": "assertroleconfiguration()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L114"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
+      "id": "staffprofiles_buildroleassignmentdrafts",
+      "label": "buildRoleAssignmentDrafts()",
+      "norm_label": "buildroleassignmentdrafts()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
+      "id": "staffprofiles_buildstafffullname",
+      "label": "buildStaffFullName()",
+      "norm_label": "buildstafffullname()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
+      "id": "staffprofiles_buildstaffprofileresult",
+      "label": "buildStaffProfileResult()",
+      "norm_label": "buildstaffprofileresult()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L197"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
+      "id": "staffprofiles_createstaffprofilewithctx",
+      "label": "createStaffProfileWithCtx()",
+      "norm_label": "createstaffprofilewithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L305"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
+      "id": "staffprofiles_ensurelinkeduseravailable",
+      "label": "ensureLinkedUserAvailable()",
+      "norm_label": "ensurelinkeduseravailable()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
+      "id": "staffprofiles_getstaffprofilebyidwithctx",
+      "label": "getStaffProfileByIdWithCtx()",
+      "norm_label": "getstaffprofilebyidwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L215"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
+      "id": "staffprofiles_liststaffprofileswithctx",
+      "label": "listStaffProfilesWithCtx()",
+      "norm_label": "liststaffprofileswithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L254"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
+      "id": "staffprofiles_normalizeoptionalstring",
+      "label": "normalizeOptionalString()",
+      "norm_label": "normalizeoptionalstring()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L44"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
+      "id": "staffprofiles_normalizestaffprofilepatch",
+      "label": "normalizeStaffProfilePatch()",
+      "norm_label": "normalizestaffprofilepatch()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L179"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
+      "id": "staffprofiles_requirenamesegment",
+      "label": "requireNameSegment()",
+      "norm_label": "requirenamesegment()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
+      "id": "staffprofiles_syncstaffroleassignmentswithctx",
+      "label": "syncStaffRoleAssignmentsWithCtx()",
+      "norm_label": "syncstaffroleassignmentswithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
+      "id": "staffprofiles_updatestaffprofilewithctx",
+      "label": "updateStaffProfileWithCtx()",
+      "norm_label": "updatestaffprofilewithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L381"
     },
     {
       "community": 1580,
@@ -197625,128 +197640,128 @@
     {
       "community": 159,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_staffprofiles_ts",
-      "label": "staffProfiles.ts",
-      "norm_label": "staffprofiles.ts",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "id": "cloudrepairpolicy_buildterminalcloudrepairpreconditionhash",
+      "label": "buildTerminalCloudRepairPreconditionHash()",
+      "norm_label": "buildterminalcloudrepairpreconditionhash()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L143"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_buildterminalcloudrepairpreview",
+      "label": "buildTerminalCloudRepairPreview()",
+      "norm_label": "buildterminalcloudrepairpreview()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_canprojectregisteropenforterminalcloudrepair",
+      "label": "canProjectRegisterOpenForTerminalCloudRepair()",
+      "norm_label": "canprojectregisteropenforterminalcloudrepair()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L167"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_classifyterminalcloudrepairconflict",
+      "label": "classifyTerminalCloudRepairConflict()",
+      "norm_label": "classifyterminalcloudrepairconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_containsbusinessfacts",
+      "label": "containsBusinessFacts()",
+      "norm_label": "containsbusinessfacts()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L374"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_getrepairconflictcloseoutreviewboundaryat",
+      "label": "getRepairConflictCloseoutReviewBoundaryAt()",
+      "norm_label": "getrepairconflictcloseoutreviewboundaryat()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L289"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_getrepairopenregistercloseoutreviewstate",
+      "label": "getRepairOpenRegisterCloseoutReviewState()",
+      "norm_label": "getrepairopenregistercloseoutreviewstate()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L261"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_getrepairregistersessioncloseoutboundaryat",
+      "label": "getRepairRegisterSessionCloseoutBoundaryAt()",
+      "norm_label": "getrepairregistersessioncloseoutboundaryat()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L297"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_isduplicateregisteropenconflict",
+      "label": "isDuplicateRegisterOpenConflict()",
+      "norm_label": "isduplicateregisteropenconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L354"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_normalizerepairstring",
+      "label": "normalizeRepairString()",
+      "norm_label": "normalizerepairstring()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L395"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_repairfactmatchesregistersessioncloseoutreview",
+      "label": "repairFactMatchesRegisterSessionCloseoutReview()",
+      "norm_label": "repairfactmatchesregistersessioncloseoutreview()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L326"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_skipped",
+      "label": "skipped()",
+      "norm_label": "skipped()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L343"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_skipterminalcloudrepairconflict",
+      "label": "skipTerminalCloudRepairConflict()",
+      "norm_label": "skipterminalcloudrepairconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L132"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_cloudrepairpolicy_ts",
+      "label": "cloudRepairPolicy.ts",
+      "norm_label": "cloudrepairpolicy.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "staffprofiles_assertroleconfiguration",
-      "label": "assertRoleConfiguration()",
-      "norm_label": "assertroleconfiguration()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L114"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "staffprofiles_buildroleassignmentdrafts",
-      "label": "buildRoleAssignmentDrafts()",
-      "norm_label": "buildroleassignmentdrafts()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L92"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "staffprofiles_buildstafffullname",
-      "label": "buildStaffFullName()",
-      "norm_label": "buildstafffullname()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "staffprofiles_buildstaffprofileresult",
-      "label": "buildStaffProfileResult()",
-      "norm_label": "buildstaffprofileresult()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L197"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "staffprofiles_createstaffprofilewithctx",
-      "label": "createStaffProfileWithCtx()",
-      "norm_label": "createstaffprofilewithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L305"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "staffprofiles_ensurelinkeduseravailable",
-      "label": "ensureLinkedUserAvailable()",
-      "norm_label": "ensurelinkeduseravailable()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "staffprofiles_getstaffprofilebyidwithctx",
-      "label": "getStaffProfileByIdWithCtx()",
-      "norm_label": "getstaffprofilebyidwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L215"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "staffprofiles_liststaffprofileswithctx",
-      "label": "listStaffProfilesWithCtx()",
-      "norm_label": "liststaffprofileswithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L254"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "staffprofiles_normalizeoptionalstring",
-      "label": "normalizeOptionalString()",
-      "norm_label": "normalizeoptionalstring()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L44"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "staffprofiles_normalizestaffprofilepatch",
-      "label": "normalizeStaffProfilePatch()",
-      "norm_label": "normalizestaffprofilepatch()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L179"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "staffprofiles_requirenamesegment",
-      "label": "requireNameSegment()",
-      "norm_label": "requirenamesegment()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "staffprofiles_syncstaffroleassignmentswithctx",
-      "label": "syncStaffRoleAssignmentsWithCtx()",
-      "norm_label": "syncstaffroleassignmentswithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "staffprofiles_updatestaffprofilewithctx",
-      "label": "updateStaffProfileWithCtx()",
-      "norm_label": "updatestaffprofilewithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L381"
     },
     {
       "community": 1590,
@@ -198318,128 +198333,128 @@
     {
       "community": 160,
       "file_type": "code",
-      "id": "cloudrepairpolicy_buildterminalcloudrepairpreconditionhash",
-      "label": "buildTerminalCloudRepairPreconditionHash()",
-      "norm_label": "buildterminalcloudrepairpreconditionhash()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L143"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_buildterminalcloudrepairpreview",
-      "label": "buildTerminalCloudRepairPreview()",
-      "norm_label": "buildterminalcloudrepairpreview()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_canprojectregisteropenforterminalcloudrepair",
-      "label": "canProjectRegisterOpenForTerminalCloudRepair()",
-      "norm_label": "canprojectregisteropenforterminalcloudrepair()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L167"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_classifyterminalcloudrepairconflict",
-      "label": "classifyTerminalCloudRepairConflict()",
-      "norm_label": "classifyterminalcloudrepairconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_containsbusinessfacts",
-      "label": "containsBusinessFacts()",
-      "norm_label": "containsbusinessfacts()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L374"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_getrepairconflictcloseoutreviewboundaryat",
-      "label": "getRepairConflictCloseoutReviewBoundaryAt()",
-      "norm_label": "getrepairconflictcloseoutreviewboundaryat()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L289"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_getrepairopenregistercloseoutreviewstate",
-      "label": "getRepairOpenRegisterCloseoutReviewState()",
-      "norm_label": "getrepairopenregistercloseoutreviewstate()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L261"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_getrepairregistersessioncloseoutboundaryat",
-      "label": "getRepairRegisterSessionCloseoutBoundaryAt()",
-      "norm_label": "getrepairregistersessioncloseoutboundaryat()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L297"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_isduplicateregisteropenconflict",
-      "label": "isDuplicateRegisterOpenConflict()",
-      "norm_label": "isduplicateregisteropenconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L354"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_normalizerepairstring",
-      "label": "normalizeRepairString()",
-      "norm_label": "normalizerepairstring()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L395"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_repairfactmatchesregistersessioncloseoutreview",
-      "label": "repairFactMatchesRegisterSessionCloseoutReview()",
-      "norm_label": "repairfactmatchesregistersessioncloseoutreview()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L326"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_skipped",
-      "label": "skipped()",
-      "norm_label": "skipped()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L343"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_skipterminalcloudrepairconflict",
-      "label": "skipTerminalCloudRepairConflict()",
-      "norm_label": "skipterminalcloudrepairconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L132"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_cloudrepairpolicy_ts",
-      "label": "cloudRepairPolicy.ts",
-      "norm_label": "cloudrepairpolicy.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "id": "packages_athena_webapp_convex_reports_weekly_test_ts",
+      "label": "weekly.test.ts",
+      "norm_label": "weekly.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "weekly_test_day",
+      "label": "day()",
+      "norm_label": "day()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L68"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "weekly_test_fact",
+      "label": "fact()",
+      "norm_label": "fact()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "weekly_test_insertcompletedclose",
+      "label": "insertCompletedClose()",
+      "norm_label": "insertcompletedclose()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L253"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "weekly_test_insertfact",
+      "label": "insertFact()",
+      "norm_label": "insertfact()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L224"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "weekly_test_insertfoldedcloseday",
+      "label": "insertFoldedCloseDay()",
+      "norm_label": "insertfoldedcloseday()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L328"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "weekly_test_inserthistoricalweekdays",
+      "label": "insertHistoricalWeekDays()",
+      "norm_label": "inserthistoricalweekdays()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L355"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "weekly_test_linkclosetoday",
+      "label": "linkCloseToDay()",
+      "norm_label": "linkclosetoday()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L2559"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "weekly_test_patchscheduleexceptions",
+      "label": "patchScheduleExceptions()",
+      "norm_label": "patchscheduleexceptions()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L2538"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "weekly_test_period",
+      "label": "period()",
+      "norm_label": "period()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "weekly_test_readbaseline",
+      "label": "readBaseline()",
+      "norm_label": "readbaseline()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L2049"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "weekly_test_readweekmark",
+      "label": "readWeekMark()",
+      "norm_label": "readweekmark()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L2040"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "weekly_test_seedstore",
+      "label": "seedStore()",
+      "norm_label": "seedstore()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L185"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "weekly_test_withcloses",
+      "label": "withCloses()",
+      "norm_label": "withcloses()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L380"
     },
     {
       "community": 1600,
@@ -198624,128 +198639,128 @@
     {
       "community": 161,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_weekly_test_ts",
-      "label": "weekly.test.ts",
-      "norm_label": "weekly.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "id": "domainrestore_capturebaselinedocumentswithctx",
+      "label": "captureBaselineDocumentsWithCtx()",
+      "norm_label": "capturebaselinedocumentswithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
+      "source_location": "L359"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "domainrestore_countmutabledemostorerowswithctx",
+      "label": "countMutableDemoStoreRowsWithCtx()",
+      "norm_label": "countmutabledemostorerowswithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
+      "source_location": "L346"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "domainrestore_isderivedrestoretable",
+      "label": "isDerivedRestoreTable()",
+      "norm_label": "isderivedrestoretable()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
+      "source_location": "L104"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "domainrestore_liststorerows",
+      "label": "listStoreRows()",
+      "norm_label": "liststorerows()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
+      "source_location": "L198"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "domainrestore_planbaselinedocumentpromotion",
+      "label": "planBaselineDocumentPromotion()",
+      "norm_label": "planbaselinedocumentpromotion()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
+      "source_location": "L138"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "domainrestore_plandomainrestore",
+      "label": "planDomainRestore()",
+      "norm_label": "plandomainrestore()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
+      "source_location": "L162"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "domainrestore_promotebaselinedocumentswithctx",
+      "label": "promoteBaselineDocumentsWithCtx()",
+      "norm_label": "promotebaselinedocumentswithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
+      "source_location": "L385"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "domainrestore_remapdocumentids",
+      "label": "remapDocumentIds()",
+      "norm_label": "remapdocumentids()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
+      "source_location": "L179"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "domainrestore_requireboundedbatch",
+      "label": "requireBoundedBatch()",
+      "norm_label": "requireboundedbatch()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
+      "source_location": "L111"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "domainrestore_requirecurrentbaselinedocuments",
+      "label": "requireCurrentBaselineDocuments()",
+      "norm_label": "requirecurrentbaselinedocuments()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
+      "source_location": "L120"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "domainrestore_restorebatchlimitfor",
+      "label": "restoreBatchLimitFor()",
+      "norm_label": "restorebatchlimitfor()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "domainrestore_restoremutabledemostorerowswithctx",
+      "label": "restoreMutableDemoStoreRowsWithCtx()",
+      "norm_label": "restoremutabledemostorerowswithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
+      "source_location": "L424"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "domainrestore_withoutsystemfields",
+      "label": "withoutSystemFields()",
+      "norm_label": "withoutsystemfields()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
+      "source_location": "L191"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_shareddemo_domainrestore_ts",
+      "label": "domainRestore.ts",
+      "norm_label": "domainrestore.ts",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "weekly_test_day",
-      "label": "day()",
-      "norm_label": "day()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L68"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "weekly_test_fact",
-      "label": "fact()",
-      "norm_label": "fact()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "weekly_test_insertcompletedclose",
-      "label": "insertCompletedClose()",
-      "norm_label": "insertcompletedclose()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L253"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "weekly_test_insertfact",
-      "label": "insertFact()",
-      "norm_label": "insertfact()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L224"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "weekly_test_insertfoldedcloseday",
-      "label": "insertFoldedCloseDay()",
-      "norm_label": "insertfoldedcloseday()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L328"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "weekly_test_inserthistoricalweekdays",
-      "label": "insertHistoricalWeekDays()",
-      "norm_label": "inserthistoricalweekdays()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L355"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "weekly_test_linkclosetoday",
-      "label": "linkCloseToDay()",
-      "norm_label": "linkclosetoday()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L2559"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "weekly_test_patchscheduleexceptions",
-      "label": "patchScheduleExceptions()",
-      "norm_label": "patchscheduleexceptions()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L2538"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "weekly_test_period",
-      "label": "period()",
-      "norm_label": "period()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L50"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "weekly_test_readbaseline",
-      "label": "readBaseline()",
-      "norm_label": "readbaseline()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L2049"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "weekly_test_readweekmark",
-      "label": "readWeekMark()",
-      "norm_label": "readweekmark()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L2040"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "weekly_test_seedstore",
-      "label": "seedStore()",
-      "norm_label": "seedstore()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L185"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "weekly_test_withcloses",
-      "label": "withCloses()",
-      "norm_label": "withcloses()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L380"
     },
     {
       "community": 1610,
@@ -198930,128 +198945,128 @@
     {
       "community": 162,
       "file_type": "code",
-      "id": "domainrestore_capturebaselinedocumentswithctx",
-      "label": "captureBaselineDocumentsWithCtx()",
-      "norm_label": "capturebaselinedocumentswithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L359"
+      "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_tsx",
+      "label": "PaymentsAddedList.tsx",
+      "norm_label": "paymentsaddedlist.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L1"
     },
     {
       "community": 162,
       "file_type": "code",
-      "id": "domainrestore_countmutabledemostorerowswithctx",
-      "label": "countMutableDemoStoreRowsWithCtx()",
-      "norm_label": "countmutabledemostorerowswithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L346"
+      "id": "paymentsaddedlist_clearpaymentediting",
+      "label": "clearPaymentEditing()",
+      "norm_label": "clearpaymentediting()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L139"
     },
     {
       "community": 162,
       "file_type": "code",
-      "id": "domainrestore_isderivedrestoretable",
-      "label": "isDerivedRestoreTable()",
-      "norm_label": "isderivedrestoretable()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L104"
+      "id": "paymentsaddedlist_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L384"
     },
     {
       "community": 162,
       "file_type": "code",
-      "id": "domainrestore_liststorerows",
-      "label": "listStoreRows()",
-      "norm_label": "liststorerows()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
+      "id": "paymentsaddedlist_getpaymentmethodicon",
+      "label": "getPaymentMethodIcon()",
+      "norm_label": "getpaymentmethodicon()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L52"
+    },
+    {
+      "community": 162,
+      "file_type": "code",
+      "id": "paymentsaddedlist_getpaymentmethodlabel",
+      "label": "getPaymentMethodLabel()",
+      "norm_label": "getpaymentmethodlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 162,
+      "file_type": "code",
+      "id": "paymentsaddedlist_handlecanceledit",
+      "label": "handleCancelEdit()",
+      "norm_label": "handlecanceledit()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L180"
+    },
+    {
+      "community": 162,
+      "file_type": "code",
+      "id": "paymentsaddedlist_handleclearpayments",
+      "label": "handleClearPayments()",
+      "norm_label": "handleclearpayments()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L198"
     },
     {
       "community": 162,
       "file_type": "code",
-      "id": "domainrestore_planbaselinedocumentpromotion",
-      "label": "planBaselineDocumentPromotion()",
-      "norm_label": "planbaselinedocumentpromotion()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L138"
+      "id": "paymentsaddedlist_handleremovepayment",
+      "label": "handleRemovePayment()",
+      "norm_label": "handleremovepayment()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L204"
     },
     {
       "community": 162,
       "file_type": "code",
-      "id": "domainrestore_plandomainrestore",
-      "label": "planDomainRestore()",
-      "norm_label": "plandomainrestore()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L162"
+      "id": "paymentsaddedlist_handlesaveedit",
+      "label": "handleSaveEdit()",
+      "norm_label": "handlesaveedit()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L145"
     },
     {
       "community": 162,
       "file_type": "code",
-      "id": "domainrestore_promotebaselinedocumentswithctx",
-      "label": "promoteBaselineDocumentsWithCtx()",
-      "norm_label": "promotebaselinedocumentswithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L385"
+      "id": "paymentsaddedlist_handlestartedit",
+      "label": "handleStartEdit()",
+      "norm_label": "handlestartedit()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L132"
     },
     {
       "community": 162,
       "file_type": "code",
-      "id": "domainrestore_remapdocumentids",
-      "label": "remapDocumentIds()",
-      "norm_label": "remapdocumentids()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L179"
+      "id": "paymentsaddedlist_if",
+      "label": "if()",
+      "norm_label": "if()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L315"
     },
     {
       "community": 162,
       "file_type": "code",
-      "id": "domainrestore_requireboundedbatch",
-      "label": "requireBoundedBatch()",
-      "norm_label": "requireboundedbatch()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L111"
+      "id": "paymentsaddedlist_resetpaymentcollectioncontrols",
+      "label": "resetPaymentCollectionControls()",
+      "norm_label": "resetpaymentcollectioncontrols()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L193"
     },
     {
       "community": 162,
       "file_type": "code",
-      "id": "domainrestore_requirecurrentbaselinedocuments",
-      "label": "requireCurrentBaselineDocuments()",
-      "norm_label": "requirecurrentbaselinedocuments()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L120"
+      "id": "paymentsaddedlist_setpaymentediting",
+      "label": "setPaymentEditing()",
+      "norm_label": "setpaymentediting()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L123"
     },
     {
       "community": 162,
       "file_type": "code",
-      "id": "domainrestore_restorebatchlimitfor",
-      "label": "restoreBatchLimitFor()",
-      "norm_label": "restorebatchlimitfor()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L92"
-    },
-    {
-      "community": 162,
-      "file_type": "code",
-      "id": "domainrestore_restoremutabledemostorerowswithctx",
-      "label": "restoreMutableDemoStoreRowsWithCtx()",
-      "norm_label": "restoremutabledemostorerowswithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L424"
-    },
-    {
-      "community": 162,
-      "file_type": "code",
-      "id": "domainrestore_withoutsystemfields",
-      "label": "withoutSystemFields()",
-      "norm_label": "withoutsystemfields()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L191"
-    },
-    {
-      "community": 162,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_shareddemo_domainrestore_ts",
-      "label": "domainRestore.ts",
-      "norm_label": "domainrestore.ts",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L1"
+      "id": "paymentsaddedlist_setpaymentsexpanded",
+      "label": "setPaymentsExpanded()",
+      "norm_label": "setpaymentsexpanded()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L115"
     },
     {
       "community": 1620,
@@ -199236,128 +199251,128 @@
     {
       "community": 163,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_tsx",
-      "label": "PaymentsAddedList.tsx",
-      "norm_label": "paymentsaddedlist.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "id": "packages_athena_webapp_src_components_product_quickaddproductdialog_tsx",
+      "label": "QuickAddProductDialog.tsx",
+      "norm_label": "quickaddproductdialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
       "source_location": "L1"
     },
     {
       "community": 163,
       "file_type": "code",
-      "id": "paymentsaddedlist_clearpaymentediting",
-      "label": "clearPaymentEditing()",
-      "norm_label": "clearpaymentediting()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L139"
+      "id": "quickaddproductdialog_addquickaddextravariant",
+      "label": "addQuickAddExtraVariant()",
+      "norm_label": "addquickaddextravariant()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L455"
     },
     {
       "community": 163,
       "file_type": "code",
-      "id": "paymentsaddedlist_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L384"
+      "id": "quickaddproductdialog_buildquickaddexistingskuoptionfromsearchresult",
+      "label": "buildQuickAddExistingSkuOptionFromSearchResult()",
+      "norm_label": "buildquickaddexistingskuoptionfromsearchresult()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L170"
     },
     {
       "community": 163,
       "file_type": "code",
-      "id": "paymentsaddedlist_getpaymentmethodicon",
-      "label": "getPaymentMethodIcon()",
-      "norm_label": "getpaymentmethodicon()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L52"
+      "id": "quickaddproductdialog_formatquickadddialogerror",
+      "label": "formatQuickAddDialogError()",
+      "norm_label": "formatquickadddialogerror()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L119"
     },
     {
       "community": 163,
       "file_type": "code",
-      "id": "paymentsaddedlist_getpaymentmethodlabel",
-      "label": "getPaymentMethodLabel()",
-      "norm_label": "getpaymentmethodlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L63"
+      "id": "quickaddproductdialog_getexistingskumetadata",
+      "label": "getExistingSkuMetadata()",
+      "norm_label": "getexistingskumetadata()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L159"
     },
     {
       "community": 163,
       "file_type": "code",
-      "id": "paymentsaddedlist_handlecanceledit",
-      "label": "handleCancelEdit()",
-      "norm_label": "handlecanceledit()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L180"
+      "id": "quickaddproductdialog_handleattachbarcode",
+      "label": "handleAttachBarcode()",
+      "norm_label": "handleattachbarcode()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L683"
     },
     {
       "community": 163,
       "file_type": "code",
-      "id": "paymentsaddedlist_handleclearpayments",
-      "label": "handleClearPayments()",
-      "norm_label": "handleclearpayments()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L198"
+      "id": "quickaddproductdialog_handlecancel",
+      "label": "handleCancel()",
+      "norm_label": "handlecancel()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L475"
     },
     {
       "community": 163,
       "file_type": "code",
-      "id": "paymentsaddedlist_handleremovepayment",
-      "label": "handleRemovePayment()",
-      "norm_label": "handleremovepayment()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L204"
+      "id": "quickaddproductdialog_handleopenchange",
+      "label": "handleOpenChange()",
+      "norm_label": "handleopenchange()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L468"
     },
     {
       "community": 163,
       "file_type": "code",
-      "id": "paymentsaddedlist_handlesaveedit",
-      "label": "handleSaveEdit()",
-      "norm_label": "handlesaveedit()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L145"
+      "id": "quickaddproductdialog_handlequickaddmultiplevariantschange",
+      "label": "handleQuickAddMultipleVariantsChange()",
+      "norm_label": "handlequickaddmultiplevariantschange()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L437"
     },
     {
       "community": 163,
       "file_type": "code",
-      "id": "paymentsaddedlist_handlestartedit",
-      "label": "handleStartEdit()",
-      "norm_label": "handlestartedit()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L132"
+      "id": "quickaddproductdialog_handlequickaddsubmit",
+      "label": "handleQuickAddSubmit()",
+      "norm_label": "handlequickaddsubmit()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L489"
     },
     {
       "community": 163,
       "file_type": "code",
-      "id": "paymentsaddedlist_if",
-      "label": "if()",
-      "norm_label": "if()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L315"
+      "id": "quickaddproductdialog_preventoutsidedismiss",
+      "label": "preventOutsideDismiss()",
+      "norm_label": "preventoutsidedismiss()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L480"
     },
     {
       "community": 163,
       "file_type": "code",
-      "id": "paymentsaddedlist_resetpaymentcollectioncontrols",
-      "label": "resetPaymentCollectionControls()",
-      "norm_label": "resetpaymentcollectioncontrols()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L193"
+      "id": "quickaddproductdialog_removequickaddextravariant",
+      "label": "removeQuickAddExtraVariant()",
+      "norm_label": "removequickaddextravariant()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L462"
     },
     {
       "community": 163,
       "file_type": "code",
-      "id": "paymentsaddedlist_setpaymentediting",
-      "label": "setPaymentEditing()",
-      "norm_label": "setpaymentediting()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L123"
+      "id": "quickaddproductdialog_updatequickaddextravariant",
+      "label": "updateQuickAddExtraVariant()",
+      "norm_label": "updatequickaddextravariant()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L444"
     },
     {
       "community": 163,
       "file_type": "code",
-      "id": "paymentsaddedlist_setpaymentsexpanded",
-      "label": "setPaymentsExpanded()",
-      "norm_label": "setpaymentsexpanded()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L115"
+      "id": "quickaddproductdialog_validatequickaddlookupcode",
+      "label": "validateQuickAddLookupCode()",
+      "norm_label": "validatequickaddlookupcode()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L137"
     },
     {
       "community": 1630,
@@ -204771,119 +204786,119 @@
     {
       "community": 182,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_sessions_possessionsview_tsx",
-      "label": "POSSessionsView.tsx",
-      "norm_label": "possessionsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "id": "packages_athena_webapp_convex_inventory_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
       "source_location": "L1"
     },
     {
       "community": 182,
       "file_type": "code",
-      "id": "possessionsview_formatexpiry",
-      "label": "formatExpiry()",
-      "norm_label": "formatexpiry()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L190"
+      "id": "packages_athena_webapp_src_components_orders_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 182,
       "file_type": "code",
-      "id": "possessionsview_formatholddetails",
-      "label": "formatHoldDetails()",
-      "norm_label": "formatholddetails()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L216"
+      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 182,
       "file_type": "code",
-      "id": "possessionsview_formatregisterlabel",
-      "label": "formatRegisterLabel()",
-      "norm_label": "formatregisterlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L147"
+      "id": "utils_formatdeliveryaddress",
+      "label": "formatDeliveryAddress()",
+      "norm_label": "formatdeliveryaddress()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L74"
     },
     {
       "community": 182,
       "file_type": "code",
-      "id": "possessionsview_formatstatuslabel",
-      "label": "formatStatusLabel()",
-      "norm_label": "formatstatuslabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L122"
+      "id": "utils_getamountpaidfororder",
+      "label": "getAmountPaidForOrder()",
+      "norm_label": "getamountpaidfororder()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L191"
     },
     {
       "community": 182,
       "file_type": "code",
-      "id": "possessionsview_getcartcount",
-      "label": "getCartCount()",
-      "norm_label": "getcartcount()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L180"
+      "id": "utils_getdiscountvalue",
+      "label": "getDiscountValue()",
+      "norm_label": "getdiscountvalue()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L17"
     },
     {
       "community": 182,
       "file_type": "code",
-      "id": "possessionsview_getcustomerlabel",
-      "label": "getCustomerLabel()",
-      "norm_label": "getcustomerlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L176"
+      "id": "utils_getonlineorderplacedat",
+      "label": "getOnlineOrderPlacedAt()",
+      "norm_label": "getonlineorderplacedat()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 182,
       "file_type": "code",
-      "id": "possessionsview_getoperatorlabel",
-      "label": "getOperatorLabel()",
-      "norm_label": "getoperatorlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L138"
+      "id": "utils_getorderamount",
+      "label": "getOrderAmount()",
+      "norm_label": "getorderamount()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L51"
     },
     {
       "community": 182,
       "file_type": "code",
-      "id": "possessionsview_getregisterlabel",
-      "label": "getRegisterLabel()",
-      "norm_label": "getregisterlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L157"
+      "id": "utils_getorderstate",
+      "label": "getOrderState()",
+      "norm_label": "getorderstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L40"
     },
     {
       "community": 182,
       "file_type": "code",
-      "id": "possessionsview_getsessioncode",
-      "label": "getSessionCode()",
-      "norm_label": "getsessioncode()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L131"
+      "id": "utils_getpickupactionstate",
+      "label": "getPickupActionState()",
+      "norm_label": "getpickupactionstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L102"
     },
     {
       "community": 182,
       "file_type": "code",
-      "id": "possessionsview_getsessions",
-      "label": "getSessions()",
-      "norm_label": "getsessions()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L114"
+      "id": "utils_getpotentialpoints",
+      "label": "getPotentialPoints()",
+      "norm_label": "getpotentialpoints()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L107"
     },
     {
       "community": 182,
       "file_type": "code",
-      "id": "possessionsview_getstatusbadgeclass",
-      "label": "getStatusBadgeClass()",
-      "norm_label": "getstatusbadgeclass()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L250"
+      "id": "utils_getproductdiscountvalue",
+      "label": "getProductDiscountValue()",
+      "norm_label": "getproductdiscountvalue()",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L75"
     },
     {
       "community": 182,
       "file_type": "code",
-      "id": "possessionsview_possessionsheader",
-      "label": "POSSessionsHeader()",
-      "norm_label": "possessionsheader()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L261"
+      "id": "utils_shouldshowpickupexceptionaction",
+      "label": "shouldShowPickupExceptionAction()",
+      "norm_label": "shouldshowpickupexceptionaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L116"
     },
     {
       "community": 1820,
@@ -204978,119 +204993,119 @@
     {
       "community": 183,
       "file_type": "code",
-      "id": "localposreadiness_blocked",
-      "label": "blocked()",
-      "norm_label": "blocked()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L638"
-    },
-    {
-      "community": 183,
-      "file_type": "code",
-      "id": "localposreadiness_evaluatelocalposreadiness",
-      "label": "evaluateLocalPosReadiness()",
-      "norm_label": "evaluatelocalposreadiness()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L124"
-    },
-    {
-      "community": 183,
-      "file_type": "code",
-      "id": "localposreadiness_evaluatelocalposservicecatalogreadiness",
-      "label": "evaluateLocalPosServiceCatalogReadiness()",
-      "norm_label": "evaluatelocalposservicecatalogreadiness()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L258"
-    },
-    {
-      "community": 183,
-      "file_type": "code",
-      "id": "localposreadiness_formatreadinessstatekey",
-      "label": "formatReadinessStateKey()",
-      "norm_label": "formatreadinessstatekey()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L591"
-    },
-    {
-      "community": 183,
-      "file_type": "code",
-      "id": "localposreadiness_hassettledlocalcloseout",
-      "label": "hasSettledLocalCloseout()",
-      "norm_label": "hassettledlocalcloseout()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L248"
-    },
-    {
-      "community": 183,
-      "file_type": "code",
-      "id": "localposreadiness_localreadinessmatchesinput",
-      "label": "localReadinessMatchesInput()",
-      "norm_label": "localreadinessmatchesinput()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L287"
-    },
-    {
-      "community": 183,
-      "file_type": "code",
-      "id": "localposreadiness_localreadinessrecordfromsnapshots",
-      "label": "localReadinessRecordFromSnapshots()",
-      "norm_label": "localreadinessrecordfromsnapshots()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L83"
-    },
-    {
-      "community": 183,
-      "file_type": "code",
-      "id": "localposreadiness_readinessstatekey",
-      "label": "readinessStateKey()",
-      "norm_label": "readinessstatekey()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L610"
-    },
-    {
-      "community": 183,
-      "file_type": "code",
-      "id": "localposreadiness_readinessstatekeysequal",
-      "label": "readinessStateKeysEqual()",
-      "norm_label": "readinessstatekeysequal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L624"
-    },
-    {
-      "community": 183,
-      "file_type": "code",
-      "id": "localposreadiness_readlocalposreadiness",
-      "label": "readLocalPosReadiness()",
-      "norm_label": "readlocalposreadiness()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L299"
-    },
-    {
-      "community": 183,
-      "file_type": "code",
-      "id": "localposreadiness_refreshlocalposreadinessfromsnapshots",
-      "label": "refreshLocalPosReadinessFromSnapshots()",
-      "norm_label": "refreshlocalposreadinessfromsnapshots()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L343"
-    },
-    {
-      "community": 183,
-      "file_type": "code",
-      "id": "localposreadiness_uselocalposreadiness",
-      "label": "useLocalPosReadiness()",
-      "norm_label": "uselocalposreadiness()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L391"
-    },
-    {
-      "community": 183,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localposreadiness_ts",
-      "label": "localPosReadiness.ts",
-      "norm_label": "localposreadiness.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "id": "packages_athena_webapp_src_components_pos_sessions_possessionsview_tsx",
+      "label": "POSSessionsView.tsx",
+      "norm_label": "possessionsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 183,
+      "file_type": "code",
+      "id": "possessionsview_formatexpiry",
+      "label": "formatExpiry()",
+      "norm_label": "formatexpiry()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L190"
+    },
+    {
+      "community": 183,
+      "file_type": "code",
+      "id": "possessionsview_formatholddetails",
+      "label": "formatHoldDetails()",
+      "norm_label": "formatholddetails()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L216"
+    },
+    {
+      "community": 183,
+      "file_type": "code",
+      "id": "possessionsview_formatregisterlabel",
+      "label": "formatRegisterLabel()",
+      "norm_label": "formatregisterlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L147"
+    },
+    {
+      "community": 183,
+      "file_type": "code",
+      "id": "possessionsview_formatstatuslabel",
+      "label": "formatStatusLabel()",
+      "norm_label": "formatstatuslabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L122"
+    },
+    {
+      "community": 183,
+      "file_type": "code",
+      "id": "possessionsview_getcartcount",
+      "label": "getCartCount()",
+      "norm_label": "getcartcount()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L180"
+    },
+    {
+      "community": 183,
+      "file_type": "code",
+      "id": "possessionsview_getcustomerlabel",
+      "label": "getCustomerLabel()",
+      "norm_label": "getcustomerlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L176"
+    },
+    {
+      "community": 183,
+      "file_type": "code",
+      "id": "possessionsview_getoperatorlabel",
+      "label": "getOperatorLabel()",
+      "norm_label": "getoperatorlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L138"
+    },
+    {
+      "community": 183,
+      "file_type": "code",
+      "id": "possessionsview_getregisterlabel",
+      "label": "getRegisterLabel()",
+      "norm_label": "getregisterlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L157"
+    },
+    {
+      "community": 183,
+      "file_type": "code",
+      "id": "possessionsview_getsessioncode",
+      "label": "getSessionCode()",
+      "norm_label": "getsessioncode()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L131"
+    },
+    {
+      "community": 183,
+      "file_type": "code",
+      "id": "possessionsview_getsessions",
+      "label": "getSessions()",
+      "norm_label": "getsessions()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L114"
+    },
+    {
+      "community": 183,
+      "file_type": "code",
+      "id": "possessionsview_getstatusbadgeclass",
+      "label": "getStatusBadgeClass()",
+      "norm_label": "getstatusbadgeclass()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L250"
+    },
+    {
+      "community": 183,
+      "file_type": "code",
+      "id": "possessionsview_possessionsheader",
+      "label": "POSSessionsHeader()",
+      "norm_label": "possessionsheader()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L261"
     },
     {
       "community": 1830,
@@ -205185,119 +205200,119 @@
     {
       "community": 184,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registercatalogpinruntime_ts",
-      "label": "registerCatalogPinRuntime.ts",
-      "norm_label": "registercatalogpinruntime.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "id": "localposreadiness_blocked",
+      "label": "blocked()",
+      "norm_label": "blocked()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L638"
+    },
+    {
+      "community": 184,
+      "file_type": "code",
+      "id": "localposreadiness_evaluatelocalposreadiness",
+      "label": "evaluateLocalPosReadiness()",
+      "norm_label": "evaluatelocalposreadiness()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L124"
+    },
+    {
+      "community": 184,
+      "file_type": "code",
+      "id": "localposreadiness_evaluatelocalposservicecatalogreadiness",
+      "label": "evaluateLocalPosServiceCatalogReadiness()",
+      "norm_label": "evaluatelocalposservicecatalogreadiness()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L258"
+    },
+    {
+      "community": 184,
+      "file_type": "code",
+      "id": "localposreadiness_formatreadinessstatekey",
+      "label": "formatReadinessStateKey()",
+      "norm_label": "formatreadinessstatekey()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L591"
+    },
+    {
+      "community": 184,
+      "file_type": "code",
+      "id": "localposreadiness_hassettledlocalcloseout",
+      "label": "hasSettledLocalCloseout()",
+      "norm_label": "hassettledlocalcloseout()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L248"
+    },
+    {
+      "community": 184,
+      "file_type": "code",
+      "id": "localposreadiness_localreadinessmatchesinput",
+      "label": "localReadinessMatchesInput()",
+      "norm_label": "localreadinessmatchesinput()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L287"
+    },
+    {
+      "community": 184,
+      "file_type": "code",
+      "id": "localposreadiness_localreadinessrecordfromsnapshots",
+      "label": "localReadinessRecordFromSnapshots()",
+      "norm_label": "localreadinessrecordfromsnapshots()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 184,
+      "file_type": "code",
+      "id": "localposreadiness_readinessstatekey",
+      "label": "readinessStateKey()",
+      "norm_label": "readinessstatekey()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L610"
+    },
+    {
+      "community": 184,
+      "file_type": "code",
+      "id": "localposreadiness_readinessstatekeysequal",
+      "label": "readinessStateKeysEqual()",
+      "norm_label": "readinessstatekeysequal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L624"
+    },
+    {
+      "community": 184,
+      "file_type": "code",
+      "id": "localposreadiness_readlocalposreadiness",
+      "label": "readLocalPosReadiness()",
+      "norm_label": "readlocalposreadiness()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L299"
+    },
+    {
+      "community": 184,
+      "file_type": "code",
+      "id": "localposreadiness_refreshlocalposreadinessfromsnapshots",
+      "label": "refreshLocalPosReadinessFromSnapshots()",
+      "norm_label": "refreshlocalposreadinessfromsnapshots()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L343"
+    },
+    {
+      "community": 184,
+      "file_type": "code",
+      "id": "localposreadiness_uselocalposreadiness",
+      "label": "useLocalPosReadiness()",
+      "norm_label": "uselocalposreadiness()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L391"
+    },
+    {
+      "community": 184,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localposreadiness_ts",
+      "label": "localPosReadiness.ts",
+      "norm_label": "localposreadiness.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 184,
-      "file_type": "code",
-      "id": "registercatalogpinruntime_captureregistercatalogruntimepin",
-      "label": "captureRegisterCatalogRuntimePin()",
-      "norm_label": "captureregistercatalogruntimepin()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L138"
-    },
-    {
-      "community": 184,
-      "file_type": "code",
-      "id": "registercatalogpinruntime_chooseregistercatalogruntimeownerid",
-      "label": "chooseRegisterCatalogRuntimeOwnerId()",
-      "norm_label": "chooseregistercatalogruntimeownerid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 184,
-      "file_type": "code",
-      "id": "registercatalogpinruntime_clearregistercatalogruntimeactionguard",
-      "label": "clearRegisterCatalogRuntimeActionGuard()",
-      "norm_label": "clearregistercatalogruntimeactionguard()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L171"
-    },
-    {
-      "community": 184,
-      "file_type": "code",
-      "id": "registercatalogpinruntime_clearregistercatalogruntimeselection",
-      "label": "clearRegisterCatalogRuntimeSelection()",
-      "norm_label": "clearregistercatalogruntimeselection()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L132"
-    },
-    {
-      "community": 184,
-      "file_type": "code",
-      "id": "registercatalogpinruntime_getregistercatalogruntimeownerid",
-      "label": "getRegisterCatalogRuntimeOwnerId()",
-      "norm_label": "getregistercatalogruntimeownerid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L177"
-    },
-    {
-      "community": 184,
-      "file_type": "code",
-      "id": "registercatalogpinruntime_hasregistercatalogruntimeactionguard",
-      "label": "hasRegisterCatalogRuntimeActionGuard()",
-      "norm_label": "hasregistercatalogruntimeactionguard()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L165"
-    },
-    {
-      "community": 184,
-      "file_type": "code",
-      "id": "registercatalogpinruntime_keyforscope",
-      "label": "keyForScope()",
-      "norm_label": "keyforscope()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L122"
-    },
-    {
-      "community": 184,
-      "file_type": "code",
-      "id": "registercatalogpinruntime_maintainownerclaim",
-      "label": "maintainOwnerClaim()",
-      "norm_label": "maintainownerclaim()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L87"
-    },
-    {
-      "community": 184,
-      "file_type": "code",
-      "id": "registercatalogpinruntime_ownerclaimkey",
-      "label": "ownerClaimKey()",
-      "norm_label": "ownerclaimkey()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L47"
-    },
-    {
-      "community": 184,
-      "file_type": "code",
-      "id": "registercatalogpinruntime_readownerclaim",
-      "label": "readOwnerClaim()",
-      "norm_label": "readownerclaim()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 184,
-      "file_type": "code",
-      "id": "registercatalogpinruntime_setregistercatalogruntimeselection",
-      "label": "setRegisterCatalogRuntimeSelection()",
-      "norm_label": "setregistercatalogruntimeselection()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L126"
-    },
-    {
-      "community": 184,
-      "file_type": "code",
-      "id": "registercatalogpinruntime_writeownerclaim",
-      "label": "writeOwnerClaim()",
-      "norm_label": "writeownerclaim()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L71"
     },
     {
       "community": 1840,
@@ -205392,119 +205407,119 @@
     {
       "community": 185,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_telemetrybuffer_ts",
-      "label": "telemetryBuffer.ts",
-      "norm_label": "telemetrybuffer.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registercatalogpinruntime_ts",
+      "label": "registerCatalogPinRuntime.ts",
+      "norm_label": "registercatalogpinruntime.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
       "source_location": "L1"
     },
     {
       "community": 185,
       "file_type": "code",
-      "id": "telemetrybuffer_clearposclienttelemetrybuffer",
-      "label": "clearPosClientTelemetryBuffer()",
-      "norm_label": "clearposclienttelemetrybuffer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L212"
+      "id": "registercatalogpinruntime_captureregistercatalogruntimepin",
+      "label": "captureRegisterCatalogRuntimePin()",
+      "norm_label": "captureregistercatalogruntimepin()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L138"
     },
     {
       "community": 185,
       "file_type": "code",
-      "id": "telemetrybuffer_enqueueposclientevent",
-      "label": "enqueuePosClientEvent()",
-      "norm_label": "enqueueposclientevent()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L167"
+      "id": "registercatalogpinruntime_chooseregistercatalogruntimeownerid",
+      "label": "chooseRegisterCatalogRuntimeOwnerId()",
+      "norm_label": "chooseregistercatalogruntimeownerid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L31"
     },
     {
       "community": 185,
       "file_type": "code",
-      "id": "telemetrybuffer_isbufferedevent",
-      "label": "isBufferedEvent()",
-      "norm_label": "isbufferedevent()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L100"
+      "id": "registercatalogpinruntime_clearregistercatalogruntimeactionguard",
+      "label": "clearRegisterCatalogRuntimeActionGuard()",
+      "norm_label": "clearregistercatalogruntimeactionguard()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L171"
     },
     {
       "community": 185,
       "file_type": "code",
-      "id": "telemetrybuffer_mintclienteventid",
-      "label": "mintClientEventId()",
-      "norm_label": "mintclienteventid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L63"
+      "id": "registercatalogpinruntime_clearregistercatalogruntimeselection",
+      "label": "clearRegisterCatalogRuntimeSelection()",
+      "norm_label": "clearregistercatalogruntimeselection()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L132"
     },
     {
       "community": 185,
       "file_type": "code",
-      "id": "telemetrybuffer_normalizepostelemetryerror",
-      "label": "normalizePosTelemetryError()",
-      "norm_label": "normalizepostelemetryerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L116"
+      "id": "registercatalogpinruntime_getregistercatalogruntimeownerid",
+      "label": "getRegisterCatalogRuntimeOwnerId()",
+      "norm_label": "getregistercatalogruntimeownerid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L177"
     },
     {
       "community": 185,
       "file_type": "code",
-      "id": "telemetrybuffer_peekposclienteventbatch",
-      "label": "peekPosClientEventBatch()",
-      "norm_label": "peekposclienteventbatch()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L194"
+      "id": "registercatalogpinruntime_hasregistercatalogruntimeactionguard",
+      "label": "hasRegisterCatalogRuntimeActionGuard()",
+      "norm_label": "hasregistercatalogruntimeactionguard()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L165"
     },
     {
       "community": 185,
       "file_type": "code",
-      "id": "telemetrybuffer_posclienttelemetrybuffersize",
-      "label": "posClientTelemetryBufferSize()",
-      "norm_label": "posclienttelemetrybuffersize()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L208"
+      "id": "registercatalogpinruntime_keyforscope",
+      "label": "keyForScope()",
+      "norm_label": "keyforscope()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L122"
     },
     {
       "community": 185,
       "file_type": "code",
-      "id": "telemetrybuffer_readbuffer",
-      "label": "readBuffer()",
-      "norm_label": "readbuffer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L74"
+      "id": "registercatalogpinruntime_maintainownerclaim",
+      "label": "maintainOwnerClaim()",
+      "norm_label": "maintainownerclaim()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L87"
     },
     {
       "community": 185,
       "file_type": "code",
-      "id": "telemetrybuffer_removeposclientevents",
-      "label": "removePosClientEvents()",
-      "norm_label": "removeposclientevents()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L200"
+      "id": "registercatalogpinruntime_ownerclaimkey",
+      "label": "ownerClaimKey()",
+      "norm_label": "ownerclaimkey()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L47"
     },
     {
       "community": 185,
       "file_type": "code",
-      "id": "telemetrybuffer_sanitizemetadata",
-      "label": "sanitizeMetadata()",
-      "norm_label": "sanitizemetadata()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L145"
+      "id": "registercatalogpinruntime_readownerclaim",
+      "label": "readOwnerClaim()",
+      "norm_label": "readownerclaim()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L51"
     },
     {
       "community": 185,
       "file_type": "code",
-      "id": "telemetrybuffer_truncate",
-      "label": "truncate()",
-      "norm_label": "truncate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L59"
+      "id": "registercatalogpinruntime_setregistercatalogruntimeselection",
+      "label": "setRegisterCatalogRuntimeSelection()",
+      "norm_label": "setregistercatalogruntimeselection()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L126"
     },
     {
       "community": 185,
       "file_type": "code",
-      "id": "telemetrybuffer_writebuffer",
-      "label": "writeBuffer()",
-      "norm_label": "writebuffer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L90"
+      "id": "registercatalogpinruntime_writeownerclaim",
+      "label": "writeOwnerClaim()",
+      "norm_label": "writeownerclaim()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L71"
     },
     {
       "community": 1850,
@@ -205599,119 +205614,119 @@
     {
       "community": 186,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registercheckoutprojection_ts",
-      "label": "registerCheckoutProjection.ts",
-      "norm_label": "registercheckoutprojection.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_telemetrybuffer_ts",
+      "label": "telemetryBuffer.ts",
+      "norm_label": "telemetrybuffer.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
       "source_location": "L1"
     },
     {
       "community": 186,
       "file_type": "code",
-      "id": "registercheckoutprojection_buildcompletedsalepayload",
-      "label": "buildCompletedSalePayload()",
-      "norm_label": "buildcompletedsalepayload()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L121"
+      "id": "telemetrybuffer_clearposclienttelemetrybuffer",
+      "label": "clearPosClientTelemetryBuffer()",
+      "norm_label": "clearposclienttelemetrybuffer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L212"
     },
     {
       "community": 186,
       "file_type": "code",
-      "id": "registercheckoutprojection_buildservicecheckoutblockmessage",
-      "label": "buildServiceCheckoutBlockMessage()",
-      "norm_label": "buildservicecheckoutblockmessage()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L16"
+      "id": "telemetrybuffer_enqueueposclientevent",
+      "label": "enqueuePosClientEvent()",
+      "norm_label": "enqueueposclientevent()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L167"
     },
     {
       "community": 186,
       "file_type": "code",
-      "id": "registercheckoutprojection_combinepaymentsbymethod",
-      "label": "combinePaymentsByMethod()",
-      "norm_label": "combinepaymentsbymethod()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L78"
+      "id": "telemetrybuffer_isbufferedevent",
+      "label": "isBufferedEvent()",
+      "norm_label": "isbufferedevent()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L100"
     },
     {
       "community": 186,
       "file_type": "code",
-      "id": "registercheckoutprojection_completedcustomerinfo",
-      "label": "completedCustomerInfo()",
-      "norm_label": "completedcustomerinfo()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L290"
+      "id": "telemetrybuffer_mintclienteventid",
+      "label": "mintClientEventId()",
+      "norm_label": "mintclienteventid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L63"
     },
     {
       "community": 186,
       "file_type": "code",
-      "id": "registercheckoutprojection_hascustomerdetails",
-      "label": "hasCustomerDetails()",
-      "norm_label": "hascustomerdetails()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L50"
+      "id": "telemetrybuffer_normalizepostelemetryerror",
+      "label": "normalizePosTelemetryError()",
+      "norm_label": "normalizepostelemetryerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L116"
     },
     {
       "community": 186,
       "file_type": "code",
-      "id": "registercheckoutprojection_ispospaymentmethod",
-      "label": "isPosPaymentMethod()",
-      "norm_label": "ispospaymentmethod()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L98"
+      "id": "telemetrybuffer_peekposclienteventbatch",
+      "label": "peekPosClientEventBatch()",
+      "norm_label": "peekposclienteventbatch()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L194"
     },
     {
       "community": 186,
       "file_type": "code",
-      "id": "registercheckoutprojection_maplocalpaymenttopayment",
-      "label": "mapLocalPaymentToPayment()",
-      "norm_label": "maplocalpaymenttopayment()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L102"
+      "id": "telemetrybuffer_posclienttelemetrybuffersize",
+      "label": "posClientTelemetryBufferSize()",
+      "norm_label": "posclienttelemetrybuffersize()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L208"
     },
     {
       "community": 186,
       "file_type": "code",
-      "id": "registercheckoutprojection_maplocalservicelinetostate",
-      "label": "mapLocalServiceLineToState()",
-      "norm_label": "maplocalservicelinetostate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L197"
+      "id": "telemetrybuffer_readbuffer",
+      "label": "readBuffer()",
+      "norm_label": "readbuffer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L74"
     },
     {
       "community": 186,
       "file_type": "code",
-      "id": "registercheckoutprojection_mapsessioncustomer",
-      "label": "mapSessionCustomer()",
-      "norm_label": "mapsessioncustomer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L65"
+      "id": "telemetrybuffer_removeposclientevents",
+      "label": "removePosClientEvents()",
+      "norm_label": "removeposclientevents()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L200"
     },
     {
       "community": 186,
       "file_type": "code",
-      "id": "registercheckoutprojection_matchingservicelinedraft",
-      "label": "matchingServiceLineDraft()",
-      "norm_label": "matchingservicelinedraft()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L223"
+      "id": "telemetrybuffer_sanitizemetadata",
+      "label": "sanitizeMetadata()",
+      "norm_label": "sanitizemetadata()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L145"
     },
     {
       "community": 186,
       "file_type": "code",
-      "id": "registercheckoutprojection_servicelinestatetocartline",
-      "label": "serviceLineStateToCartLine()",
-      "norm_label": "servicelinestatetocartline()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L272"
+      "id": "telemetrybuffer_truncate",
+      "label": "truncate()",
+      "norm_label": "truncate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L59"
     },
     {
       "community": 186,
       "file_type": "code",
-      "id": "registercheckoutprojection_servicelinestatetolocalpayload",
-      "label": "serviceLineStateToLocalPayload()",
-      "norm_label": "servicelinestatetolocalpayload()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L254"
+      "id": "telemetrybuffer_writebuffer",
+      "label": "writeBuffer()",
+      "norm_label": "writebuffer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L90"
     },
     {
       "community": 1860,
@@ -205806,119 +205821,119 @@
     {
       "community": 187,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registerdrawerpresentation_ts",
-      "label": "registerDrawerPresentation.ts",
-      "norm_label": "registerdrawerpresentation.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registercheckoutprojection_ts",
+      "label": "registerCheckoutProjection.ts",
+      "norm_label": "registercheckoutprojection.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
       "source_location": "L1"
     },
     {
       "community": 187,
       "file_type": "code",
-      "id": "registerdrawerpresentation_buildopendrawerfailuremessage",
-      "label": "buildOpenDrawerFailureMessage()",
-      "norm_label": "buildopendrawerfailuremessage()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L189"
+      "id": "registercheckoutprojection_buildcompletedsalepayload",
+      "label": "buildCompletedSalePayload()",
+      "norm_label": "buildcompletedsalepayload()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L121"
     },
     {
       "community": 187,
       "file_type": "code",
-      "id": "registerdrawerpresentation_findregistercloseoutreviewitem",
-      "label": "findRegisterCloseoutReviewItem()",
-      "norm_label": "findregistercloseoutreviewitem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L171"
+      "id": "registercheckoutprojection_buildservicecheckoutblockmessage",
+      "label": "buildServiceCheckoutBlockMessage()",
+      "norm_label": "buildservicecheckoutblockmessage()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L16"
     },
     {
       "community": 187,
       "file_type": "code",
-      "id": "registerdrawerpresentation_formatcloseoutcloudregistersessioncode",
-      "label": "formatCloseoutCloudRegisterSessionCode()",
-      "norm_label": "formatcloseoutcloudregistersessioncode()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L98"
+      "id": "registercheckoutprojection_combinepaymentsbymethod",
+      "label": "combinePaymentsByMethod()",
+      "norm_label": "combinepaymentsbymethod()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L78"
     },
     {
       "community": 187,
       "file_type": "code",
-      "id": "registerdrawerpresentation_getcloseoutcloudregistersessioncode",
-      "label": "getCloseoutCloudRegisterSessionCode()",
-      "norm_label": "getcloseoutcloudregistersessioncode()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L68"
+      "id": "registercheckoutprojection_completedcustomerinfo",
+      "label": "completedCustomerInfo()",
+      "norm_label": "completedcustomerinfo()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L290"
     },
     {
       "community": 187,
       "file_type": "code",
-      "id": "registerdrawerpresentation_getcloseoutcloudregistersessionid",
-      "label": "getCloseoutCloudRegisterSessionId()",
-      "norm_label": "getcloseoutcloudregistersessionid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "id": "registercheckoutprojection_hascustomerdetails",
+      "label": "hasCustomerDetails()",
+      "norm_label": "hascustomerdetails()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
       "source_location": "L50"
     },
     {
       "community": 187,
       "file_type": "code",
-      "id": "registerdrawerpresentation_getcloseoutlocalregistersessionid",
-      "label": "getCloseoutLocalRegisterSessionId()",
-      "norm_label": "getcloseoutlocalregistersessionid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L29"
+      "id": "registercheckoutprojection_ispospaymentmethod",
+      "label": "isPosPaymentMethod()",
+      "norm_label": "ispospaymentmethod()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L98"
     },
     {
       "community": 187,
       "file_type": "code",
-      "id": "registerdrawerpresentation_getlatestlocalregisterlifecycleevent",
-      "label": "getLatestLocalRegisterLifecycleEvent()",
-      "norm_label": "getlatestlocalregisterlifecycleevent()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L207"
+      "id": "registercheckoutprojection_maplocalpaymenttopayment",
+      "label": "mapLocalPaymentToPayment()",
+      "norm_label": "maplocalpaymenttopayment()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L102"
     },
     {
       "community": 187,
       "file_type": "code",
-      "id": "registerdrawerpresentation_getpendinglocalcashvoidapprovals",
-      "label": "getPendingLocalCashVoidApprovals()",
-      "norm_label": "getpendinglocalcashvoidapprovals()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L270"
+      "id": "registercheckoutprojection_maplocalservicelinetostate",
+      "label": "mapLocalServiceLineToState()",
+      "norm_label": "maplocalservicelinetostate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L197"
     },
     {
       "community": 187,
       "file_type": "code",
-      "id": "registerdrawerpresentation_getpendinglocalcloseoutregistersession",
-      "label": "getPendingLocalCloseoutRegisterSession()",
-      "norm_label": "getpendinglocalcloseoutregistersession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L234"
+      "id": "registercheckoutprojection_mapsessioncustomer",
+      "label": "mapSessionCustomer()",
+      "norm_label": "mapsessioncustomer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L65"
     },
     {
       "community": 187,
       "file_type": "code",
-      "id": "registerdrawerpresentation_isknowncloudregistersessionblockinglocalprojection",
-      "label": "isKnownCloudRegisterSessionBlockingLocalProjection()",
-      "norm_label": "isknowncloudregistersessionblockinglocalprojection()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L114"
+      "id": "registercheckoutprojection_matchingservicelinedraft",
+      "label": "matchingServiceLineDraft()",
+      "norm_label": "matchingservicelinedraft()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L223"
     },
     {
       "community": 187,
       "file_type": "code",
-      "id": "registerdrawerpresentation_readlocalsyncstatus",
-      "label": "readLocalSyncStatus()",
-      "norm_label": "readlocalsyncstatus()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L146"
+      "id": "registercheckoutprojection_servicelinestatetocartline",
+      "label": "serviceLineStateToCartLine()",
+      "norm_label": "servicelinestatetocartline()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L272"
     },
     {
       "community": 187,
       "file_type": "code",
-      "id": "registerdrawerpresentation_stringfield",
-      "label": "stringField()",
-      "norm_label": "stringfield()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L334"
+      "id": "registercheckoutprojection_servicelinestatetolocalpayload",
+      "label": "serviceLineStateToLocalPayload()",
+      "norm_label": "servicelinestatetolocalpayload()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L254"
     },
     {
       "community": 1870,
@@ -206013,119 +206028,119 @@
     {
       "community": 188,
       "file_type": "code",
-      "id": "localpinverifier_base64tobytes",
-      "label": "base64ToBytes()",
-      "norm_label": "base64tobytes()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registerdrawerpresentation_ts",
+      "label": "registerDrawerPresentation.ts",
+      "norm_label": "registerdrawerpresentation.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "registerdrawerpresentation_buildopendrawerfailuremessage",
+      "label": "buildOpenDrawerFailureMessage()",
+      "norm_label": "buildopendrawerfailuremessage()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L189"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "registerdrawerpresentation_findregistercloseoutreviewitem",
+      "label": "findRegisterCloseoutReviewItem()",
+      "norm_label": "findregistercloseoutreviewitem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L171"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "registerdrawerpresentation_formatcloseoutcloudregistersessioncode",
+      "label": "formatCloseoutCloudRegisterSessionCode()",
+      "norm_label": "formatcloseoutcloudregistersessioncode()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L98"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "registerdrawerpresentation_getcloseoutcloudregistersessioncode",
+      "label": "getCloseoutCloudRegisterSessionCode()",
+      "norm_label": "getcloseoutcloudregistersessioncode()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L68"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "registerdrawerpresentation_getcloseoutcloudregistersessionid",
+      "label": "getCloseoutCloudRegisterSessionId()",
+      "norm_label": "getcloseoutcloudregistersessionid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
       "source_location": "L50"
     },
     {
       "community": 188,
       "file_type": "code",
-      "id": "localpinverifier_bytestobase64",
-      "label": "bytesToBase64()",
-      "norm_label": "bytestobase64()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L38"
+      "id": "registerdrawerpresentation_getcloseoutlocalregistersessionid",
+      "label": "getCloseoutLocalRegisterSessionId()",
+      "norm_label": "getcloseoutlocalregistersessionid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L29"
     },
     {
       "community": 188,
       "file_type": "code",
-      "id": "localpinverifier_createlocalpinverifier",
-      "label": "createLocalPinVerifier()",
-      "norm_label": "createlocalpinverifier()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L131"
+      "id": "registerdrawerpresentation_getlatestlocalregisterlifecycleevent",
+      "label": "getLatestLocalRegisterLifecycleEvent()",
+      "norm_label": "getlatestlocalregisterlifecycleevent()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L207"
     },
     {
       "community": 188,
       "file_type": "code",
-      "id": "localpinverifier_cryptorefdecrypt",
-      "label": "cryptoRefDecrypt()",
-      "norm_label": "cryptorefdecrypt()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L268"
+      "id": "registerdrawerpresentation_getpendinglocalcashvoidapprovals",
+      "label": "getPendingLocalCashVoidApprovals()",
+      "norm_label": "getpendinglocalcashvoidapprovals()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L270"
     },
     {
       "community": 188,
       "file_type": "code",
-      "id": "localpinverifier_derivepinhash",
-      "label": "derivePinHash()",
-      "norm_label": "derivepinhash()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L76"
+      "id": "registerdrawerpresentation_getpendinglocalcloseoutregistersession",
+      "label": "getPendingLocalCloseoutRegisterSession()",
+      "norm_label": "getpendinglocalcloseoutregistersession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L234"
     },
     {
       "community": 188,
       "file_type": "code",
-      "id": "localpinverifier_derivewrappingkey",
-      "label": "deriveWrappingKey()",
-      "norm_label": "derivewrappingkey()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L103"
+      "id": "registerdrawerpresentation_isknowncloudregistersessionblockinglocalprojection",
+      "label": "isKnownCloudRegisterSessionBlockingLocalProjection()",
+      "norm_label": "isknowncloudregistersessionblockinglocalprojection()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L114"
     },
     {
       "community": 188,
       "file_type": "code",
-      "id": "localpinverifier_getcrypto",
-      "label": "getCrypto()",
-      "norm_label": "getcrypto()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L30"
+      "id": "registerdrawerpresentation_readlocalsyncstatus",
+      "label": "readLocalSyncStatus()",
+      "norm_label": "readlocalsyncstatus()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L146"
     },
     {
       "community": 188,
       "file_type": "code",
-      "id": "localpinverifier_islocalpinverifiermetadata",
-      "label": "isLocalPinVerifierMetadata()",
-      "norm_label": "islocalpinverifiermetadata()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L281"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "localpinverifier_timingsafeequal",
-      "label": "timingSafeEqual()",
-      "norm_label": "timingsafeequal()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "localpinverifier_unwraplocalstaffprooftoken",
-      "label": "unwrapLocalStaffProofToken()",
-      "norm_label": "unwraplocalstaffprooftoken()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L221"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "localpinverifier_verifylocalpin",
-      "label": "verifyLocalPin()",
-      "norm_label": "verifylocalpin()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L152"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "localpinverifier_wraplocalstaffprooftoken",
-      "label": "wrapLocalStaffProofToken()",
-      "norm_label": "wraplocalstaffprooftoken()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L183"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_security_localpinverifier_ts",
-      "label": "localPinVerifier.ts",
-      "norm_label": "localpinverifier.ts",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L1"
+      "id": "registerdrawerpresentation_stringfield",
+      "label": "stringField()",
+      "norm_label": "stringfield()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L334"
     },
     {
       "community": 1880,
@@ -206220,119 +206235,119 @@
     {
       "community": 189,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_reviews_ts",
-      "label": "reviews.ts",
-      "norm_label": "reviews.ts",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L1"
+      "id": "localpinverifier_base64tobytes",
+      "label": "base64ToBytes()",
+      "norm_label": "base64tobytes()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L50"
     },
     {
       "community": 189,
       "file_type": "code",
-      "id": "reviews_createreview",
-      "label": "createReview()",
-      "norm_label": "createreview()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L13"
+      "id": "localpinverifier_bytestobase64",
+      "label": "bytesToBase64()",
+      "norm_label": "bytestobase64()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L38"
     },
     {
       "community": 189,
       "file_type": "code",
-      "id": "reviews_deletereview",
-      "label": "deleteReview()",
-      "norm_label": "deletereview()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L69"
+      "id": "localpinverifier_createlocalpinverifier",
+      "label": "createLocalPinVerifier()",
+      "norm_label": "createlocalpinverifier()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L131"
     },
     {
       "community": 189,
       "file_type": "code",
-      "id": "reviews_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L4"
+      "id": "localpinverifier_cryptorefdecrypt",
+      "label": "cryptoRefDecrypt()",
+      "norm_label": "cryptorefdecrypt()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L268"
     },
     {
       "community": 189,
       "file_type": "code",
-      "id": "reviews_getreviewbyorderitem",
-      "label": "getReviewByOrderItem()",
-      "norm_label": "getreviewbyorderitem()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L32"
+      "id": "localpinverifier_derivepinhash",
+      "label": "derivePinHash()",
+      "norm_label": "derivepinhash()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L76"
     },
     {
       "community": 189,
       "file_type": "code",
-      "id": "reviews_getreviewsbyproductid",
-      "label": "getReviewsByProductId()",
-      "norm_label": "getreviewsbyproductid()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L132"
+      "id": "localpinverifier_derivewrappingkey",
+      "label": "deriveWrappingKey()",
+      "norm_label": "derivewrappingkey()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L103"
     },
     {
       "community": 189,
       "file_type": "code",
-      "id": "reviews_getreviewsbyproductskuid",
-      "label": "getReviewsByProductSkuId()",
-      "norm_label": "getreviewsbyproductskuid()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L83"
+      "id": "localpinverifier_getcrypto",
+      "label": "getCrypto()",
+      "norm_label": "getcrypto()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L30"
     },
     {
       "community": 189,
       "file_type": "code",
-      "id": "reviews_getuserreviews",
-      "label": "getUserReviews()",
-      "norm_label": "getuserreviews()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L99"
+      "id": "localpinverifier_islocalpinverifiermetadata",
+      "label": "isLocalPinVerifierMetadata()",
+      "norm_label": "islocalpinverifiermetadata()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L281"
     },
     {
       "community": 189,
       "file_type": "code",
-      "id": "reviews_getuserreviewsforproduct",
-      "label": "getUserReviewsForProduct()",
-      "norm_label": "getuserreviewsforproduct()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L113"
+      "id": "localpinverifier_timingsafeequal",
+      "label": "timingSafeEqual()",
+      "norm_label": "timingsafeequal()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L63"
     },
     {
       "community": 189,
       "file_type": "code",
-      "id": "reviews_hasreviewfororderitem",
-      "label": "hasReviewForOrderItem()",
-      "norm_label": "hasreviewfororderitem()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L164"
+      "id": "localpinverifier_unwraplocalstaffprooftoken",
+      "label": "unwrapLocalStaffProofToken()",
+      "norm_label": "unwraplocalstaffprooftoken()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L221"
     },
     {
       "community": 189,
       "file_type": "code",
-      "id": "reviews_hasuserreviewfororderitem",
-      "label": "hasUserReviewForOrderItem()",
-      "norm_label": "hasuserreviewfororderitem()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "id": "localpinverifier_verifylocalpin",
+      "label": "verifyLocalPin()",
+      "norm_label": "verifylocalpin()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L152"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "localpinverifier_wraplocalstaffprooftoken",
+      "label": "wrapLocalStaffProofToken()",
+      "norm_label": "wraplocalstaffprooftoken()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
       "source_location": "L183"
     },
     {
       "community": 189,
       "file_type": "code",
-      "id": "reviews_markreviewhelpful",
-      "label": "markReviewHelpful()",
-      "norm_label": "markreviewhelpful()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L148"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "reviews_updatereview",
-      "label": "updateReview()",
-      "norm_label": "updatereview()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L48"
+      "id": "packages_athena_webapp_src_lib_security_localpinverifier_ts",
+      "label": "localPinVerifier.ts",
+      "norm_label": "localpinverifier.ts",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L1"
     },
     {
       "community": 1890,
@@ -206796,119 +206811,119 @@
     {
       "community": 190,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "id": "packages_storefront_webapp_src_api_reviews_ts",
+      "label": "reviews.ts",
+      "norm_label": "reviews.ts",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L1"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
+      "id": "reviews_createreview",
+      "label": "createReview()",
+      "norm_label": "createreview()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L13"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L1"
+      "id": "reviews_deletereview",
+      "label": "deleteReview()",
+      "norm_label": "deletereview()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L69"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "utils_formatdeliveryaddress",
-      "label": "formatDeliveryAddress()",
-      "norm_label": "formatdeliveryaddress()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L74"
+      "id": "reviews_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L4"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "utils_getamountpaidfororder",
-      "label": "getAmountPaidForOrder()",
-      "norm_label": "getamountpaidfororder()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L191"
+      "id": "reviews_getreviewbyorderitem",
+      "label": "getReviewByOrderItem()",
+      "norm_label": "getreviewbyorderitem()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L32"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "utils_getdiscountvalue",
-      "label": "getDiscountValue()",
-      "norm_label": "getdiscountvalue()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L17"
+      "id": "reviews_getreviewsbyproductid",
+      "label": "getReviewsByProductId()",
+      "norm_label": "getreviewsbyproductid()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L132"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "utils_getonlineorderplacedat",
-      "label": "getOnlineOrderPlacedAt()",
-      "norm_label": "getonlineorderplacedat()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
+      "id": "reviews_getreviewsbyproductskuid",
+      "label": "getReviewsByProductSkuId()",
+      "norm_label": "getreviewsbyproductskuid()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L83"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "utils_getorderamount",
-      "label": "getOrderAmount()",
-      "norm_label": "getorderamount()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L51"
+      "id": "reviews_getuserreviews",
+      "label": "getUserReviews()",
+      "norm_label": "getuserreviews()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L99"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "utils_getorderstate",
-      "label": "getOrderState()",
-      "norm_label": "getorderstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L40"
+      "id": "reviews_getuserreviewsforproduct",
+      "label": "getUserReviewsForProduct()",
+      "norm_label": "getuserreviewsforproduct()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L113"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "utils_getpickupactionstate",
-      "label": "getPickupActionState()",
-      "norm_label": "getpickupactionstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L102"
+      "id": "reviews_hasreviewfororderitem",
+      "label": "hasReviewForOrderItem()",
+      "norm_label": "hasreviewfororderitem()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L164"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "utils_getpotentialpoints",
-      "label": "getPotentialPoints()",
-      "norm_label": "getpotentialpoints()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L107"
+      "id": "reviews_hasuserreviewfororderitem",
+      "label": "hasUserReviewForOrderItem()",
+      "norm_label": "hasuserreviewfororderitem()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L183"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "utils_getproductdiscountvalue",
-      "label": "getProductDiscountValue()",
-      "norm_label": "getproductdiscountvalue()",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
-      "source_location": "L75"
+      "id": "reviews_markreviewhelpful",
+      "label": "markReviewHelpful()",
+      "norm_label": "markreviewhelpful()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L148"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "utils_shouldshowpickupexceptionaction",
-      "label": "shouldShowPickupExceptionAction()",
-      "norm_label": "shouldshowpickupexceptionaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L116"
+      "id": "reviews_updatereview",
+      "label": "updateReview()",
+      "norm_label": "updatereview()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L48"
     },
     {
       "community": 1900,
@@ -217506,19 +217521,19 @@
     {
       "community": 2338,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_input_tsx",
-      "label": "input.tsx",
-      "norm_label": "input.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/input.tsx",
+      "id": "packages_athena_webapp_src_components_ui_input_test_tsx",
+      "label": "input.test.tsx",
+      "norm_label": "input.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/input.test.tsx",
       "source_location": "L1"
     },
     {
       "community": 2339,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
-      "label": "action-modal.tsx",
-      "norm_label": "action-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/action-modal.tsx",
+      "id": "packages_athena_webapp_src_components_ui_input_tsx",
+      "label": "input.tsx",
+      "norm_label": "input.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/input.tsx",
       "source_location": "L1"
     },
     {
@@ -217614,6 +217629,15 @@
     {
       "community": 2340,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
+      "label": "action-modal.tsx",
+      "norm_label": "action-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/action-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2341,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_panel_header_tsx",
       "label": "panel-header.tsx",
       "norm_label": "panel-header.tsx",
@@ -217621,7 +217645,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2341,
+      "community": 2342,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -217630,7 +217654,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2342,
+      "community": 2343,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_primitives_test_tsx",
       "label": "primitives.test.tsx",
@@ -217639,7 +217663,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2343,
+      "community": 2344,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -217648,7 +217672,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2344,
+      "community": 2345,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -217657,7 +217681,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2345,
+      "community": 2346,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -217666,7 +217690,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2346,
+      "community": 2347,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -217675,7 +217699,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2347,
+      "community": 2348,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -217684,21 +217708,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2348,
+      "community": 2349,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_switch_tsx",
       "label": "switch.tsx",
       "norm_label": "switch.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/switch.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2349,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_table_test_tsx",
-      "label": "table.test.tsx",
-      "norm_label": "table.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/table.test.tsx",
       "source_location": "L1"
     },
     {
@@ -217794,6 +217809,15 @@
     {
       "community": 2350,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_table_test_tsx",
+      "label": "table.test.tsx",
+      "norm_label": "table.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/table.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2351,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
       "norm_label": "table.tsx",
@@ -217801,7 +217825,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2351,
+      "community": 2352,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -217810,7 +217834,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2352,
+      "community": 2353,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -217819,7 +217843,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2353,
+      "community": 2354,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -217828,7 +217852,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2354,
+      "community": 2355,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -217837,7 +217861,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2355,
+      "community": 2356,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
@@ -217846,7 +217870,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2356,
+      "community": 2357,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_upload_button_tsx",
       "label": "upload-button.tsx",
@@ -217855,7 +217879,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2357,
+      "community": 2358,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
       "label": "BagView.tsx",
@@ -217864,21 +217888,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2358,
+      "community": 2359,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2359,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/constants.ts",
       "source_location": "L1"
     },
     {
@@ -217974,6 +217989,15 @@
     {
       "community": 2360,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2361,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -217981,7 +218005,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2361,
+      "community": 2362,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -217990,7 +218014,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2362,
+      "community": 2363,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -217999,7 +218023,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2363,
+      "community": 2364,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
       "label": "data.ts",
@@ -218008,7 +218032,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2364,
+      "community": 2365,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
       "label": "bag-columns.tsx",
@@ -218017,7 +218041,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2365,
+      "community": 2366,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
       "label": "bags-table.tsx",
@@ -218026,7 +218050,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2366,
+      "community": 2367,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
       "label": "columns.tsx",
@@ -218035,7 +218059,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2367,
+      "community": 2368,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -218044,21 +218068,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2368,
+      "community": 2369,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2369,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
@@ -218154,6 +218169,15 @@
     {
       "community": 2370,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2371,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -218161,7 +218185,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2371,
+      "community": 2372,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
       "label": "LinkedAccounts.tsx",
@@ -218170,7 +218194,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2372,
+      "community": 2373,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
       "label": "TimelineEventCard.test.tsx",
@@ -218179,7 +218203,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2373,
+      "community": 2374,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
       "label": "UserCheckoutSession.tsx",
@@ -218188,7 +218212,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2374,
+      "community": 2375,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
       "label": "index.ts",
@@ -218197,7 +218221,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2375,
+      "community": 2376,
       "file_type": "code",
       "id": "packages_athena_webapp_src_config_test_ts",
       "label": "config.test.ts",
@@ -218206,7 +218230,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2376,
+      "community": 2377,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexttracking_docsworkspacetracking_test_ts",
       "label": "docsWorkspaceTracking.test.ts",
@@ -218215,7 +218239,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2377,
+      "community": 2378,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
       "label": "ThemeContext.tsx",
@@ -218224,21 +218248,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2378,
+      "community": 2379,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_onlineordersessionoverlay_test_ts",
       "label": "onlineOrderSessionOverlay.test.ts",
       "norm_label": "onlineordersessionoverlay.test.ts",
       "source_file": "packages/athena-webapp/src/contexts/onlineOrderSessionOverlay.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2379,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_design_system_build_config_test_ts",
-      "label": "design-system-build-config.test.ts",
-      "norm_label": "design-system-build-config.test.ts",
-      "source_file": "packages/athena-webapp/src/design-system-build-config.test.ts",
       "source_location": "L1"
     },
     {
@@ -218248,7 +218263,7 @@
       "label": "ask()",
       "norm_label": "ask()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L396"
+      "source_location": "L424"
     },
     {
       "community": 238,
@@ -218257,7 +218272,7 @@
       "label": "askForDay()",
       "norm_label": "askforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L549"
+      "source_location": "L577"
     },
     {
       "community": 238,
@@ -218266,7 +218281,7 @@
       "label": "insertCompletedClose()",
       "norm_label": "insertcompletedclose()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L456"
+      "source_location": "L484"
     },
     {
       "community": 238,
@@ -218275,7 +218290,7 @@
       "label": "insertLegacyDelivery()",
       "norm_label": "insertlegacydelivery()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L367"
+      "source_location": "L395"
     },
     {
       "community": 238,
@@ -218284,7 +218299,7 @@
       "label": "insertReportDay()",
       "norm_label": "insertreportday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L506"
+      "source_location": "L534"
     },
     {
       "community": 238,
@@ -218293,7 +218308,7 @@
       "label": "money()",
       "norm_label": "money()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L75"
+      "source_location": "L76"
     },
     {
       "community": 238,
@@ -218302,7 +218317,7 @@
       "label": "seedStore()",
       "norm_label": "seedstore()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L436"
+      "source_location": "L464"
     },
     {
       "community": 238,
@@ -218311,7 +218326,7 @@
       "label": "seedStoreAndRun()",
       "norm_label": "seedstoreandrun()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L329"
+      "source_location": "L357"
     },
     {
       "community": 238,
@@ -218320,7 +218335,7 @@
       "label": "unitsMetric()",
       "norm_label": "unitsmetric()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L540"
+      "source_location": "L568"
     },
     {
       "community": 238,
@@ -218334,6 +218349,15 @@
     {
       "community": 2380,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_design_system_build_config_test_ts",
+      "label": "design-system-build-config.test.ts",
+      "norm_label": "design-system-build-config.test.ts",
+      "source_file": "packages/athena-webapp/src/design-system-build-config.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2381,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_pagination_persistence_test_ts",
       "label": "use-pagination-persistence.test.ts",
       "norm_label": "use-pagination-persistence.test.ts",
@@ -218341,7 +218365,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2381,
+      "community": 2382,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
@@ -218350,7 +218374,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2382,
+      "community": 2383,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_test_tsx",
       "label": "useAuth.test.tsx",
@@ -218359,7 +218383,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2383,
+      "community": 2384,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_test_ts",
       "label": "useExpenseSessions.test.ts",
@@ -218368,7 +218392,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2384,
+      "community": 2385,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactivestore_test_ts",
       "label": "useGetActiveStore.test.ts",
@@ -218377,7 +218401,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2385,
+      "community": 2386,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetterminal_test_ts",
       "label": "useGetTerminal.test.ts",
@@ -218386,7 +218410,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2386,
+      "community": 2387,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
@@ -218395,7 +218419,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2387,
+      "community": 2388,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useposproducts_test_ts",
       "label": "usePOSProducts.test.ts",
@@ -218404,21 +218428,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2388,
+      "community": 2389,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprotectedadminpagestate_test_tsx",
       "label": "useProtectedAdminPageState.test.tsx",
       "norm_label": "useprotectedadminpagestate.test.tsx",
       "source_file": "packages/athena-webapp/src/hooks/useProtectedAdminPageState.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2389,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useshareddemocontext_test_ts",
-      "label": "useSharedDemoContext.test.ts",
-      "norm_label": "useshareddemocontext.test.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useSharedDemoContext.test.ts",
       "source_location": "L1"
     },
     {
@@ -218514,6 +218529,15 @@
     {
       "community": 2390,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useshareddemocontext_test_ts",
+      "label": "useSharedDemoContext.test.ts",
+      "norm_label": "useshareddemocontext.test.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useSharedDemoContext.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2391,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usestoreoperatingclock_test_tsx",
       "label": "useStoreOperatingClock.test.tsx",
       "norm_label": "usestoreoperatingclock.test.tsx",
@@ -218521,7 +218545,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2391,
+      "community": 2392,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_access_capabilities_test_ts",
       "label": "capabilities.test.ts",
@@ -218530,7 +218554,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2392,
+      "community": 2393,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_messages_appmessagescontext_ts",
       "label": "AppMessagesContext.ts",
@@ -218539,7 +218563,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2393,
+      "community": 2394,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_messages_appmessagecommunicationpreferencecontext_ts",
       "label": "appMessageCommunicationPreferenceContext.ts",
@@ -218548,7 +218572,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2394,
+      "community": 2395,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_messages_index_ts",
       "label": "index.ts",
@@ -218557,7 +218581,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2395,
+      "community": 2396,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_update_appupdateactions_ts",
       "label": "appUpdateActions.ts",
@@ -218566,7 +218590,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2396,
+      "community": 2397,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_update_index_ts",
       "label": "index.ts",
@@ -218575,7 +218599,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2397,
+      "community": 2398,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_update_updatecommunicationpreferencecontext_ts",
       "label": "updateCommunicationPreferenceContext.ts",
@@ -218584,21 +218608,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2398,
+      "community": 2399,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_update_updatecoordinator_test_ts",
       "label": "updateCoordinator.test.ts",
       "norm_label": "updatecoordinator.test.ts",
       "source_file": "packages/athena-webapp/src/lib/app-update/updateCoordinator.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2399,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_aws_ts",
-      "label": "aws.ts",
-      "norm_label": "aws.ts",
-      "source_file": "packages/athena-webapp/src/lib/aws.ts",
       "source_location": "L1"
     },
     {
@@ -219036,6 +219051,15 @@
     {
       "community": 2400,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_aws_ts",
+      "label": "aws.ts",
+      "norm_label": "aws.ts",
+      "source_file": "packages/athena-webapp/src/lib/aws.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2401,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
@@ -219043,7 +219067,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2401,
+      "community": 2402,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -219052,7 +219076,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2402,
+      "community": 2403,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_docs_access_test_ts",
       "label": "access.test.ts",
@@ -219061,7 +219085,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2403,
+      "community": 2404,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_docs_content_test_ts",
       "label": "content.test.ts",
@@ -219070,7 +219094,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2404,
+      "community": 2405,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_docs_navigation_test_ts",
       "label": "navigation.test.ts",
@@ -219079,7 +219103,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2405,
+      "community": 2406,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_docs_parsing_test_ts",
       "label": "parsing.test.ts",
@@ -219088,7 +219112,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2406,
+      "community": 2407,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_docs_reportcontract_test_ts",
       "label": "reportContract.test.ts",
@@ -219097,7 +219121,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2407,
+      "community": 2408,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_docs_scrollprogress_test_ts",
       "label": "scrollProgress.test.ts",
@@ -219106,21 +219130,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2408,
+      "community": 2409,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_docs_virtual_docs_index_d_ts",
       "label": "virtual-docs-index.d.ts",
       "norm_label": "virtual-docs-index.d.ts",
       "source_file": "packages/athena-webapp/src/lib/docs/virtual-docs-index.d.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2409,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_errors_operatormessages_test_ts",
-      "label": "operatorMessages.test.ts",
-      "norm_label": "operatormessages.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/errors/operatorMessages.test.ts",
       "source_location": "L1"
     },
     {
@@ -219216,6 +219231,15 @@
     {
       "community": 2410,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_errors_operatormessages_test_ts",
+      "label": "operatorMessages.test.ts",
+      "norm_label": "operatormessages.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/errors/operatorMessages.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2411,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_test_ts",
       "label": "presentCommandToast.test.ts",
       "norm_label": "presentcommandtoast.test.ts",
@@ -219223,7 +219247,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2411,
+      "community": 2412,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_test_ts",
       "label": "presentUnexpectedErrorToast.test.ts",
@@ -219232,7 +219256,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2412,
+      "community": 2413,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_test_ts",
       "label": "runCommand.test.ts",
@@ -219241,7 +219265,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2413,
+      "community": 2414,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -219250,7 +219274,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2414,
+      "community": 2415,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -219259,7 +219283,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2415,
+      "community": 2416,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_inventory_import_inventoryimportparser_test_ts",
       "label": "inventoryImportParser.test.ts",
@@ -219268,7 +219292,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2416,
+      "community": 2417,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_marketing_landingfunnelclient_test_ts",
       "label": "landingFunnelClient.test.ts",
@@ -219277,7 +219301,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2417,
+      "community": 2418,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_marketing_walkthroughprivacy_ts",
       "label": "walkthroughPrivacy.ts",
@@ -219286,21 +219310,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2418,
+      "community": 2419,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_marketing_walkthroughrequestclient_test_ts",
       "label": "walkthroughRequestClient.test.ts",
       "norm_label": "walkthroughrequestclient.test.ts",
       "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2419,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_navigation_appentryroutes_test_ts",
-      "label": "appEntryRoutes.test.ts",
-      "norm_label": "appentryroutes.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/navigation/appEntryRoutes.test.ts",
       "source_location": "L1"
     },
     {
@@ -219396,6 +219411,15 @@
     {
       "community": 2420,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_navigation_appentryroutes_test_ts",
+      "label": "appEntryRoutes.test.ts",
+      "norm_label": "appentryroutes.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/navigation/appEntryRoutes.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2421,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_navigation_storeentryroute_test_ts",
       "label": "storeEntryRoute.test.ts",
       "norm_label": "storeentryroute.test.ts",
@@ -219403,7 +219427,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2421,
+      "community": 2422,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_operations_operatingdate_test_ts",
       "label": "operatingDate.test.ts",
@@ -219412,7 +219436,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2422,
+      "community": 2423,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_dto_ts",
       "label": "dto.ts",
@@ -219421,7 +219445,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2423,
+      "community": 2424,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_ports_ts",
       "label": "ports.ts",
@@ -219430,7 +219454,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2424,
+      "community": 2425,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_poslocalstoreport_ts",
       "label": "posLocalStorePort.ts",
@@ -219439,7 +219463,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2425,
+      "community": 2426,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_results_test_ts",
       "label": "results.test.ts",
@@ -219448,7 +219472,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2426,
+      "community": 2427,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_constants_ts",
       "label": "constants.ts",
@@ -219457,7 +219481,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2427,
+      "community": 2428,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
       "label": "displayAmounts.test.ts",
@@ -219466,21 +219490,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2428,
+      "community": 2429,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_cart_test_ts",
       "label": "cart.test.ts",
       "norm_label": "cart.test.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2429,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/index.ts",
       "source_location": "L1"
     },
     {
@@ -219576,6 +219591,15 @@
     {
       "community": 2430,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_domain_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2431,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_session_test_ts",
       "label": "session.test.ts",
       "norm_label": "session.test.ts",
@@ -219583,7 +219607,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2431,
+      "community": 2432,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_types_ts",
       "label": "types.ts",
@@ -219592,7 +219616,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2432,
+      "community": 2433,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_expensereceipt_test_ts",
       "label": "expenseReceipt.test.ts",
@@ -219601,7 +219625,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2433,
+      "community": 2434,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_test_ts",
       "label": "registerGateway.test.ts",
@@ -219610,7 +219634,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2434,
+      "community": 2435,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registerlifecycleauthoritygateway_test_ts",
       "label": "registerLifecycleAuthorityGateway.test.ts",
@@ -219619,7 +219643,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2435,
+      "community": 2436,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_test_ts",
       "label": "sessionGateway.test.ts",
@@ -219628,7 +219652,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2436,
+      "community": 2437,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_drawerauthorityreconciliation_test_ts",
       "label": "drawerAuthorityReconciliation.test.ts",
@@ -219637,7 +219661,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2437,
+      "community": 2438,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_indexeddbposlocalstorageengine_test_ts",
       "label": "indexedDbPosLocalStorageEngine.test.ts",
@@ -219646,21 +219670,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2438,
+      "community": 2439,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localposentrycontext_test_ts",
       "label": "localPosEntryContext.test.ts",
       "norm_label": "localposentrycontext.test.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosEntryContext.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2439,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localposreadiness_test_ts",
-      "label": "localPosReadiness.test.ts",
-      "norm_label": "localposreadiness.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.test.ts",
       "source_location": "L1"
     },
     {
@@ -219756,6 +219771,15 @@
     {
       "community": 2440,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localposreadiness_test_ts",
+      "label": "localPosReadiness.test.ts",
+      "norm_label": "localposreadiness.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2441,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalledgerpolicy_test_ts",
       "label": "posLocalLedgerPolicy.test.ts",
       "norm_label": "poslocalledgerpolicy.test.ts",
@@ -219763,7 +219787,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2441,
+      "community": 2442,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoragehealth_test_ts",
       "label": "posLocalStorageHealth.test.ts",
@@ -219772,7 +219796,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2442,
+      "community": 2443,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstorageruntime_test_ts",
       "label": "posLocalStorageRuntime.test.ts",
@@ -219781,7 +219805,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2443,
+      "community": 2444,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoreinitialization_test_ts",
       "label": "posLocalStoreInitialization.test.ts",
@@ -219790,7 +219814,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2444,
+      "community": 2445,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoremaintenance_test_ts",
       "label": "posLocalStoreMaintenance.test.ts",
@@ -219799,7 +219823,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2445,
+      "community": 2446,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoremigrations_test_ts",
       "label": "posLocalStoreMigrations.test.ts",
@@ -219808,7 +219832,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2446,
+      "community": 2447,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoresnapshot_test_ts",
       "label": "posLocalStoreSnapshot.test.ts",
@@ -219817,7 +219841,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2447,
+      "community": 2448,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registercatalogpinruntime_test_ts",
       "label": "registerCatalogPinRuntime.test.ts",
@@ -219826,21 +219850,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2448,
+      "community": 2449,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registerlifecycleauthorityrollout_test_ts",
       "label": "registerLifecycleAuthorityRollout.test.ts",
       "norm_label": "registerlifecycleauthorityrollout.test.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerLifecycleAuthorityRollout.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2449,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registersessionauthoritybootstrap_test_ts",
-      "label": "registerSessionAuthorityBootstrap.test.ts",
-      "norm_label": "registersessionauthoritybootstrap.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerSessionAuthorityBootstrap.test.ts",
       "source_location": "L1"
     },
     {
@@ -219936,6 +219951,15 @@
     {
       "community": 2450,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registersessionauthoritybootstrap_test_ts",
+      "label": "registerSessionAuthorityBootstrap.test.ts",
+      "norm_label": "registersessionauthoritybootstrap.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerSessionAuthorityBootstrap.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2451,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_saleblockerpolicy_test_ts",
       "label": "saleBlockerPolicy.test.ts",
       "norm_label": "saleblockerpolicy.test.ts",
@@ -219943,7 +219967,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2451,
+      "community": 2452,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_syncgapdiagnosis_test_ts",
       "label": "syncGapDiagnosis.test.ts",
@@ -219952,7 +219976,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2452,
+      "community": 2453,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_runtimecounters_test_ts",
       "label": "runtimeCounters.test.ts",
@@ -219961,7 +219985,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2453,
+      "community": 2454,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_telemetrybuffer_test_ts",
       "label": "telemetryBuffer.test.ts",
@@ -219970,7 +219994,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2454,
+      "community": 2455,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearch_test_ts",
       "label": "catalogSearch.test.ts",
@@ -219979,7 +220003,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2455,
+      "community": 2456,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearchpresentation_test_ts",
       "label": "catalogSearchPresentation.test.ts",
@@ -219988,7 +220012,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2456,
+      "community": 2457,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_registercashierpresence_test_ts",
       "label": "registerCashierPresence.test.ts",
@@ -219997,7 +220021,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2457,
+      "community": 2458,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_registercheckoutprojection_test_ts",
       "label": "registerCheckoutProjection.test.ts",
@@ -220006,21 +220030,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2458,
+      "community": 2459,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_registeruistate_test_ts",
       "label": "registerUiState.test.ts",
       "norm_label": "registeruistate.test.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2459,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregistercheckoutdraftstate_test_ts",
-      "label": "useRegisterCheckoutDraftState.test.ts",
-      "norm_label": "useregistercheckoutdraftstate.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterCheckoutDraftState.test.ts",
       "source_location": "L1"
     },
     {
@@ -220116,6 +220131,15 @@
     {
       "community": 2460,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregistercheckoutdraftstate_test_ts",
+      "label": "useRegisterCheckoutDraftState.test.ts",
+      "norm_label": "useregistercheckoutdraftstate.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterCheckoutDraftState.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2461,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_registersessioncode_test_ts",
       "label": "registerSessionCode.test.ts",
       "norm_label": "registersessioncode.test.ts",
@@ -220123,7 +220147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2461,
+      "community": 2462,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_syncstatuspresentation_test_ts",
       "label": "syncStatusPresentation.test.ts",
@@ -220132,7 +220156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2462,
+      "community": 2463,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_productutils_test_ts",
       "label": "productUtils.test.ts",
@@ -220141,7 +220165,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2463,
+      "community": 2464,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_remote_assist_contract_test_ts",
       "label": "contract.test.ts",
@@ -220150,7 +220174,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2464,
+      "community": 2465,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_remote_assist_guardrails_test_ts",
       "label": "guardrails.test.ts",
@@ -220159,7 +220183,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2465,
+      "community": 2466,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_remote_assist_index_ts",
       "label": "index.ts",
@@ -220168,7 +220192,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2466,
+      "community": 2467,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_runtimebuildmetadata_test_ts",
       "label": "runtimeBuildMetadata.test.ts",
@@ -220177,7 +220201,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2467,
+      "community": 2468,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -220186,21 +220210,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2468,
+      "community": 2469,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
       "norm_label": "product.ts",
       "source_file": "packages/athena-webapp/src/lib/schemas/product.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2469,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_store_ts",
-      "label": "store.ts",
-      "norm_label": "store.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/store.ts",
       "source_location": "L1"
     },
     {
@@ -220296,6 +220311,15 @@
     {
       "community": 2470,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_schemas_store_ts",
+      "label": "store.ts",
+      "norm_label": "store.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/store.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2471,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
       "norm_label": "subcategory.ts",
@@ -220303,7 +220327,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2471,
+      "community": 2472,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -220312,7 +220336,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2472,
+      "community": 2473,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_security_localpinverifier_test_ts",
       "label": "localPinVerifier.test.ts",
@@ -220321,7 +220345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2473,
+      "community": 2474,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_sheetreturn_test_ts",
       "label": "sheetReturn.test.ts",
@@ -220330,7 +220354,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2474,
+      "community": 2475,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_stockops_skusearch_test_ts",
       "label": "skuSearch.test.ts",
@@ -220339,7 +220363,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2475,
+      "community": 2476,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
@@ -220348,7 +220372,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2476,
+      "community": 2477,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_traces_createworkflowtraceid_test_ts",
       "label": "createWorkflowTraceId.test.ts",
@@ -220357,7 +220381,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2477,
+      "community": 2478,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -220366,21 +220390,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2478,
+      "community": 2479,
       "file_type": "code",
       "id": "packages_athena_webapp_src_main_tsx",
       "label": "main.tsx",
       "norm_label": "main.tsx",
       "source_file": "packages/athena-webapp/src/main.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2479,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_offline_posappshellreadiness_test_ts",
-      "label": "posAppShellReadiness.test.ts",
-      "norm_label": "posappshellreadiness.test.ts",
-      "source_file": "packages/athena-webapp/src/offline/posAppShellReadiness.test.ts",
       "source_location": "L1"
     },
     {
@@ -220476,6 +220491,15 @@
     {
       "community": 2480,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_offline_posappshellreadiness_test_ts",
+      "label": "posAppShellReadiness.test.ts",
+      "norm_label": "posappshellreadiness.test.ts",
+      "source_file": "packages/athena-webapp/src/offline/posAppShellReadiness.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2481,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_offline_posappshellroutes_test_ts",
       "label": "posAppShellRoutes.test.ts",
       "norm_label": "posappshellroutes.test.ts",
@@ -220483,7 +220507,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2481,
+      "community": 2482,
       "file_type": "code",
       "id": "packages_athena_webapp_src_offline_posofflinereadiness_test_ts",
       "label": "posOfflineReadiness.test.ts",
@@ -220492,7 +220516,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2482,
+      "community": 2483,
       "file_type": "code",
       "id": "packages_athena_webapp_src_offline_registerposappshellserviceworker_test_ts",
       "label": "registerPosAppShellServiceWorker.test.ts",
@@ -220501,7 +220525,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2483,
+      "community": 2484,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -220510,7 +220534,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2484,
+      "community": 2485,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_app_entry_route_tsx",
       "label": "-app-entry-route.tsx",
@@ -220519,7 +220543,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2485,
+      "community": 2486,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_privacy_page_tsx",
       "label": "-privacy-page.tsx",
@@ -220528,7 +220552,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2486,
+      "community": 2487,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_root_page_search_ts",
       "label": "-root-page-search.ts",
@@ -220537,7 +220561,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2487,
+      "community": 2488,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_shared_demo_entry_tsx",
       "label": "-shared-demo-entry.tsx",
@@ -220546,21 +220570,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2488,
+      "community": 2489,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_walkthrough_page_tsx",
       "label": "-walkthrough-page.tsx",
       "norm_label": "-walkthrough-page.tsx",
       "source_file": "packages/athena-webapp/src/routes/-walkthrough-page.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2489,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_root_test_ts",
-      "label": "__root.test.ts",
-      "norm_label": "__root.test.ts",
-      "source_file": "packages/athena-webapp/src/routes/__root.test.ts",
       "source_location": "L1"
     },
     {
@@ -220656,6 +220671,15 @@
     {
       "community": 2490,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_root_test_ts",
+      "label": "__root.test.ts",
+      "norm_label": "__root.test.ts",
+      "source_file": "packages/athena-webapp/src/routes/__root.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2491,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
@@ -220663,7 +220687,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2491,
+      "community": 2492,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
       "label": "index.tsx",
@@ -220672,7 +220696,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2492,
+      "community": 2493,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
       "label": "index.tsx",
@@ -220681,7 +220705,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2493,
+      "community": 2494,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
       "label": "$storeUrlSlug.tsx",
@@ -220690,7 +220714,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2494,
+      "community": 2495,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_app_settings_tsx",
       "label": "app-settings.tsx",
@@ -220699,7 +220723,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2495,
+      "community": 2496,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
       "label": "assets.index.tsx",
@@ -220708,7 +220732,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2496,
+      "community": 2497,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
       "label": "bags.$bagId.tsx",
@@ -220717,7 +220741,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2497,
+      "community": 2498,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
       "label": "bags.index.tsx",
@@ -220726,21 +220750,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2498,
+      "community": 2499,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bulk-operations/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2499,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
-      "label": "checkout-sessions.index.tsx",
-      "norm_label": "checkout-sessions.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/checkout-sessions.index.tsx",
       "source_location": "L1"
     },
     {
@@ -221169,6 +221184,15 @@
     {
       "community": 2500,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
+      "label": "checkout-sessions.index.tsx",
+      "norm_label": "checkout-sessions.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/checkout-sessions.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2501,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
       "label": "configuration.index.tsx",
       "norm_label": "configuration.index.tsx",
@@ -221176,7 +221200,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2501,
+      "community": 2502,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
       "label": "dashboard.index.tsx",
@@ -221185,7 +221209,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2502,
+      "community": 2503,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
       "label": "home.tsx",
@@ -221194,7 +221218,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2503,
+      "community": 2504,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
       "label": "logs.$logId.tsx",
@@ -221203,7 +221227,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2504,
+      "community": 2505,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
       "label": "logs.index.tsx",
@@ -221212,7 +221236,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2505,
+      "community": 2506,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
       "label": "members.index.tsx",
@@ -221221,7 +221245,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2506,
+      "community": 2507,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_test_ts",
       "label": "index.test.ts",
@@ -221230,7 +221254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2507,
+      "community": 2508,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_inventory_import_cost_overlay_search_ts",
       "label": "-cost-overlay-search.ts",
@@ -221239,21 +221263,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2508,
+      "community": 2509,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_inventory_import_cost_overlay_test_ts",
       "label": "cost-overlay.test.ts",
       "norm_label": "cost-overlay.test.ts",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/inventory-import/cost-overlay.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2509,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_inventory_import_cost_overlay_tsx",
-      "label": "cost-overlay.tsx",
-      "norm_label": "cost-overlay.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/inventory-import/cost-overlay.tsx",
       "source_location": "L1"
     },
     {
@@ -221349,6 +221364,15 @@
     {
       "community": 2510,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_inventory_import_cost_overlay_tsx",
+      "label": "cost-overlay.tsx",
+      "norm_label": "cost-overlay.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/inventory-import/cost-overlay.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2511,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_inventory_import_review_tsx",
       "label": "review.tsx",
       "norm_label": "review.tsx",
@@ -221356,7 +221380,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2511,
+      "community": 2512,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_inventory_import_test_tsx",
       "label": "inventory-import.test.tsx",
@@ -221365,7 +221389,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2512,
+      "community": 2513,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_inventory_import_tsx",
       "label": "inventory-import.tsx",
@@ -221374,7 +221398,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2513,
+      "community": 2514,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_sku_activity_test_tsx",
       "label": "sku-activity.test.tsx",
@@ -221383,7 +221407,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2514,
+      "community": 2515,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
       "label": "index.tsx",
@@ -221392,7 +221416,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2515,
+      "community": 2516,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
       "label": "all.index.tsx",
@@ -221401,7 +221425,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2516,
+      "community": 2517,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
       "label": "cancelled.index.tsx",
@@ -221410,7 +221434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2517,
+      "community": 2518,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
       "label": "completed.index.tsx",
@@ -221419,21 +221443,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2518,
+      "community": 2519,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2519,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
-      "label": "open.index.tsx",
-      "norm_label": "open.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/open.index.tsx",
       "source_location": "L1"
     },
     {
@@ -221529,6 +221544,15 @@
     {
       "community": 2520,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
+      "label": "open.index.tsx",
+      "norm_label": "open.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/open.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2521,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
       "label": "out-for-delivery.index.tsx",
       "norm_label": "out-for-delivery.index.tsx",
@@ -221536,7 +221560,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2521,
+      "community": 2522,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
       "label": "ready.index.tsx",
@@ -221545,7 +221569,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2522,
+      "community": 2523,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
       "label": "refunded.index.tsx",
@@ -221554,7 +221578,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2523,
+      "community": 2524,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
       "label": "$reportId.tsx",
@@ -221563,7 +221587,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2524,
+      "community": 2525,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
       "label": "expense-reports.index.tsx",
@@ -221572,7 +221596,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2525,
+      "community": 2526,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_test_tsx",
       "label": "expense.index.test.tsx",
@@ -221581,7 +221605,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2526,
+      "community": 2527,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
       "label": "register.index.tsx",
@@ -221590,7 +221614,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2527,
+      "community": 2528,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_sessions_index_tsx",
       "label": "sessions.index.tsx",
@@ -221599,21 +221623,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2528,
+      "community": 2529,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_terminals_terminalid_tsx",
       "label": "$terminalId.tsx",
       "norm_label": "$terminalid.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/terminals/$terminalId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2529,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_terminals_index_tsx",
-      "label": "terminals.index.tsx",
-      "norm_label": "terminals.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/terminals.index.tsx",
       "source_location": "L1"
     },
     {
@@ -221709,6 +221724,15 @@
     {
       "community": 2530,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_terminals_index_tsx",
+      "label": "terminals.index.tsx",
+      "norm_label": "terminals.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/terminals.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2531,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
       "label": "$transactionId.tsx",
       "norm_label": "$transactionid.tsx",
@@ -221716,7 +221740,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2531,
+      "community": 2532,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
       "label": "transactions.index.tsx",
@@ -221725,7 +221749,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2532,
+      "community": 2533,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_test_ts",
       "label": "procurement.index.test.ts",
@@ -221734,7 +221758,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2533,
+      "community": 2534,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
       "label": "edit.tsx",
@@ -221743,7 +221767,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2534,
+      "community": 2535,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
       "label": "index.tsx",
@@ -221752,7 +221776,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2535,
+      "community": 2536,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_archived_tsx",
       "label": "archived.tsx",
@@ -221761,7 +221785,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2536,
+      "community": 2537,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
       "label": "new.tsx",
@@ -221770,7 +221794,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2537,
+      "community": 2538,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
       "label": "new.tsx",
@@ -221779,21 +221803,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2538,
+      "community": 2539,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
       "label": "unresolved.tsx",
       "norm_label": "unresolved.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/unresolved.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2539,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
-      "label": "$promoCodeSlug.tsx",
-      "norm_label": "$promocodeslug.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/$promoCodeSlug.tsx",
       "source_location": "L1"
     },
     {
@@ -221889,6 +221904,15 @@
     {
       "community": 2540,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
+      "label": "$promoCodeSlug.tsx",
+      "norm_label": "$promocodeslug.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/$promoCodeSlug.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2541,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
@@ -221896,7 +221920,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2541,
+      "community": 2542,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
       "label": "new.tsx",
@@ -221905,7 +221929,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2542,
+      "community": 2543,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_items_productskuid_test_ts",
       "label": "$productSkuId.test.ts",
@@ -221914,7 +221938,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2543,
+      "community": 2544,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_items_index_test_ts",
       "label": "index.test.ts",
@@ -221923,7 +221947,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2544,
+      "community": 2545,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_items_tsx",
       "label": "items.tsx",
@@ -221932,7 +221956,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2545,
+      "community": 2546,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_weekly_test_ts",
       "label": "weekly.test.ts",
@@ -221941,7 +221965,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2546,
+      "community": 2547,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_tsx",
       "label": "reports.tsx",
@@ -221950,7 +221974,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2547,
+      "community": 2548,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
       "label": "index.tsx",
@@ -221959,21 +221983,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2548,
+      "community": 2549,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
       "label": "new.index.tsx",
       "norm_label": "new.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/new.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2549,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_active_cases_index_tsx",
-      "label": "active-cases.index.tsx",
-      "norm_label": "active-cases.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/active-cases.index.tsx",
       "source_location": "L1"
     },
     {
@@ -222069,6 +222084,15 @@
     {
       "community": 2550,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_active_cases_index_tsx",
+      "label": "active-cases.index.tsx",
+      "norm_label": "active-cases.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/active-cases.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2551,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_appointments_index_tsx",
       "label": "appointments.index.tsx",
       "norm_label": "appointments.index.tsx",
@@ -222076,7 +222100,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2551,
+      "community": 2552,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_catalog_management_index_tsx",
       "label": "catalog-management.index.tsx",
@@ -222085,7 +222109,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2552,
+      "community": 2553,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_index_tsx",
       "label": "index.tsx",
@@ -222094,7 +222118,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2553,
+      "community": 2554,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_intake_index_tsx",
       "label": "intake.index.tsx",
@@ -222103,7 +222127,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2554,
+      "community": 2555,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_test_tsx",
       "label": "$traceId.test.tsx",
@@ -222112,7 +222136,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2555,
+      "community": 2556,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
       "label": "users.$userId.tsx",
@@ -222121,7 +222145,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2556,
+      "community": 2557,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
       "label": "index.tsx",
@@ -222130,7 +222154,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2557,
+      "community": 2558,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_shell_test_tsx",
       "label": "_authed-shell.test.tsx",
@@ -222139,21 +222163,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2558,
+      "community": 2559,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_test_tsx",
       "label": "_authed.test.tsx",
       "norm_label": "_authed.test.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2559,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_app_route_test_tsx",
-      "label": "app.route.test.tsx",
-      "norm_label": "app.route.test.tsx",
-      "source_file": "packages/athena-webapp/src/routes/app.route.test.tsx",
       "source_location": "L1"
     },
     {
@@ -222249,6 +222264,15 @@
     {
       "community": 2560,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_app_route_test_tsx",
+      "label": "app.route.test.tsx",
+      "norm_label": "app.route.test.tsx",
+      "source_file": "packages/athena-webapp/src/routes/app.route.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2561,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_app_test_tsx",
       "label": "app.test.tsx",
       "norm_label": "app.test.tsx",
@@ -222256,7 +222280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2561,
+      "community": 2562,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_app_tsx",
       "label": "app.tsx",
@@ -222265,7 +222289,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2562,
+      "community": 2563,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_demo_test_tsx",
       "label": "demo.test.tsx",
@@ -222274,7 +222298,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2563,
+      "community": 2564,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_demo_tsx",
       "label": "demo.tsx",
@@ -222283,7 +222307,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2564,
+      "community": 2565,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_docs_index_tsx",
       "label": "docs.index.tsx",
@@ -222292,7 +222316,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2565,
+      "community": 2566,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_docs_reports_slug_tsx",
       "label": "docs.reports.$slug.tsx",
@@ -222301,7 +222325,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2566,
+      "community": 2567,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_docs_solutions_category_slug_test_tsx",
       "label": "docs.solutions.$category.$slug.test.tsx",
@@ -222310,7 +222334,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2567,
+      "community": 2568,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_docs_tsx",
       "label": "docs.tsx",
@@ -222319,21 +222343,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2568,
+      "community": 2569,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_test_tsx",
       "label": "index.test.tsx",
       "norm_label": "index.test.tsx",
       "source_file": "packages/athena-webapp/src/routes/index.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2569,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/index.tsx",
       "source_location": "L1"
     },
     {
@@ -222429,6 +222444,15 @@
     {
       "community": 2570,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2571,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
       "label": "join-team.index.tsx",
       "norm_label": "join-team.index.tsx",
@@ -222436,7 +222460,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2571,
+      "community": 2572,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_landing_tsx",
       "label": "landing.tsx",
@@ -222445,7 +222469,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2572,
+      "community": 2573,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_test_tsx",
       "label": "_layout.index.test.tsx",
@@ -222454,7 +222478,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2573,
+      "community": 2574,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
       "label": "_layout.index.tsx",
@@ -222463,7 +222487,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2574,
+      "community": 2575,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_tsx",
       "label": "_layout.tsx",
@@ -222472,7 +222496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2575,
+      "community": 2576,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_privacy_test_tsx",
       "label": "privacy.test.tsx",
@@ -222481,7 +222505,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2576,
+      "community": 2577,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_privacy_tsx",
       "label": "privacy.tsx",
@@ -222490,7 +222514,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2577,
+      "community": 2578,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_register_interest_tsx",
       "label": "register-interest.tsx",
@@ -222499,21 +222523,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2578,
+      "community": 2579,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_walkthrough_test_tsx",
       "label": "walkthrough.test.tsx",
       "norm_label": "walkthrough.test.tsx",
       "source_file": "packages/athena-webapp/src/routes/walkthrough.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2579,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_walkthrough_tsx",
-      "label": "walkthrough.tsx",
-      "norm_label": "walkthrough.tsx",
-      "source_file": "packages/athena-webapp/src/routes/walkthrough.tsx",
       "source_location": "L1"
     },
     {
@@ -222609,6 +222624,15 @@
     {
       "community": 2580,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_walkthrough_tsx",
+      "label": "walkthrough.tsx",
+      "norm_label": "walkthrough.tsx",
+      "source_file": "packages/athena-webapp/src/routes/walkthrough.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2581,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
       "label": "StoresSettingsAccordion.tsx",
       "norm_label": "storessettingsaccordion.tsx",
@@ -222616,7 +222640,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2581,
+      "community": 2582,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stores_expensestore_test_ts",
       "label": "expenseStore.test.ts",
@@ -222625,7 +222649,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2582,
+      "community": 2583,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -222634,7 +222658,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2583,
+      "community": 2584,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
       "label": "foundations-content.test.tsx",
@@ -222643,7 +222667,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2584,
+      "community": 2585,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
       "label": "Introduction.stories.tsx",
@@ -222652,7 +222676,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2585,
+      "community": 2586,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
       "label": "introduction-content.test.tsx",
@@ -222661,7 +222685,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2586,
+      "community": 2587,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
       "label": "introduction-content.tsx",
@@ -222670,7 +222694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2587,
+      "community": 2588,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_adminshell_stories_tsx",
       "label": "AdminShell.stories.tsx",
@@ -222679,21 +222703,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2588,
+      "community": 2589,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_view_stories_tsx",
       "label": "View.stories.tsx",
       "norm_label": "view.stories.tsx",
       "source_file": "packages/athena-webapp/src/stories/Patterns/View.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2589,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_test_tsx",
-      "label": "admin-shell-patterns.test.tsx",
-      "norm_label": "admin-shell-patterns.test.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Patterns/admin-shell-patterns.test.tsx",
       "source_location": "L1"
     },
     {
@@ -222789,6 +222804,15 @@
     {
       "community": 2590,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_test_tsx",
+      "label": "admin-shell-patterns.test.tsx",
+      "norm_label": "admin-shell-patterns.test.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Patterns/admin-shell-patterns.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2591,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_view_patterns_test_tsx",
       "label": "view-patterns.test.tsx",
       "norm_label": "view-patterns.test.tsx",
@@ -222796,7 +222820,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2591,
+      "community": 2592,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_surfaces_stories_tsx",
       "label": "Surfaces.stories.tsx",
@@ -222805,7 +222829,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2592,
+      "community": 2593,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
       "label": "DashboardWorkspace.stories.tsx",
@@ -222814,7 +222838,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2593,
+      "community": 2594,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
       "label": "DataWorkspace.stories.tsx",
@@ -222823,7 +222847,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2594,
+      "community": 2595,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_settingsworkspace_stories_tsx",
       "label": "SettingsWorkspace.stories.tsx",
@@ -222832,7 +222856,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2595,
+      "community": 2596,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_test_tsx",
       "label": "reference-fixtures.test.tsx",
@@ -222841,7 +222865,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2596,
+      "community": 2597,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_operations_eodreviewfixtures_ts",
       "label": "eodReviewFixtures.ts",
@@ -222850,7 +222874,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2597,
+      "community": 2598,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_config_test_ts",
       "label": "storybook-config.test.ts",
@@ -222859,21 +222883,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2598,
+      "community": 2599,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_test_ts",
       "label": "storybook-theme-decorator.test.ts",
       "norm_label": "storybook-theme-decorator.test.ts",
       "source_file": "packages/athena-webapp/src/stories/storybook-theme-decorator.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2599,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_test_setup_ts",
-      "label": "setup.ts",
-      "norm_label": "setup.ts",
-      "source_file": "packages/athena-webapp/src/test/setup.ts",
       "source_location": "L1"
     },
     {
@@ -223302,6 +223317,15 @@
     {
       "community": 2600,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_test_setup_ts",
+      "label": "setup.ts",
+      "norm_label": "setup.ts",
+      "source_file": "packages/athena-webapp/src/test/setup.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2601,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_vite_env_d_ts",
       "label": "vite-env.d.ts",
       "norm_label": "vite-env.d.ts",
@@ -223309,7 +223333,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2601,
+      "community": 2602,
       "file_type": "code",
       "id": "packages_athena_webapp_src_viteconfig_test_ts",
       "label": "viteConfig.test.ts",
@@ -223318,7 +223342,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2602,
+      "community": 2603,
       "file_type": "code",
       "id": "packages_athena_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -223327,7 +223351,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2603,
+      "community": 2604,
       "file_type": "code",
       "id": "packages_athena_webapp_types_ts",
       "label": "types.ts",
@@ -223336,7 +223360,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2604,
+      "community": 2605,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -223345,7 +223369,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2605,
+      "community": 2606,
       "file_type": "code",
       "id": "packages_storefront_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -223354,7 +223378,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2606,
+      "community": 2607,
       "file_type": "code",
       "id": "packages_storefront_webapp_global_d_ts",
       "label": "global.d.ts",
@@ -223363,7 +223387,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2607,
+      "community": 2608,
       "file_type": "code",
       "id": "packages_storefront_webapp_playwright_config_ts",
       "label": "playwright.config.ts",
@@ -223372,21 +223396,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2608,
+      "community": 2609,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_test_ts",
       "label": "analytics.test.ts",
       "norm_label": "analytics.test.ts",
       "source_file": "packages/storefront-webapp/src/api/analytics.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2609,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_homepagesnapshot_test_ts",
-      "label": "homepageSnapshot.test.ts",
-      "norm_label": "homepagesnapshot.test.ts",
-      "source_file": "packages/storefront-webapp/src/api/homepageSnapshot.test.ts",
       "source_location": "L1"
     },
     {
@@ -223482,6 +223497,15 @@
     {
       "community": 2610,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_homepagesnapshot_test_ts",
+      "label": "homepageSnapshot.test.ts",
+      "norm_label": "homepagesnapshot.test.ts",
+      "source_file": "packages/storefront-webapp/src/api/homepageSnapshot.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2611,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_trackingevents_test_ts",
       "label": "trackingEvents.test.ts",
       "norm_label": "trackingevents.test.ts",
@@ -223489,7 +223513,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2611,
+      "community": 2612,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_types_ts",
       "label": "types.ts",
@@ -223498,7 +223522,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2612,
+      "community": 2613,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
       "label": "HeartIconFilled.tsx",
@@ -223507,7 +223531,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2613,
+      "community": 2614,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -223516,7 +223540,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2614,
+      "community": 2615,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
       "label": "HomePage.test.tsx",
@@ -223525,7 +223549,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2615,
+      "community": 2616,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
       "label": "ProductCard.test.tsx",
@@ -223534,7 +223558,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2616,
+      "community": 2617,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_upsell_tsx",
       "label": "Upsell.tsx",
@@ -223543,7 +223567,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2617,
+      "community": 2618,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_test_tsx",
       "label": "Checkout.test.tsx",
@@ -223552,21 +223576,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2618,
+      "community": 2619,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
       "label": "Checkout.tsx",
       "norm_label": "checkout.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/Checkout.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2619,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
-      "label": "CustomerInfoSection.tsx",
-      "norm_label": "customerinfosection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/CustomerInfoSection.tsx",
       "source_location": "L1"
     },
     {
@@ -223662,6 +223677,15 @@
     {
       "community": 2620,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
+      "label": "CustomerInfoSection.tsx",
+      "norm_label": "customerinfosection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/CustomerInfoSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2621,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_schema_ts",
       "label": "schema.ts",
       "norm_label": "schema.ts",
@@ -223669,7 +223693,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2621,
+      "community": 2622,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetailssection_tsx",
       "label": "DeliveryDetailsSection.tsx",
@@ -223678,7 +223702,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2622,
+      "community": 2623,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_test_ts",
       "label": "checkoutStorage.test.ts",
@@ -223687,7 +223711,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2623,
+      "community": 2624,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
       "label": "deliveryFees.test.ts",
@@ -223696,7 +223720,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2624,
+      "community": 2625,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
       "label": "deriveCheckoutState.test.ts",
@@ -223705,7 +223729,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2625,
+      "community": 2626,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
       "label": "billingDetailsSchema.ts",
@@ -223714,7 +223738,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2626,
+      "community": 2627,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
       "label": "checkoutFormSchema.ts",
@@ -223723,7 +223747,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2627,
+      "community": 2628,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_customerdetailsschema_ts",
       "label": "customerDetailsSchema.ts",
@@ -223732,21 +223756,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2628,
+      "community": 2629,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
       "label": "deliveryDetailsSchema.ts",
       "norm_label": "deliverydetailsschema.ts",
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/deliveryDetailsSchema.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2629,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
-      "label": "webOrderSchema.ts",
-      "norm_label": "weborderschema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.ts",
       "source_location": "L1"
     },
     {
@@ -223842,6 +223857,15 @@
     {
       "community": 2630,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
+      "label": "webOrderSchema.ts",
+      "norm_label": "weborderschema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2631,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
@@ -223849,7 +223873,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2631,
+      "community": 2632,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_utils_test_ts",
       "label": "utils.test.ts",
@@ -223858,7 +223882,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2632,
+      "community": 2633,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilterbar_tsx",
       "label": "ProductFilterBar.tsx",
@@ -223867,7 +223891,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2633,
+      "community": 2634,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_test_tsx",
       "label": "BestSellersSection.test.tsx",
@@ -223876,7 +223900,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2634,
+      "community": 2635,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
       "label": "HomeHero.tsx",
@@ -223885,7 +223909,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2635,
+      "community": 2636,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
       "label": "HomeHeroSection.tsx",
@@ -223894,7 +223918,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2636,
+      "community": 2637,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_test_ts",
       "label": "homePageContent.test.ts",
@@ -223903,7 +223927,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2637,
+      "community": 2638,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilemenu_tsx",
       "label": "MobileMenu.tsx",
@@ -223912,21 +223936,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2638,
+      "community": 2639,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2639,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
-      "label": "navBarConstants.ts",
-      "norm_label": "navbarconstants.ts",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarConstants.ts",
       "source_location": "L1"
     },
     {
@@ -224022,6 +224037,15 @@
     {
       "community": 2640,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
+      "label": "navBarConstants.ts",
+      "norm_label": "navbarconstants.ts",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarConstants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2641,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_about_tsx",
       "label": "About.tsx",
       "norm_label": "about.tsx",
@@ -224029,7 +224053,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2641,
+      "community": 2642,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_aboutproduct_tsx",
       "label": "AboutProduct.tsx",
@@ -224038,7 +224062,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2642,
+      "community": 2643,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_test_tsx",
       "label": "ProductActions.test.tsx",
@@ -224047,7 +224071,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2643,
+      "community": 2644,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
       "label": "ProductInfo.tsx",
@@ -224056,7 +224080,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2644,
+      "community": 2645,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
       "label": "ProductReviews.tsx",
@@ -224065,7 +224089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2645,
+      "community": 2646,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
       "label": "ProductsNavigationBar.tsx",
@@ -224074,7 +224098,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2646,
+      "community": 2647,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
       "label": "ErrorMessage.tsx",
@@ -224083,7 +224107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2647,
+      "community": 2648,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_existingreviewmessage_tsx",
       "label": "ExistingReviewMessage.tsx",
@@ -224092,21 +224116,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2648,
+      "community": 2649,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_test_tsx",
       "label": "OrderItem.test.tsx",
       "norm_label": "orderitem.test.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2649,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
-      "label": "ReviewForm.tsx",
-      "norm_label": "reviewform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewForm.tsx",
       "source_location": "L1"
     },
     {
@@ -224202,6 +224217,15 @@
     {
       "community": 2650,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
+      "label": "ReviewForm.tsx",
+      "norm_label": "reviewform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2651,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
       "label": "SuccessMessage.tsx",
       "norm_label": "successmessage.tsx",
@@ -224209,7 +224233,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2651,
+      "community": 2652,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_types_ts",
       "label": "types.ts",
@@ -224218,7 +224242,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2652,
+      "community": 2653,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
       "label": "SavedBag.tsx",
@@ -224227,7 +224251,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2653,
+      "community": 2654,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
       "label": "SavedIcon.tsx",
@@ -224236,7 +224260,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2654,
+      "community": 2655,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_carticon_tsx",
       "label": "CartIcon.tsx",
@@ -224245,7 +224269,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2655,
+      "community": 2656,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
       "label": "ShoppingBag.test.tsx",
@@ -224254,7 +224278,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2656,
+      "community": 2657,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -224263,7 +224287,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2657,
+      "community": 2658,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_test_tsx",
       "label": "Maintenance.test.tsx",
@@ -224272,21 +224296,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2658,
+      "community": 2659,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_tsx",
       "label": "Maintenance.tsx",
       "norm_label": "maintenance.tsx",
       "source_file": "packages/storefront-webapp/src/components/states/maintenance/Maintenance.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2659,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
-      "label": "AnimatedCard.tsx",
-      "norm_label": "animatedcard.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/AnimatedCard.tsx",
       "source_location": "L1"
     },
     {
@@ -224382,6 +224397,15 @@
     {
       "community": 2660,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
+      "label": "AnimatedCard.tsx",
+      "norm_label": "animatedcard.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/AnimatedCard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2661,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
       "norm_label": "accordion.tsx",
@@ -224389,7 +224413,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2661,
+      "community": 2662,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
       "label": "alert.tsx",
@@ -224398,7 +224422,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2662,
+      "community": 2663,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
       "label": "breadcrumb.tsx",
@@ -224407,7 +224431,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2663,
+      "community": 2664,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -224416,7 +224440,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2664,
+      "community": 2665,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
@@ -224425,7 +224449,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2665,
+      "community": 2666,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
@@ -224434,7 +224458,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2666,
+      "community": 2667,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -224443,7 +224467,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2667,
+      "community": 2668,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
@@ -224452,21 +224476,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2668,
+      "community": 2669,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
       "norm_label": "dialog.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/dialog.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2669,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
-      "label": "dropdown-menu.tsx",
-      "norm_label": "dropdown-menu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/dropdown-menu.tsx",
       "source_location": "L1"
     },
     {
@@ -224562,6 +224577,15 @@
     {
       "community": 2670,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
+      "label": "dropdown-menu.tsx",
+      "norm_label": "dropdown-menu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/dropdown-menu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2671,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
       "norm_label": "form.tsx",
@@ -224569,7 +224593,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2671,
+      "community": 2672,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -224578,7 +224602,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2672,
+      "community": 2673,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
       "label": "image-with-fallback.tsx",
@@ -224587,7 +224611,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2673,
+      "community": 2674,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -224596,7 +224620,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2674,
+      "community": 2675,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_with_end_button_tsx",
       "label": "input-with-end-button.tsx",
@@ -224605,7 +224629,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2675,
+      "community": 2676,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -224614,7 +224638,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2676,
+      "community": 2677,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
@@ -224623,7 +224647,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2677,
+      "community": 2678,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
       "label": "LeaveAReviewModalForm.tsx",
@@ -224632,21 +224656,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2678,
+      "community": 2679,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
       "norm_label": "action-modal.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/action-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2679,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_animations_welcomebackmodalanimations_ts",
-      "label": "welcomeBackModalAnimations.ts",
-      "norm_label": "welcomebackmodalanimations.ts",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/animations/welcomeBackModalAnimations.ts",
       "source_location": "L1"
     },
     {
@@ -224742,6 +224757,15 @@
     {
       "community": 2680,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_animations_welcomebackmodalanimations_ts",
+      "label": "welcomeBackModalAnimations.ts",
+      "norm_label": "welcomebackmodalanimations.ts",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/animations/welcomeBackModalAnimations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2681,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
@@ -224749,7 +224773,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2681,
+      "community": 2682,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_types_ts",
       "label": "types.ts",
@@ -224758,7 +224782,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2682,
+      "community": 2683,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_navigation_menu_tsx",
       "label": "navigation-menu.tsx",
@@ -224767,7 +224791,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2683,
+      "community": 2684,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -224776,7 +224800,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2684,
+      "community": 2685,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -224785,7 +224809,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2685,
+      "community": 2686,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -224794,7 +224818,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2686,
+      "community": 2687,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -224803,7 +224827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2687,
+      "community": 2688,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -224812,21 +224836,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2688,
+      "community": 2689,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
       "norm_label": "sheet.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/sheet.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2689,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_table_tsx",
-      "label": "table.tsx",
-      "norm_label": "table.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/table.tsx",
       "source_location": "L1"
     },
     {
@@ -224922,6 +224937,15 @@
     {
       "community": 2690,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_table_tsx",
+      "label": "table.tsx",
+      "norm_label": "table.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2691,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
       "norm_label": "tabs.tsx",
@@ -224929,7 +224953,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2691,
+      "community": 2692,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -224938,7 +224962,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2692,
+      "community": 2693,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -224947,7 +224971,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2693,
+      "community": 2694,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -224956,7 +224980,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2694,
+      "community": 2695,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
@@ -224965,7 +224989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2695,
+      "community": 2696,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_config_ts",
       "label": "config.ts",
@@ -224974,7 +224998,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2696,
+      "community": 2697,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_test_tsx",
       "label": "StorefrontObservabilityProvider.test.tsx",
@@ -224983,7 +225007,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2697,
+      "community": 2698,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
@@ -224992,21 +225016,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2698,
+      "community": 2699,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
       "norm_label": "useorganizationmodal.tsx",
       "source_file": "packages/storefront-webapp/src/hooks/useOrganizationModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2699,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usequeryenabled_test_ts",
-      "label": "useQueryEnabled.test.ts",
-      "norm_label": "usequeryenabled.test.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useQueryEnabled.test.ts",
       "source_location": "L1"
     },
     {
@@ -225426,6 +225441,15 @@
     {
       "community": 2700,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usequeryenabled_test_ts",
+      "label": "useQueryEnabled.test.ts",
+      "norm_label": "usequeryenabled.test.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useQueryEnabled.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2701,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
       "label": "useStorefrontObservability.ts",
       "norm_label": "usestorefrontobservability.ts",
@@ -225433,7 +225457,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2701,
+      "community": 2702,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -225442,7 +225466,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2702,
+      "community": 2703,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -225451,7 +225475,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2703,
+      "community": 2704,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_feeutils_test_ts",
       "label": "feeUtils.test.ts",
@@ -225460,7 +225484,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2704,
+      "community": 2705,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -225469,7 +225493,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2705,
+      "community": 2706,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -225478,7 +225502,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2706,
+      "community": 2707,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
       "label": "maintenanceUtils.test.ts",
@@ -225487,7 +225511,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2707,
+      "community": 2708,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
       "label": "index.ts",
@@ -225496,21 +225520,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2708,
+      "community": 2709,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_productutils_test_ts",
       "label": "productUtils.test.ts",
       "norm_label": "productutils.test.ts",
       "source_file": "packages/storefront-webapp/src/lib/productUtils.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2709,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_store_ts",
-      "label": "store.ts",
-      "norm_label": "store.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/store.ts",
       "source_location": "L1"
     },
     {
@@ -225597,6 +225612,15 @@
     {
       "community": 2710,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_store_ts",
+      "label": "store.ts",
+      "norm_label": "store.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/store.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2711,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
       "label": "bag.ts",
       "norm_label": "bag.ts",
@@ -225604,7 +225628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2711,
+      "community": 2712,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
       "label": "bagItem.ts",
@@ -225613,7 +225637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2712,
+      "community": 2713,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -225622,7 +225646,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2713,
+      "community": 2714,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_organization_ts",
       "label": "organization.ts",
@@ -225631,7 +225655,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2714,
+      "community": 2715,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
@@ -225640,7 +225664,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2715,
+      "community": 2716,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -225649,7 +225673,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2716,
+      "community": 2717,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -225658,7 +225682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2717,
+      "community": 2718,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -225667,21 +225691,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2718,
+      "community": 2719,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_states_ts",
       "label": "states.ts",
       "norm_label": "states.ts",
       "source_file": "packages/storefront-webapp/src/lib/states.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2719,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontcontextevents_test_ts",
-      "label": "storefrontContextEvents.test.ts",
-      "norm_label": "storefrontcontextevents.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.test.ts",
       "source_location": "L1"
     },
     {
@@ -225768,6 +225783,15 @@
     {
       "community": 2720,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_storefrontcontextevents_test_ts",
+      "label": "storefrontContextEvents.test.ts",
+      "norm_label": "storefrontcontextevents.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2721,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
       "label": "storefrontFailureObservability.test.ts",
       "norm_label": "storefrontfailureobservability.test.ts",
@@ -225775,7 +225799,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2721,
+      "community": 2722,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
       "label": "storefrontJourneyEvents.test.ts",
@@ -225784,7 +225808,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2722,
+      "community": 2723,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -225793,7 +225817,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2723,
+      "community": 2724,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -225802,7 +225826,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2724,
+      "community": 2725,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_test_ts",
       "label": "-homePageLoader.test.ts",
@@ -225811,7 +225835,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2725,
+      "community": 2726,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -225820,7 +225844,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2726,
+      "community": 2727,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_orderitemid_review_tsx",
       "label": "$orderItemId.review.tsx",
@@ -225829,7 +225853,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2727,
+      "community": 2728,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_index_tsx",
       "label": "index.tsx",
@@ -225838,21 +225862,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2728,
+      "community": 2729,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
       "label": "$subcategorySlug.tsx",
       "norm_label": "$subcategoryslug.tsx",
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/$subcategorySlug.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2729,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/index.tsx",
       "source_location": "L1"
     },
     {
@@ -225939,6 +225954,15 @@
     {
       "community": 2730,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2731,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
       "label": "rewards.index.tsx",
       "norm_label": "rewards.index.tsx",
@@ -225946,7 +225970,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2731,
+      "community": 2732,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
       "label": "shop.saved.index.tsx",
@@ -225955,7 +225979,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2732,
+      "community": 2733,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
       "label": "bag.index.tsx",
@@ -225964,7 +225988,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2733,
+      "community": 2734,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_complete_tsx",
       "label": "complete.tsx",
@@ -225973,7 +225997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2734,
+      "community": 2735,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_incomplete_tsx",
       "label": "incomplete.tsx",
@@ -225982,7 +226006,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2735,
+      "community": 2736,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_index_tsx",
       "label": "index.tsx",
@@ -225991,7 +226015,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2736,
+      "community": 2737,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pending_tsx",
       "label": "pending.tsx",
@@ -226000,7 +226024,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2737,
+      "community": 2738,
       "file_type": "code",
       "id": "packages_storefront_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -226009,21 +226033,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2738,
+      "community": 2739,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_storefront_boot_e2e_ts",
       "label": "storefront-boot.e2e.ts",
       "norm_label": "storefront-boot.e2e.ts",
       "source_file": "packages/storefront-webapp/tests/e2e/storefront-boot.e2e.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2739,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_vitest_config_ts",
-      "label": "vitest.config.ts",
-      "norm_label": "vitest.config.ts",
-      "source_file": "packages/storefront-webapp/vitest.config.ts",
       "source_location": "L1"
     },
     {
@@ -226110,6 +226125,15 @@
     {
       "community": 2740,
       "file_type": "code",
+      "id": "packages_storefront_webapp_vitest_config_ts",
+      "label": "vitest.config.ts",
+      "norm_label": "vitest.config.ts",
+      "source_file": "packages/storefront-webapp/vitest.config.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2741,
+      "file_type": "code",
       "id": "packages_storefront_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
       "norm_label": "vitest.setup.ts",
@@ -226117,7 +226141,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2741,
+      "community": 2742,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_index_js",
       "label": "index.js",
@@ -226126,7 +226150,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2742,
+      "community": 2743,
       "file_type": "code",
       "id": "scripts_check_register_session_authority_writers_test_ts",
       "label": "check-register-session-authority-writers.test.ts",
@@ -226135,7 +226159,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2743,
+      "community": 2744,
       "file_type": "code",
       "id": "scripts_delivery_documentation_check_test_ts",
       "label": "delivery-documentation-check.test.ts",
@@ -226144,7 +226168,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2744,
+      "community": 2745,
       "file_type": "code",
       "id": "scripts_harness_app_registry_test_ts",
       "label": "harness-app-registry.test.ts",
@@ -226153,7 +226177,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2745,
+      "community": 2746,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_athena_runtime_app_test_ts",
       "label": "athena-runtime-app.test.ts",
@@ -226162,7 +226186,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2746,
+      "community": 2747,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_test_ts",
       "label": "storefront-runtime-api.test.ts",
@@ -226171,7 +226195,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2747,
+      "community": 2748,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_test_ts",
       "label": "valkey-runtime-app.test.ts",
@@ -226180,21 +226204,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2748,
+      "community": 2749,
       "file_type": "code",
       "id": "scripts_harness_behavior_scenarios_test_ts",
       "label": "harness-behavior-scenarios.test.ts",
       "norm_label": "harness-behavior-scenarios.test.ts",
       "source_file": "scripts/harness-behavior-scenarios.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2749,
-      "file_type": "code",
-      "id": "scripts_harness_repo_validation_test_ts",
-      "label": "harness-repo-validation.test.ts",
-      "norm_label": "harness-repo-validation.test.ts",
-      "source_file": "scripts/harness-repo-validation.test.ts",
       "source_location": "L1"
     },
     {
@@ -226281,6 +226296,15 @@
     {
       "community": 2750,
       "file_type": "code",
+      "id": "scripts_harness_repo_validation_test_ts",
+      "label": "harness-repo-validation.test.ts",
+      "norm_label": "harness-repo-validation.test.ts",
+      "source_file": "scripts/harness-repo-validation.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2751,
+      "file_type": "code",
       "id": "scripts_operational_work_repair_test_ts",
       "label": "operational-work-repair.test.ts",
       "norm_label": "operational-work-repair.test.ts",
@@ -226288,7 +226312,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2751,
+      "community": 2752,
       "file_type": "code",
       "id": "tools_screen_redact_extension_background_js",
       "label": "background.js",
@@ -226297,7 +226321,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2752,
+      "community": 2753,
       "file_type": "code",
       "id": "tools_screen_redact_extension_popup_js",
       "label": "popup.js",
@@ -227464,7 +227488,7 @@
       "label": "cn()",
       "norm_label": "cn()",
       "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
-      "source_location": "L467"
+      "source_location": "L472"
     },
     {
       "community": 286,
@@ -227775,325 +227799,325 @@
     {
       "community": 29,
       "file_type": "code",
-      "id": "adjustments_applystockadjustmentbatchwithctx",
-      "label": "applyStockAdjustmentBatchWithCtx()",
-      "norm_label": "applystockadjustmentbatchwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L422"
+      "id": "dailymanagerreportemail_buildblockers",
+      "label": "buildBlockers()",
+      "norm_label": "buildblockers()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L792"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "adjustments_assertdistinctstockadjustmentlineitems",
-      "label": "assertDistinctStockAdjustmentLineItems()",
-      "norm_label": "assertdistinctstockadjustmentlineitems()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L300"
+      "id": "dailymanagerreportemail_buildcarryforwarditems",
+      "label": "buildCarryForwardItems()",
+      "norm_label": "buildcarryforwarditems()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L768"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "adjustments_assertnormalizedlineitem",
-      "label": "assertNormalizedLineItem()",
-      "norm_label": "assertnormalizedlineitem()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L374"
+      "id": "dailymanagerreportemail_buildcashmetrics",
+      "label": "buildCashMetrics()",
+      "norm_label": "buildcashmetrics()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L958"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "adjustments_buildinventorysnapshotrowsforproductskuswithctx",
-      "label": "buildInventorySnapshotRowsForProductSkusWithCtx()",
-      "norm_label": "buildinventorysnapshotrowsforproductskuswithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L1073"
+      "id": "dailymanagerreportemail_builddailymanagerreportpayload",
+      "label": "buildDailyManagerReportPayload()",
+      "norm_label": "builddailymanagerreportpayload()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L484"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "adjustments_buildresolvedstockadjustmentstatus",
-      "label": "buildResolvedStockAdjustmentStatus()",
-      "norm_label": "buildresolvedstockadjustmentstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L767"
+      "id": "dailymanagerreportemail_buildopendailymanagerreportpayload",
+      "label": "buildOpenDailyManagerReportPayload()",
+      "norm_label": "buildopendailymanagerreportpayload()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L555"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "adjustments_buildstockadjustmentdecisioneventtype",
-      "label": "buildStockAdjustmentDecisionEventType()",
-      "norm_label": "buildstockadjustmentdecisioneventtype()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "id": "dailymanagerreportemail_buildpaymenttotals",
+      "label": "buildPaymentTotals()",
+      "norm_label": "buildpaymenttotals()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L836"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "dailymanagerreportemail_buildpreparedblockers",
+      "label": "buildPreparedBlockers()",
+      "norm_label": "buildpreparedblockers()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L806"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "dailymanagerreportemail_buildpreparedcarryforwarditems",
+      "label": "buildPreparedCarryForwardItems()",
+      "norm_label": "buildpreparedcarryforwarditems()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L781"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "dailymanagerreportemail_buildprepareddailymanagerreportpayload",
+      "label": "buildPreparedDailyManagerReportPayload()",
+      "norm_label": "buildprepareddailymanagerreportpayload()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L538"
+    },
+    {
+      "community": 29,
+      "file_type": "code",
+      "id": "dailymanagerreportemail_buildpreparedreviewitems",
+      "label": "buildPreparedReviewItems()",
+      "norm_label": "buildpreparedreviewitems()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
       "source_location": "L757"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "adjustments_buildstockadjustmentoperationaleventmessage",
-      "label": "buildStockAdjustmentOperationalEventMessage()",
-      "norm_label": "buildstockadjustmentoperationaleventmessage()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L354"
+      "id": "dailymanagerreportemail_buildregistercashpositionsummary",
+      "label": "buildRegisterCashPositionSummary()",
+      "norm_label": "buildregistercashpositionsummary()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L594"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "adjustments_buildstockadjustmentsourceid",
-      "label": "buildStockAdjustmentSourceId()",
-      "norm_label": "buildstockadjustmentsourceid()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L316"
+      "id": "dailymanagerreportemail_buildrevieweditems",
+      "label": "buildReviewedItems()",
+      "norm_label": "buildrevieweditems()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L681"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "adjustments_buildstockadjustmenttitle",
-      "label": "buildStockAdjustmentTitle()",
-      "norm_label": "buildstockadjustmenttitle()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L320"
+      "id": "dailymanagerreportemail_buildsummarymetrics",
+      "label": "buildSummaryMetrics()",
+      "norm_label": "buildsummarymetrics()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L876"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "adjustments_formatsignedquantity",
-      "label": "formatSignedQuantity()",
-      "norm_label": "formatsignedquantity()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L350"
+      "id": "dailymanagerreportemail_buildunitssoldsummary",
+      "label": "buildUnitsSoldSummary()",
+      "norm_label": "buildunitssoldsummary()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L466"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "adjustments_getactorlabel",
-      "label": "getActorLabel()",
-      "norm_label": "getactorlabel()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L330"
+      "id": "dailymanagerreportemail_comparisonfromsummary",
+      "label": "comparisonFromSummary()",
+      "norm_label": "comparisonfromsummary()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L1036"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "adjustments_getinventoryunitsummarywithctx",
-      "label": "getInventoryUnitSummaryWithCtx()",
-      "norm_label": "getinventoryunitsummarywithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L1012"
+      "id": "dailymanagerreportemail_countlabel",
+      "label": "countLabel()",
+      "norm_label": "countlabel()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L1072"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "adjustments_getstockadjustmentscopekey",
-      "label": "getStockAdjustmentScopeKey()",
-      "norm_label": "getstockadjustmentscopekey()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L136"
+      "id": "dailymanagerreportemail_formatblockermessage",
+      "label": "formatBlockerMessage()",
+      "norm_label": "formatblockermessage()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L816"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "adjustments_isonboardedtrustedproductforstockadjustment",
-      "label": "isOnboardedTrustedProductForStockAdjustment()",
-      "norm_label": "isonboardedtrustedproductforstockadjustment()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L176"
+      "id": "dailymanagerreportemail_formatcompletedat",
+      "label": "formatCompletedAt()",
+      "norm_label": "formatcompletedat()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L1116"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "adjustments_listinventorysnapshotforproductskuswithctx",
-      "label": "listInventorySnapshotForProductSkusWithCtx()",
-      "norm_label": "listinventorysnapshotforproductskuswithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L982"
+      "id": "dailymanagerreportemail_formatoperatingdate",
+      "label": "formatOperatingDate()",
+      "norm_label": "formatoperatingdate()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L1095"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "adjustments_listinventorysnapshotwithctx",
-      "label": "listInventorySnapshotWithCtx()",
-      "norm_label": "listinventorysnapshotwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L957"
+      "id": "dailymanagerreportemail_formatpaymentmethod",
+      "label": "formatPaymentMethod()",
+      "norm_label": "formatpaymentmethod()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L1082"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "adjustments_listproductskusforstockadjustmentscopewithctx",
-      "label": "listProductSkusForStockAdjustmentScopeWithCtx()",
-      "norm_label": "listproductskusforstockadjustmentscopewithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L243"
+      "id": "dailymanagerreportemail_formatpriordaycomparison",
+      "label": "formatPriorDayComparison()",
+      "norm_label": "formatpriordaycomparison()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L1051"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "adjustments_mapsubmitstockadjustmentbatcherror",
-      "label": "mapSubmitStockAdjustmentBatchError()",
-      "norm_label": "mapsubmitstockadjustmentbatcherror()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L1668"
+      "id": "dailymanagerreportemail_formatunitcount",
+      "label": "formatUnitCount()",
+      "norm_label": "formatunitcount()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L1068"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "adjustments_pluralize",
-      "label": "pluralize()",
-      "norm_label": "pluralize()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L346"
+      "id": "dailymanagerreportemail_ispaymenttotal",
+      "label": "isPaymentTotal()",
+      "norm_label": "ispaymenttotal()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L1003"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "adjustments_readactivecheckoutreservedquantitiesforstockopssnapshot",
-      "label": "readActiveCheckoutReservedQuantitiesForStockOpsSnapshot()",
-      "norm_label": "readactivecheckoutreservedquantitiesforstockopssnapshot()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L905"
+      "id": "dailymanagerreportemail_moneyformatter",
+      "label": "moneyFormatter()",
+      "norm_label": "moneyformatter()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L1016"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "adjustments_readactiveheldquantitiesforstockopssnapshot",
-      "label": "readActiveHeldQuantitiesForStockOpsSnapshot()",
-      "norm_label": "readactiveheldquantitiesforstockopssnapshot()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L873"
+      "id": "dailymanagerreportemail_normalizecurrency",
+      "label": "normalizeCurrency()",
+      "norm_label": "normalizecurrency()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L1076"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "adjustments_readactivependingcheckoutskuidswithctx",
-      "label": "readActivePendingCheckoutSkuIdsWithCtx()",
-      "norm_label": "readactivependingcheckoutskuidswithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L634"
+      "id": "dailymanagerreportemail_normalizepaymentmethod",
+      "label": "normalizePaymentMethod()",
+      "norm_label": "normalizepaymentmethod()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L1088"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "adjustments_readactiveprovisionalimportskuidswithctx",
-      "label": "readActiveProvisionalImportSkuIdsWithCtx()",
-      "norm_label": "readactiveprovisionalimportskuidswithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L541"
+      "id": "dailymanagerreportemail_numberfromsummary",
+      "label": "numberFromSummary()",
+      "norm_label": "numberfromsummary()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L1022"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "adjustments_readcategorywithcache",
-      "label": "readCategoryWithCache()",
-      "norm_label": "readcategorywithcache()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L152"
+      "id": "dailymanagerreportemail_numberfromsummarywithfallback",
+      "label": "numberFromSummaryWithFallback()",
+      "norm_label": "numberfromsummarywithfallback()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L1027"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "adjustments_readproductwithcache",
-      "label": "readProductWithCache()",
-      "norm_label": "readproductwithcache()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L140"
+      "id": "dailymanagerreportemail_optionalmetadatalabel",
+      "label": "optionalMetadataLabel()",
+      "norm_label": "optionalmetadatalabel()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L828"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "adjustments_readstockadjustmentblockedskustatuseswithctx",
-      "label": "readStockAdjustmentBlockedSkuStatusesWithCtx()",
-      "norm_label": "readstockadjustmentblockedskustatuseswithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L709"
+      "id": "dailymanagerreportemail_readunitssoldforday",
+      "label": "readUnitsSoldForDay()",
+      "norm_label": "readunitssoldforday()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L448"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "adjustments_readsubcategorywithcache",
-      "label": "readSubcategoryWithCache()",
-      "norm_label": "readsubcategorywithcache()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L164"
+      "id": "dailymanagerreportemail_resolveappurl",
+      "label": "resolveAppUrl()",
+      "norm_label": "resolveappurl()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L1124"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "adjustments_requireinventorysnapshotforproductskusaccess",
-      "label": "requireInventorySnapshotForProductSkusAccess()",
-      "norm_label": "requireinventorysnapshotforproductskusaccess()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L1263"
+      "id": "dailymanagerreportemail_resolvestaffname",
+      "label": "resolveStaffName()",
+      "norm_label": "resolvestaffname()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L426"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
-      "label": "resolveStockAdjustmentApprovalDecisionWithCtx()",
-      "norm_label": "resolvestockadjustmentapprovaldecisionwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L773"
+      "id": "dailymanagerreportemail_resolvestore",
+      "label": "resolveStore()",
+      "norm_label": "resolvestore()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L405"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "adjustments_schedulecatalogsummarydirtymarker",
-      "label": "scheduleCatalogSummaryDirtyMarker()",
-      "norm_label": "schedulecatalogsummarydirtymarker()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L104"
+      "id": "dailymanagerreportemail_resolvestorescheduletimezoneforat",
+      "label": "resolveStoreScheduleTimezoneForAt()",
+      "norm_label": "resolvestorescheduletimezoneforat()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L1108"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "adjustments_shouldblockstockadjustmentforprovisionalimportrow",
-      "label": "shouldBlockStockAdjustmentForProvisionalImportRow()",
-      "norm_label": "shouldblockstockadjustmentforprovisionalimportrow()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L216"
+      "id": "dailymanagerreportemail_trimtrailingslash",
+      "label": "trimTrailingSlash()",
+      "norm_label": "trimtrailingslash()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "source_location": "L1137"
     },
     {
       "community": 29,
       "file_type": "code",
-      "id": "adjustments_submitstockadjustmentbatchcommandwithctx",
-      "label": "submitStockAdjustmentBatchCommandWithCtx()",
-      "norm_label": "submitstockadjustmentbatchcommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L1726"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "adjustments_submitstockadjustmentbatchwithctx",
-      "label": "submitStockAdjustmentBatchWithCtx()",
-      "norm_label": "submitstockadjustmentbatchwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L1450"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "adjustments_temporarydeletestockadjustmentscopeskuswithctx",
-      "label": "temporaryDeleteStockAdjustmentScopeSkusWithCtx()",
-      "norm_label": "temporarydeletestockadjustmentscopeskuswithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L1364"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "adjustments_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
-      "source_location": "L131"
-    },
-    {
-      "community": 29,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_adjustments_ts",
-      "label": "adjustments.ts",
-      "norm_label": "adjustments.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "id": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
+      "label": "dailyManagerReportEmail.ts",
+      "norm_label": "dailymanagerreportemail.ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
       "source_location": "L1"
     },
     {
@@ -229602,316 +229626,325 @@
     {
       "community": 30,
       "file_type": "code",
-      "id": "dailyopeningview_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L1353"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "dailyopeningview_dailyopeningstatustitle",
-      "label": "DailyOpeningStatusTitle()",
-      "norm_label": "dailyopeningstatustitle()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L666"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "dailyopeningview_formatmetadatadisplayvalue",
-      "label": "formatMetadataDisplayValue()",
-      "norm_label": "formatmetadatadisplayvalue()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L504"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "dailyopeningview_formatmetadatavalue",
-      "label": "formatMetadataValue()",
-      "norm_label": "formatmetadatavalue()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L430"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "dailyopeningview_formatopeningitemtitle",
-      "label": "formatOpeningItemTitle()",
-      "norm_label": "formatopeningitemtitle()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L328"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "dailyopeningview_formatoperatingdate",
-      "label": "formatOperatingDate()",
-      "norm_label": "formatoperatingdate()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L272"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "dailyopeningview_formatoperatingdatewithweekday",
-      "label": "formatOperatingDateWithWeekday()",
-      "norm_label": "formatoperatingdatewithweekday()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L288"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "dailyopeningview_formatoperationalworktypelabel",
-      "label": "formatOperationalWorkTypeLabel()",
-      "norm_label": "formatoperationalworktypelabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L360"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "dailyopeningview_formattimestamp",
-      "label": "formatTimestamp()",
-      "norm_label": "formattimestamp()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L305"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "dailyopeningview_getacknowledgementkey",
-      "label": "getAcknowledgementKey()",
-      "norm_label": "getacknowledgementkey()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L407"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "dailyopeningview_getarraymetadatastringvalue",
-      "label": "getArrayMetadataStringValue()",
-      "norm_label": "getarraymetadatastringvalue()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L490"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "dailyopeningview_getdailyopeningapi",
-      "label": "getDailyOpeningApi()",
-      "norm_label": "getdailyopeningapi()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L262"
-    },
-    {
-      "community": 30,
-      "file_type": "code",
-      "id": "dailyopeningview_getitemcontextlabel",
-      "label": "getItemContextLabel()",
-      "norm_label": "getitemcontextlabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "id": "adjustments_applystockadjustmentbatchwithctx",
+      "label": "applyStockAdjustmentBatchWithCtx()",
+      "norm_label": "applystockadjustmentbatchwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
       "source_location": "L422"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "dailyopeningview_getitemdescription",
-      "label": "getItemDescription()",
-      "norm_label": "getitemdescription()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L418"
+      "id": "adjustments_assertdistinctstockadjustmentlineitems",
+      "label": "assertDistinctStockAdjustmentLineItems()",
+      "norm_label": "assertdistinctstockadjustmentlineitems()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L300"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "dailyopeningview_getitemid",
-      "label": "getItemId()",
-      "norm_label": "getitemid()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L399"
+      "id": "adjustments_assertnormalizedlineitem",
+      "label": "assertNormalizedLineItem()",
+      "norm_label": "assertnormalizedlineitem()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L374"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "dailyopeningview_getmetadataentries",
-      "label": "getMetadataEntries()",
-      "norm_label": "getmetadataentries()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L564"
+      "id": "adjustments_buildinventorysnapshotrowsforproductskuswithctx",
+      "label": "buildInventorySnapshotRowsForProductSkusWithCtx()",
+      "norm_label": "buildinventorysnapshotrowsforproductskuswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L1073"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "dailyopeningview_getmetadatalabel",
-      "label": "getMetadataLabel()",
-      "norm_label": "getmetadatalabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L443"
+      "id": "adjustments_buildresolvedstockadjustmentstatus",
+      "label": "buildResolvedStockAdjustmentStatus()",
+      "norm_label": "buildresolvedstockadjustmentstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L767"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "dailyopeningview_getmetadatavalue",
-      "label": "getMetadataValue()",
-      "norm_label": "getmetadatavalue()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L465"
+      "id": "adjustments_buildstockadjustmentdecisioneventtype",
+      "label": "buildStockAdjustmentDecisionEventType()",
+      "norm_label": "buildstockadjustmentdecisioneventtype()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L757"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "dailyopeningview_getopeningautomationmessage",
-      "label": "getOpeningAutomationMessage()",
-      "norm_label": "getopeningautomationmessage()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L701"
+      "id": "adjustments_buildstockadjustmentoperationaleventmessage",
+      "label": "buildStockAdjustmentOperationalEventMessage()",
+      "norm_label": "buildstockadjustmentoperationaleventmessage()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L354"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "dailyopeningview_getopeningreviewevidence",
-      "label": "getOpeningReviewEvidence()",
-      "norm_label": "getopeningreviewevidence()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L779"
+      "id": "adjustments_buildstockadjustmentsourceid",
+      "label": "buildStockAdjustmentSourceId()",
+      "norm_label": "buildstockadjustmentsourceid()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L316"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "dailyopeningview_getopeningstartedbylabel",
-      "label": "getOpeningStartedByLabel()",
-      "norm_label": "getopeningstartedbylabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L787"
+      "id": "adjustments_buildstockadjustmenttitle",
+      "label": "buildStockAdjustmentTitle()",
+      "norm_label": "buildstockadjustmenttitle()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L320"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "dailyopeningview_getopeningstatus",
-      "label": "getOpeningStatus()",
-      "norm_label": "getopeningstatus()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L385"
+      "id": "adjustments_formatsignedquantity",
+      "label": "formatSignedQuantity()",
+      "norm_label": "formatsignedquantity()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L350"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "dailyopeningview_getrequiredacknowledgementkeys",
-      "label": "getRequiredAcknowledgementKeys()",
-      "norm_label": "getrequiredacknowledgementkeys()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L411"
+      "id": "adjustments_getactorlabel",
+      "label": "getActorLabel()",
+      "norm_label": "getactorlabel()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L330"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "dailyopeningview_getstatussignatureclassname",
-      "label": "getStatusSignatureClassName()",
-      "norm_label": "getstatussignatureclassname()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L626"
+      "id": "adjustments_getinventoryunitsummarywithctx",
+      "label": "getInventoryUnitSummaryWithCtx()",
+      "norm_label": "getinventoryunitsummarywithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L1012"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "dailyopeningview_getstatussignatureiconclassname",
-      "label": "getStatusSignatureIconClassName()",
-      "norm_label": "getstatussignatureiconclassname()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L635"
+      "id": "adjustments_getstockadjustmentscopekey",
+      "label": "getStockAdjustmentScopeKey()",
+      "norm_label": "getstockadjustmentscopekey()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L136"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "dailyopeningview_getvisibleopeningautomationstatus",
-      "label": "getVisibleOpeningAutomationStatus()",
-      "norm_label": "getvisibleopeningautomationstatus()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L737"
+      "id": "adjustments_isonboardedtrustedproductforstockadjustment",
+      "label": "isOnboardedTrustedProductForStockAdjustment()",
+      "norm_label": "isonboardedtrustedproductforstockadjustment()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L176"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "dailyopeningview_handlepagechange",
-      "label": "handlePageChange()",
-      "norm_label": "handlepagechange()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L826"
+      "id": "adjustments_listinventorysnapshotforproductskuswithctx",
+      "label": "listInventorySnapshotForProductSkusWithCtx()",
+      "norm_label": "listinventorysnapshotforproductskuswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L982"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "dailyopeningview_humanizemetadatalabel",
-      "label": "humanizeMetadataLabel()",
-      "norm_label": "humanizemetadatalabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L317"
+      "id": "adjustments_listinventorysnapshotwithctx",
+      "label": "listInventorySnapshotWithCtx()",
+      "norm_label": "listinventorysnapshotwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L957"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "dailyopeningview_isoperatorfacingopeningmetadata",
-      "label": "isOperatorFacingOpeningMetadata()",
-      "norm_label": "isoperatorfacingopeningmetadata()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L560"
+      "id": "adjustments_listproductskusforstockadjustmentscopewithctx",
+      "label": "listProductSkusForStockAdjustmentScopeWithCtx()",
+      "norm_label": "listproductskusforstockadjustmentscopewithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L243"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "dailyopeningview_normalizecommandmessage",
-      "label": "normalizeCommandMessage()",
-      "norm_label": "normalizecommandmessage()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L606"
+      "id": "adjustments_mapsubmitstockadjustmentbatcherror",
+      "label": "mapSubmitStockAdjustmentBatchError()",
+      "norm_label": "mapsubmitstockadjustmentbatcherror()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L1668"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "dailyopeningview_normalizemetadatalabel",
-      "label": "normalizeMetadataLabel()",
-      "norm_label": "normalizemetadatalabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L324"
+      "id": "adjustments_pluralize",
+      "label": "pluralize()",
+      "norm_label": "pluralize()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L346"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "dailyopeningview_openingautomationstatuspanel",
-      "label": "OpeningAutomationStatusPanel()",
-      "norm_label": "openingautomationstatuspanel()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L754"
+      "id": "adjustments_readactivecheckoutreservedquantitiesforstockopssnapshot",
+      "label": "readActiveCheckoutReservedQuantitiesForStockOpsSnapshot()",
+      "norm_label": "readactivecheckoutreservedquantitiesforstockopssnapshot()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L905"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "dailyopeningview_successcheckicon",
-      "label": "SuccessCheckIcon()",
-      "norm_label": "successcheckicon()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L644"
+      "id": "adjustments_readactiveheldquantitiesforstockopssnapshot",
+      "label": "readActiveHeldQuantitiesForStockOpsSnapshot()",
+      "norm_label": "readactiveheldquantitiesforstockopssnapshot()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L873"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "dailyopeningview_toggleallacknowledgements",
-      "label": "toggleAllAcknowledgements()",
-      "norm_label": "toggleallacknowledgements()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
-      "source_location": "L1434"
+      "id": "adjustments_readactivependingcheckoutskuidswithctx",
+      "label": "readActivePendingCheckoutSkuIdsWithCtx()",
+      "norm_label": "readactivependingcheckoutskuidswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L634"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
-      "label": "DailyOpeningView.tsx",
-      "norm_label": "dailyopeningview.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "id": "adjustments_readactiveprovisionalimportskuidswithctx",
+      "label": "readActiveProvisionalImportSkuIdsWithCtx()",
+      "norm_label": "readactiveprovisionalimportskuidswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L541"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "adjustments_readcategorywithcache",
+      "label": "readCategoryWithCache()",
+      "norm_label": "readcategorywithcache()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L152"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "adjustments_readproductwithcache",
+      "label": "readProductWithCache()",
+      "norm_label": "readproductwithcache()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L140"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "adjustments_readstockadjustmentblockedskustatuseswithctx",
+      "label": "readStockAdjustmentBlockedSkuStatusesWithCtx()",
+      "norm_label": "readstockadjustmentblockedskustatuseswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L709"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "adjustments_readsubcategorywithcache",
+      "label": "readSubcategoryWithCache()",
+      "norm_label": "readsubcategorywithcache()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L164"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "adjustments_requireinventorysnapshotforproductskusaccess",
+      "label": "requireInventorySnapshotForProductSkusAccess()",
+      "norm_label": "requireinventorysnapshotforproductskusaccess()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L1263"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "adjustments_resolvestockadjustmentapprovaldecisionwithctx",
+      "label": "resolveStockAdjustmentApprovalDecisionWithCtx()",
+      "norm_label": "resolvestockadjustmentapprovaldecisionwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L773"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "adjustments_schedulecatalogsummarydirtymarker",
+      "label": "scheduleCatalogSummaryDirtyMarker()",
+      "norm_label": "schedulecatalogsummarydirtymarker()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L104"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "adjustments_shouldblockstockadjustmentforprovisionalimportrow",
+      "label": "shouldBlockStockAdjustmentForProvisionalImportRow()",
+      "norm_label": "shouldblockstockadjustmentforprovisionalimportrow()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L216"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "adjustments_submitstockadjustmentbatchcommandwithctx",
+      "label": "submitStockAdjustmentBatchCommandWithCtx()",
+      "norm_label": "submitstockadjustmentbatchcommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L1726"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "adjustments_submitstockadjustmentbatchwithctx",
+      "label": "submitStockAdjustmentBatchWithCtx()",
+      "norm_label": "submitstockadjustmentbatchwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L1450"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "adjustments_temporarydeletestockadjustmentscopeskuswithctx",
+      "label": "temporaryDeleteStockAdjustmentScopeSkusWithCtx()",
+      "norm_label": "temporarydeletestockadjustmentscopeskuswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L1364"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "adjustments_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
+      "source_location": "L131"
+    },
+    {
+      "community": 30,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_adjustments_ts",
+      "label": "adjustments.ts",
+      "norm_label": "adjustments.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.ts",
       "source_location": "L1"
     },
     {
@@ -230718,307 +230751,316 @@
     {
       "community": 31,
       "file_type": "code",
-      "id": "dailymanagerreportemail_buildblockers",
-      "label": "buildBlockers()",
-      "norm_label": "buildblockers()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L792"
+      "id": "dailyopeningview_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L1353"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "dailymanagerreportemail_buildcarryforwarditems",
-      "label": "buildCarryForwardItems()",
-      "norm_label": "buildcarryforwarditems()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L768"
+      "id": "dailyopeningview_dailyopeningstatustitle",
+      "label": "DailyOpeningStatusTitle()",
+      "norm_label": "dailyopeningstatustitle()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L666"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "dailymanagerreportemail_buildcashmetrics",
-      "label": "buildCashMetrics()",
-      "norm_label": "buildcashmetrics()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L938"
+      "id": "dailyopeningview_formatmetadatadisplayvalue",
+      "label": "formatMetadataDisplayValue()",
+      "norm_label": "formatmetadatadisplayvalue()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L504"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "dailymanagerreportemail_builddailymanagerreportpayload",
-      "label": "buildDailyManagerReportPayload()",
-      "norm_label": "builddailymanagerreportpayload()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L484"
+      "id": "dailyopeningview_formatmetadatavalue",
+      "label": "formatMetadataValue()",
+      "norm_label": "formatmetadatavalue()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L430"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "dailymanagerreportemail_buildopendailymanagerreportpayload",
-      "label": "buildOpenDailyManagerReportPayload()",
-      "norm_label": "buildopendailymanagerreportpayload()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L555"
+      "id": "dailyopeningview_formatopeningitemtitle",
+      "label": "formatOpeningItemTitle()",
+      "norm_label": "formatopeningitemtitle()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L328"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "dailymanagerreportemail_buildpaymenttotals",
-      "label": "buildPaymentTotals()",
-      "norm_label": "buildpaymenttotals()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L816"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "dailymanagerreportemail_buildpreparedblockers",
-      "label": "buildPreparedBlockers()",
-      "norm_label": "buildpreparedblockers()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L806"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "dailymanagerreportemail_buildpreparedcarryforwarditems",
-      "label": "buildPreparedCarryForwardItems()",
-      "norm_label": "buildpreparedcarryforwarditems()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L781"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "dailymanagerreportemail_buildprepareddailymanagerreportpayload",
-      "label": "buildPreparedDailyManagerReportPayload()",
-      "norm_label": "buildprepareddailymanagerreportpayload()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L538"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "dailymanagerreportemail_buildpreparedreviewitems",
-      "label": "buildPreparedReviewItems()",
-      "norm_label": "buildpreparedreviewitems()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L757"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "dailymanagerreportemail_buildregistercashpositionsummary",
-      "label": "buildRegisterCashPositionSummary()",
-      "norm_label": "buildregistercashpositionsummary()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L594"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "dailymanagerreportemail_buildrevieweditems",
-      "label": "buildReviewedItems()",
-      "norm_label": "buildrevieweditems()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L681"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "dailymanagerreportemail_buildsummarymetrics",
-      "label": "buildSummaryMetrics()",
-      "norm_label": "buildsummarymetrics()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L856"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "dailymanagerreportemail_buildunitssoldsummary",
-      "label": "buildUnitsSoldSummary()",
-      "norm_label": "buildunitssoldsummary()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L466"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "dailymanagerreportemail_comparisonfromsummary",
-      "label": "comparisonFromSummary()",
-      "norm_label": "comparisonfromsummary()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1016"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "dailymanagerreportemail_countlabel",
-      "label": "countLabel()",
-      "norm_label": "countlabel()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1052"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "dailymanagerreportemail_formatcompletedat",
-      "label": "formatCompletedAt()",
-      "norm_label": "formatcompletedat()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1096"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "dailymanagerreportemail_formatoperatingdate",
+      "id": "dailyopeningview_formatoperatingdate",
       "label": "formatOperatingDate()",
       "norm_label": "formatoperatingdate()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1075"
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L272"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "dailymanagerreportemail_formatpaymentmethod",
-      "label": "formatPaymentMethod()",
-      "norm_label": "formatpaymentmethod()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1062"
+      "id": "dailyopeningview_formatoperatingdatewithweekday",
+      "label": "formatOperatingDateWithWeekday()",
+      "norm_label": "formatoperatingdatewithweekday()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L288"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "dailymanagerreportemail_formatpriordaycomparison",
-      "label": "formatPriorDayComparison()",
-      "norm_label": "formatpriordaycomparison()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1031"
+      "id": "dailyopeningview_formatoperationalworktypelabel",
+      "label": "formatOperationalWorkTypeLabel()",
+      "norm_label": "formatoperationalworktypelabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L360"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "dailymanagerreportemail_formatunitcount",
-      "label": "formatUnitCount()",
-      "norm_label": "formatunitcount()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1048"
+      "id": "dailyopeningview_formattimestamp",
+      "label": "formatTimestamp()",
+      "norm_label": "formattimestamp()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L305"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "dailymanagerreportemail_ispaymenttotal",
-      "label": "isPaymentTotal()",
-      "norm_label": "ispaymenttotal()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L983"
+      "id": "dailyopeningview_getacknowledgementkey",
+      "label": "getAcknowledgementKey()",
+      "norm_label": "getacknowledgementkey()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L407"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "dailymanagerreportemail_moneyformatter",
-      "label": "moneyFormatter()",
-      "norm_label": "moneyformatter()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L996"
+      "id": "dailyopeningview_getarraymetadatastringvalue",
+      "label": "getArrayMetadataStringValue()",
+      "norm_label": "getarraymetadatastringvalue()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L490"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "dailymanagerreportemail_normalizecurrency",
-      "label": "normalizeCurrency()",
-      "norm_label": "normalizecurrency()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1056"
+      "id": "dailyopeningview_getdailyopeningapi",
+      "label": "getDailyOpeningApi()",
+      "norm_label": "getdailyopeningapi()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L262"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "dailymanagerreportemail_normalizepaymentmethod",
-      "label": "normalizePaymentMethod()",
-      "norm_label": "normalizepaymentmethod()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1068"
+      "id": "dailyopeningview_getitemcontextlabel",
+      "label": "getItemContextLabel()",
+      "norm_label": "getitemcontextlabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L422"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "dailymanagerreportemail_numberfromsummary",
-      "label": "numberFromSummary()",
-      "norm_label": "numberfromsummary()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1002"
+      "id": "dailyopeningview_getitemdescription",
+      "label": "getItemDescription()",
+      "norm_label": "getitemdescription()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L418"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "dailymanagerreportemail_numberfromsummarywithfallback",
-      "label": "numberFromSummaryWithFallback()",
-      "norm_label": "numberfromsummarywithfallback()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1007"
+      "id": "dailyopeningview_getitemid",
+      "label": "getItemId()",
+      "norm_label": "getitemid()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L399"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "dailymanagerreportemail_readunitssoldforday",
-      "label": "readUnitsSoldForDay()",
-      "norm_label": "readunitssoldforday()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L448"
+      "id": "dailyopeningview_getmetadataentries",
+      "label": "getMetadataEntries()",
+      "norm_label": "getmetadataentries()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L564"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "dailymanagerreportemail_resolveappurl",
-      "label": "resolveAppUrl()",
-      "norm_label": "resolveappurl()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1104"
+      "id": "dailyopeningview_getmetadatalabel",
+      "label": "getMetadataLabel()",
+      "norm_label": "getmetadatalabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L443"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "dailymanagerreportemail_resolvestaffname",
-      "label": "resolveStaffName()",
-      "norm_label": "resolvestaffname()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L426"
+      "id": "dailyopeningview_getmetadatavalue",
+      "label": "getMetadataValue()",
+      "norm_label": "getmetadatavalue()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L465"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "dailymanagerreportemail_resolvestore",
-      "label": "resolveStore()",
-      "norm_label": "resolvestore()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L405"
+      "id": "dailyopeningview_getopeningautomationmessage",
+      "label": "getOpeningAutomationMessage()",
+      "norm_label": "getopeningautomationmessage()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L701"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "dailymanagerreportemail_resolvestorescheduletimezoneforat",
-      "label": "resolveStoreScheduleTimezoneForAt()",
-      "norm_label": "resolvestorescheduletimezoneforat()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1088"
+      "id": "dailyopeningview_getopeningreviewevidence",
+      "label": "getOpeningReviewEvidence()",
+      "norm_label": "getopeningreviewevidence()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L779"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "dailymanagerreportemail_trimtrailingslash",
-      "label": "trimTrailingSlash()",
-      "norm_label": "trimtrailingslash()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1117"
+      "id": "dailyopeningview_getopeningstartedbylabel",
+      "label": "getOpeningStartedByLabel()",
+      "norm_label": "getopeningstartedbylabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L787"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
-      "label": "dailyManagerReportEmail.ts",
-      "norm_label": "dailymanagerreportemail.ts",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
+      "id": "dailyopeningview_getopeningstatus",
+      "label": "getOpeningStatus()",
+      "norm_label": "getopeningstatus()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L385"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "dailyopeningview_getrequiredacknowledgementkeys",
+      "label": "getRequiredAcknowledgementKeys()",
+      "norm_label": "getrequiredacknowledgementkeys()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L411"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "dailyopeningview_getstatussignatureclassname",
+      "label": "getStatusSignatureClassName()",
+      "norm_label": "getstatussignatureclassname()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L626"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "dailyopeningview_getstatussignatureiconclassname",
+      "label": "getStatusSignatureIconClassName()",
+      "norm_label": "getstatussignatureiconclassname()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L635"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "dailyopeningview_getvisibleopeningautomationstatus",
+      "label": "getVisibleOpeningAutomationStatus()",
+      "norm_label": "getvisibleopeningautomationstatus()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L737"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "dailyopeningview_handlepagechange",
+      "label": "handlePageChange()",
+      "norm_label": "handlepagechange()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L826"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "dailyopeningview_humanizemetadatalabel",
+      "label": "humanizeMetadataLabel()",
+      "norm_label": "humanizemetadatalabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L317"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "dailyopeningview_isoperatorfacingopeningmetadata",
+      "label": "isOperatorFacingOpeningMetadata()",
+      "norm_label": "isoperatorfacingopeningmetadata()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L560"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "dailyopeningview_normalizecommandmessage",
+      "label": "normalizeCommandMessage()",
+      "norm_label": "normalizecommandmessage()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L606"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "dailyopeningview_normalizemetadatalabel",
+      "label": "normalizeMetadataLabel()",
+      "norm_label": "normalizemetadatalabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L324"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "dailyopeningview_openingautomationstatuspanel",
+      "label": "OpeningAutomationStatusPanel()",
+      "norm_label": "openingautomationstatuspanel()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L754"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "dailyopeningview_successcheckicon",
+      "label": "SuccessCheckIcon()",
+      "norm_label": "successcheckicon()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L644"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "dailyopeningview_toggleallacknowledgements",
+      "label": "toggleAllAcknowledgements()",
+      "norm_label": "toggleallacknowledgements()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
+      "source_location": "L1434"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_operations_dailyopeningview_tsx",
+      "label": "DailyOpeningView.tsx",
+      "norm_label": "dailyopeningview.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.tsx",
       "source_location": "L1"
     },
     {
@@ -238615,7 +238657,7 @@
       "label": "precedingEqualRange()",
       "norm_label": "precedingequalrange()",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L1500"
+      "source_location": "L1503"
     },
     {
       "community": 39,
@@ -238678,7 +238720,7 @@
       "label": "skuRangeTotals()",
       "norm_label": "skurangetotals()",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L1509"
+      "source_location": "L1512"
     },
     {
       "community": 39,
@@ -238687,7 +238729,7 @@
       "label": "sum()",
       "norm_label": "sum()",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L1747"
+      "source_location": "L1750"
     },
     {
       "community": 39,
@@ -238786,7 +238828,7 @@
       "label": "withSkuIdentity()",
       "norm_label": "withskuidentity()",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L1481"
+      "source_location": "L1484"
     },
     {
       "community": 390,
@@ -239371,7 +239413,7 @@
       "label": "makeProduct()",
       "norm_label": "makeproduct()",
       "source_file": "packages/athena-webapp/src/components/products/Products.test.tsx",
-      "source_location": "L830"
+      "source_location": "L863"
     },
     {
       "community": 399,
@@ -239380,7 +239422,7 @@
       "label": "makeSkuSearchResult()",
       "norm_label": "makeskusearchresult()",
       "source_file": "packages/athena-webapp/src/components/products/Products.test.tsx",
-      "source_location": "L903"
+      "source_location": "L936"
     },
     {
       "community": 399,
@@ -240136,7 +240178,7 @@
       "label": "admissibleMovementDayRevision()",
       "norm_label": "admissiblemovementdayrevision()",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1385"
+      "source_location": "L1387"
     },
     {
       "community": 40,
@@ -240154,7 +240196,7 @@
       "label": "computeMixRequestKey()",
       "norm_label": "computemixrequestkey()",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1581"
+      "source_location": "L1583"
     },
     {
       "community": 40,
@@ -240163,7 +240205,7 @@
       "label": "computeMovementRequestKey()",
       "norm_label": "computemovementrequestkey()",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1362"
+      "source_location": "L1364"
     },
     {
       "community": 40,
@@ -240181,7 +240223,7 @@
       "label": "deriveMixRequestLifecycle()",
       "norm_label": "derivemixrequestlifecycle()",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1628"
+      "source_location": "L1630"
     },
     {
       "community": 40,
@@ -240190,7 +240232,7 @@
       "label": "deriveMovementRequestLifecycle()",
       "norm_label": "derivemovementrequestlifecycle()",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1492"
+      "source_location": "L1494"
     },
     {
       "community": 40,
@@ -240217,7 +240259,7 @@
       "label": "inclusiveOperatingDaySpan()",
       "norm_label": "inclusiveoperatingdayspan()",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1277"
+      "source_location": "L1279"
     },
     {
       "community": 40,
@@ -240235,7 +240277,7 @@
       "label": "isValidOperatingDateLabel()",
       "norm_label": "isvalidoperatingdatelabel()",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1265"
+      "source_location": "L1267"
     },
     {
       "community": 40,
@@ -240244,7 +240286,7 @@
       "label": "mixRequestKeyIdentity()",
       "norm_label": "mixrequestkeyidentity()",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1566"
+      "source_location": "L1568"
     },
     {
       "community": 40,
@@ -240253,7 +240295,7 @@
       "label": "mixUnitsSoldSortKey()",
       "norm_label": "mixunitssoldsortkey()",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1596"
+      "source_location": "L1598"
     },
     {
       "community": 40,
@@ -240271,7 +240313,7 @@
       "label": "movementAbsNetUnitsSortKey()",
       "norm_label": "movementabsnetunitssortkey()",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1428"
+      "source_location": "L1430"
     },
     {
       "community": 40,
@@ -240280,7 +240322,7 @@
       "label": "movementPageCount()",
       "norm_label": "movementpagecount()",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1478"
+      "source_location": "L1480"
     },
     {
       "community": 40,
@@ -240289,7 +240331,7 @@
       "label": "movementRequestKeyIdentity()",
       "norm_label": "movementrequestkeyidentity()",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1342"
+      "source_location": "L1344"
     },
     {
       "community": 40,
@@ -240298,7 +240340,7 @@
       "label": "movementSourceRowMatchesRevision()",
       "norm_label": "movementsourcerowmatchesrevision()",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1407"
+      "source_location": "L1409"
     },
     {
       "community": 40,
@@ -240343,7 +240385,7 @@
       "label": "skuMixSyncRowProbe()",
       "norm_label": "skumixsyncrowprobe()",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1203"
+      "source_location": "L1205"
     },
     {
       "community": 40,
@@ -240379,7 +240421,7 @@
       "label": "validateReportRangeRequest()",
       "norm_label": "validatereportrangerequest()",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1292"
+      "source_location": "L1294"
     },
     {
       "community": 40,
@@ -265786,7 +265828,7 @@
       "label": "capitalizeProductName()",
       "norm_label": "capitalizeproductname()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsCatalogLookup.tsx",
-      "source_location": "L32"
+      "source_location": "L33"
     },
     {
       "community": 739,
@@ -265795,7 +265837,7 @@
       "label": "clearQuery()",
       "norm_label": "clearquery()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsCatalogLookup.tsx",
-      "source_location": "L134"
+      "source_location": "L135"
     },
     {
       "community": 739,
@@ -265804,7 +265846,7 @@
       "label": "inspectSku()",
       "norm_label": "inspectsku()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsCatalogLookup.tsx",
-      "source_location": "L139"
+      "source_location": "L140"
     },
     {
       "community": 74,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 2828
-- Graph nodes: 11814
-- Graph edges: 14440
-- Communities: 2753
+- Code files discovered: 2829
+- Graph nodes: 11816
+- Graph edges: 14442
+- Communities: 2754
 
 ## Graph Hotspots
 - `dailyClose.ts` (95 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)

--- a/packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts
@@ -10,6 +10,7 @@ import schema from "../schema";
 import {
   buildCashMetrics,
   buildPaymentTotals,
+  buildPreparedBlockers,
   buildSummaryMetrics,
   resolveAppUrl,
 } from "./dailyManagerReportEmail";
@@ -98,6 +99,33 @@ describe("daily manager report email URLs", () => {
         money,
       ),
     ).toContainEqual({ label: "Voids", value: "2" });
+  });
+
+  it("identifies the terminal and register for an open-session blocker", () => {
+    expect(
+      buildPreparedBlockers({
+        blockers: [
+          {
+            category: "register_session",
+            message:
+              "Close the register session before completing the end of day review.",
+            metadata: {
+              register: "Register 3",
+              terminal: "Front Counter",
+            },
+            severity: "blocker",
+            title: "Register session is still open",
+          },
+        ],
+      } as never),
+    ).toEqual([
+      {
+        message:
+          "Front Counter · Register 3. Close the register session before completing the end of day review.",
+        title: "Register session is still open",
+        tone: "danger",
+      },
+    ]);
   });
 
   it("builds cash metrics from register expected and counted totals", () => {

--- a/packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts
+++ b/packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts
@@ -798,19 +798,39 @@ function buildBlockers(
     .filter((item) => item.severity === "blocker")
     .map((item) => ({
       title: item.title,
-      message: item.message,
+      message: formatBlockerMessage(item),
       tone: "danger" as const,
     }));
 }
 
-function buildPreparedBlockers(
+export function buildPreparedBlockers(
   snapshot: PreparedDailyCloseSnapshot,
 ): DailyManagerReportItem[] {
   return snapshot.blockers.map((item) => ({
     title: item.title,
-    message: item.message,
+    message: formatBlockerMessage(item),
     tone: "danger" as const,
   }));
+}
+
+function formatBlockerMessage(item: DailyCloseReportItem) {
+  if (item.category !== "register_session") {
+    return item.message;
+  }
+
+  const terminal = optionalMetadataLabel(item.metadata, "terminal");
+  const register = optionalMetadataLabel(item.metadata, "register");
+  const location = [terminal, register].filter(Boolean).join(" · ");
+
+  return location ? `${location}. ${item.message}` : item.message;
+}
+
+function optionalMetadataLabel(
+  metadata: Record<string, unknown> | undefined,
+  key: string,
+) {
+  const value = metadata?.[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
 export function buildPaymentTotals(

--- a/packages/athena-webapp/convex/reports/queries.test.ts
+++ b/packages/athena-webapp/convex/reports/queries.test.ts
@@ -1333,6 +1333,28 @@ describe("getSkuDetail", () => {
     expect(result?.identity?.quantityAvailable).toBe(10);
   });
 
+  it("includes the archived catalog status in SKU identity", async () => {
+    const t = convexTest(schema, modules);
+    const { storeId } = await seedStore(t);
+    const productSkuId = await seedSku(t, storeId);
+    await t.run(async (ctx) => {
+      const sku = await ctx.db.get("productSku", productSkuId);
+      if (!sku) throw new Error("Seeded SKU missing");
+      await ctx.db.patch("product", sku.productId, { availability: "archived" });
+    });
+
+    const result = await t.run((ctx) =>
+      handlerOf(getSkuDetail)(ctx, {
+        storeId,
+        productSkuId,
+        startDate: "2026-07-01",
+        endDate: "2026-07-28",
+      }),
+    );
+
+    expect(result?.identity?.productAvailability).toBe("archived");
+  });
+
   it("sums metrics across days, with operatingDate per row", async () => {
     const t = convexTest(schema, modules);
     const { storeId } = await seedStore(t);

--- a/packages/athena-webapp/convex/reports/queries.ts
+++ b/packages/athena-webapp/convex/reports/queries.ts
@@ -1468,6 +1468,9 @@ export async function resolveSkuIdentity(
       String(productSkuId),
     ...(sku.netPrice !== undefined ? { netPriceMinor: sku.netPrice } : {}),
     ...(unitCostMinor !== undefined ? { unitCostMinor } : {}),
+    ...(product?.storeId === sku.storeId
+      ? { productAvailability: product.availability }
+      : {}),
     // Stock on hand. Required on the `productSku` document already read
     // above, so it is free — no extra read, no widened budget.
     quantityAvailable: sku.quantityAvailable,

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -7,7 +7,7 @@ This key-folder index highlights the main directories agents are likely to need 
 ## Core app surfaces
 
 - [`src/routes`](../../src/routes) — TanStack route entrypoints and authenticated shells. Currently 145 file(s); key children: -app-entry-route.tsx, -authed-layout.tsx, -authenticated-layout.tsx, -demo-presentation.ts, -docs-back-link.tsx.
-- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 796 file(s); key children: GenericComboBox.tsx, Navbar.test.tsx, Navbar.tsx, OrganizationView.test.tsx, OrganizationView.tsx.
+- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 797 file(s); key children: GenericComboBox.tsx, Navbar.test.tsx, Navbar.tsx, OrganizationView.test.tsx, OrganizationView.tsx.
 - [`src/components/traces`](../../src/components/traces) — Shared workflow trace screens, ordered timelines, and trace detail primitives. Currently 3 file(s); key children: WorkflowTraceRouteLink.tsx, WorkflowTraceView.test.tsx, WorkflowTraceView.tsx.
 - [`src/components/operations`](../../src/components/operations) — Manager-queue and stock-adjustment workflows that share approval rails with other operational surfaces. Currently 37 file(s); key children: CommandApprovalDialog.test.tsx, CommandApprovalDialog.tsx, DailyCloseHistoryView.test.tsx, DailyCloseHistoryView.tsx, DailyCloseView.test.tsx.
 - [`src/components/procurement`](../../src/components/procurement) — Procurement planning and receiving views for replenishment pressure and purchase-order execution. Currently 4 file(s); key children: ProcurementView.test.tsx, ProcurementView.tsx, ReceivingView.test.tsx, ReceivingView.tsx.

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -541,6 +541,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`src/components/ui/button.test.tsx`](../../src/components/ui/button.test.tsx)
 - [`src/components/ui/calendar.test.tsx`](../../src/components/ui/calendar.test.tsx)
 - [`src/components/ui/input-otp.test.tsx`](../../src/components/ui/input-otp.test.tsx)
+- [`src/components/ui/input.test.tsx`](../../src/components/ui/input.test.tsx)
 - [`src/components/ui/primitives.test.tsx`](../../src/components/ui/primitives.test.tsx)
 - [`src/components/ui/relative-timestamp.test.tsx`](../../src/components/ui/relative-timestamp.test.tsx)
 - [`src/components/ui/sidebar.test.tsx`](../../src/components/ui/sidebar.test.tsx)

--- a/packages/athena-webapp/shared/reportsContract.ts
+++ b/packages/athena-webapp/shared/reportsContract.ts
@@ -1018,6 +1018,8 @@ export type ReportDayRow = ReportDayMetrics & {
  */
 export type ReportSkuIdentity = {
   displayName: string;
+  /** Current owning-product availability, when the product still exists. */
+  productAvailability?: "archived" | "draft" | "live";
   sku?: string;
   size?: string;
   /** Current catalog net price in the store's minor currency unit, when set. */

--- a/packages/athena-webapp/src/components/pos/PointOfSaleView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/PointOfSaleView.test.tsx
@@ -471,6 +471,13 @@ describe("PointOfSaleView", () => {
     expect(
       screen.queryByRole("link", { name: /POS Settings/i }),
     ).not.toBeInTheDocument();
+    expect(
+      Array.from(
+        document.querySelectorAll(
+          '[data-remote-assist-control="pos-workspace-feature"]',
+        ),
+      ).map((link) => link.getAttribute("data-remote-assist-control-label")),
+    ).toEqual(["POS", "Expense Products", "Expense Reports", "Transactions"]);
   });
 
   it("links manager-level users to POS settings from the POS landing page", () => {

--- a/packages/athena-webapp/src/components/pos/PointOfSaleView.tsx
+++ b/packages/athena-webapp/src/components/pos/PointOfSaleView.tsx
@@ -237,7 +237,7 @@ export function buildPosFeatures({
   posLinkParams: { orgUrlSlug: string; storeUrlSlug: string } | null;
   setupRequired: boolean;
 }): PosFeatureConfig[] {
-  return [
+  const features: PosFeatureConfig[] = [
     {
       title: "POS",
       description: setupRequired
@@ -319,6 +319,28 @@ export function buildPosFeatures({
       available:
         canAccessPOS && hasFinancialDetailsAccess && Boolean(liveLinkParams),
     },
+  ];
+
+  if (hasFinancialDetailsAccess) {
+    return features;
+  }
+
+  const [
+    pos,
+    expenseProducts,
+    productLookup,
+    transactions,
+    expenseReports,
+    ...remainingFeatures
+  ] = features;
+
+  return [
+    pos,
+    expenseProducts,
+    expenseReports,
+    transactions,
+    productLookup,
+    ...remainingFeatures,
   ];
 }
 

--- a/packages/athena-webapp/src/components/procurement/ProcurementView.tsx
+++ b/packages/athena-webapp/src/components/procurement/ProcurementView.tsx
@@ -1687,33 +1687,42 @@ export function ProcurementViewContent({
                     </p>
                   </div>
                   <div className="divide-y divide-border/70">
-                    {catalogOnlySearchOptions.map((option) => (
-                      <article
-                        className="bg-background px-layout-md py-layout-md"
-                        key={option.productSkuId}
-                      >
-                        <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-                          <div className="min-w-0">
-                            <h4 className="text-sm font-semibold capitalize text-foreground">
-                              {option.productName}
-                            </h4>
-                            <p className="mt-1 text-xs text-muted-foreground">
-                              {option.subtitle || option.metadata}
-                            </p>
-                          </div>
-                          <div className="flex flex-wrap items-center gap-2">
-                            {option.sku ? (
-                              <span className="rounded-md border border-border bg-surface px-2 py-1 text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                                {option.sku}
+                    {catalogOnlySearchOptions.map((option) => {
+                      const isArchived =
+                        option.searchResult.productAvailability === "archived";
+
+                      return (
+                        <article
+                          className={cn(
+                            "bg-background px-layout-md py-layout-md",
+                            isArchived &&
+                              "bg-muted/30 [&_h4]:opacity-45 [&_p]:opacity-45 [&_span]:opacity-45",
+                          )}
+                          key={option.productSkuId}
+                        >
+                          <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                            <div className="min-w-0">
+                              <h4 className="text-sm font-semibold capitalize text-foreground">
+                                {option.productName}
+                              </h4>
+                              <p className="mt-1 text-xs text-muted-foreground">
+                                {option.subtitle || option.metadata}
+                              </p>
+                            </div>
+                            <div className="flex flex-wrap items-center gap-2">
+                              {option.sku ? (
+                                <span className="rounded-md border border-border bg-surface px-2 py-1 text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+                                  {option.sku}
+                                </span>
+                              ) : null}
+                              <span className="rounded-md border border-border bg-muted/50 px-2 py-1 text-[11px] font-medium text-muted-foreground">
+                                No procurement action
                               </span>
-                            ) : null}
-                            <span className="rounded-md border border-border bg-muted/50 px-2 py-1 text-[11px] font-medium text-muted-foreground">
-                              No procurement action
-                            </span>
+                            </div>
                           </div>
-                        </div>
-                      </article>
-                    ))}
+                        </article>
+                      );
+                    })}
                   </div>
                 </section>
               ) : null}

--- a/packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx
+++ b/packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx
@@ -57,6 +57,7 @@ export type QuickAddExistingSkuOption = {
   productSkuId: string;
   name: string;
   sku: string;
+  productAvailability?: "archived" | "draft" | "live";
   priceLabel?: string;
   category?: string;
   barcode?: string;
@@ -173,6 +174,7 @@ function buildQuickAddExistingSkuOptionFromSearchResult(
     barcode: result.barcode ?? undefined,
     category: result.categoryName ?? undefined,
     name: result.productName,
+    productAvailability: result.productAvailability,
     productSkuId: String(result.productSkuId),
     sku: result.sku?.trim() || String(result.productSkuId),
     variantAttributes: [
@@ -815,6 +817,8 @@ export function QuickAddProductDialog({
                       matchingExistingSkus.map((option) => {
                         const isSelected =
                           selectedExistingSkuId === option.productSkuId;
+                        const isArchived =
+                          option.productAvailability === "archived";
                         const metadata = getExistingSkuMetadata(option);
 
                         return (
@@ -823,7 +827,9 @@ export function QuickAddProductDialog({
                             type="button"
                             className={cn(
                               "flex min-h-14 w-full items-center justify-between gap-4 rounded-md border px-4 py-3 text-left text-sm transition-colors",
-                              isSelected
+                              isArchived
+                                ? "border-border bg-muted/30 [&_span]:opacity-45"
+                                : isSelected
                                 ? "border-primary bg-primary/5"
                                 : "border-border bg-background hover:bg-muted/50",
                             )}
@@ -840,6 +846,11 @@ export function QuickAddProductDialog({
                               <span className="block truncate text-xs text-muted-foreground">
                                 {metadata.join(" - ")}
                               </span>
+                              {isArchived ? (
+                                <span className="mt-1 block text-xs text-muted-foreground">
+                                  Archived
+                                </span>
+                              ) : null}
                             </span>
                             {isSelected && (
                               <span className="shrink-0 text-xs font-medium text-primary">

--- a/packages/athena-webapp/src/components/products/Products.test.tsx
+++ b/packages/athena-webapp/src/components/products/Products.test.tsx
@@ -784,6 +784,39 @@ describe("Products", () => {
     expect(screen.getByText("Draft Book")).toBeInTheDocument();
   });
 
+  it("visually separates archived products returned by search", async () => {
+    const user = userEvent.setup();
+    const archivedWig = makeProduct({
+      availability: "archived",
+      id: "product-archived-wig",
+      inventoryCount: 0,
+      name: "Archived Wig",
+      sku: "ARCHIVED-18",
+    });
+    mockedProducts.skuSearchResults = [
+      makeSkuSearchResult(archivedWig, {
+        match: { kind: "text", matchedValue: "archived", rank: 1 },
+      }),
+    ];
+
+    render(<Products />);
+
+    await user.type(
+      screen.getByRole("textbox", {
+        name: /search products, skus, or barcodes/i,
+      }),
+      "archived",
+    );
+
+    expect(screen.getByText("Archived")).toBeInTheDocument();
+    expect(screen.getByText("Archived Wig").closest("tr")).toHaveClass(
+      "[&>td]:opacity-45",
+    );
+    expect(screen.getByText("Archived Wig").closest("tr")).toHaveClass(
+      "border-dashed",
+    );
+  });
+
   it("searches hidden SKUs for hidden draft products", async () => {
     const user = userEvent.setup();
     mockedProducts.categories = [

--- a/packages/athena-webapp/src/components/products/Products.tsx
+++ b/packages/athena-webapp/src/components/products/Products.tsx
@@ -367,6 +367,11 @@ export default function Products() {
                   <GenericDataTable
                     data={filteredProducts}
                     columns={productColumns}
+                    getRowClassName={(row) =>
+                      row.original.availability === "archived"
+                        ? "border-y border-dashed border-border/70 bg-background hover:bg-background [&>td]:opacity-45"
+                        : undefined
+                    }
                     pageIndex={searchPageIndex}
                     onPageIndexChange={handleSearchPageIndexChange}
                     tableId="all-products-search"

--- a/packages/athena-webapp/src/components/reports/ReportsCatalogLookup.test.tsx
+++ b/packages/athena-webapp/src/components/reports/ReportsCatalogLookup.test.tsx
@@ -74,6 +74,16 @@ function result(
 }
 
 describe("ReportsCatalogLookup", () => {
+  it("keeps the search container focus ring transparent", () => {
+    render(
+      <ReportsCatalogLookup endDate="2026-07-29" startDate="2026-06-30" />,
+    );
+
+    expect(
+      screen.getByTestId("reports-catalog-lookup").firstElementChild,
+    ).toHaveClass("focus-within:ring-transparent");
+  });
+
   beforeEach(() => {
     activeStoreId = "store-1";
     sharedDemoContext = null;
@@ -247,7 +257,14 @@ describe("ReportsCatalogLookup", () => {
       "123456789012",
     );
 
-    expect(screen.getByText(/Archived/)).toBeInTheDocument();
+    expect(screen.getByLabelText("Archived product")).toHaveClass(
+      "opacity-45",
+    );
+    expect(
+      screen
+        .getByRole("heading", { name: "Body Wave Bundle" })
+        .parentElement?.parentElement?.parentElement,
+    ).toHaveClass("[&_span]:opacity-45");
     expect(screen.getByText(/Refine your search/)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /BW-18/ })).toBeEnabled();
     expect(

--- a/packages/athena-webapp/src/components/reports/ReportsCatalogLookup.tsx
+++ b/packages/athena-webapp/src/components/reports/ReportsCatalogLookup.tsx
@@ -1,10 +1,11 @@
 import { useNavigate, useParams } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
-import { ChevronRight, Search, X } from "lucide-react";
+import { Archive, ChevronRight, Search, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { AnimatedHeight } from "@/components/common/AnimatedHeight";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import useGetActiveStore from "@/hooks/useGetActiveStore";
 import { useDebounce } from "@/hooks/useDebounce";
@@ -162,7 +163,7 @@ export function ReportsCatalogLookup({
     >
       <div
         className={cn(
-          "border border-border bg-surface-raised focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-background",
+          "border border-border bg-surface-raised focus-within:ring-2 focus-within:ring-transparent focus-within:ring-offset-2 focus-within:ring-offset-background",
           hasQuery ? "rounded-t-xl" : "rounded-xl",
         )}
       >
@@ -236,20 +237,37 @@ export function ReportsCatalogLookup({
                     const productName = capitalizeProductName(
                       group.productName,
                     );
+                    const isArchived = group.skus.some(
+                      (option) =>
+                        option.searchResult.productAvailability === "archived",
+                    );
 
                     return (
                       <div
-                        className={
-                          groupIndex === 0
-                            ? undefined
-                            : "border-t border-border"
-                        }
+                        className={cn(
+                          groupIndex !== 0 && "border-t border-border",
+                          isArchived &&
+                            "bg-muted/30 [&_h3]:opacity-45 [&_span]:opacity-45",
+                        )}
                         key={group.productId}
                       >
                         <div className="flex items-baseline justify-between gap-layout-sm px-layout-md pb-1 pt-layout-sm">
-                          <h3 className="truncate text-sm font-semibold tracking-tight text-foreground">
-                            {productName}
-                          </h3>
+                          <div className="flex min-w-0 items-center gap-layout-sm">
+                            <h3 className="truncate text-sm font-semibold tracking-tight text-foreground">
+                              {productName}
+                            </h3>
+                            {isArchived ? (
+                              <Badge
+                                aria-label="Archived product"
+                                className="h-5 shrink-0 gap-1 border-border/80 bg-background/70 px-1.5 text-[10px] font-medium text-muted-foreground opacity-45"
+                                size="sm"
+                                variant="outline"
+                              >
+                                <Archive aria-hidden="true" className="h-3 w-3" />
+                                Archived
+                              </Badge>
+                            ) : null}
+                          </div>
                           <span className="shrink-0 text-xs text-muted-foreground">
                             {group.skus.length}{" "}
                             {group.skus.length === 1 ? "variant" : "variants"}

--- a/packages/athena-webapp/src/components/reports/ReportsItemsPerformance.tsx
+++ b/packages/athena-webapp/src/components/reports/ReportsItemsPerformance.tsx
@@ -162,7 +162,7 @@ export function ReportsItemsPerformance({
             >
               <SelectTrigger
                 aria-label="Period type"
-                className="h-9 w-28 rounded-lg border-0 bg-transparent px-3 shadow-none focus:ring-2 focus:ring-ring focus:ring-offset-0"
+                className="h-9 w-28 rounded-lg border-0 bg-transparent px-3 shadow-none focus:ring-2 focus:ring-transparent focus:ring-offset-0"
               >
                 <SelectValue />
               </SelectTrigger>

--- a/packages/athena-webapp/src/components/reports/ReportsSkuDetailView.test.tsx
+++ b/packages/athena-webapp/src/components/reports/ReportsSkuDetailView.test.tsx
@@ -372,6 +372,22 @@ describe("ReportsSkuDetailView", () => {
     expect(productHref.searchParams.get("variant")).toBe("6N2Y-JY3-5G6");
   });
 
+  it("shows a quiet archived status beside an archived SKU identity", () => {
+    useQuery.mockReturnValue({
+      days: [],
+      totals: null,
+      identity: {
+        displayName: "Archived Oshe",
+        productAvailability: "archived",
+        sku: "6N2Y-ARCHIVED",
+      },
+    });
+
+    render(<ReportsSkuDetailView {...baseProps} />);
+
+    expect(screen.getByLabelText("Archived product")).toBeInTheDocument();
+  });
+
   it("includes the weekday in a single-day reporting period", () => {
     useQuery.mockReturnValue({
       days: [],

--- a/packages/athena-webapp/src/components/reports/ReportsSkuDetailView.tsx
+++ b/packages/athena-webapp/src/components/reports/ReportsSkuDetailView.tsx
@@ -1,8 +1,9 @@
 import { useQuery } from "convex/react";
 import { Link, useParams } from "@tanstack/react-router";
 import { useMemo } from "react";
-import { ArrowDown, ArrowUpRight, Package } from "lucide-react";
+import { Archive, ArrowDown, ArrowUpRight, Package } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { OperationsSummaryMetric } from "@/components/operations/OperationsSummaryMetric";
 import { formatOperationsMetricComparison } from "@/components/operations/operationsMetricFormatting";
 import { getOrigin } from "@/lib/navigationUtils";
@@ -308,14 +309,27 @@ export function ReportsSkuDetailView({
                 className="min-w-0"
                 data-testid="reports-sku-primary-identity"
               >
-                <h2
-                  className="truncate text-2xl font-semibold tracking-tight text-foreground"
-                  data-testid="reports-sku-detail-name"
-                >
-                  {detail
-                    ? formatSkuDisplayName(detail.identity, productSkuId)
-                    : "\u00A0"}
-                </h2>
+                <div className="flex min-w-0 items-center gap-layout-sm">
+                  <h2
+                    className="truncate text-2xl font-semibold tracking-tight text-foreground"
+                    data-testid="reports-sku-detail-name"
+                  >
+                    {detail
+                      ? formatSkuDisplayName(detail.identity, productSkuId)
+                      : "\u00A0"}
+                  </h2>
+                  {detail?.identity?.productAvailability === "archived" ? (
+                    <Badge
+                      aria-label="Archived product"
+                      className="h-5 shrink-0 gap-1 border-border/80 bg-muted/60 px-1.5 text-[10px] font-medium text-muted-foreground"
+                      size="sm"
+                      variant="outline"
+                    >
+                      <Archive aria-hidden="true" className="h-3 w-3" />
+                      Archived
+                    </Badge>
+                  ) : null}
+                </div>
               </div>
               {detail ? (
                 <div

--- a/packages/athena-webapp/src/components/ui/input.test.tsx
+++ b/packages/athena-webapp/src/components/ui/input.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Input } from "./input";
+
+describe("Input", () => {
+  it("uses a transparent focus ring by default", () => {
+    render(<Input aria-label="Product search" />);
+
+    expect(screen.getByRole("textbox", { name: "Product search" })).toHaveClass(
+      "focus-visible:ring-transparent",
+    );
+  });
+});

--- a/packages/athena-webapp/src/components/ui/input.tsx
+++ b/packages/athena-webapp/src/components/ui/input.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const inputVariants = cva(
-  "flex w-full rounded-md border border-input bg-background ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+  "flex w-full rounded-md border border-input bg-background ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-transparent focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
   {
     variants: {
       size: {

--- a/packages/athena-webapp/src/components/ui/select-native.tsx
+++ b/packages/athena-webapp/src/components/ui/select-native.tsx
@@ -13,7 +13,7 @@ const SelectNative = ({
       <select
         data-slot="select-native"
         className={cn(
-          "peer border-input text-foreground focus-visible:border-ring focus-visible:ring-ring/50 has-[option[disabled]:checked]:text-muted-foreground aria-invalid:ring-destructive/20 aria-invalid:border-destructive inline-flex w-full cursor-pointer appearance-none items-center rounded-md border text-sm shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+          "peer border-input text-foreground focus-visible:border-ring focus-visible:ring-transparent has-[option[disabled]:checked]:text-muted-foreground aria-invalid:ring-destructive/20 aria-invalid:border-destructive inline-flex w-full cursor-pointer appearance-none items-center rounded-md border text-sm shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
           props.multiple
             ? "[&_option:checked]:bg-accent py-1 *:px-3 *:py-1"
             : "h-9 ps-3 pe-8",

--- a/packages/athena-webapp/src/components/ui/select.tsx
+++ b/packages/athena-webapp/src/components/ui/select.tsx
@@ -12,7 +12,7 @@ const SelectGroup = SelectPrimitive.Group
 const SelectValue = SelectPrimitive.Value
 
 const selectTriggerVariants = cva(
-  "flex w-full items-center justify-between rounded-md border border-input bg-background ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+  "flex w-full items-center justify-between rounded-md border border-input bg-background ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-transparent focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
   {
     variants: {
       size: {

--- a/packages/athena-webapp/src/components/ui/textarea.tsx
+++ b/packages/athena-webapp/src/components/ui/textarea.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const textareaVariants = cva(
-  "flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+  "flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-transparent focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
   {
     variants: {
       size: {


### PR DESCRIPTION
## Summary

Archived catalog results now have a consistent low-emphasis treatment across products, reports, procurement, and quick add, while report SKU details state when their product is archived. POS-only users see Expense Reports before Transactions, and EOD alerts identify the terminal and register for an open session.

Shared input primitives use transparent focus rings so a surface-level override cannot leave the Reports search field with the prior solid ring.

## Validation

- `bun run pr:athena`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![HARNESS](https://img.shields.io/badge/Codex-000000)