### PR TITLE
[V26-1182]: normalize report email product names

### DIFF
--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -11675,7 +11675,7 @@
       "relation": "calls",
       "source": "dailymanagerreport_compactcomparison",
       "source_file": "packages/athena-webapp/convex/emails/DailyManagerReport.tsx",
-      "source_location": "L859",
+      "source_location": "L865",
       "target": "dailymanagerreport_capitalize",
       "weight": 1
     },
@@ -35939,7 +35939,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_emails_dailymanagerreport_tsx",
       "source_file": "packages/athena-webapp/convex/emails/DailyManagerReport.tsx",
-      "source_location": "L877",
+      "source_location": "L883",
       "target": "dailymanagerreport_capitalize",
       "weight": 1
     },
@@ -35951,7 +35951,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_emails_dailymanagerreport_tsx",
       "source_file": "packages/athena-webapp/convex/emails/DailyManagerReport.tsx",
-      "source_location": "L852",
+      "source_location": "L858",
       "target": "dailymanagerreport_compactcomparison",
       "weight": 1
     },
@@ -35963,7 +35963,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_emails_dailymanagerreport_tsx",
       "source_file": "packages/athena-webapp/convex/emails/DailyManagerReport.tsx",
-      "source_location": "L873",
+      "source_location": "L879",
       "target": "dailymanagerreport_comparisondetaillabel",
       "weight": 1
     },
@@ -35975,7 +35975,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_emails_dailymanagerreport_tsx",
       "source_file": "packages/athena-webapp/convex/emails/DailyManagerReport.tsx",
-      "source_location": "L911",
+      "source_location": "L917",
       "target": "dailymanagerreport_statuspanelstylefor",
       "weight": 1
     },
@@ -35987,7 +35987,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_emails_dailymanagerreport_tsx",
       "source_file": "packages/athena-webapp/convex/emails/DailyManagerReport.tsx",
-      "source_location": "L725",
+      "source_location": "L731",
       "target": "dailymanagerreport_summaryvaluestylefor",
       "weight": 1
     },
@@ -243391,7 +243391,7 @@
       "label": "capitalize()",
       "norm_label": "capitalize()",
       "source_file": "packages/athena-webapp/convex/emails/DailyManagerReport.tsx",
-      "source_location": "L877"
+      "source_location": "L883"
     },
     {
       "community": 421,
@@ -243400,7 +243400,7 @@
       "label": "compactComparison()",
       "norm_label": "compactcomparison()",
       "source_file": "packages/athena-webapp/convex/emails/DailyManagerReport.tsx",
-      "source_location": "L852"
+      "source_location": "L858"
     },
     {
       "community": 421,
@@ -243409,7 +243409,7 @@
       "label": "comparisonDetailLabel()",
       "norm_label": "comparisondetaillabel()",
       "source_file": "packages/athena-webapp/convex/emails/DailyManagerReport.tsx",
-      "source_location": "L873"
+      "source_location": "L879"
     },
     {
       "community": 421,
@@ -243418,7 +243418,7 @@
       "label": "statusPanelStyleFor()",
       "norm_label": "statuspanelstylefor()",
       "source_file": "packages/athena-webapp/convex/emails/DailyManagerReport.tsx",
-      "source_location": "L911"
+      "source_location": "L917"
     },
     {
       "community": 421,
@@ -243427,7 +243427,7 @@
       "label": "summaryValueStyleFor()",
       "norm_label": "summaryvaluestylefor()",
       "source_file": "packages/athena-webapp/convex/emails/DailyManagerReport.tsx",
-      "source_location": "L725"
+      "source_location": "L731"
     },
     {
       "community": 421,

--- a/packages/athena-webapp/convex/emails/DailyManagerReport.test.tsx
+++ b/packages/athena-webapp/convex/emails/DailyManagerReport.test.tsx
@@ -34,8 +34,8 @@ const baseProps: DailyManagerReportProps = {
     { method: "Cash", amount: ghs.format(1201.82), transactionCount: 18 },
   ],
   topItems: [
-    { name: "Silk Press 18\"", detail: "SP18-NAT", unitsSold: 8 },
-    { name: "Body Wave 20\"", detail: "BW20-1B", unitsSold: 6 },
+    { name: '  silk   press 18" ', detail: "SP18-NAT", unitsSold: 8 },
+    { name: 'body wave 20"', detail: "BW20-1B", unitsSold: 6 },
     { name: "HD Lace Closure", detail: "HDLC-14", unitsSold: 4 },
   ],
   topItemsUrl:
@@ -76,6 +76,8 @@ describe("DailyManagerReport", () => {
     expect(html).not.toContain("Athena keeps the full close record");
     expect(html).toContain("Top items by units sold");
     expect(html).toContain("Silk Press 18");
+    expect(html).toContain("Body Wave 20");
+    expect(html).not.toContain("  silk   press 18");
     expect(html).toContain("8 units");
     expect(html).toContain("View all top movers");
     expect(html).toContain(baseProps.topItemsUrl?.replaceAll("&", "&amp;"));

--- a/packages/athena-webapp/convex/emails/DailyManagerReport.tsx
+++ b/packages/athena-webapp/convex/emails/DailyManagerReport.tsx
@@ -12,7 +12,7 @@ import {
   Section,
   Text,
 } from "@react-email/components";
-import { currencyFormatter } from "../utils";
+import { capitalizeWords, currencyFormatter } from "../utils";
 import { operationalEmailOutlineButton } from "./emailOperationalCtaStyles";
 
 type DailyReportStatus =
@@ -666,7 +666,9 @@ function TopItemsSection({
         {items.slice(0, 3).map((item, index) => (
           <Row key={`${item.name}-${index}`} style={styles.topItemRow}>
             <Column>
-              <Text style={styles.topItemName}>{item.name}</Text>
+              <Text style={styles.topItemName}>
+                {formatTopItemName(item.name)}
+              </Text>
               {item.detail ? (
                 <Text style={styles.topItemDetail}>{item.detail}</Text>
               ) : null}
@@ -684,6 +686,10 @@ function TopItemsSection({
       </Link>
     </Section>
   );
+}
+
+function formatTopItemName(name: string) {
+  return capitalizeWords(name.trim().replace(/\s+/g, " "));
 }
 
 function OperatingMetric({ metric }: { metric: DailyManagerReportMetric }) {


### PR DESCRIPTION
## Summary

- Normalize whitespace and title-case product names in the shared top-items report-email section.
- Add regression coverage for lowercase and all-caps source names.

## Why

Report emails previously exposed raw catalog casing, making top sellers harder to scan. The display-only change preserves catalog values and reporting rankings.

## Validation

- `bun run pr:athena`

https://linear.app/v26-labs/issue/V26-1182/normalize-top-item-names-in-report-emails