### PR TITLE
feat(deploy): serve the admin app on athena-os.app alongside the legacy host

### DIFF
--- a/.github/workflows/athena-production-rollback.yml
+++ b/.github/workflows/athena-production-rollback.yml
@@ -93,10 +93,12 @@ jobs:
 
           case "$APP" in
             athena)
-              host="athena.wigclub.store"
+              # Both hosts serve the same document root; a rollback that leaves
+              # either one broken is a failed rollback.
+              hosts="athena-os.app athena.wigclub.store"
               ;;
             storefront)
-              host="wigclub.store"
+              hosts="wigclub.store"
               ;;
             *)
               echo "Unsupported app: $APP" >&2
@@ -104,4 +106,7 @@ jobs:
               ;;
           esac
 
-          ssh athena-vps "curl -fsS -I -H \"Host: $host\" http://127.0.0.1/ | head -n 1"
+          for host in $hosts; do
+            echo "Smoke checking $host"
+            ssh athena-vps "curl -fsS -I -H \"Host: $host\" http://127.0.0.1/ | head -n 1"
+          done

--- a/docs/deployment/vps-production.md
+++ b/docs/deployment/vps-production.md
@@ -17,7 +17,10 @@ This runbook captures the production VPS shape for `wigclub.store` and the steps
 | ------------------------- | --------------------------------------------------------------------- |
 | `wigclub.store`           | nginx static storefront                                               |
 | `www.wigclub.store`       | nginx static storefront                                               |
-| `athena.wigclub.store`    | nginx static Athena admin app                                         |
+| `athena-os.app`           | nginx static Athena admin app (primary)                               |
+| `athena.wigclub.store`    | nginx static Athena admin app (legacy alias, same document root)      |
+| `www.athena-os.app`       | nginx 301 redirect to `athena-os.app`                                 |
+| `qa.athena-os.app`        | nginx reverse proxy to the Athena QA Vite dev server (with `athena-qa.wigclub.store`) |
 | `qa.wigclub.store`        | nginx reverse proxy to storefront Vite dev server on `127.0.0.1:5176` |
 | `athena-qa.wigclub.store` | nginx reverse proxy to Athena Vite dev server on `127.0.0.1:5175`     |
 | `api.wigclub.store`       | nginx reverse proxy to prod Convex HTTP                               |
@@ -95,7 +98,7 @@ The generated server blocks are:
 | nginx server_name                 | Behavior                                                                                              |
 | --------------------------------- | ----------------------------------------------------------------------------------------------------- |
 | `wigclub.store www.wigclub.store` | Serves `/root/athena/storefront/current` with SPA fallback                                            |
-| `athena.wigclub.store`            | Serves `/root/athena/athena-webapp/current` with SPA fallback                                         |
+| `athena-os.app athena.wigclub.store` | Serves `/root/athena/athena-webapp/current` with SPA fallback. One server block, two names — see "Dual admin hostnames" below |
 | `qa.wigclub.store`                | Proxies to the storefront QA Vite dev server at `127.0.0.1:5176`, including websocket upgrade headers |
 | `athena-qa.wigclub.store`         | Proxies to the QA Vite dev server at `127.0.0.1:5175`, including websocket upgrade headers            |
 | `api.wigclub.store`               | Proxies to the production Convex HTTP site with CORS handling                                         |
@@ -121,10 +124,25 @@ Verify each local nginx route before checking Cloudflare:
 
 ```bash
 curl -sS -I -H 'Host: wigclub.store' http://127.0.0.1/
+curl -sS -I -H 'Host: athena-os.app' http://127.0.0.1/
 curl -sS -I -H 'Host: athena.wigclub.store' http://127.0.0.1/
 curl -sS -I -H 'Host: qa.wigclub.store' http://127.0.0.1/
 curl -sS -I -H 'Host: athena-qa.wigclub.store' http://127.0.0.1/
 ```
+
+### Dual admin hostnames
+
+The Athena admin app is served on `athena-os.app` (primary) and `athena.wigclub.store` (legacy) from a single nginx server block sharing one document root. This is deliberately **not** a redirect.
+
+The production POS terminal is bookmarked to the legacy host, and its offline state — the `athena-pos-local` IndexedDB, the app-shell service worker cache, and the Convex auth session — is origin-scoped. Redirecting the legacy host to the primary one would strand any unsynced sales on an origin the terminal could no longer reach.
+
+Both hostnames need a Cloudflare Tunnel ingress entry and a DNS route. Both are smoke-checked by `.github/workflows/athena-production-rollback.yml`; a rollback that leaves either one broken is a failed rollback.
+
+`www.athena-os.app` redirects to the apex rather than serving the app a second time, so the admin app keeps exactly one origin and one session store. `qa.athena-os.app` joins the existing QA server block. Note that the QA host requires two application-side settings, not just nginx: `qa.athena-os.app` must be in `server.allowedHosts` in `packages/athena-webapp/vite.config.ts` (Vite returns 403 for unknown `Host` headers), and the QA dev server must receive `VITE_STOREFRONT_URL` — its storefront URL cannot be derived from an `athena-os.app` hostname.
+
+Every DNS record for these hostnames is a **proxied** CNAME to `<tunnel-id>.cfargotunnel.com`. A `cfargotunnel.com` target left as DNS-only will not resolve publicly.
+
+Retire the legacy host only after that terminal has drained to zero unsynced events and been re-onboarded on `athena-os.app`. Until then, treat `ATHENA_LEGACY_HOST` in `scripts/setup-production-vps.sh` as permanent.
 
 If the config changes manually during incident response, copy the working change back into `scripts/setup-production-vps.sh` so a new VPS can reproduce it.
 
@@ -148,6 +166,8 @@ ingress:
   - hostname: wigclub.store
     service: http://localhost:80
   - hostname: www.wigclub.store
+    service: http://localhost:80
+  - hostname: athena-os.app
     service: http://localhost:80
   - hostname: athena.wigclub.store
     service: http://localhost:80
@@ -299,6 +319,7 @@ scripts/deploy-vps.sh rollback-storefront previous
 After rollback, verify the local nginx route before checking Cloudflare:
 
 ```bash
+curl -sS -I -H 'Host: athena-os.app' http://127.0.0.1/
 curl -sS -I -H 'Host: athena.wigclub.store' http://127.0.0.1/
 curl -sS -I -H 'Host: wigclub.store' http://127.0.0.1/
 ```

--- a/docs/solutions/architecture-patterns/athena-dual-origin-admin-hosts-2026-08-10.md
+++ b/docs/solutions/architecture-patterns/athena-dual-origin-admin-hosts-2026-08-10.md
@@ -1,0 +1,108 @@
+---
+title: A Second Admin Origin Is an Alias, Not a Redirect, When the Client Holds State
+date: 2026-08-10
+category: architecture-patterns
+module: Athena admin app / VPS nginx + Cloudflare Tunnel
+problem_type: architecture_pattern
+component: deployment_infrastructure
+resolution_type: config_change
+severity: medium
+applies_when:
+  - "An app is moving to a new hostname and an offline-capable client is bookmarked to the old one"
+  - "A hostname-derived config value silently falls back instead of failing when the host is unrecognised"
+  - "A domain being repointed already serves a live site through the same CDN"
+  - "A dev-server-backed environment gains a hostname the framework does not know about"
+related_components:
+  - "athena-webapp-config-storefront-url"
+  - "vps-nginx-server-blocks"
+  - "cloudflare-tunnel-ingress"
+  - "convex-email-deep-links"
+tags:
+  - origin-scoped-state
+  - dual-host-serving
+  - silent-config-fallback
+  - cloudflare-tunnel
+  - vite-allowed-hosts
+delivery_diff_fingerprint: abf7d4500c98b31fb79177a925049209a5a8f98a1cc8e1c29e4a6abb4c297d03
+---
+
+# A Second Admin Origin Is an Alias, Not a Redirect, When the Client Holds State
+
+## Problem
+
+The admin app moved from `athena.wigclub.store` to `athena-os.app`. The obvious
+implementation — repoint DNS and 301 the old host at the new one — would have
+destroyed data.
+
+The production POS terminal is bookmarked to the legacy host and is offline-capable.
+Its unsynced sales live in an `athena-pos-local` IndexedDB, its shell in a service
+worker cache, its session in `localStorage` — all three are **origin-scoped**. A
+redirect moves the browser to an origin where none of that exists, and the old origin
+becomes unreachable, so any sale not yet synced is stranded with no path back.
+
+Three smaller traps sat alongside it:
+
+- `resolveStoreFrontUrl` derived the storefront hostname from the admin hostname by
+  string transform (`athena.X` → `X`). `athena-os.app` matches no branch and fell
+  through to `http://localhost:5174` — silently. Production was masked only because
+  the deploy passes `VITE_STOREFRONT_URL`; nothing said so, and QA did not pass it.
+- The target domain was already serving a live Squarespace site through the same
+  Cloudflare zone, so this was a repoint of a working site, not an empty-zone setup.
+- Adding a hostname to the QA environment is not an infrastructure-only change: Vite's
+  dev server rejects unknown `Host` headers with a 403.
+
+## Solution
+
+**Serve both origins from one document root. Never redirect the legacy host.**
+`server_name athena-os.app athena.wigclub.store;` on a single nginx block, with
+`ATHENA_LEGACY_HOST` as a named variable carrying a comment explaining why it is not a
+redirect, so a later reader does not "simplify" it. The legacy host is retired only
+after the terminal has drained to zero unsynced events and been re-onboarded.
+
+**Make the environment variable authoritative and the fallback loud.** The hostname
+transform is kept for the legacy `athena*.wigclub.store` hosts, where it is genuinely
+mechanical, and factored into a named helper. Any unrecognised deployed host now warns
+that `VITE_STOREFRONT_URL` is missing instead of silently pointing every storefront
+link at a dev server. No `athena-os.app → wigclub.store` mapping was added: that would
+hardcode tenant identity into the platform host.
+
+**Everything a rename touches must be enumerated, not assumed.** The primary-host
+change reached four Convex email builders, the static `index.html` metadata, the
+Playwright prod default, the rollback smoke check (which now loops over both hosts —
+a rollback leaving either broken is a failed rollback), and the screen-redact
+extension's origin list.
+
+## Prevention
+
+- **Ask what the client stores before choosing redirect vs alias.** The question is not
+  "is the old URL still needed" but "does anything at that origin hold state the user
+  cannot re-create". IndexedDB, service worker caches, and sessions all answer yes.
+- **A config fallback that cannot be right should say so.** A `localhost` default
+  reached from a production hostname is not a fallback, it is a silent failure. Warn.
+- **`cfargotunnel.com` CNAMEs must be Proxied.** A DNS-only record does not resolve
+  publicly at all. This is the most common way the setup fails and the symptom
+  (NXDOMAIN-ish) does not point at the cause.
+- **Check for an HTTPS/SVCB record when repointing a proxied domain.** One carrying an
+  `ipv4hint` at the old origin will send browsers there even after A/CNAME records are
+  fixed — `curl` passes, Chrome does not. `cloudflared tunnel route dns` does not touch
+  it. In this case the record existed at the registrar but had never been copied into
+  Cloudflare.
+- **cloudflared has no reload.** `systemctl reload` fails; the unit ships without
+  `ExecReload` and there is no supported signal for ingress changes. A restart drops
+  every hostname on the tunnel, so on a shared tunnel use the documented replica
+  overlap during trading hours.
+- **cloudflared parses flags before positionals.** `route dns <id> <host>
+  --overwrite-dns` reads the flag as a third positional and fails with a confusing
+  argument-count error. Flags go first.
+- **A new QA hostname needs `server.allowedHosts` in `vite.config.ts`** and, where the
+  storefront URL is not derivable from it, an explicit `VITE_STOREFRONT_URL` in the
+  deploy path.
+
+## Evidence
+
+Verified externally after the cutover: `athena-os.app` returns 200 serving the admin
+app with no Squarespace markers (`crumb` cookie, `x-contextid` header both absent),
+`www.athena-os.app` returns 301 to the apex, and `athena.wigclub.store` still returns
+200 for the POS terminal. `qa.athena-os.app` returns 403 from Vite until the
+`allowedHosts` change deploys — that 403 is itself proof the
+Cloudflare → tunnel → nginx → dev-server path is intact.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 11927 nodes · 14588 edges · 2775 communities detected
+- 11928 nodes · 14590 edges · 2775 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -4045,12 +4045,12 @@ Cohesion: 0.22
 Nodes (0):
 
 ### Community 308 - "Community 308"
-Cohesion: 0.39
-Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
-
-### Community 309 - "Community 309"
 Cohesion: 0.31
 Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+
+### Community 309 - "Community 309"
+Cohesion: 0.39
+Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
 
 ### Community 310 - "Community 310"
 Cohesion: 0.22
@@ -4765,68 +4765,68 @@ Cohesion: 0.4
 Nodes (2): isValidRecipientEmail(), normalizeRecipientEmailInput()
 
 ### Community 488 - "Community 488"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 489 - "Community 489"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.6
+Nodes (5): deriveStoreFrontFromAdminHost(), getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
 ### Community 490 - "Community 490"
-Cohesion: 0.73
-Nodes (5): canAccessCashControlsSurface(), canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 491 - "Community 491"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 492 - "Community 492"
+Cohesion: 0.73
+Nodes (5): canAccessCashControlsSurface(), canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
+
+### Community 493 - "Community 493"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 493 - "Community 493"
+### Community 494 - "Community 494"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 495 - "Community 495"
 Cohesion: 0.4
 Nodes (2): deriveRegisterLifecycleAuthorityCandidates(), mappingCandidate()
 
-### Community 494 - "Community 494"
+### Community 496 - "Community 496"
 Cohesion: 0.4
 Nodes (2): buildRecoveryCommandStore(), storeFactory()
 
-### Community 495 - "Community 495"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 496 - "Community 496"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 497 - "Community 497"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 498 - "Community 498"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 499 - "Community 499"
 Cohesion: 0.4
 Nodes (2): encodeFocusKey(), encodeSheetReturn()
 
-### Community 498 - "Community 498"
+### Community 500 - "Community 500"
 Cohesion: 0.47
 Nodes (3): buildAdminSkuSearchOption(), compactJoin(), presentationText()
 
-### Community 499 - "Community 499"
+### Community 501 - "Community 501"
 Cohesion: 0.53
 Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
 
-### Community 500 - "Community 500"
+### Community 502 - "Community 502"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 501 - "Community 501"
-Cohesion: 0.33
-Nodes (1): MemoryCache
-
-### Community 502 - "Community 502"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 503 - "Community 503"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): MemoryCache
 
 ### Community 504 - "Community 504"
 Cohesion: 0.33
@@ -4837,296 +4837,296 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 506 - "Community 506"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 507 - "Community 507"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 508 - "Community 508"
 Cohesion: 0.47
 Nodes (3): completePendingAuthSync(), navigationTargetForRedirect(), sleep()
 
-### Community 507 - "Community 507"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 508 - "Community 508"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
 ### Community 509 - "Community 509"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
+### Community 510 - "Community 510"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
+### Community 511 - "Community 511"
 Cohesion: 0.6
 Nodes (5): useDailyCloseFixture(), useDailyOpeningFixture(), useDailyOperationsFixture(), usePosHubFixture(), useWorkspaceFixture()
 
-### Community 510 - "Community 510"
+### Community 512 - "Community 512"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 511 - "Community 511"
+### Community 513 - "Community 513"
 Cohesion: 0.47
 Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
-### Community 512 - "Community 512"
+### Community 514 - "Community 514"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
-### Community 513 - "Community 513"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 514 - "Community 514"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 515 - "Community 515"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 516 - "Community 516"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 517 - "Community 517"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
 
 ### Community 518 - "Community 518"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 519 - "Community 519"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 519 - "Community 519"
+### Community 520 - "Community 520"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 520 - "Community 520"
+### Community 521 - "Community 521"
 Cohesion: 0.53
 Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
 
-### Community 521 - "Community 521"
+### Community 522 - "Community 522"
 Cohesion: 0.47
 Nodes (3): assertDeliveryDocumentationCheck(), findingsFrom(), isPolicyFailure()
 
-### Community 522 - "Community 522"
+### Community 523 - "Community 523"
 Cohesion: 0.67
 Nodes (5): assertDocsLinks(), classifyLink(), collectDocsLinkFindings(), collectSolutionSlugs(), solutionsRoot()
 
-### Community 523 - "Community 523"
+### Community 524 - "Community 524"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 524 - "Community 524"
+### Community 525 - "Community 525"
 Cohesion: 0.47
 Nodes (4): commitFixtureRepo(), createFixtureRepo(), runFixtureCommand(), write()
 
-### Community 525 - "Community 525"
+### Community 526 - "Community 526"
 Cohesion: 0.47
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
-### Community 526 - "Community 526"
+### Community 527 - "Community 527"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 527 - "Community 527"
+### Community 528 - "Community 528"
 Cohesion: 0.53
 Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
 
-### Community 528 - "Community 528"
+### Community 529 - "Community 529"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 529 - "Community 529"
-Cohesion: 0.6
-Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
 
 ### Community 530 - "Community 530"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
 
 ### Community 531 - "Community 531"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 532 - "Community 532"
-Cohesion: 0.6
-Nodes (3): isDisplayableMarker(), presentSnapshotAtRequestTime(), resolveHomepageSnapshotBootstrap()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 533 - "Community 533"
 Cohesion: 0.6
-Nodes (4): assertArtifactTransition(), assertRunTransition(), canTransitionArtifact(), canTransitionRun()
+Nodes (3): isDisplayableMarker(), presentSnapshotAtRequestTime(), resolveHomepageSnapshotBootstrap()
 
 ### Community 534 - "Community 534"
+Cohesion: 0.6
+Nodes (4): assertArtifactTransition(), assertRunTransition(), canTransitionArtifact(), canTransitionRun()
+
+### Community 535 - "Community 535"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 535 - "Community 535"
+### Community 536 - "Community 536"
 Cohesion: 0.5
 Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
 
-### Community 536 - "Community 536"
+### Community 537 - "Community 537"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 537 - "Community 537"
+### Community 538 - "Community 538"
 Cohesion: 0.6
 Nodes (4): applyCommerceInventoryEffectWithCtx(), outboundBasisFromEffect(), reportingLineCostFromEffect(), uncostedOutboundBasis()
 
-### Community 538 - "Community 538"
+### Community 539 - "Community 539"
 Cohesion: 0.5
 Nodes (2): historicalCostLane(), materializeDeferredAdjustmentWithCtx()
 
-### Community 539 - "Community 539"
+### Community 540 - "Community 540"
 Cohesion: 0.6
 Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
-
-### Community 540 - "Community 540"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 541 - "Community 541"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 542 - "Community 542"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 543 - "Community 543"
 Cohesion: 0.7
 Nodes (4): backfillStoreTimezoneAuthorityWithCtx(), buildRow(), listSchedulesForStore(), normalizeLimit()
 
-### Community 543 - "Community 543"
+### Community 544 - "Community 544"
 Cohesion: 0.5
 Nodes (2): recordNotificationFailureEventWithCtx(), recordTerminalDeliveryFailureEvent()
 
-### Community 544 - "Community 544"
+### Community 545 - "Community 545"
 Cohesion: 0.6
 Nodes (4): dedupeKey(), keyFor(), prepare(), stubCtx()
 
-### Community 545 - "Community 545"
+### Community 546 - "Community 546"
 Cohesion: 0.7
 Nodes (4): createNormalUserOperationAdapter(), createPublicOperationAdapter(), isAdmitted(), resolveOperationAdmission()
 
-### Community 546 - "Community 546"
+### Community 547 - "Community 547"
 Cohesion: 0.6
 Nodes (4): consumeApprovalRequesterChallengeWithCtx(), createApprovalRequesterChallengeWithCtx(), invalidApprovalRequesterChallengeResult(), toRequesterBinding()
 
-### Community 547 - "Community 547"
+### Community 548 - "Community 548"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
-
-### Community 548 - "Community 548"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 549 - "Community 549"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 550 - "Community 550"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 551 - "Community 551"
 Cohesion: 0.6
 Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
 
-### Community 551 - "Community 551"
+### Community 552 - "Community 552"
 Cohesion: 0.5
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
 
-### Community 552 - "Community 552"
+### Community 553 - "Community 553"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 553 - "Community 553"
-Cohesion: 0.7
-Nodes (4): acknowledgeRegisterLifecycleAuthority(), equivalentAcknowledgement(), isRevision(), normalizeSafeMetadata()
 
 ### Community 554 - "Community 554"
 Cohesion: 0.7
-Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
+Nodes (4): acknowledgeRegisterLifecycleAuthority(), equivalentAcknowledgement(), isRevision(), normalizeSafeMetadata()
 
 ### Community 555 - "Community 555"
+Cohesion: 0.7
+Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
+
+### Community 556 - "Community 556"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 556 - "Community 556"
+### Community 557 - "Community 557"
 Cohesion: 0.5
 Nodes (2): baseInput(), buildRuntimeStatus()
 
-### Community 557 - "Community 557"
+### Community 558 - "Community 558"
 Cohesion: 0.6
 Nodes (4): buildCtx(), buildQueryCtx(), filterRows(), orderedRows()
 
-### Community 558 - "Community 558"
+### Community 559 - "Community 559"
 Cohesion: 0.6
 Nodes (4): requirePosCustomerAccessById(), requirePosCustomerReadAccessById(), requirePosCustomerStoreAccess(), requirePosCustomerStoreReadAccess()
-
-### Community 559 - "Community 559"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 560 - "Community 560"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 561 - "Community 561"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 562 - "Community 562"
 Cohesion: 0.5
 Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
-### Community 562 - "Community 562"
+### Community 563 - "Community 563"
 Cohesion: 0.6
 Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
 
-### Community 563 - "Community 563"
+### Community 564 - "Community 564"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 564 - "Community 564"
+### Community 565 - "Community 565"
 Cohesion: 0.7
 Nodes (4): factFingerprint(), fingerprintPayload(), matchesStoredFingerprint(), stableStringHash()
 
-### Community 565 - "Community 565"
+### Community 566 - "Community 566"
 Cohesion: 0.5
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 566 - "Community 566"
+### Community 567 - "Community 567"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 567 - "Community 567"
+### Community 568 - "Community 568"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 568 - "Community 568"
+### Community 569 - "Community 569"
 Cohesion: 0.6
 Nodes (3): isSharedDemoEnabled(), readRuntimeSharedDemoConfig(), readSharedDemoConfig()
 
-### Community 569 - "Community 569"
+### Community 570 - "Community 570"
 Cohesion: 0.8
 Nodes (4): buildSharedDemoOpeningBaseline(), buildSharedDemoStoreDayEvent(), rollSharedDemoOpeningBaselineWithCtx(), sharedDemoOperatingDateRange()
 
-### Community 570 - "Community 570"
+### Community 571 - "Community 571"
 Cohesion: 0.5
 Nodes (2): sharedDemoDenialError(), sharedDemoDenied()
 
-### Community 571 - "Community 571"
+### Community 572 - "Community 572"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
-### Community 572 - "Community 572"
+### Community 573 - "Community 573"
 Cohesion: 0.7
 Nodes (4): buildLookup(), buildOnlineOrderTraceSeed(), buildSafeExternalReferenceRef(), stableFingerprint()
 
-### Community 573 - "Community 573"
+### Community 574 - "Community 574"
 Cohesion: 0.5
 Nodes (2): createAdminTraceReadCtx(), createTestCtx()
 
-### Community 574 - "Community 574"
+### Community 575 - "Community 575"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 575 - "Community 575"
+### Community 576 - "Community 576"
 Cohesion: 0.5
 Nodes (2): cancel(), handleClick()
 
-### Community 576 - "Community 576"
+### Community 577 - "Community 577"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 577 - "Community 577"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 578 - "Community 578"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 579 - "Community 579"
 Cohesion: 0.4
@@ -5137,12 +5137,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 581 - "Community 581"
-Cohesion: 0.5
-Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
-
-### Community 582 - "Community 582"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 582 - "Community 582"
+Cohesion: 0.5
+Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 583 - "Community 583"
 Cohesion: 0.4
@@ -5173,8 +5173,8 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 590 - "Community 590"
-Cohesion: 0.7
-Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 591 - "Community 591"
 Cohesion: 0.4
@@ -5509,40 +5509,40 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 674 - "Community 674"
-Cohesion: 0.5
-Nodes (1): buildCtx()
-
-### Community 675 - "Community 675"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 676 - "Community 676"
+### Community 675 - "Community 675"
 Cohesion: 0.83
 Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
-### Community 677 - "Community 677"
+### Community 676 - "Community 676"
 Cohesion: 0.83
 Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
-### Community 678 - "Community 678"
+### Community 677 - "Community 677"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 679 - "Community 679"
+### Community 678 - "Community 678"
 Cohesion: 0.67
 Nodes (2): buildActivity(), buildReport()
 
-### Community 680 - "Community 680"
+### Community 679 - "Community 679"
 Cohesion: 0.83
 Nodes (3): advanceRegisterCatalogRevision(), readRegisterCatalogRevision(), readRegisterCatalogRevisionRow()
 
-### Community 681 - "Community 681"
+### Community 680 - "Community 680"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 682 - "Community 682"
+### Community 681 - "Community 681"
 Cohesion: 0.83
 Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
+
+### Community 682 - "Community 682"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 683 - "Community 683"
 Cohesion: 0.5
@@ -5554,7 +5554,7 @@ Nodes (0):
 
 ### Community 685 - "Community 685"
 Cohesion: 0.5
-Nodes (0):
+Nodes (1): buildCtx()
 
 ### Community 686 - "Community 686"
 Cohesion: 0.5

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -6629,13 +6629,25 @@
     },
     {
       "_src": "config_resolvestorefronturl",
+      "_tgt": "config_derivestorefrontfromadminhost",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "config_derivestorefrontfromadminhost",
+      "source_file": "packages/athena-webapp/src/config.ts",
+      "source_location": "L76",
+      "target": "config_resolvestorefronturl",
+      "weight": 1
+    },
+    {
+      "_src": "config_resolvestorefronturl",
       "_tgt": "config_getruntimeorigin",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "calls",
       "source": "config_getruntimeorigin",
       "source_file": "packages/athena-webapp/src/config.ts",
-      "source_location": "L33",
+      "source_location": "L60",
       "target": "config_resolvestorefronturl",
       "weight": 1
     },
@@ -6647,7 +6659,7 @@
       "relation": "calls",
       "source": "config_islocalhost",
       "source_file": "packages/athena-webapp/src/config.ts",
-      "source_location": "L45",
+      "source_location": "L72",
       "target": "config_resolvestorefronturl",
       "weight": 1
     },
@@ -6659,7 +6671,7 @@
       "relation": "calls",
       "source": "config_trimtrailingslash",
       "source_file": "packages/athena-webapp/src/config.ts",
-      "source_location": "L30",
+      "source_location": "L57",
       "target": "config_resolvestorefronturl",
       "weight": 1
     },
@@ -106529,6 +106541,18 @@
     },
     {
       "_src": "packages_athena_webapp_src_config_ts",
+      "_tgt": "config_derivestorefrontfromadminhost",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_config_ts",
+      "source_file": "packages/athena-webapp/src/config.ts",
+      "source_location": "L29",
+      "target": "config_derivestorefrontfromadminhost",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_config_ts",
       "_tgt": "config_getruntimeorigin",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
@@ -106559,7 +106583,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_config_ts",
       "source_file": "packages/athena-webapp/src/config.ts",
-      "source_location": "L24",
+      "source_location": "L51",
       "target": "config_resolvestorefronturl",
       "weight": 1
     },
@@ -232998,87 +233022,6 @@
     {
       "community": 308,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontobservability_ts",
-      "label": "storefrontObservability.ts",
-      "norm_label": "storefrontobservability.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 308,
-      "file_type": "code",
-      "id": "storefrontobservability_createstorefrontobservabilitycontext",
-      "label": "createStorefrontObservabilityContext()",
-      "norm_label": "createstorefrontobservabilitycontext()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L182"
-    },
-    {
-      "community": 308,
-      "file_type": "code",
-      "id": "storefrontobservability_createstorefrontobservabilitypayload",
-      "label": "createStorefrontObservabilityPayload()",
-      "norm_label": "createstorefrontobservabilitypayload()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L229"
-    },
-    {
-      "community": 308,
-      "file_type": "code",
-      "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
-      "label": "getOrCreateStorefrontObservabilitySessionId()",
-      "norm_label": "getorcreatestorefrontobservabilitysessionid()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L157"
-    },
-    {
-      "community": 308,
-      "file_type": "code",
-      "id": "storefrontobservability_isbrowserautomationcontext",
-      "label": "isBrowserAutomationContext()",
-      "norm_label": "isbrowserautomationcontext()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L125"
-    },
-    {
-      "community": 308,
-      "file_type": "code",
-      "id": "storefrontobservability_issyntheticmonitororigin",
-      "label": "isSyntheticMonitorOrigin()",
-      "norm_label": "issyntheticmonitororigin()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L121"
-    },
-    {
-      "community": 308,
-      "file_type": "code",
-      "id": "storefrontobservability_resolvestorefrontanalyticsorigin",
-      "label": "resolveStorefrontAnalyticsOrigin()",
-      "norm_label": "resolvestorefrontanalyticsorigin()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L135"
-    },
-    {
-      "community": 308,
-      "file_type": "code",
-      "id": "storefrontobservability_resolveviewportbucket",
-      "label": "resolveViewportBucket()",
-      "norm_label": "resolveviewportbucket()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L211"
-    },
-    {
-      "community": 308,
-      "file_type": "code",
-      "id": "storefrontobservability_trackstorefrontevent",
-      "label": "trackStorefrontEvent()",
-      "norm_label": "trackstorefrontevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L265"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
       "norm_label": "versionchecker.ts",
@@ -233086,7 +233029,7 @@
       "source_location": "L1"
     },
     {
-      "community": 309,
+      "community": 308,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -233095,7 +233038,7 @@
       "source_location": "L1"
     },
     {
-      "community": 309,
+      "community": 308,
       "file_type": "code",
       "id": "versionchecker_buildidfromscripts",
       "label": "buildIdFromScripts()",
@@ -233104,7 +233047,7 @@
       "source_location": "L192"
     },
     {
-      "community": 309,
+      "community": 308,
       "file_type": "code",
       "id": "versionchecker_createversionchecker",
       "label": "createVersionChecker()",
@@ -233113,7 +233056,7 @@
       "source_location": "L16"
     },
     {
-      "community": 309,
+      "community": 308,
       "file_type": "code",
       "id": "versionchecker_getinitialdeploybuildid",
       "label": "getInitialDeployBuildId()",
@@ -233122,7 +233065,7 @@
       "source_location": "L135"
     },
     {
-      "community": 309,
+      "community": 308,
       "file_type": "code",
       "id": "versionchecker_readdeploybuildid",
       "label": "readDeployBuildId()",
@@ -233131,7 +233074,7 @@
       "source_location": "L141"
     },
     {
-      "community": 309,
+      "community": 308,
       "file_type": "code",
       "id": "versionchecker_readdocumentscriptsources",
       "label": "readDocumentScriptSources()",
@@ -233140,7 +233083,7 @@
       "source_location": "L174"
     },
     {
-      "community": 309,
+      "community": 308,
       "file_type": "code",
       "id": "versionchecker_readentryhtmlscripts",
       "label": "readEntryHtmlScripts()",
@@ -233149,13 +233092,94 @@
       "source_location": "L151"
     },
     {
-      "community": 309,
+      "community": 308,
       "file_type": "code",
       "id": "versionchecker_readscriptsources",
       "label": "readScriptSources()",
       "norm_label": "readscriptsources()",
       "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
       "source_location": "L182"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_storefrontobservability_ts",
+      "label": "storefrontObservability.ts",
+      "norm_label": "storefrontobservability.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "storefrontobservability_createstorefrontobservabilitycontext",
+      "label": "createStorefrontObservabilityContext()",
+      "norm_label": "createstorefrontobservabilitycontext()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L182"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "storefrontobservability_createstorefrontobservabilitypayload",
+      "label": "createStorefrontObservabilityPayload()",
+      "norm_label": "createstorefrontobservabilitypayload()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L229"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
+      "label": "getOrCreateStorefrontObservabilitySessionId()",
+      "norm_label": "getorcreatestorefrontobservabilitysessionid()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L157"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "storefrontobservability_isbrowserautomationcontext",
+      "label": "isBrowserAutomationContext()",
+      "norm_label": "isbrowserautomationcontext()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L125"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "storefrontobservability_issyntheticmonitororigin",
+      "label": "isSyntheticMonitorOrigin()",
+      "norm_label": "issyntheticmonitororigin()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L121"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "storefrontobservability_resolvestorefrontanalyticsorigin",
+      "label": "resolveStorefrontAnalyticsOrigin()",
+      "norm_label": "resolvestorefrontanalyticsorigin()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "storefrontobservability_resolveviewportbucket",
+      "label": "resolveViewportBucket()",
+      "norm_label": "resolveviewportbucket()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L211"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "storefrontobservability_trackstorefrontevent",
+      "label": "trackStorefrontEvent()",
+      "norm_label": "trackstorefrontevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L265"
     },
     {
       "community": 31,
@@ -250044,110 +250068,110 @@
     {
       "community": 488,
       "file_type": "code",
-      "id": "managerelevationcontext_getstaffdisplayname",
-      "label": "getStaffDisplayName()",
-      "norm_label": "getstaffdisplayname()",
-      "source_file": "packages/athena-webapp/src/contexts/ManagerElevationContext.tsx",
-      "source_location": "L64"
-    },
-    {
-      "community": 488,
-      "file_type": "code",
-      "id": "managerelevationcontext_managerelevationprovider",
-      "label": "ManagerElevationProvider()",
-      "norm_label": "managerelevationprovider()",
-      "source_file": "packages/athena-webapp/src/contexts/ManagerElevationContext.tsx",
-      "source_location": "L87"
-    },
-    {
-      "community": 488,
-      "file_type": "code",
-      "id": "managerelevationcontext_tostaffauthenticationresult",
-      "label": "toStaffAuthenticationResult()",
-      "norm_label": "tostaffauthenticationresult()",
-      "source_file": "packages/athena-webapp/src/contexts/ManagerElevationContext.tsx",
-      "source_location": "L74"
-    },
-    {
-      "community": 488,
-      "file_type": "code",
-      "id": "managerelevationcontext_usemanagerelevation",
-      "label": "useManagerElevation()",
-      "norm_label": "usemanagerelevation()",
-      "source_file": "packages/athena-webapp/src/contexts/ManagerElevationContext.tsx",
-      "source_location": "L242"
-    },
-    {
-      "community": 488,
-      "file_type": "code",
-      "id": "managerelevationcontext_useoptionalmanagerelevation",
-      "label": "useOptionalManagerElevation()",
-      "norm_label": "useoptionalmanagerelevation()",
-      "source_file": "packages/athena-webapp/src/contexts/ManagerElevationContext.tsx",
-      "source_location": "L251"
-    },
-    {
-      "community": 488,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_contexts_managerelevationcontext_tsx",
-      "label": "ManagerElevationContext.tsx",
-      "norm_label": "managerelevationcontext.tsx",
-      "source_file": "packages/athena-webapp/src/contexts/ManagerElevationContext.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
-      "label": "useExpenseSessions.ts",
-      "norm_label": "useexpensesessions.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpenseactivesession",
-      "label": "useExpenseActiveSession()",
-      "norm_label": "useexpenseactivesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesession",
-      "label": "useExpenseSession()",
-      "norm_label": "useexpensesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesessioncreate",
-      "label": "useExpenseSessionCreate()",
-      "norm_label": "useexpensesessioncreate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesessionupdate",
-      "label": "useExpenseSessionUpdate()",
-      "norm_label": "useexpensesessionupdate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L101"
     },
     {
+      "community": 488,
+      "file_type": "code",
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 488,
+      "file_type": "code",
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 488,
+      "file_type": "code",
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 488,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 488,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
       "community": 489,
       "file_type": "code",
-      "id": "useexpensesessions_useexpensestoresessions",
-      "label": "useExpenseStoreSessions()",
-      "norm_label": "useexpensestoresessions()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L10"
+      "id": "config_derivestorefrontfromadminhost",
+      "label": "deriveStoreFrontFromAdminHost()",
+      "norm_label": "derivestorefrontfromadminhost()",
+      "source_file": "packages/athena-webapp/src/config.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 489,
+      "file_type": "code",
+      "id": "config_getruntimeorigin",
+      "label": "getRuntimeOrigin()",
+      "norm_label": "getruntimeorigin()",
+      "source_file": "packages/athena-webapp/src/config.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 489,
+      "file_type": "code",
+      "id": "config_islocalhost",
+      "label": "isLocalHost()",
+      "norm_label": "islocalhost()",
+      "source_file": "packages/athena-webapp/src/config.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 489,
+      "file_type": "code",
+      "id": "config_resolvestorefronturl",
+      "label": "resolveStoreFrontUrl()",
+      "norm_label": "resolvestorefronturl()",
+      "source_file": "packages/athena-webapp/src/config.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 489,
+      "file_type": "code",
+      "id": "config_trimtrailingslash",
+      "label": "trimTrailingSlash()",
+      "norm_label": "trimtrailingslash()",
+      "source_file": "packages/athena-webapp/src/config.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 489,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_config_ts",
+      "label": "config.ts",
+      "norm_label": "config.ts",
+      "source_file": "packages/athena-webapp/src/config.ts",
+      "source_location": "L1"
     },
     {
       "community": 49,
@@ -250413,6 +250437,114 @@
     {
       "community": 490,
       "file_type": "code",
+      "id": "managerelevationcontext_getstaffdisplayname",
+      "label": "getStaffDisplayName()",
+      "norm_label": "getstaffdisplayname()",
+      "source_file": "packages/athena-webapp/src/contexts/ManagerElevationContext.tsx",
+      "source_location": "L64"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "managerelevationcontext_managerelevationprovider",
+      "label": "ManagerElevationProvider()",
+      "norm_label": "managerelevationprovider()",
+      "source_file": "packages/athena-webapp/src/contexts/ManagerElevationContext.tsx",
+      "source_location": "L87"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "managerelevationcontext_tostaffauthenticationresult",
+      "label": "toStaffAuthenticationResult()",
+      "norm_label": "tostaffauthenticationresult()",
+      "source_file": "packages/athena-webapp/src/contexts/ManagerElevationContext.tsx",
+      "source_location": "L74"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "managerelevationcontext_usemanagerelevation",
+      "label": "useManagerElevation()",
+      "norm_label": "usemanagerelevation()",
+      "source_file": "packages/athena-webapp/src/contexts/ManagerElevationContext.tsx",
+      "source_location": "L242"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "managerelevationcontext_useoptionalmanagerelevation",
+      "label": "useOptionalManagerElevation()",
+      "norm_label": "useoptionalmanagerelevation()",
+      "source_file": "packages/athena-webapp/src/contexts/ManagerElevationContext.tsx",
+      "source_location": "L251"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_contexts_managerelevationcontext_tsx",
+      "label": "ManagerElevationContext.tsx",
+      "norm_label": "managerelevationcontext.tsx",
+      "source_file": "packages/athena-webapp/src/contexts/ManagerElevationContext.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
+      "label": "useExpenseSessions.ts",
+      "norm_label": "useexpensesessions.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpenseactivesession",
+      "label": "useExpenseActiveSession()",
+      "norm_label": "useexpenseactivesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesession",
+      "label": "useExpenseSession()",
+      "norm_label": "useexpensesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesessioncreate",
+      "label": "useExpenseSessionCreate()",
+      "norm_label": "useexpensesessioncreate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesessionupdate",
+      "label": "useExpenseSessionUpdate()",
+      "norm_label": "useexpensesessionupdate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensestoresessions",
+      "label": "useExpenseStoreSessions()",
+      "norm_label": "useexpensestoresessions()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 492,
+      "file_type": "code",
       "id": "capabilities_canaccesscashcontrolssurface",
       "label": "canAccessCashControlsSurface()",
       "norm_label": "canaccesscashcontrolssurface()",
@@ -250420,7 +250552,7 @@
       "source_location": "L54"
     },
     {
-      "community": 490,
+      "community": 492,
       "file_type": "code",
       "id": "capabilities_canaccessfulladminsurface",
       "label": "canAccessFullAdminSurface()",
@@ -250429,7 +250561,7 @@
       "source_location": "L41"
     },
     {
-      "community": 490,
+      "community": 492,
       "file_type": "code",
       "id": "capabilities_canaccessstoredaysurface",
       "label": "canAccessStoreDaySurface()",
@@ -250438,7 +250570,7 @@
       "source_location": "L47"
     },
     {
-      "community": 490,
+      "community": 492,
       "file_type": "code",
       "id": "capabilities_canviewfinancialdetails",
       "label": "canViewFinancialDetails()",
@@ -250447,7 +250579,7 @@
       "source_location": "L61"
     },
     {
-      "community": 490,
+      "community": 492,
       "file_type": "code",
       "id": "capabilities_getsurfaceaccess",
       "label": "getSurfaceAccess()",
@@ -250456,7 +250588,7 @@
       "source_location": "L68"
     },
     {
-      "community": 490,
+      "community": 492,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_access_capabilities_ts",
       "label": "capabilities.ts",
@@ -250465,7 +250597,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 493,
       "file_type": "code",
       "id": "behaviorutils_calculateengagementmetrics",
       "label": "calculateEngagementMetrics()",
@@ -250474,7 +250606,7 @@
       "source_location": "L173"
     },
     {
-      "community": 491,
+      "community": 493,
       "file_type": "code",
       "id": "behaviorutils_calculateriskindicators",
       "label": "calculateRiskIndicators()",
@@ -250483,7 +250615,7 @@
       "source_location": "L71"
     },
     {
-      "community": 491,
+      "community": 493,
       "file_type": "code",
       "id": "behaviorutils_getactivitypriority",
       "label": "getActivityPriority()",
@@ -250492,7 +250624,7 @@
       "source_location": "L251"
     },
     {
-      "community": 491,
+      "community": 493,
       "file_type": "code",
       "id": "behaviorutils_getcustomerjourneystage",
       "label": "getCustomerJourneyStage()",
@@ -250501,7 +250633,7 @@
       "source_location": "L36"
     },
     {
-      "community": 491,
+      "community": 493,
       "file_type": "code",
       "id": "behaviorutils_getjourneystageinfo",
       "label": "getJourneyStageInfo()",
@@ -250510,7 +250642,7 @@
       "source_location": "L277"
     },
     {
-      "community": 491,
+      "community": 493,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
       "label": "behaviorUtils.ts",
@@ -250519,7 +250651,7 @@
       "source_location": "L1"
     },
     {
-      "community": 492,
+      "community": 494,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
       "label": "results.ts",
@@ -250528,7 +250660,7 @@
       "source_location": "L1"
     },
     {
-      "community": 492,
+      "community": 494,
       "file_type": "code",
       "id": "results_isposusecasesuccess",
       "label": "isPosUseCaseSuccess()",
@@ -250537,7 +250669,7 @@
       "source_location": "L134"
     },
     {
-      "community": 492,
+      "community": 494,
       "file_type": "code",
       "id": "results_mapcommandoutcome",
       "label": "mapCommandOutcome()",
@@ -250546,7 +250678,7 @@
       "source_location": "L69"
     },
     {
-      "community": 492,
+      "community": 494,
       "file_type": "code",
       "id": "results_mapcommandresult",
       "label": "mapCommandResult()",
@@ -250555,7 +250687,7 @@
       "source_location": "L86"
     },
     {
-      "community": 492,
+      "community": 494,
       "file_type": "code",
       "id": "results_maplegacymutationresult",
       "label": "mapLegacyMutationResult()",
@@ -250564,7 +250696,7 @@
       "source_location": "L52"
     },
     {
-      "community": 492,
+      "community": 494,
       "file_type": "code",
       "id": "results_mapthrownerror",
       "label": "mapThrownError()",
@@ -250573,7 +250705,7 @@
       "source_location": "L103"
     },
     {
-      "community": 493,
+      "community": 495,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registerlifecycleauthoritycandidates_ts",
       "label": "registerLifecycleAuthorityCandidates.ts",
@@ -250582,7 +250714,7 @@
       "source_location": "L1"
     },
     {
-      "community": 493,
+      "community": 495,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_deriveregisterlifecycleauthoritycandidates",
       "label": "deriveRegisterLifecycleAuthorityCandidates()",
@@ -250591,7 +250723,7 @@
       "source_location": "L45"
     },
     {
-      "community": 493,
+      "community": 495,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_isboundedidentifier",
       "label": "isBoundedIdentifier()",
@@ -250600,7 +250732,7 @@
       "source_location": "L220"
     },
     {
-      "community": 493,
+      "community": 495,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_iseligibleregistermapping",
       "label": "isEligibleRegisterMapping()",
@@ -250609,7 +250741,7 @@
       "source_location": "L167"
     },
     {
-      "community": 493,
+      "community": 495,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_legacymappingmatchesactivesession",
       "label": "legacyMappingMatchesActiveSession()",
@@ -250618,7 +250750,7 @@
       "source_location": "L182"
     },
     {
-      "community": 493,
+      "community": 495,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_mappingcandidate",
       "label": "mappingCandidate()",
@@ -250627,7 +250759,7 @@
       "source_location": "L194"
     },
     {
-      "community": 494,
+      "community": 496,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_useposlocalsyncruntime_test_ts",
       "label": "usePosLocalSyncRuntime.test.ts",
@@ -250636,7 +250768,7 @@
       "source_location": "L1"
     },
     {
-      "community": 494,
+      "community": 496,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_buildlocalevent",
       "label": "buildLocalEvent()",
@@ -250645,7 +250777,7 @@
       "source_location": "L7444"
     },
     {
-      "community": 494,
+      "community": 496,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_buildrecoverycommand",
       "label": "buildRecoveryCommand()",
@@ -250654,7 +250786,7 @@
       "source_location": "L7467"
     },
     {
-      "community": 494,
+      "community": 496,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_buildrecoverycommandstore",
       "label": "buildRecoveryCommandStore()",
@@ -250663,7 +250795,7 @@
       "source_location": "L7486"
     },
     {
-      "community": 494,
+      "community": 496,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_deferred",
       "label": "deferred()",
@@ -250672,7 +250804,7 @@
       "source_location": "L108"
     },
     {
-      "community": 494,
+      "community": 496,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_storefactory",
       "label": "storeFactory()",
@@ -250681,7 +250813,7 @@
       "source_location": "L352"
     },
     {
-      "community": 495,
+      "community": 497,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
       "label": "selectors.ts",
@@ -250690,7 +250822,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 497,
       "file_type": "code",
       "id": "selectors_buildregisterheaderstate",
       "label": "buildRegisterHeaderState()",
@@ -250699,7 +250831,7 @@
       "source_location": "L28"
     },
     {
-      "community": 495,
+      "community": 497,
       "file_type": "code",
       "id": "selectors_buildregisterinfostate",
       "label": "buildRegisterInfoState()",
@@ -250708,7 +250840,7 @@
       "source_location": "L37"
     },
     {
-      "community": 495,
+      "community": 497,
       "file_type": "code",
       "id": "selectors_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -250717,7 +250849,7 @@
       "source_location": "L12"
     },
     {
-      "community": 495,
+      "community": 497,
       "file_type": "code",
       "id": "selectors_getregistercustomerinfo",
       "label": "getRegisterCustomerInfo()",
@@ -250726,7 +250858,7 @@
       "source_location": "L6"
     },
     {
-      "community": 495,
+      "community": 497,
       "file_type": "code",
       "id": "selectors_isregistersessionactive",
       "label": "isRegisterSessionActive()",
@@ -250735,7 +250867,7 @@
       "source_location": "L49"
     },
     {
-      "community": 496,
+      "community": 498,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
       "label": "toastService.ts",
@@ -250744,7 +250876,7 @@
       "source_location": "L1"
     },
     {
-      "community": 496,
+      "community": 498,
       "file_type": "code",
       "id": "toastservice_handleposoperation",
       "label": "handlePOSOperation()",
@@ -250753,7 +250885,7 @@
       "source_location": "L171"
     },
     {
-      "community": 496,
+      "community": 498,
       "file_type": "code",
       "id": "toastservice_showinventoryerror",
       "label": "showInventoryError()",
@@ -250762,7 +250894,7 @@
       "source_location": "L302"
     },
     {
-      "community": 496,
+      "community": 498,
       "file_type": "code",
       "id": "toastservice_shownoactivesessionerror",
       "label": "showNoActiveSessionError()",
@@ -250771,7 +250903,7 @@
       "source_location": "L319"
     },
     {
-      "community": 496,
+      "community": 498,
       "file_type": "code",
       "id": "toastservice_showsessionexpirederror",
       "label": "showSessionExpiredError()",
@@ -250780,7 +250912,7 @@
       "source_location": "L312"
     },
     {
-      "community": 496,
+      "community": 498,
       "file_type": "code",
       "id": "toastservice_showvalidationerror",
       "label": "showValidationError()",
@@ -250789,7 +250921,7 @@
       "source_location": "L293"
     },
     {
-      "community": 497,
+      "community": 499,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_sheetreturn_ts",
       "label": "sheetReturn.ts",
@@ -250798,7 +250930,7 @@
       "source_location": "L1"
     },
     {
-      "community": 497,
+      "community": 499,
       "file_type": "code",
       "id": "sheetreturn_decodesheetreturn",
       "label": "decodeSheetReturn()",
@@ -250807,7 +250939,7 @@
       "source_location": "L85"
     },
     {
-      "community": 497,
+      "community": 499,
       "file_type": "code",
       "id": "sheetreturn_encodefocuskey",
       "label": "encodeFocusKey()",
@@ -250816,7 +250948,7 @@
       "source_location": "L74"
     },
     {
-      "community": 497,
+      "community": 499,
       "file_type": "code",
       "id": "sheetreturn_encodesheetreturn",
       "label": "encodeSheetReturn()",
@@ -250825,7 +250957,7 @@
       "source_location": "L55"
     },
     {
-      "community": 497,
+      "community": 499,
       "file_type": "code",
       "id": "sheetreturn_sheetreturnfocusselector",
       "label": "sheetReturnFocusSelector()",
@@ -250834,121 +250966,13 @@
       "source_location": "L126"
     },
     {
-      "community": 497,
+      "community": 499,
       "file_type": "code",
       "id": "sheetreturn_sheetreturntargetprops",
       "label": "sheetReturnTargetProps()",
       "norm_label": "sheetreturntargetprops()",
       "source_file": "packages/athena-webapp/src/lib/sheetReturn.ts",
       "source_location": "L131"
-    },
-    {
-      "community": 498,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_skusearch_productskusearchadapters_ts",
-      "label": "productSkuSearchAdapters.ts",
-      "norm_label": "productskusearchadapters.ts",
-      "source_file": "packages/athena-webapp/src/lib/skuSearch/productSkuSearchAdapters.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 498,
-      "file_type": "code",
-      "id": "productskusearchadapters_buildadminskusearchoption",
-      "label": "buildAdminSkuSearchOption()",
-      "norm_label": "buildadminskusearchoption()",
-      "source_file": "packages/athena-webapp/src/lib/skuSearch/productSkuSearchAdapters.ts",
-      "source_location": "L80"
-    },
-    {
-      "community": 498,
-      "file_type": "code",
-      "id": "productskusearchadapters_buildadminskusearchoptions",
-      "label": "buildAdminSkuSearchOptions()",
-      "norm_label": "buildadminskusearchoptions()",
-      "source_file": "packages/athena-webapp/src/lib/skuSearch/productSkuSearchAdapters.ts",
-      "source_location": "L132"
-    },
-    {
-      "community": 498,
-      "file_type": "code",
-      "id": "productskusearchadapters_compactjoin",
-      "label": "compactJoin()",
-      "norm_label": "compactjoin()",
-      "source_file": "packages/athena-webapp/src/lib/skuSearch/productSkuSearchAdapters.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 498,
-      "file_type": "code",
-      "id": "productskusearchadapters_groupadminskusearchoptionsbyproduct",
-      "label": "groupAdminSkuSearchOptionsByProduct()",
-      "norm_label": "groupadminskusearchoptionsbyproduct()",
-      "source_file": "packages/athena-webapp/src/lib/skuSearch/productSkuSearchAdapters.ts",
-      "source_location": "L138"
-    },
-    {
-      "community": 498,
-      "file_type": "code",
-      "id": "productskusearchadapters_presentationtext",
-      "label": "presentationText()",
-      "norm_label": "presentationtext()",
-      "source_file": "packages/athena-webapp/src/lib/skuSearch/productSkuSearchAdapters.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_stockops_skusearch_ts",
-      "label": "skuSearch.ts",
-      "norm_label": "skusearch.ts",
-      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "skusearch_isbarcodeshapedsearchquery",
-      "label": "isBarcodeShapedSearchQuery()",
-      "norm_label": "isbarcodeshapedsearchquery()",
-      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "skusearch_matchesskusearchterms",
-      "label": "matchesSkuSearchTerms()",
-      "norm_label": "matchesskusearchterms()",
-      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "skusearch_normalizeidentifier",
-      "label": "normalizeIdentifier()",
-      "norm_label": "normalizeidentifier()",
-      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
-      "source_location": "L53"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "skusearch_normalizeskusearchquery",
-      "label": "normalizeSkuSearchQuery()",
-      "norm_label": "normalizeskusearchquery()",
-      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "skusearch_scoreskusearchterms",
-      "label": "scoreSkuSearchTerms()",
-      "norm_label": "scoreskusearchterms()",
-      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
-      "source_location": "L18"
     },
     {
       "community": 5,
@@ -251898,6 +251922,114 @@
     {
       "community": 500,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_skusearch_productskusearchadapters_ts",
+      "label": "productSkuSearchAdapters.ts",
+      "norm_label": "productskusearchadapters.ts",
+      "source_file": "packages/athena-webapp/src/lib/skuSearch/productSkuSearchAdapters.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "productskusearchadapters_buildadminskusearchoption",
+      "label": "buildAdminSkuSearchOption()",
+      "norm_label": "buildadminskusearchoption()",
+      "source_file": "packages/athena-webapp/src/lib/skuSearch/productSkuSearchAdapters.ts",
+      "source_location": "L80"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "productskusearchadapters_buildadminskusearchoptions",
+      "label": "buildAdminSkuSearchOptions()",
+      "norm_label": "buildadminskusearchoptions()",
+      "source_file": "packages/athena-webapp/src/lib/skuSearch/productSkuSearchAdapters.ts",
+      "source_location": "L132"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "productskusearchadapters_compactjoin",
+      "label": "compactJoin()",
+      "norm_label": "compactjoin()",
+      "source_file": "packages/athena-webapp/src/lib/skuSearch/productSkuSearchAdapters.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "productskusearchadapters_groupadminskusearchoptionsbyproduct",
+      "label": "groupAdminSkuSearchOptionsByProduct()",
+      "norm_label": "groupadminskusearchoptionsbyproduct()",
+      "source_file": "packages/athena-webapp/src/lib/skuSearch/productSkuSearchAdapters.ts",
+      "source_location": "L138"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "productskusearchadapters_presentationtext",
+      "label": "presentationText()",
+      "norm_label": "presentationtext()",
+      "source_file": "packages/athena-webapp/src/lib/skuSearch/productSkuSearchAdapters.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_stockops_skusearch_ts",
+      "label": "skuSearch.ts",
+      "norm_label": "skusearch.ts",
+      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
+      "id": "skusearch_isbarcodeshapedsearchquery",
+      "label": "isBarcodeShapedSearchQuery()",
+      "norm_label": "isbarcodeshapedsearchquery()",
+      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
+      "id": "skusearch_matchesskusearchterms",
+      "label": "matchesSkuSearchTerms()",
+      "norm_label": "matchesskusearchterms()",
+      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
+      "id": "skusearch_normalizeidentifier",
+      "label": "normalizeIdentifier()",
+      "norm_label": "normalizeidentifier()",
+      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
+      "id": "skusearch_normalizeskusearchquery",
+      "label": "normalizeSkuSearchQuery()",
+      "norm_label": "normalizeskusearchquery()",
+      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
+      "id": "skusearch_scoreskusearchterms",
+      "label": "scoreSkuSearchTerms()",
+      "norm_label": "scoreskusearchterms()",
+      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 502,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_offline_posappshellroutes_ts",
       "label": "posAppShellRoutes.ts",
       "norm_label": "posappshellroutes.ts",
@@ -251905,7 +252037,7 @@
       "source_location": "L1"
     },
     {
-      "community": 500,
+      "community": 502,
       "file_type": "code",
       "id": "posappshellroutes_isexcludedfromposappshellcache",
       "label": "isExcludedFromPosAppShellCache()",
@@ -251914,7 +252046,7 @@
       "source_location": "L53"
     },
     {
-      "community": 500,
+      "community": 502,
       "file_type": "code",
       "id": "posappshellroutes_isposappshellnavigationrequest",
       "label": "isPosAppShellNavigationRequest()",
@@ -251923,7 +252055,7 @@
       "source_location": "L71"
     },
     {
-      "community": 500,
+      "community": 502,
       "file_type": "code",
       "id": "posappshellroutes_isposappshellroutepath",
       "label": "isPosAppShellRoutePath()",
@@ -251932,7 +252064,7 @@
       "source_location": "L48"
     },
     {
-      "community": 500,
+      "community": 502,
       "file_type": "code",
       "id": "posappshellroutes_isposappshellstaticassetrequest",
       "label": "isPosAppShellStaticAssetRequest()",
@@ -251941,7 +252073,7 @@
       "source_location": "L88"
     },
     {
-      "community": 500,
+      "community": 502,
       "file_type": "code",
       "id": "posappshellroutes_readheader",
       "label": "readHeader()",
@@ -251950,7 +252082,7 @@
       "source_location": "L107"
     },
     {
-      "community": 501,
+      "community": 503,
       "file_type": "code",
       "id": "packages_athena_webapp_src_offline_posappshellserviceworkerstaging_test_ts",
       "label": "posAppShellServiceWorkerStaging.test.ts",
@@ -251959,7 +252091,7 @@
       "source_location": "L1"
     },
     {
-      "community": 501,
+      "community": 503,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_createserviceworkerfixture",
       "label": "createServiceWorkerFixture()",
@@ -251968,7 +252100,7 @@
       "source_location": "L32"
     },
     {
-      "community": 501,
+      "community": 503,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_memorycache",
       "label": "MemoryCache",
@@ -251977,7 +252109,7 @@
       "source_location": "L14"
     },
     {
-      "community": 501,
+      "community": 503,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_memorycache_keys",
       "label": ".keys()",
@@ -251986,7 +252118,7 @@
       "source_location": "L27"
     },
     {
-      "community": 501,
+      "community": 503,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_memorycache_match",
       "label": ".match()",
@@ -251995,7 +252127,7 @@
       "source_location": "L17"
     },
     {
-      "community": 501,
+      "community": 503,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_memorycache_put",
       "label": ".put()",
@@ -252004,7 +252136,7 @@
       "source_location": "L22"
     },
     {
-      "community": 502,
+      "community": 504,
       "file_type": "code",
       "id": "docs_shared_companionsection",
       "label": "CompanionSection()",
@@ -252013,7 +252145,7 @@
       "source_location": "L81"
     },
     {
-      "community": 502,
+      "community": 504,
       "file_type": "code",
       "id": "docs_shared_formatcategorylabel",
       "label": "formatCategoryLabel()",
@@ -252022,7 +252154,7 @@
       "source_location": "L7"
     },
     {
-      "community": 502,
+      "community": 504,
       "file_type": "code",
       "id": "docs_shared_formatdocdate",
       "label": "formatDocDate()",
@@ -252031,7 +252163,7 @@
       "source_location": "L11"
     },
     {
-      "community": 502,
+      "community": 504,
       "file_type": "code",
       "id": "docs_shared_severityindicator",
       "label": "SeverityIndicator()",
@@ -252040,7 +252172,7 @@
       "source_location": "L32"
     },
     {
-      "community": 502,
+      "community": 504,
       "file_type": "code",
       "id": "docs_shared_solutiondoccard",
       "label": "SolutionDocCard()",
@@ -252049,7 +252181,7 @@
       "source_location": "L48"
     },
     {
-      "community": 502,
+      "community": 504,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_docs_shared_tsx",
       "label": "-docs-shared.tsx",
@@ -252058,7 +252190,7 @@
       "source_location": "L1"
     },
     {
-      "community": 503,
+      "community": 505,
       "file_type": "code",
       "id": "index_route_view_democtabutton",
       "label": "DemoCtaButton()",
@@ -252067,7 +252199,7 @@
       "source_location": "L192"
     },
     {
-      "community": 503,
+      "community": 505,
       "file_type": "code",
       "id": "index_route_view_herogrid",
       "label": "HeroGrid()",
@@ -252076,7 +252208,7 @@
       "source_location": "L178"
     },
     {
-      "community": 503,
+      "community": 505,
       "file_type": "code",
       "id": "index_route_view_rest",
       "label": "rest()",
@@ -252085,7 +252217,7 @@
       "source_location": "L246"
     },
     {
-      "community": 503,
+      "community": 505,
       "file_type": "code",
       "id": "index_route_view_useheroshotrevealref",
       "label": "useHeroShotRevealRef()",
@@ -252094,7 +252226,7 @@
       "source_location": "L54"
     },
     {
-      "community": 503,
+      "community": 505,
       "file_type": "code",
       "id": "index_route_view_useheroshottiltref",
       "label": "useHeroShotTiltRef()",
@@ -252103,7 +252235,7 @@
       "source_location": "L107"
     },
     {
-      "community": 503,
+      "community": 505,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_route_view_tsx",
       "label": "-index-route-view.tsx",
@@ -252112,7 +252244,7 @@
       "source_location": "L1"
     },
     {
-      "community": 504,
+      "community": 506,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
       "label": "procurement.index.tsx",
@@ -252121,7 +252253,7 @@
       "source_location": "L1"
     },
     {
-      "community": 504,
+      "community": 506,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementmodesearch",
       "label": "getNextProcurementModeSearch()",
@@ -252130,7 +252262,7 @@
       "source_location": "L19"
     },
     {
-      "community": 504,
+      "community": 506,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementpagesearch",
       "label": "getNextProcurementPageSearch()",
@@ -252139,7 +252271,7 @@
       "source_location": "L37"
     },
     {
-      "community": 504,
+      "community": 506,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementquerysearch",
       "label": "getNextProcurementQuerySearch()",
@@ -252148,7 +252280,7 @@
       "source_location": "L47"
     },
     {
-      "community": 504,
+      "community": 506,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementselectedskusearch",
       "label": "getNextProcurementSelectedSkuSearch()",
@@ -252157,7 +252289,7 @@
       "source_location": "L62"
     },
     {
-      "community": 504,
+      "community": 506,
       "file_type": "code",
       "id": "procurement_index_procurementroute",
       "label": "ProcurementRoute()",
@@ -252166,7 +252298,7 @@
       "source_location": "L88"
     },
     {
-      "community": 505,
+      "community": 507,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_weekly_lifecycle_test_tsx",
       "label": "weekly.lifecycle.test.tsx",
@@ -252175,7 +252307,7 @@
       "source_location": "L1"
     },
     {
-      "community": 505,
+      "community": 507,
       "file_type": "code",
       "id": "weekly_lifecycle_test_installcompletedmovement",
       "label": "installCompletedMovement()",
@@ -252184,7 +252316,7 @@
       "source_location": "L283"
     },
     {
-      "community": 505,
+      "community": 507,
       "file_type": "code",
       "id": "weekly_lifecycle_test_isshareddemostandingread",
       "label": "isSharedDemoStandingRead()",
@@ -252193,7 +252325,7 @@
       "source_location": "L102"
     },
     {
-      "community": 505,
+      "community": 507,
       "file_type": "code",
       "id": "weekly_lifecycle_test_movementrow",
       "label": "movementRow()",
@@ -252202,7 +252334,7 @@
       "source_location": "L268"
     },
     {
-      "community": 505,
+      "community": 507,
       "file_type": "code",
       "id": "weekly_lifecycle_test_params",
       "label": "params()",
@@ -252211,7 +252343,7 @@
       "source_location": "L40"
     },
     {
-      "community": 505,
+      "community": 507,
       "file_type": "code",
       "id": "weekly_lifecycle_test_stubensuremutation",
       "label": "stubEnsureMutation()",
@@ -252220,7 +252352,7 @@
       "source_location": "L81"
     },
     {
-      "community": 506,
+      "community": 508,
       "file_type": "code",
       "id": "login_layout_completependingauthsync",
       "label": "completePendingAuthSync()",
@@ -252229,7 +252361,7 @@
       "source_location": "L145"
     },
     {
-      "community": 506,
+      "community": 508,
       "file_type": "code",
       "id": "login_layout_handlependingauthsync",
       "label": "handlePendingAuthSync()",
@@ -252238,7 +252370,7 @@
       "source_location": "L95"
     },
     {
-      "community": 506,
+      "community": 508,
       "file_type": "code",
       "id": "login_layout_navigationtargetforredirect",
       "label": "navigationTargetForRedirect()",
@@ -252247,7 +252379,7 @@
       "source_location": "L33"
     },
     {
-      "community": 506,
+      "community": 508,
       "file_type": "code",
       "id": "login_layout_sleep",
       "label": "sleep()",
@@ -252256,7 +252388,7 @@
       "source_location": "L29"
     },
     {
-      "community": 506,
+      "community": 508,
       "file_type": "code",
       "id": "login_layout_usedocumentscrolllock",
       "label": "useDocumentScrollLock()",
@@ -252265,7 +252397,7 @@
       "source_location": "L45"
     },
     {
-      "community": 506,
+      "community": 508,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_login_layout_tsx",
       "label": "-login-layout.tsx",
@@ -252274,7 +252406,7 @@
       "source_location": "L1"
     },
     {
-      "community": 507,
+      "community": 509,
       "file_type": "code",
       "id": "organizationsettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -252283,7 +252415,7 @@
       "source_location": "L155"
     },
     {
-      "community": 507,
+      "community": 509,
       "file_type": "code",
       "id": "organizationsettingsview_navigation",
       "label": "Navigation()",
@@ -252292,7 +252424,7 @@
       "source_location": "L197"
     },
     {
-      "community": 507,
+      "community": 509,
       "file_type": "code",
       "id": "organizationsettingsview_onsubmit",
       "label": "onSubmit()",
@@ -252301,7 +252433,7 @@
       "source_location": "L104"
     },
     {
-      "community": 507,
+      "community": 509,
       "file_type": "code",
       "id": "organizationsettingsview_organizationsettings",
       "label": "OrganizationSettings()",
@@ -252310,7 +252442,7 @@
       "source_location": "L25"
     },
     {
-      "community": 507,
+      "community": 509,
       "file_type": "code",
       "id": "organizationsettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -252319,120 +252451,12 @@
       "source_location": "L72"
     },
     {
-      "community": 507,
+      "community": 509,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
       "label": "OrganizationSettingsView.tsx",
       "norm_label": "organizationsettingsview.tsx",
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 508,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
-      "label": "StoreSettingsView.tsx",
-      "norm_label": "storesettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 508,
-      "file_type": "code",
-      "id": "storesettingsview_handledeleteallproductsinstore",
-      "label": "handleDeleteAllProductsInStore()",
-      "norm_label": "handledeleteallproductsinstore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L231"
-    },
-    {
-      "community": 508,
-      "file_type": "code",
-      "id": "storesettingsview_handledeletestore",
-      "label": "handleDeleteStore()",
-      "norm_label": "handledeletestore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L167"
-    },
-    {
-      "community": 508,
-      "file_type": "code",
-      "id": "storesettingsview_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L116"
-    },
-    {
-      "community": 508,
-      "file_type": "code",
-      "id": "storesettingsview_savestorechanges",
-      "label": "saveStoreChanges()",
-      "norm_label": "savestorechanges()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L83"
-    },
-    {
-      "community": 508,
-      "file_type": "code",
-      "id": "storesettingsview_storesettings",
-      "label": "StoreSettings()",
-      "norm_label": "storesettings()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L29"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "devfixtureactivation_usedailyclosefixture",
-      "label": "useDailyCloseFixture()",
-      "norm_label": "usedailyclosefixture()",
-      "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "devfixtureactivation_usedailyopeningfixture",
-      "label": "useDailyOpeningFixture()",
-      "norm_label": "usedailyopeningfixture()",
-      "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "devfixtureactivation_usedailyoperationsfixture",
-      "label": "useDailyOperationsFixture()",
-      "norm_label": "usedailyoperationsfixture()",
-      "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "devfixtureactivation_useposhubfixture",
-      "label": "usePosHubFixture()",
-      "norm_label": "useposhubfixture()",
-      "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
-      "source_location": "L108"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "devfixtureactivation_useworkspacefixture",
-      "label": "useWorkspaceFixture()",
-      "norm_label": "useworkspacefixture()",
-      "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_operations_devfixtureactivation_ts",
-      "label": "devFixtureActivation.ts",
-      "norm_label": "devfixtureactivation.ts",
-      "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
       "source_location": "L1"
     },
     {
@@ -252699,6 +252723,114 @@
     {
       "community": 510,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
+      "label": "StoreSettingsView.tsx",
+      "norm_label": "storesettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "storesettingsview_handledeleteallproductsinstore",
+      "label": "handleDeleteAllProductsInStore()",
+      "norm_label": "handledeleteallproductsinstore()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L231"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "storesettingsview_handledeletestore",
+      "label": "handleDeleteStore()",
+      "norm_label": "handledeletestore()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "storesettingsview_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L116"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "storesettingsview_savestorechanges",
+      "label": "saveStoreChanges()",
+      "norm_label": "savestorechanges()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L83"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "storesettingsview_storesettings",
+      "label": "StoreSettings()",
+      "norm_label": "storesettings()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L29"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
+      "id": "devfixtureactivation_usedailyclosefixture",
+      "label": "useDailyCloseFixture()",
+      "norm_label": "usedailyclosefixture()",
+      "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
+      "source_location": "L102"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
+      "id": "devfixtureactivation_usedailyopeningfixture",
+      "label": "useDailyOpeningFixture()",
+      "norm_label": "usedailyopeningfixture()",
+      "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
+      "id": "devfixtureactivation_usedailyoperationsfixture",
+      "label": "useDailyOperationsFixture()",
+      "norm_label": "usedailyoperationsfixture()",
+      "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
+      "id": "devfixtureactivation_useposhubfixture",
+      "label": "usePosHubFixture()",
+      "norm_label": "useposhubfixture()",
+      "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
+      "source_location": "L108"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
+      "id": "devfixtureactivation_useworkspacefixture",
+      "label": "useWorkspaceFixture()",
+      "norm_label": "useworkspacefixture()",
+      "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_operations_devfixtureactivation_ts",
+      "label": "devFixtureActivation.ts",
+      "norm_label": "devfixtureactivation.ts",
+      "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 512,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
       "label": "storybook-shell.tsx",
       "norm_label": "storybook-shell.tsx",
@@ -252706,7 +252838,7 @@
       "source_location": "L1"
     },
     {
-      "community": 510,
+      "community": 512,
       "file_type": "code",
       "id": "storybook_shell_storybookcallout",
       "label": "StorybookCallout()",
@@ -252715,7 +252847,7 @@
       "source_location": "L76"
     },
     {
-      "community": 510,
+      "community": 512,
       "file_type": "code",
       "id": "storybook_shell_storybooklist",
       "label": "StorybookList()",
@@ -252724,7 +252856,7 @@
       "source_location": "L55"
     },
     {
-      "community": 510,
+      "community": 512,
       "file_type": "code",
       "id": "storybook_shell_storybookpillrow",
       "label": "StorybookPillRow()",
@@ -252733,7 +252865,7 @@
       "source_location": "L88"
     },
     {
-      "community": 510,
+      "community": 512,
       "file_type": "code",
       "id": "storybook_shell_storybooksection",
       "label": "StorybookSection()",
@@ -252742,7 +252874,7 @@
       "source_location": "L34"
     },
     {
-      "community": 510,
+      "community": 512,
       "file_type": "code",
       "id": "storybook_shell_storybookshell",
       "label": "StorybookShell()",
@@ -252751,7 +252883,7 @@
       "source_location": "L13"
     },
     {
-      "community": 511,
+      "community": 513,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_postransaction_ts",
       "label": "posTransaction.ts",
@@ -252760,7 +252892,7 @@
       "source_location": "L1"
     },
     {
-      "community": 511,
+      "community": 513,
       "file_type": "code",
       "id": "postransaction_fetchpostransaction",
       "label": "fetchPosTransaction()",
@@ -252769,7 +252901,7 @@
       "source_location": "L69"
     },
     {
-      "community": 511,
+      "community": 513,
       "file_type": "code",
       "id": "postransaction_getbaseurl",
       "label": "getBaseUrl()",
@@ -252778,7 +252910,7 @@
       "source_location": "L57"
     },
     {
-      "community": 511,
+      "community": 513,
       "file_type": "code",
       "id": "postransaction_getpostransactionbyreceipttoken",
       "label": "getPosTransactionByReceiptToken()",
@@ -252787,7 +252919,7 @@
       "source_location": "L90"
     },
     {
-      "community": 511,
+      "community": 513,
       "file_type": "code",
       "id": "postransaction_postransactionreceipterror",
       "label": "PosTransactionReceiptError",
@@ -252796,7 +252928,7 @@
       "source_location": "L59"
     },
     {
-      "community": 511,
+      "community": 513,
       "file_type": "code",
       "id": "postransaction_postransactionreceipterror_constructor",
       "label": ".constructor()",
@@ -252805,7 +252937,7 @@
       "source_location": "L62"
     },
     {
-      "community": 512,
+      "community": 514,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_promocodes_ts",
       "label": "promoCodes.ts",
@@ -252814,7 +252946,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 514,
       "file_type": "code",
       "id": "promocodes_getbaseurl",
       "label": "getBaseUrl()",
@@ -252823,7 +252955,7 @@
       "source_location": "L4"
     },
     {
-      "community": 512,
+      "community": 514,
       "file_type": "code",
       "id": "promocodes_getpromocodeitems",
       "label": "getPromoCodeItems()",
@@ -252832,7 +252964,7 @@
       "source_location": "L49"
     },
     {
-      "community": 512,
+      "community": 514,
       "file_type": "code",
       "id": "promocodes_getpromocodes",
       "label": "getPromoCodes()",
@@ -252841,7 +252973,7 @@
       "source_location": "L34"
     },
     {
-      "community": 512,
+      "community": 514,
       "file_type": "code",
       "id": "promocodes_getredeemedpromocodes",
       "label": "getRedeemedPromoCodes()",
@@ -252850,7 +252982,7 @@
       "source_location": "L74"
     },
     {
-      "community": 512,
+      "community": 514,
       "file_type": "code",
       "id": "promocodes_redeempromocode",
       "label": "redeemPromoCode()",
@@ -252859,7 +252991,7 @@
       "source_location": "L6"
     },
     {
-      "community": 513,
+      "community": 515,
       "file_type": "code",
       "id": "billingdetails_clearform",
       "label": "clearForm()",
@@ -252868,7 +253000,7 @@
       "source_location": "L173"
     },
     {
-      "community": 513,
+      "community": 515,
       "file_type": "code",
       "id": "billingdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -252877,7 +253009,7 @@
       "source_location": "L102"
     },
     {
-      "community": 513,
+      "community": 515,
       "file_type": "code",
       "id": "billingdetails_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -252886,7 +253018,7 @@
       "source_location": "L201"
     },
     {
-      "community": 513,
+      "community": 515,
       "file_type": "code",
       "id": "billingdetails_onsubmit",
       "label": "onSubmit()",
@@ -252895,7 +253027,7 @@
       "source_location": "L150"
     },
     {
-      "community": 513,
+      "community": 515,
       "file_type": "code",
       "id": "billingdetails_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -252904,7 +253036,7 @@
       "source_location": "L155"
     },
     {
-      "community": 513,
+      "community": 515,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
       "label": "BillingDetails.tsx",
@@ -252913,7 +253045,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 516,
       "file_type": "code",
       "id": "homehero_test_attachmedia",
       "label": "attachMedia()",
@@ -252922,7 +253054,7 @@
       "source_location": "L22"
     },
     {
-      "community": 514,
+      "community": 516,
       "file_type": "code",
       "id": "homehero_test_destroy",
       "label": "destroy()",
@@ -252931,7 +253063,7 @@
       "source_location": "L24"
     },
     {
-      "community": 514,
+      "community": 516,
       "file_type": "code",
       "id": "homehero_test_issupported",
       "label": "isSupported()",
@@ -252940,7 +253072,7 @@
       "source_location": "L18"
     },
     {
-      "community": 514,
+      "community": 516,
       "file_type": "code",
       "id": "homehero_test_loadsource",
       "label": "loadSource()",
@@ -252949,7 +253081,7 @@
       "source_location": "L21"
     },
     {
-      "community": 514,
+      "community": 516,
       "file_type": "code",
       "id": "homehero_test_on",
       "label": "on()",
@@ -252958,7 +253090,7 @@
       "source_location": "L23"
     },
     {
-      "community": 514,
+      "community": 516,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homehero_test_tsx",
       "label": "HomeHero.test.tsx",
@@ -252967,7 +253099,7 @@
       "source_location": "L1"
     },
     {
-      "community": 515,
+      "community": 517,
       "file_type": "code",
       "id": "mobileproductactions_collapseonpageclick",
       "label": "collapseOnPageClick()",
@@ -252976,7 +253108,7 @@
       "source_location": "L76"
     },
     {
-      "community": 515,
+      "community": 517,
       "file_type": "code",
       "id": "mobileproductactions_handleconfirm",
       "label": "handleConfirm()",
@@ -252985,7 +253117,7 @@
       "source_location": "L120"
     },
     {
-      "community": 515,
+      "community": 517,
       "file_type": "code",
       "id": "mobileproductactions_handleprimaryaction",
       "label": "handlePrimaryAction()",
@@ -252994,7 +253126,7 @@
       "source_location": "L129"
     },
     {
-      "community": 515,
+      "community": 517,
       "file_type": "code",
       "id": "mobileproductactions_handlesecondaryaction",
       "label": "handleSecondaryAction()",
@@ -253003,7 +253135,7 @@
       "source_location": "L133"
     },
     {
-      "community": 515,
+      "community": 517,
       "file_type": "code",
       "id": "mobileproductactions_updateposition",
       "label": "updatePosition()",
@@ -253012,7 +253144,7 @@
       "source_location": "L44"
     },
     {
-      "community": 515,
+      "community": 517,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
       "label": "MobileProductActions.tsx",
@@ -253021,7 +253153,7 @@
       "source_location": "L1"
     },
     {
-      "community": 516,
+      "community": 518,
       "file_type": "code",
       "id": "checkoutexpired_checkoutexpired",
       "label": "CheckoutExpired()",
@@ -253030,7 +253162,7 @@
       "source_location": "L9"
     },
     {
-      "community": 516,
+      "community": 518,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessiongeneric",
       "label": "CheckoutSessionGeneric()",
@@ -253039,7 +253171,7 @@
       "source_location": "L73"
     },
     {
-      "community": 516,
+      "community": 518,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessionnotfound",
       "label": "CheckoutSessionNotFound()",
@@ -253048,7 +253180,7 @@
       "source_location": "L54"
     },
     {
-      "community": 516,
+      "community": 518,
       "file_type": "code",
       "id": "checkoutexpired_handlesendemail",
       "label": "handleSendEmail()",
@@ -253057,7 +253189,7 @@
       "source_location": "L98"
     },
     {
-      "community": 516,
+      "community": 518,
       "file_type": "code",
       "id": "checkoutexpired_nocheckoutsession",
       "label": "NoCheckoutSession()",
@@ -253066,7 +253198,7 @@
       "source_location": "L33"
     },
     {
-      "community": 516,
+      "community": 518,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
       "label": "CheckoutExpired.tsx",
@@ -253075,61 +253207,7 @@
       "source_location": "L1"
     },
     {
-      "community": 517,
-      "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L101"
-    },
-    {
-      "community": 517,
-      "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 517,
-      "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 517,
-      "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 517,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 517,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "feeutils_getremainingforfreedelivery",
       "label": "getRemainingForFreeDelivery()",
@@ -253138,7 +253216,7 @@
       "source_location": "L138"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "feeutils_haswaiverconfigured",
       "label": "hasWaiverConfigured()",
@@ -253147,7 +253225,7 @@
       "source_location": "L100"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "feeutils_isanyfeewaived",
       "label": "isAnyFeeWaived()",
@@ -253156,7 +253234,7 @@
       "source_location": "L74"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "feeutils_isfeewaived",
       "label": "isFeeWaived()",
@@ -253165,7 +253243,7 @@
       "source_location": "L34"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "feeutils_meetsthreshold",
       "label": "meetsThreshold()",
@@ -253174,66 +253252,12 @@
       "source_location": "L17"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_feeutils_ts",
       "label": "feeUtils.ts",
       "norm_label": "feeutils.ts",
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "auth_verify_formattime",
-      "label": "formatTime()",
-      "norm_label": "formattime()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L149"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "auth_verify_handlecodechange",
-      "label": "handleCodeChange()",
-      "norm_label": "handlecodechange()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L156"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "auth_verify_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L201"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "auth_verify_reportauthfailure",
-      "label": "reportAuthFailure()",
-      "norm_label": "reportauthfailure()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L93"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "auth_verify_resendverificationcode",
-      "label": "resendVerificationCode()",
-      "norm_label": "resendverificationcode()",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L282"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_auth_verify_tsx",
-      "label": "auth.verify.tsx",
-      "norm_label": "auth.verify.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L1"
     },
     {
@@ -253500,6 +253524,60 @@
     {
       "community": 520,
       "file_type": "code",
+      "id": "auth_verify_formattime",
+      "label": "formatTime()",
+      "norm_label": "formattime()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L149"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "auth_verify_handlecodechange",
+      "label": "handleCodeChange()",
+      "norm_label": "handlecodechange()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L156"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "auth_verify_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L201"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "auth_verify_reportauthfailure",
+      "label": "reportAuthFailure()",
+      "norm_label": "reportauthfailure()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L93"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "auth_verify_resendverificationcode",
+      "label": "resendVerificationCode()",
+      "norm_label": "resendverificationcode()",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L282"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_auth_verify_tsx",
+      "label": "auth.verify.tsx",
+      "norm_label": "auth.verify.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
       "id": "coverage_summary_test_coveragesummary",
       "label": "coverageSummary()",
       "norm_label": "coveragesummary()",
@@ -253507,7 +253585,7 @@
       "source_location": "L27"
     },
     {
-      "community": 520,
+      "community": 521,
       "file_type": "code",
       "id": "coverage_summary_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -253516,7 +253594,7 @@
       "source_location": "L15"
     },
     {
-      "community": 520,
+      "community": 521,
       "file_type": "code",
       "id": "coverage_summary_test_write",
       "label": "write()",
@@ -253525,7 +253603,7 @@
       "source_location": "L21"
     },
     {
-      "community": 520,
+      "community": 521,
       "file_type": "code",
       "id": "coverage_summary_test_writepackagesummaries",
       "label": "writePackageSummaries()",
@@ -253534,7 +253612,7 @@
       "source_location": "L38"
     },
     {
-      "community": 520,
+      "community": 521,
       "file_type": "code",
       "id": "coverage_summary_test_writerealbaselinesummaries",
       "label": "writeRealBaselineSummaries()",
@@ -253543,7 +253621,7 @@
       "source_location": "L54"
     },
     {
-      "community": 520,
+      "community": 521,
       "file_type": "code",
       "id": "scripts_coverage_summary_test_ts",
       "label": "coverage-summary.test.ts",
@@ -253552,7 +253630,7 @@
       "source_location": "L1"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "delivery_documentation_check_assertdeliverydocumentationcheck",
       "label": "assertDeliveryDocumentationCheck()",
@@ -253561,7 +253639,7 @@
       "source_location": "L29"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "delivery_documentation_check_changedfiles",
       "label": "changedFiles()",
@@ -253570,7 +253648,7 @@
       "source_location": "L102"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "delivery_documentation_check_findingsfrom",
       "label": "findingsFrom()",
@@ -253579,7 +253657,7 @@
       "source_location": "L22"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "delivery_documentation_check_ispolicyfailure",
       "label": "isPolicyFailure()",
@@ -253588,7 +253666,7 @@
       "source_location": "L70"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "delivery_documentation_check_parseargs",
       "label": "parseArgs()",
@@ -253597,7 +253675,7 @@
       "source_location": "L74"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "scripts_delivery_documentation_check_ts",
       "label": "delivery-documentation-check.ts",
@@ -253606,7 +253684,7 @@
       "source_location": "L1"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "docs_solution_link_check_assertdocslinks",
       "label": "assertDocsLinks()",
@@ -253615,7 +253693,7 @@
       "source_location": "L148"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "docs_solution_link_check_classifylink",
       "label": "classifyLink()",
@@ -253624,7 +253702,7 @@
       "source_location": "L49"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "docs_solution_link_check_collectdocslinkfindings",
       "label": "collectDocsLinkFindings()",
@@ -253633,7 +253711,7 @@
       "source_location": "L85"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "docs_solution_link_check_collectsolutionslugs",
       "label": "collectSolutionSlugs()",
@@ -253642,7 +253720,7 @@
       "source_location": "L36"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "docs_solution_link_check_solutionsroot",
       "label": "solutionsRoot()",
@@ -253651,7 +253729,7 @@
       "source_location": "L31"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "scripts_docs_solution_link_check_ts",
       "label": "docs-solution-link-check.ts",
@@ -253660,7 +253738,7 @@
       "source_location": "L1"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "graphify_check_collectrepocodefiles",
       "label": "collectRepoCodeFiles()",
@@ -253669,7 +253747,7 @@
       "source_location": "L73"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "graphify_check_collectstalegraphifyartifacts",
       "label": "collectStaleGraphifyArtifacts()",
@@ -253678,7 +253756,7 @@
       "source_location": "L125"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "graphify_check_copygraphifycheckinputs",
       "label": "copyGraphifyCheckInputs()",
@@ -253687,7 +253765,7 @@
       "source_location": "L107"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "graphify_check_fileexists",
       "label": "fileExists()",
@@ -253696,7 +253774,7 @@
       "source_location": "L64"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "graphify_check_rungraphifycheck",
       "label": "runGraphifyCheck()",
@@ -253705,7 +253783,7 @@
       "source_location": "L152"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "scripts_graphify_check_ts",
       "label": "graphify-check.ts",
@@ -253714,7 +253792,7 @@
       "source_location": "L1"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "harness_inferential_review_test_commitfixturerepo",
       "label": "commitFixtureRepo()",
@@ -253723,7 +253801,7 @@
       "source_location": "L169"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "harness_inferential_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -253732,7 +253810,7 @@
       "source_location": "L66"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "harness_inferential_review_test_gitfixtureenv",
       "label": "gitFixtureEnv()",
@@ -253741,7 +253819,7 @@
       "source_location": "L60"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "harness_inferential_review_test_runfixturecommand",
       "label": "runFixtureCommand()",
@@ -253750,7 +253828,7 @@
       "source_location": "L22"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "harness_inferential_review_test_write",
       "label": "write()",
@@ -253759,7 +253837,7 @@
       "source_location": "L16"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "scripts_harness_inferential_review_test_ts",
       "label": "harness-inferential-review.test.ts",
@@ -253768,7 +253846,7 @@
       "source_location": "L1"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "harness_repo_validation_collectharnessrepovalidationcapabilities",
       "label": "collectHarnessRepoValidationCapabilities()",
@@ -253777,7 +253855,7 @@
       "source_location": "L73"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "harness_repo_validation_collectharnessrepovalidationselection",
       "label": "collectHarnessRepoValidationSelection()",
@@ -253786,7 +253864,7 @@
       "source_location": "L50"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "harness_repo_validation_matchesharnessrepovalidationpath",
       "label": "matchesHarnessRepoValidationPath()",
@@ -253795,7 +253873,7 @@
       "source_location": "L42"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "harness_repo_validation_normalizerepopath",
       "label": "normalizeRepoPath()",
@@ -253804,7 +253882,7 @@
       "source_location": "L32"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "harness_repo_validation_sortuniquepaths",
       "label": "sortUniquePaths()",
@@ -253813,7 +253891,7 @@
       "source_location": "L36"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_ts",
       "label": "harness-repo-validation.ts",
@@ -253822,7 +253900,7 @@
       "source_location": "L1"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "pre_push_validation_proof_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -253831,7 +253909,7 @@
       "source_location": "L20"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "pre_push_validation_proof_test_createspawn",
       "label": "createSpawn()",
@@ -253840,7 +253918,7 @@
       "source_location": "L63"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "pre_push_validation_proof_test_log",
       "label": "log()",
@@ -253849,7 +253927,7 @@
       "source_location": "L147"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "pre_push_validation_proof_test_warn",
       "label": "warn()",
@@ -253858,7 +253936,7 @@
       "source_location": "L287"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "pre_push_validation_proof_test_write",
       "label": "write()",
@@ -253867,7 +253945,7 @@
       "source_location": "L14"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "scripts_pre_push_validation_proof_test_ts",
       "label": "pre-push-validation-proof.test.ts",
@@ -253876,7 +253954,7 @@
       "source_location": "L1"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "scripts_validate_plan_html_ts",
       "label": "validate-plan-html.ts",
@@ -253885,7 +253963,7 @@
       "source_location": "L1"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "validate_plan_html_collectdefaultplanhtmlfiles",
       "label": "collectDefaultPlanHtmlFiles()",
@@ -253894,7 +253972,7 @@
       "source_location": "L16"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "validate_plan_html_collectplanhtmlfindings",
       "label": "collectPlanHtmlFindings()",
@@ -253903,7 +253981,7 @@
       "source_location": "L31"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "validate_plan_html_hasremotereference",
       "label": "hasRemoteReference()",
@@ -253912,7 +253990,7 @@
       "source_location": "L27"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "validate_plan_html_normalizerepopath",
       "label": "normalizeRepoPath()",
@@ -253921,7 +253999,7 @@
       "source_location": "L12"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "validate_plan_html_runplanhtmlvalidation",
       "label": "runPlanHtmlValidation()",
@@ -253930,7 +254008,7 @@
       "source_location": "L119"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "closeouts_test_createcloseoutmappingholdctx",
       "label": "createCloseoutMappingHoldCtx()",
@@ -253939,7 +254017,7 @@
       "source_location": "L32"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "closeouts_test_creatependingitemadjustmentapprovalctx",
       "label": "createPendingItemAdjustmentApprovalCtx()",
@@ -253948,7 +254026,7 @@
       "source_location": "L184"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "closeouts_test_gethandler",
       "label": "getHandler()",
@@ -253957,7 +254035,7 @@
       "source_location": "L28"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "closeouts_test_getsource",
       "label": "getSource()",
@@ -253966,58 +254044,13 @@
       "source_location": "L24"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_closeouts_test_ts",
       "label": "closeouts.test.ts",
       "norm_label": "closeouts.test.ts",
       "source_file": "packages/athena-webapp/convex/cashControls/closeouts.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
-      "label": "paymentAllocationAttribution.ts",
-      "norm_label": "paymentallocationattribution.ts",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "paymentallocationattribution_buildinstorepaymentallocations",
-      "label": "buildInStorePaymentAllocations()",
-      "norm_label": "buildinstorepaymentallocations()",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "paymentallocationattribution_normalizeinstorepayments",
-      "label": "normalizeInStorePayments()",
-      "norm_label": "normalizeinstorepayments()",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L22"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "paymentallocationattribution_resolveregistersessionforinstorecollectionwithctx",
-      "label": "resolveRegisterSessionForInStoreCollectionWithCtx()",
-      "norm_label": "resolveregistersessionforinstorecollectionwithctx()",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L124"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "paymentallocationattribution_selectregistersessionforattribution",
-      "label": "selectRegisterSessionForAttribution()",
-      "norm_label": "selectregistersessionforattribution()",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
-      "source_location": "L87"
     },
     {
       "community": 53,
@@ -254274,6 +254307,51 @@
     {
       "community": 530,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
+      "label": "paymentAllocationAttribution.ts",
+      "norm_label": "paymentallocationattribution.ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "paymentallocationattribution_buildinstorepaymentallocations",
+      "label": "buildInStorePaymentAllocations()",
+      "norm_label": "buildinstorepaymentallocations()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "paymentallocationattribution_normalizeinstorepayments",
+      "label": "normalizeInStorePayments()",
+      "norm_label": "normalizeinstorepayments()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L22"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "paymentallocationattribution_resolveregistersessionforinstorecollectionwithctx",
+      "label": "resolveRegisterSessionForInStoreCollectionWithCtx()",
+      "norm_label": "resolveregistersessionforinstorecollectionwithctx()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L124"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "paymentallocationattribution_selectregistersessionforattribution",
+      "label": "selectRegisterSessionForAttribution()",
+      "norm_label": "selectregistersessionforattribution()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_registersessionactivity_test_ts",
       "label": "registerSessionActivity.test.ts",
       "norm_label": "registersessionactivity.test.ts",
@@ -254281,7 +254359,7 @@
       "source_location": "L1"
     },
     {
-      "community": 530,
+      "community": 531,
       "file_type": "code",
       "id": "registersessionactivity_test_admissionawareauthimplementation",
       "label": "admissionAwareAuthImplementation()",
@@ -254290,7 +254368,7 @@
       "source_location": "L218"
     },
     {
-      "community": 530,
+      "community": 531,
       "file_type": "code",
       "id": "registersessionactivity_test_baseevent",
       "label": "baseEvent()",
@@ -254299,7 +254377,7 @@
       "source_location": "L27"
     },
     {
-      "community": 530,
+      "community": 531,
       "file_type": "code",
       "id": "registersessionactivity_test_basemapping",
       "label": "baseMapping()",
@@ -254308,7 +254386,7 @@
       "source_location": "L58"
     },
     {
-      "community": 530,
+      "community": 531,
       "file_type": "code",
       "id": "registersessionactivity_test_gethandler",
       "label": "getHandler()",
@@ -254317,7 +254395,7 @@
       "source_location": "L22"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_registersessiontracelifecycle_test_ts",
       "label": "registerSessionTraceLifecycle.test.ts",
@@ -254326,7 +254404,7 @@
       "source_location": "L1"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_buildapprovalproof",
       "label": "buildApprovalProof()",
@@ -254335,7 +254413,7 @@
       "source_location": "L382"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -254344,7 +254422,7 @@
       "source_location": "L106"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -254353,7 +254431,7 @@
       "source_location": "L122"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_gethandler",
       "label": "getHandler()",
@@ -254362,7 +254440,7 @@
       "source_location": "L401"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "homepagesnapshot_isdisplayablemarker",
       "label": "isDisplayableMarker()",
@@ -254371,7 +254449,7 @@
       "source_location": "L29"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "homepagesnapshot_presentsnapshotatrequesttime",
       "label": "presentSnapshotAtRequestTime()",
@@ -254380,7 +254458,7 @@
       "source_location": "L33"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "homepagesnapshot_resolvehomepagesnapshotbootstrap",
       "label": "resolveHomepageSnapshotBootstrap()",
@@ -254389,7 +254467,7 @@
       "source_location": "L53"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "homepagesnapshot_setbootstrapcookie",
       "label": "setBootstrapCookie()",
@@ -254398,7 +254476,7 @@
       "source_location": "L124"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_homepagesnapshot_ts",
       "label": "homepageSnapshot.ts",
@@ -254407,7 +254485,7 @@
       "source_location": "L1"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "lifecycle_assertartifacttransition",
       "label": "assertArtifactTransition()",
@@ -254416,7 +254494,7 @@
       "source_location": "L59"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "lifecycle_assertruntransition",
       "label": "assertRunTransition()",
@@ -254425,7 +254503,7 @@
       "source_location": "L43"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "lifecycle_cantransitionartifact",
       "label": "canTransitionArtifact()",
@@ -254434,7 +254512,7 @@
       "source_location": "L52"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "lifecycle_cantransitionrun",
       "label": "canTransitionRun()",
@@ -254443,7 +254521,7 @@
       "source_location": "L36"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_intelligence_lifecycle_ts",
       "label": "lifecycle.ts",
@@ -254452,7 +254530,7 @@
       "source_location": "L1"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_intelligence_providers_tanstack_ts",
       "label": "tanstack.ts",
@@ -254461,7 +254539,7 @@
       "source_location": "L1"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "tanstack_createtanstackstructuredtextprovider",
       "label": "createTanStackStructuredTextProvider()",
@@ -254470,7 +254548,7 @@
       "source_location": "L41"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "tanstack_extractstructuredoutput",
       "label": "extractStructuredOutput()",
@@ -254479,7 +254557,7 @@
       "source_location": "L134"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "tanstack_loadopenaiadapter",
       "label": "loadOpenAiAdapter()",
@@ -254488,7 +254566,7 @@
       "source_location": "L147"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "tanstack_loadtanstackai",
       "label": "loadTanStackAi()",
@@ -254497,7 +254575,7 @@
       "source_location": "L143"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "featureditem_countfeaturedtargets",
       "label": "countFeaturedTargets()",
@@ -254506,7 +254584,7 @@
       "source_location": "L43"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "featureditem_getnextfeatureditemrank",
       "label": "getNextFeaturedItemRank()",
@@ -254515,7 +254593,7 @@
       "source_location": "L103"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "featureditem_requirehomepagestoreadmin",
       "label": "requireHomepageStoreAdmin()",
@@ -254524,7 +254602,7 @@
       "source_location": "L23"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "featureditem_validatefeaturedplacement",
       "label": "validateFeaturedPlacement()",
@@ -254533,7 +254611,7 @@
       "source_location": "L52"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -254542,7 +254620,7 @@
       "source_location": "L1"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "expensesessionvalidation_validateexpenseitembelongstosession",
       "label": "validateExpenseItemBelongsToSession()",
@@ -254551,7 +254629,7 @@
       "source_location": "L114"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "expensesessionvalidation_validateexpensesessionactive",
       "label": "validateExpenseSessionActive()",
@@ -254560,7 +254638,7 @@
       "source_location": "L39"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "expensesessionvalidation_validateexpensesessionexists",
       "label": "validateExpenseSessionExists()",
@@ -254569,7 +254647,7 @@
       "source_location": "L19"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "expensesessionvalidation_validateexpensesessionmodifiable",
       "label": "validateExpenseSessionModifiable()",
@@ -254578,7 +254656,7 @@
       "source_location": "L81"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionvalidation_ts",
       "label": "expenseSessionValidation.ts",
@@ -254587,7 +254665,7 @@
       "source_location": "L1"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "commerceeffects_applycommerceinventoryeffectwithctx",
       "label": "applyCommerceInventoryEffectWithCtx()",
@@ -254596,7 +254674,7 @@
       "source_location": "L152"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "commerceeffects_outboundbasisfromeffect",
       "label": "outboundBasisFromEffect()",
@@ -254605,7 +254683,7 @@
       "source_location": "L79"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "commerceeffects_reportinglinecostfromeffect",
       "label": "reportingLineCostFromEffect()",
@@ -254614,7 +254692,7 @@
       "source_location": "L116"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "commerceeffects_uncostedoutboundbasis",
       "label": "uncostedOutboundBasis()",
@@ -254623,7 +254701,7 @@
       "source_location": "L64"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventoryledger_commerceeffects_ts",
       "label": "commerceEffects.ts",
@@ -254632,7 +254710,7 @@
       "source_location": "L1"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "deficitresolutionwork_allocatedeferreddeficitcost",
       "label": "allocateDeferredDeficitCost()",
@@ -254641,7 +254719,7 @@
       "source_location": "L25"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "deficitresolutionwork_enqueuedeficitresolutionworkwithctx",
       "label": "enqueueDeficitResolutionWorkWithCtx()",
@@ -254650,7 +254728,7 @@
       "source_location": "L46"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "deficitresolutionwork_historicalcostlane",
       "label": "historicalCostLane()",
@@ -254659,7 +254737,7 @@
       "source_location": "L19"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "deficitresolutionwork_materializedeferredadjustmentwithctx",
       "label": "materializeDeferredAdjustmentWithCtx()",
@@ -254668,57 +254746,12 @@
       "source_location": "L107"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventoryledger_deficitresolutionwork_ts",
       "label": "deficitResolutionWork.ts",
       "norm_label": "deficitresolutionwork.ts",
       "source_file": "packages/athena-webapp/convex/inventoryLedger/deficitResolutionWork.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "currency_formatstoredamount",
-      "label": "formatStoredAmount()",
-      "norm_label": "formatstoredamount()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "currency_todisplayamount",
-      "label": "toDisplayAmount()",
-      "norm_label": "todisplayamount()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "currency_topesewas",
-      "label": "toPesewas()",
-      "norm_label": "topesewas()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
       "source_location": "L1"
     },
     {
@@ -254967,6 +255000,51 @@
     {
       "community": 540,
       "file_type": "code",
+      "id": "currency_formatstoredamount",
+      "label": "formatStoredAmount()",
+      "norm_label": "formatstoredamount()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "currency_todisplayamount",
+      "label": "toDisplayAmount()",
+      "norm_label": "todisplayamount()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "currency_topesewas",
+      "label": "toPesewas()",
+      "norm_label": "topesewas()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_marketing_walkthroughrequestnotifications_ts",
       "label": "walkthroughRequestNotifications.ts",
       "norm_label": "walkthroughrequestnotifications.ts",
@@ -254974,7 +255052,7 @@
       "source_location": "L1"
     },
     {
-      "community": 540,
+      "community": 541,
       "file_type": "code",
       "id": "walkthroughrequestnotifications_boundedauditvalue",
       "label": "boundedAuditValue()",
@@ -254983,7 +255061,7 @@
       "source_location": "L27"
     },
     {
-      "community": 540,
+      "community": 541,
       "file_type": "code",
       "id": "walkthroughrequestnotifications_classifydeliveryresult",
       "label": "classifyDeliveryResult()",
@@ -254992,7 +255070,7 @@
       "source_location": "L13"
     },
     {
-      "community": 540,
+      "community": 541,
       "file_type": "code",
       "id": "walkthroughrequestnotifications_isdeliberateretryeligible",
       "label": "isDeliberateRetryEligible()",
@@ -255001,7 +255079,7 @@
       "source_location": "L20"
     },
     {
-      "community": 540,
+      "community": 541,
       "file_type": "code",
       "id": "walkthroughrequestnotifications_nextbackoffms",
       "label": "nextBackoffMs()",
@@ -255010,7 +255088,7 @@
       "source_location": "L12"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "backfillreportingcyclestart_test_createctx",
       "label": "createCtx()",
@@ -255019,7 +255097,7 @@
       "source_location": "L80"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "backfillreportingcyclestart_test_createstoreverificationctx",
       "label": "createStoreVerificationCtx()",
@@ -255028,7 +255106,7 @@
       "source_location": "L29"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "backfillreportingcyclestart_test_finishbackfill",
       "label": "finishBackfill()",
@@ -255037,7 +255115,7 @@
       "source_location": "L118"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "backfillreportingcyclestart_test_finishverification",
       "label": "finishVerification()",
@@ -255046,7 +255124,7 @@
       "source_location": "L139"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_backfillreportingcyclestart_test_ts",
       "label": "backfillReportingCycleStart.test.ts",
@@ -255055,7 +255133,7 @@
       "source_location": "L1"
     },
     {
-      "community": 542,
+      "community": 543,
       "file_type": "code",
       "id": "backfillstoretimezoneauthority_backfillstoretimezoneauthoritywithctx",
       "label": "backfillStoreTimezoneAuthorityWithCtx()",
@@ -255064,7 +255142,7 @@
       "source_location": "L127"
     },
     {
-      "community": 542,
+      "community": 543,
       "file_type": "code",
       "id": "backfillstoretimezoneauthority_buildrow",
       "label": "buildRow()",
@@ -255073,7 +255151,7 @@
       "source_location": "L47"
     },
     {
-      "community": 542,
+      "community": 543,
       "file_type": "code",
       "id": "backfillstoretimezoneauthority_listschedulesforstore",
       "label": "listSchedulesForStore()",
@@ -255082,7 +255160,7 @@
       "source_location": "L35"
     },
     {
-      "community": 542,
+      "community": 543,
       "file_type": "code",
       "id": "backfillstoretimezoneauthority_normalizelimit",
       "label": "normalizeLimit()",
@@ -255091,7 +255169,7 @@
       "source_location": "L28"
     },
     {
-      "community": 542,
+      "community": 543,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_backfillstoretimezoneauthority_ts",
       "label": "backfillStoreTimezoneAuthority.ts",
@@ -255100,7 +255178,7 @@
       "source_location": "L1"
     },
     {
-      "community": 543,
+      "community": 544,
       "file_type": "code",
       "id": "dispatch_recordnotificationfailureeventwithctx",
       "label": "recordNotificationFailureEventWithCtx()",
@@ -255109,7 +255187,7 @@
       "source_location": "L400"
     },
     {
-      "community": 543,
+      "community": 544,
       "file_type": "code",
       "id": "dispatch_recordterminaldeliveryfailureevent",
       "label": "recordTerminalDeliveryFailureEvent()",
@@ -255118,7 +255196,7 @@
       "source_location": "L427"
     },
     {
-      "community": 543,
+      "community": 544,
       "file_type": "code",
       "id": "dispatch_resolverecipients",
       "label": "resolveRecipients()",
@@ -255127,7 +255205,7 @@
       "source_location": "L53"
     },
     {
-      "community": 543,
+      "community": 544,
       "file_type": "code",
       "id": "dispatch_suppressintentwithctx",
       "label": "suppressIntentWithCtx()",
@@ -255136,7 +255214,7 @@
       "source_location": "L85"
     },
     {
-      "community": 543,
+      "community": 544,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_notifications_dispatch_ts",
       "label": "dispatch.ts",
@@ -255145,7 +255223,7 @@
       "source_location": "L1"
     },
     {
-      "community": 544,
+      "community": 545,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_notifications_registry_test_ts",
       "label": "registry.test.ts",
@@ -255154,7 +255232,7 @@
       "source_location": "L1"
     },
     {
-      "community": 544,
+      "community": 545,
       "file_type": "code",
       "id": "registry_test_dedupekey",
       "label": "dedupeKey()",
@@ -255163,7 +255241,7 @@
       "source_location": "L453"
     },
     {
-      "community": 544,
+      "community": 545,
       "file_type": "code",
       "id": "registry_test_keyfor",
       "label": "keyFor()",
@@ -255172,7 +255250,7 @@
       "source_location": "L531"
     },
     {
-      "community": 544,
+      "community": 545,
       "file_type": "code",
       "id": "registry_test_prepare",
       "label": "prepare()",
@@ -255181,7 +255259,7 @@
       "source_location": "L44"
     },
     {
-      "community": 544,
+      "community": 545,
       "file_type": "code",
       "id": "registry_test_stubctx",
       "label": "stubCtx()",
@@ -255190,7 +255268,7 @@
       "source_location": "L28"
     },
     {
-      "community": 545,
+      "community": 546,
       "file_type": "code",
       "id": "adapters_createnormaluseroperationadapter",
       "label": "createNormalUserOperationAdapter()",
@@ -255199,7 +255277,7 @@
       "source_location": "L13"
     },
     {
-      "community": 545,
+      "community": 546,
       "file_type": "code",
       "id": "adapters_createpublicoperationadapter",
       "label": "createPublicOperationAdapter()",
@@ -255208,7 +255286,7 @@
       "source_location": "L41"
     },
     {
-      "community": 545,
+      "community": 546,
       "file_type": "code",
       "id": "adapters_isadmitted",
       "label": "isAdmitted()",
@@ -255217,7 +255295,7 @@
       "source_location": "L115"
     },
     {
-      "community": 545,
+      "community": 546,
       "file_type": "code",
       "id": "adapters_resolveoperationadmission",
       "label": "resolveOperationAdmission()",
@@ -255226,7 +255304,7 @@
       "source_location": "L59"
     },
     {
-      "community": 545,
+      "community": 546,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_adapters_ts",
       "label": "adapters.ts",
@@ -255235,7 +255313,7 @@
       "source_location": "L1"
     },
     {
-      "community": 546,
+      "community": 547,
       "file_type": "code",
       "id": "approvalrequesterchallenges_consumeapprovalrequesterchallengewithctx",
       "label": "consumeApprovalRequesterChallengeWithCtx()",
@@ -255244,7 +255322,7 @@
       "source_location": "L97"
     },
     {
-      "community": 546,
+      "community": 547,
       "file_type": "code",
       "id": "approvalrequesterchallenges_createapprovalrequesterchallengewithctx",
       "label": "createApprovalRequesterChallengeWithCtx()",
@@ -255253,7 +255331,7 @@
       "source_location": "L55"
     },
     {
-      "community": 546,
+      "community": 547,
       "file_type": "code",
       "id": "approvalrequesterchallenges_invalidapprovalrequesterchallengeresult",
       "label": "invalidApprovalRequesterChallengeResult()",
@@ -255262,7 +255340,7 @@
       "source_location": "L37"
     },
     {
-      "community": 546,
+      "community": 547,
       "file_type": "code",
       "id": "approvalrequesterchallenges_torequesterbinding",
       "label": "toRequesterBinding()",
@@ -255271,7 +255349,7 @@
       "source_location": "L44"
     },
     {
-      "community": 546,
+      "community": 547,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequesterchallenges_ts",
       "label": "approvalRequesterChallenges.ts",
@@ -255280,7 +255358,7 @@
       "source_location": "L1"
     },
     {
-      "community": 547,
+      "community": 548,
       "file_type": "code",
       "id": "customerprofiles_compactrecord",
       "label": "compactRecord()",
@@ -255289,7 +255367,7 @@
       "source_location": "L24"
     },
     {
-      "community": 547,
+      "community": 548,
       "file_type": "code",
       "id": "customerprofiles_ensurecustomerprofilefromsourceswithctx",
       "label": "ensureCustomerProfileFromSourcesWithCtx()",
@@ -255298,7 +255376,7 @@
       "source_location": "L207"
     },
     {
-      "community": 547,
+      "community": 548,
       "file_type": "code",
       "id": "customerprofiles_findexistingprofile",
       "label": "findExistingProfile()",
@@ -255307,7 +255385,7 @@
       "source_location": "L45"
     },
     {
-      "community": 547,
+      "community": 548,
       "file_type": "code",
       "id": "customerprofiles_loadcustomersources",
       "label": "loadCustomerSources()",
@@ -255316,7 +255394,7 @@
       "source_location": "L30"
     },
     {
-      "community": 547,
+      "community": 548,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_customerprofiles_ts",
       "label": "customerProfiles.ts",
@@ -255325,7 +255403,7 @@
       "source_location": "L1"
     },
     {
-      "community": 548,
+      "community": 549,
       "file_type": "code",
       "id": "operationalworkitems_test_approvalrequest",
       "label": "approvalRequest()",
@@ -255334,7 +255412,7 @@
       "source_location": "L46"
     },
     {
-      "community": 548,
+      "community": 549,
       "file_type": "code",
       "id": "operationalworkitems_test_createqueuecontext",
       "label": "createQueueContext()",
@@ -255343,7 +255421,7 @@
       "source_location": "L59"
     },
     {
-      "community": 548,
+      "community": 549,
       "file_type": "code",
       "id": "operationalworkitems_test_gethandler",
       "label": "getHandler()",
@@ -255352,7 +255430,7 @@
       "source_location": "L25"
     },
     {
-      "community": 548,
+      "community": 549,
       "file_type": "code",
       "id": "operationalworkitems_test_workitem",
       "label": "workItem()",
@@ -255361,57 +255439,12 @@
       "source_location": "L31"
     },
     {
-      "community": 548,
+      "community": 549,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalworkitems_test_ts",
       "label": "operationalWorkItems.test.ts",
       "norm_label": "operationalworkitems.test.ts",
       "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "oweddailyclosesweep_completedoperatingdatesforstore",
-      "label": "completedOperatingDatesForStore()",
-      "norm_label": "completedoperatingdatesforstore()",
-      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L149"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "oweddailyclosesweep_daysbetweenoperatingdates",
-      "label": "daysBetweenOperatingDates()",
-      "norm_label": "daysbetweenoperatingdates()",
-      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L354"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "oweddailyclosesweep_listenabledeodpolicies",
-      "label": "listEnabledEodPolicies()",
-      "norm_label": "listenabledeodpolicies()",
-      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L135"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "oweddailyclosesweep_selectoweddailyclosedates",
-      "label": "selectOwedDailyCloseDates()",
-      "norm_label": "selectoweddailyclosedates()",
-      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L84"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
-      "label": "owedDailyCloseSweep.ts",
-      "norm_label": "oweddailyclosesweep.ts",
-      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
       "source_location": "L1"
     },
     {
@@ -255660,6 +255693,51 @@
     {
       "community": 550,
       "file_type": "code",
+      "id": "oweddailyclosesweep_completedoperatingdatesforstore",
+      "label": "completedOperatingDatesForStore()",
+      "norm_label": "completedoperatingdatesforstore()",
+      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
+      "source_location": "L149"
+    },
+    {
+      "community": 550,
+      "file_type": "code",
+      "id": "oweddailyclosesweep_daysbetweenoperatingdates",
+      "label": "daysBetweenOperatingDates()",
+      "norm_label": "daysbetweenoperatingdates()",
+      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
+      "source_location": "L354"
+    },
+    {
+      "community": 550,
+      "file_type": "code",
+      "id": "oweddailyclosesweep_listenabledeodpolicies",
+      "label": "listEnabledEodPolicies()",
+      "norm_label": "listenabledeodpolicies()",
+      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 550,
+      "file_type": "code",
+      "id": "oweddailyclosesweep_selectoweddailyclosedates",
+      "label": "selectOwedDailyCloseDates()",
+      "norm_label": "selectoweddailyclosedates()",
+      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 550,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
+      "label": "owedDailyCloseSweep.ts",
+      "norm_label": "oweddailyclosesweep.ts",
+      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_paymenttotals_ts",
       "label": "paymentTotals.ts",
       "norm_label": "paymenttotals.ts",
@@ -255667,7 +255745,7 @@
       "source_location": "L1"
     },
     {
-      "community": 550,
+      "community": 551,
       "file_type": "code",
       "id": "paymenttotals_buildpaymenttotals",
       "label": "buildPaymentTotals()",
@@ -255676,7 +255754,7 @@
       "source_location": "L50"
     },
     {
-      "community": 550,
+      "community": 551,
       "file_type": "code",
       "id": "paymenttotals_listtransactionpayments",
       "label": "listTransactionPayments()",
@@ -255685,7 +255763,7 @@
       "source_location": "L11"
     },
     {
-      "community": 550,
+      "community": 551,
       "file_type": "code",
       "id": "paymenttotals_transactioncashdelta",
       "label": "transactionCashDelta()",
@@ -255694,7 +255772,7 @@
       "source_location": "L81"
     },
     {
-      "community": 550,
+      "community": 551,
       "file_type": "code",
       "id": "paymenttotals_transactionpaymenttotals",
       "label": "transactionPaymentTotals()",
@@ -255703,7 +255781,7 @@
       "source_location": "L25"
     },
     {
-      "community": 551,
+      "community": 552,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffcredentials_test_ts",
       "label": "staffCredentials.test.ts",
@@ -255712,7 +255790,7 @@
       "source_location": "L1"
     },
     {
-      "community": 551,
+      "community": 552,
       "file_type": "code",
       "id": "staffcredentials_test_admissionawareauth",
       "label": "admissionAwareAuth()",
@@ -255721,7 +255799,7 @@
       "source_location": "L256"
     },
     {
-      "community": 551,
+      "community": 552,
       "file_type": "code",
       "id": "staffcredentials_test_createrestoredproofvalidationctx",
       "label": "createRestoredProofValidationCtx()",
@@ -255730,7 +255808,7 @@
       "source_location": "L271"
     },
     {
-      "community": 551,
+      "community": 552,
       "file_type": "code",
       "id": "staffcredentials_test_createstaffcredentialsmutationctx",
       "label": "createStaffCredentialsMutationCtx()",
@@ -255739,7 +255817,7 @@
       "source_location": "L81"
     },
     {
-      "community": 551,
+      "community": 552,
       "file_type": "code",
       "id": "staffcredentials_test_gethandler",
       "label": "getHandler()",
@@ -255748,7 +255826,7 @@
       "source_location": "L267"
     },
     {
-      "community": 552,
+      "community": 553,
       "file_type": "code",
       "id": "assigncustomer_test_customerprofile",
       "label": "customerProfile()",
@@ -255757,7 +255835,7 @@
       "source_location": "L319"
     },
     {
-      "community": 552,
+      "community": 553,
       "file_type": "code",
       "id": "assigncustomer_test_guest",
       "label": "guest()",
@@ -255766,7 +255844,7 @@
       "source_location": "L346"
     },
     {
-      "community": 552,
+      "community": 553,
       "file_type": "code",
       "id": "assigncustomer_test_poscustomer",
       "label": "posCustomer()",
@@ -255775,7 +255853,7 @@
       "source_location": "L303"
     },
     {
-      "community": 552,
+      "community": 553,
       "file_type": "code",
       "id": "assigncustomer_test_storefrontuser",
       "label": "storeFrontUser()",
@@ -255784,7 +255862,7 @@
       "source_location": "L333"
     },
     {
-      "community": 552,
+      "community": 553,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_test_ts",
       "label": "assignCustomer.test.ts",
@@ -255793,7 +255871,7 @@
       "source_location": "L1"
     },
     {
-      "community": 553,
+      "community": 554,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_registerlifecycleauthority_ts",
       "label": "registerLifecycleAuthority.ts",
@@ -255802,7 +255880,7 @@
       "source_location": "L1"
     },
     {
-      "community": 553,
+      "community": 554,
       "file_type": "code",
       "id": "registerlifecycleauthority_acknowledgeregisterlifecycleauthority",
       "label": "acknowledgeRegisterLifecycleAuthority()",
@@ -255811,7 +255889,7 @@
       "source_location": "L46"
     },
     {
-      "community": 553,
+      "community": 554,
       "file_type": "code",
       "id": "registerlifecycleauthority_equivalentacknowledgement",
       "label": "equivalentAcknowledgement()",
@@ -255820,7 +255898,7 @@
       "source_location": "L124"
     },
     {
-      "community": 553,
+      "community": 554,
       "file_type": "code",
       "id": "registerlifecycleauthority_isrevision",
       "label": "isRevision()",
@@ -255829,7 +255907,7 @@
       "source_location": "L153"
     },
     {
-      "community": 553,
+      "community": 554,
       "file_type": "code",
       "id": "registerlifecycleauthority_normalizesafemetadata",
       "label": "normalizeSafeMetadata()",
@@ -255838,7 +255916,7 @@
       "source_location": "L145"
     },
     {
-      "community": 554,
+      "community": 555,
       "file_type": "code",
       "id": "correctionpolicy_builddecision",
       "label": "buildDecision()",
@@ -255847,7 +255925,7 @@
       "source_location": "L107"
     },
     {
-      "community": 554,
+      "community": 555,
       "file_type": "code",
       "id": "correctionpolicy_classifycorrectionintent",
       "label": "classifyCorrectionIntent()",
@@ -255856,7 +255934,7 @@
       "source_location": "L117"
     },
     {
-      "community": 554,
+      "community": 555,
       "file_type": "code",
       "id": "correctionpolicy_issupportedcorrectionintent",
       "label": "isSupportedCorrectionIntent()",
@@ -255865,7 +255943,7 @@
       "source_location": "L91"
     },
     {
-      "community": 554,
+      "community": 555,
       "file_type": "code",
       "id": "correctionpolicy_isunsupportedhighriskcorrectionintent",
       "label": "isUnsupportedHighRiskCorrectionIntent()",
@@ -255874,7 +255952,7 @@
       "source_location": "L99"
     },
     {
-      "community": 554,
+      "community": 555,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_corrections_correctionpolicy_ts",
       "label": "correctionPolicy.ts",
@@ -255883,7 +255961,7 @@
       "source_location": "L1"
     },
     {
-      "community": 555,
+      "community": 556,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_reconcilesequencegaps_ts",
       "label": "reconcileSequenceGaps.ts",
@@ -255892,7 +255970,7 @@
       "source_location": "L1"
     },
     {
-      "community": 555,
+      "community": 556,
       "file_type": "code",
       "id": "reconcilesequencegaps_collectterminalevidence",
       "label": "collectTerminalEvidence()",
@@ -255901,7 +255979,7 @@
       "source_location": "L185"
     },
     {
-      "community": 555,
+      "community": 556,
       "file_type": "code",
       "id": "reconcilesequencegaps_issuegapprobe",
       "label": "issueGapProbe()",
@@ -255910,7 +255988,7 @@
       "source_location": "L249"
     },
     {
-      "community": 555,
+      "community": 556,
       "file_type": "code",
       "id": "reconcilesequencegaps_listheldeventsforcursor",
       "label": "listHeldEventsForCursor()",
@@ -255919,7 +255997,7 @@
       "source_location": "L156"
     },
     {
-      "community": 555,
+      "community": 556,
       "file_type": "code",
       "id": "reconcilesequencegaps_skipsequencegap",
       "label": "skipSequenceGap()",
@@ -255928,7 +256006,7 @@
       "source_location": "L295"
     },
     {
-      "community": 556,
+      "community": 557,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminaloperationalstate_policy_test_ts",
       "label": "policy.test.ts",
@@ -255937,7 +256015,7 @@
       "source_location": "L1"
     },
     {
-      "community": 556,
+      "community": 557,
       "file_type": "code",
       "id": "policy_test_baseinput",
       "label": "baseInput()",
@@ -255946,7 +256024,7 @@
       "source_location": "L1225"
     },
     {
-      "community": 556,
+      "community": 557,
       "file_type": "code",
       "id": "policy_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -255955,7 +256033,7 @@
       "source_location": "L1329"
     },
     {
-      "community": 556,
+      "community": 557,
       "file_type": "code",
       "id": "policy_test_buildruntimestatus",
       "label": "buildRuntimeStatus()",
@@ -255964,7 +256042,7 @@
       "source_location": "L1287"
     },
     {
-      "community": 556,
+      "community": 557,
       "file_type": "code",
       "id": "policy_test_emptysyncevidence",
       "label": "emptySyncEvidence()",
@@ -255973,7 +256051,7 @@
       "source_location": "L1267"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_terminalrecoveryrepository_test_ts",
       "label": "terminalRecoveryRepository.test.ts",
@@ -255982,7 +256060,7 @@
       "source_location": "L1"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "terminalrecoveryrepository_test_buildctx",
       "label": "buildCtx()",
@@ -255991,7 +256069,7 @@
       "source_location": "L381"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "terminalrecoveryrepository_test_buildqueryctx",
       "label": "buildQueryCtx()",
@@ -256000,7 +256078,7 @@
       "source_location": "L469"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "terminalrecoveryrepository_test_filterrows",
       "label": "filterRows()",
@@ -256009,7 +256087,7 @@
       "source_location": "L483"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "terminalrecoveryrepository_test_orderedrows",
       "label": "orderedRows()",
@@ -256018,7 +256096,7 @@
       "source_location": "L492"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "customers_requireposcustomeraccessbyid",
       "label": "requirePosCustomerAccessById()",
@@ -256027,7 +256105,7 @@
       "source_location": "L76"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "customers_requireposcustomerreadaccessbyid",
       "label": "requirePosCustomerReadAccessById()",
@@ -256036,7 +256114,7 @@
       "source_location": "L123"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "customers_requireposcustomerstoreaccess",
       "label": "requirePosCustomerStoreAccess()",
@@ -256045,7 +256123,7 @@
       "source_location": "L53"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "customers_requireposcustomerstorereadaccess",
       "label": "requirePosCustomerStoreReadAccess()",
@@ -256054,58 +256132,13 @@
       "source_location": "L99"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_customers_ts",
       "label": "customers.ts",
       "norm_label": "customers.ts",
       "source_file": "packages/athena-webapp/convex/pos/public/customers.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_public_posrecoverycodes_test_ts",
-      "label": "posRecoveryCodes.test.ts",
-      "norm_label": "posrecoverycodes.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/public/posRecoveryCodes.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "posrecoverycodes_test_buildctx",
-      "label": "buildCtx()",
-      "norm_label": "buildctx()",
-      "source_file": "packages/athena-webapp/convex/pos/public/posRecoveryCodes.test.ts",
-      "source_location": "L565"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "posrecoverycodes_test_createfilter",
-      "label": "createFilter()",
-      "norm_label": "createfilter()",
-      "source_file": "packages/athena-webapp/convex/pos/public/posRecoveryCodes.test.ts",
-      "source_location": "L669"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "posrecoverycodes_test_createquery",
-      "label": "createQuery()",
-      "norm_label": "createquery()",
-      "source_file": "packages/athena-webapp/convex/pos/public/posRecoveryCodes.test.ts",
-      "source_location": "L642"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "posrecoverycodes_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/pos/public/posRecoveryCodes.test.ts",
-      "source_location": "L25"
     },
     {
       "community": 56,
@@ -256353,6 +256386,51 @@
     {
       "community": 560,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_public_posrecoverycodes_test_ts",
+      "label": "posRecoveryCodes.test.ts",
+      "norm_label": "posrecoverycodes.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/public/posRecoveryCodes.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "posrecoverycodes_test_buildctx",
+      "label": "buildCtx()",
+      "norm_label": "buildctx()",
+      "source_file": "packages/athena-webapp/convex/pos/public/posRecoveryCodes.test.ts",
+      "source_location": "L565"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "posrecoverycodes_test_createfilter",
+      "label": "createFilter()",
+      "norm_label": "createfilter()",
+      "source_file": "packages/athena-webapp/convex/pos/public/posRecoveryCodes.test.ts",
+      "source_location": "L669"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "posrecoverycodes_test_createquery",
+      "label": "createQuery()",
+      "norm_label": "createquery()",
+      "source_file": "packages/athena-webapp/convex/pos/public/posRecoveryCodes.test.ts",
+      "source_location": "L642"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "posrecoverycodes_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/pos/public/posRecoveryCodes.test.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_telemetry_test_ts",
       "label": "telemetry.test.ts",
       "norm_label": "telemetry.test.ts",
@@ -256360,7 +256438,7 @@
       "source_location": "L1"
     },
     {
-      "community": 560,
+      "community": 561,
       "file_type": "code",
       "id": "telemetry_test_baseevent",
       "label": "baseEvent()",
@@ -256369,7 +256447,7 @@
       "source_location": "L106"
     },
     {
-      "community": 560,
+      "community": 561,
       "file_type": "code",
       "id": "telemetry_test_createctx",
       "label": "createCtx()",
@@ -256378,7 +256456,7 @@
       "source_location": "L34"
     },
     {
-      "community": 560,
+      "community": 561,
       "file_type": "code",
       "id": "telemetry_test_gethandler",
       "label": "getHandler()",
@@ -256387,7 +256465,7 @@
       "source_location": "L24"
     },
     {
-      "community": 560,
+      "community": 561,
       "file_type": "code",
       "id": "telemetry_test_storedevent",
       "label": "storedEvent()",
@@ -256396,7 +256474,7 @@
       "source_location": "L371"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_ts",
       "label": "transactions.ts",
@@ -256405,7 +256483,7 @@
       "source_location": "L1"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "transactions_mapcorrectionerror",
       "label": "mapCorrectionError()",
@@ -256414,7 +256492,7 @@
       "source_location": "L339"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "transactions_redactpospulsesummary",
       "label": "redactPosPulseSummary()",
@@ -256423,7 +256501,7 @@
       "source_location": "L307"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "transactions_requirepostransactionaccess",
       "label": "requirePosTransactionAccess()",
@@ -256432,7 +256510,7 @@
       "source_location": "L93"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "transactions_requirepostransactionstoreaccess",
       "label": "requirePosTransactionStoreAccess()",
@@ -256441,7 +256519,7 @@
       "source_location": "L64"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_application_policy_ts",
       "label": "policy.ts",
@@ -256450,7 +256528,7 @@
       "source_location": "L1"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "policy_denied",
       "label": "denied()",
@@ -256459,7 +256537,7 @@
       "source_location": "L96"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "policy_evaluateremoteassistpolicy",
       "label": "evaluateRemoteAssistPolicy()",
@@ -256468,7 +256546,7 @@
       "source_location": "L31"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "policy_isclientfresh",
       "label": "isClientFresh()",
@@ -256477,7 +256555,7 @@
       "source_location": "L88"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "policy_policydecisiontocommandresult",
       "label": "policyDecisionToCommandResult()",
@@ -256486,7 +256564,7 @@
       "source_location": "L76"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_infrastructure_remoteassistreadrepository_ts",
       "label": "remoteAssistReadRepository.ts",
@@ -256495,7 +256573,7 @@
       "source_location": "L1"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "remoteassistreadrepository_compareremoteassistsessionforsupportview",
       "label": "compareRemoteAssistSessionForSupportView()",
@@ -256504,7 +256582,7 @@
       "source_location": "L88"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "remoteassistreadrepository_createremoteassistreadrepository",
       "label": "createRemoteAssistReadRepository()",
@@ -256513,7 +256591,7 @@
       "source_location": "L10"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "remoteassistreadrepository_toremoteassistclient",
       "label": "toRemoteAssistClient()",
@@ -256522,7 +256600,7 @@
       "source_location": "L108"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "remoteassistreadrepository_toremoteassistsession",
       "label": "toRemoteAssistSession()",
@@ -256531,7 +256609,7 @@
       "source_location": "L121"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "fingerprint_factfingerprint",
       "label": "factFingerprint()",
@@ -256540,7 +256618,7 @@
       "source_location": "L69"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "fingerprint_fingerprintpayload",
       "label": "fingerprintPayload()",
@@ -256549,7 +256627,7 @@
       "source_location": "L26"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "fingerprint_matchesstoredfingerprint",
       "label": "matchesStoredFingerprint()",
@@ -256558,7 +256636,7 @@
       "source_location": "L86"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "fingerprint_stablestringhash",
       "label": "stableStringHash()",
@@ -256567,7 +256645,7 @@
       "source_location": "L55"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_fingerprint_ts",
       "label": "fingerprint.ts",
@@ -256576,7 +256654,7 @@
       "source_location": "L1"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_servicecases_test_ts",
       "label": "serviceCases.test.ts",
@@ -256585,7 +256663,7 @@
       "source_location": "L1"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "servicecases_test_createinventoryusagectx",
       "label": "createInventoryUsageCtx()",
@@ -256594,7 +256672,7 @@
       "source_location": "L77"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "servicecases_test_expectindex",
       "label": "expectIndex()",
@@ -256603,7 +256681,7 @@
       "source_location": "L66"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "servicecases_test_gethandler",
       "label": "getHandler()",
@@ -256612,7 +256690,7 @@
       "source_location": "L73"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "servicecases_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -256621,7 +256699,7 @@
       "source_location": "L59"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_services_paystackservice_ts",
       "label": "paystackService.ts",
@@ -256630,7 +256708,7 @@
       "source_location": "L1"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "paystackservice_getpaystackheaders",
       "label": "getPaystackHeaders()",
@@ -256639,7 +256717,7 @@
       "source_location": "L11"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "paystackservice_initializetransaction",
       "label": "initializeTransaction()",
@@ -256648,7 +256726,7 @@
       "source_location": "L21"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "paystackservice_initiaterefund",
       "label": "initiateRefund()",
@@ -256657,7 +256735,7 @@
       "source_location": "L87"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "paystackservice_verifytransaction",
       "label": "verifyTransaction()",
@@ -256666,7 +256744,7 @@
       "source_location": "L65"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "admission_test_admissioncontext",
       "label": "admissionContext()",
@@ -256675,7 +256753,7 @@
       "source_location": "L17"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "admission_test_configureadmissionenvironment",
       "label": "configureAdmissionEnvironment()",
@@ -256684,7 +256762,7 @@
       "source_location": "L60"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "admission_test_contextwith",
       "label": "contextWith()",
@@ -256693,7 +256771,7 @@
       "source_location": "L120"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "admission_test_invoke",
       "label": "invoke()",
@@ -256702,7 +256780,7 @@
       "source_location": "L14"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_admission_test_ts",
       "label": "admission.test.ts",
@@ -256711,7 +256789,7 @@
       "source_location": "L1"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "config_calculateshareddemoexpectedcash",
       "label": "calculateSharedDemoExpectedCash()",
@@ -256720,7 +256798,7 @@
       "source_location": "L23"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "config_isshareddemoenabled",
       "label": "isSharedDemoEnabled()",
@@ -256729,7 +256807,7 @@
       "source_location": "L33"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "config_readruntimeshareddemoconfig",
       "label": "readRuntimeSharedDemoConfig()",
@@ -256738,7 +256816,7 @@
       "source_location": "L59"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "config_readshareddemoconfig",
       "label": "readSharedDemoConfig()",
@@ -256747,57 +256825,12 @@
       "source_location": "L40"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_config_ts",
       "label": "config.ts",
       "norm_label": "config.ts",
       "source_file": "packages/athena-webapp/convex/sharedDemo/config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "openingbaseline_buildshareddemoopeningbaseline",
-      "label": "buildSharedDemoOpeningBaseline()",
-      "norm_label": "buildshareddemoopeningbaseline()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/openingBaseline.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "openingbaseline_buildshareddemostoredayevent",
-      "label": "buildSharedDemoStoreDayEvent()",
-      "norm_label": "buildshareddemostoredayevent()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/openingBaseline.ts",
-      "source_location": "L105"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "openingbaseline_rollshareddemoopeningbaselinewithctx",
-      "label": "rollSharedDemoOpeningBaselineWithCtx()",
-      "norm_label": "rollshareddemoopeningbaselinewithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/openingBaseline.ts",
-      "source_location": "L132"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "openingbaseline_shareddemooperatingdaterange",
-      "label": "sharedDemoOperatingDateRange()",
-      "norm_label": "shareddemooperatingdaterange()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/openingBaseline.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_shareddemo_openingbaseline_ts",
-      "label": "openingBaseline.ts",
-      "norm_label": "openingbaseline.ts",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/openingBaseline.ts",
       "source_location": "L1"
     },
     {
@@ -257046,6 +257079,51 @@
     {
       "community": 570,
       "file_type": "code",
+      "id": "openingbaseline_buildshareddemoopeningbaseline",
+      "label": "buildSharedDemoOpeningBaseline()",
+      "norm_label": "buildshareddemoopeningbaseline()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/openingBaseline.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "openingbaseline_buildshareddemostoredayevent",
+      "label": "buildSharedDemoStoreDayEvent()",
+      "norm_label": "buildshareddemostoredayevent()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/openingBaseline.ts",
+      "source_location": "L105"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "openingbaseline_rollshareddemoopeningbaselinewithctx",
+      "label": "rollSharedDemoOpeningBaselineWithCtx()",
+      "norm_label": "rollshareddemoopeningbaselinewithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/openingBaseline.ts",
+      "source_location": "L132"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "openingbaseline_shareddemooperatingdaterange",
+      "label": "sharedDemoOperatingDateRange()",
+      "norm_label": "shareddemooperatingdaterange()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/openingBaseline.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_shareddemo_openingbaseline_ts",
+      "label": "openingBaseline.ts",
+      "norm_label": "openingbaseline.ts",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/openingBaseline.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
       "id": "operationadapter_createshareddemooperationadapter",
       "label": "createSharedDemoOperationAdapter()",
       "norm_label": "createshareddemooperationadapter()",
@@ -257053,7 +257131,7 @@
       "source_location": "L18"
     },
     {
-      "community": 570,
+      "community": 571,
       "file_type": "code",
       "id": "operationadapter_isrecognizedshareddemoactorerror",
       "label": "isRecognizedSharedDemoActorError()",
@@ -257062,7 +257140,7 @@
       "source_location": "L100"
     },
     {
-      "community": 570,
+      "community": 571,
       "file_type": "code",
       "id": "operationadapter_shareddemodenialerror",
       "label": "sharedDemoDenialError()",
@@ -257071,7 +257149,7 @@
       "source_location": "L124"
     },
     {
-      "community": 570,
+      "community": 571,
       "file_type": "code",
       "id": "operationadapter_shareddemodenied",
       "label": "sharedDemoDenied()",
@@ -257080,7 +257158,7 @@
       "source_location": "L108"
     },
     {
-      "community": 570,
+      "community": 571,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_operationadapter_ts",
       "label": "operationAdapter.ts",
@@ -257089,7 +257167,7 @@
       "source_location": "L1"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_ts",
       "label": "storefrontObservabilityReport.ts",
@@ -257098,7 +257176,7 @@
       "source_location": "L1"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "storefrontobservabilityreport_buildstorefrontobservabilityreport",
       "label": "buildStorefrontObservabilityReport()",
@@ -257107,7 +257185,7 @@
       "source_location": "L124"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "storefrontobservabilityreport_getnonemptystring",
       "label": "getNonEmptyString()",
@@ -257116,7 +257194,7 @@
       "source_location": "L67"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "storefrontobservabilityreport_gettrafficsource",
       "label": "getTrafficSource()",
@@ -257125,7 +257203,7 @@
       "source_location": "L106"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "storefrontobservabilityreport_normalizestorefrontobservabilityevent",
       "label": "normalizeStorefrontObservabilityEvent()",
@@ -257134,7 +257212,7 @@
       "source_location": "L73"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "onlineorder_buildlookup",
       "label": "buildLookup()",
@@ -257143,7 +257221,7 @@
       "source_location": "L65"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "onlineorder_buildonlineordertraceseed",
       "label": "buildOnlineOrderTraceSeed()",
@@ -257152,7 +257230,7 @@
       "source_location": "L85"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "onlineorder_buildsafeexternalreferenceref",
       "label": "buildSafeExternalReferenceRef()",
@@ -257161,7 +257239,7 @@
       "source_location": "L53"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "onlineorder_stablefingerprint",
       "label": "stableFingerprint()",
@@ -257170,7 +257248,7 @@
       "source_location": "L43"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -257179,7 +257257,7 @@
       "source_location": "L1"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_queryusage_test_ts",
       "label": "queryUsage.test.ts",
@@ -257188,7 +257266,7 @@
       "source_location": "L1"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "queryusage_test_comparebyfields",
       "label": "compareByFields()",
@@ -257197,7 +257275,7 @@
       "source_location": "L102"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "queryusage_test_createadmintracereadctx",
       "label": "createAdminTraceReadCtx()",
@@ -257206,7 +257284,7 @@
       "source_location": "L220"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "queryusage_test_createtestctx",
       "label": "createTestCtx()",
@@ -257215,7 +257293,7 @@
       "source_location": "L118"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "queryusage_test_deniedauthorizer",
       "label": "deniedAuthorizer()",
@@ -257224,7 +257302,7 @@
       "source_location": "L1071"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "dashboard_getperiodrange",
       "label": "getPeriodRange()",
@@ -257233,7 +257311,7 @@
       "source_location": "L19"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "dashboard_loadingsection",
       "label": "LoadingSection()",
@@ -257242,7 +257320,7 @@
       "source_location": "L49"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "dashboard_renderproductssection",
       "label": "renderProductsSection()",
@@ -257251,7 +257329,7 @@
       "source_location": "L341"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "dashboard_rendersalessection",
       "label": "renderSalesSection()",
@@ -257260,7 +257338,7 @@
       "source_location": "L321"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
       "label": "Dashboard.tsx",
@@ -257269,7 +257347,7 @@
       "source_location": "L1"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "docsscrolltotop_cancel",
       "label": "cancel()",
@@ -257278,7 +257356,7 @@
       "source_location": "L87"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "docsscrolltotop_handleclick",
       "label": "handleClick()",
@@ -257287,7 +257365,7 @@
       "source_location": "L103"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "docsscrolltotop_read",
       "label": "read()",
@@ -257296,7 +257374,7 @@
       "source_location": "L37"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "docsscrolltotop_schedule",
       "label": "schedule()",
@@ -257305,7 +257383,7 @@
       "source_location": "L59"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_docs_docsscrolltotop_tsx",
       "label": "DocsScrollToTop.tsx",
@@ -257314,7 +257392,7 @@
       "source_location": "L1"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "herosectiontabs_handledisplaytypechange",
       "label": "handleDisplayTypeChange()",
@@ -257323,7 +257401,7 @@
       "source_location": "L61"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "herosectiontabs_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -257332,7 +257410,7 @@
       "source_location": "L57"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "herosectiontabs_handleoverlaytoggle",
       "label": "handleOverlayToggle()",
@@ -257341,7 +257419,7 @@
       "source_location": "L98"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "herosectiontabs_handletexttoggle",
       "label": "handleTextToggle()",
@@ -257350,7 +257428,7 @@
       "source_location": "L134"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
       "label": "HeroSectionTabs.tsx",
@@ -257359,7 +257437,7 @@
       "source_location": "L1"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
       "label": "ReelUploader.tsx",
@@ -257368,7 +257446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "reeluploader_formatfilesize",
       "label": "formatFileSize()",
@@ -257377,7 +257455,7 @@
       "source_location": "L38"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "reeluploader_handlefileselect",
       "label": "handleFileSelect()",
@@ -257386,7 +257464,7 @@
       "source_location": "L64"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "reeluploader_handleupload",
       "label": "handleUpload()",
@@ -257395,7 +257473,7 @@
       "source_location": "L135"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "reeluploader_validatefile",
       "label": "validateFile()",
@@ -257404,7 +257482,7 @@
       "source_location": "L43"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "activityview_iscreatedaction",
       "label": "isCreatedAction()",
@@ -257413,7 +257491,7 @@
       "source_location": "L90"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "activityview_isfeedbackrequestaction",
       "label": "isFeedbackRequestAction()",
@@ -257422,7 +257500,7 @@
       "source_location": "L95"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "activityview_isrefundaction",
       "label": "isRefundAction()",
@@ -257431,7 +257509,7 @@
       "source_location": "L82"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "activityview_istransitionaction",
       "label": "isTransitionAction()",
@@ -257440,57 +257518,12 @@
       "source_location": "L85"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
       "label": "ActivityView.tsx",
       "norm_label": "activityview.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "orderitemsview_handlerequestfeedback",
-      "label": "handleRequestFeedback()",
-      "norm_label": "handlerequestfeedback()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L113"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "orderitemsview_handlerestockall",
-      "label": "handleRestockAll()",
-      "norm_label": "handlerestockall()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L349"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "orderitemsview_handlereturnitemtostock",
-      "label": "handleReturnItemToStock()",
-      "norm_label": "handlereturnitemtostock()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L86"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "orderitemsview_handleupdateorderitem",
-      "label": "handleUpdateOrderItem()",
-      "norm_label": "handleupdateorderitem()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L62"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
-      "label": "OrderItemsView.tsx",
-      "norm_label": "orderitemsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
       "source_location": "L1"
     },
     {
@@ -257730,6 +257763,51 @@
     {
       "community": 580,
       "file_type": "code",
+      "id": "orderitemsview_handlerequestfeedback",
+      "label": "handleRequestFeedback()",
+      "norm_label": "handlerequestfeedback()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L113"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "orderitemsview_handlerestockall",
+      "label": "handleRestockAll()",
+      "norm_label": "handlerestockall()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L349"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "orderitemsview_handlereturnitemtostock",
+      "label": "handleReturnItemToStock()",
+      "norm_label": "handlereturnitemtostock()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L86"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "orderitemsview_handleupdateorderitem",
+      "label": "handleUpdateOrderItem()",
+      "norm_label": "handleupdateorderitem()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L62"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
+      "label": "OrderItemsView.tsx",
+      "norm_label": "orderitemsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
       "id": "cashierauthdialog_test_buildlocalauthorityrecord",
       "label": "buildLocalAuthorityRecord()",
       "norm_label": "buildlocalauthorityrecord()",
@@ -257737,7 +257815,7 @@
       "source_location": "L121"
     },
     {
-      "community": 580,
+      "community": 581,
       "file_type": "code",
       "id": "cashierauthdialog_test_renderdialog",
       "label": "renderDialog()",
@@ -257746,7 +257824,7 @@
       "source_location": "L152"
     },
     {
-      "community": 580,
+      "community": 581,
       "file_type": "code",
       "id": "cashierauthdialog_test_submitcredentials",
       "label": "submitCredentials()",
@@ -257755,7 +257833,7 @@
       "source_location": "L216"
     },
     {
-      "community": 580,
+      "community": 581,
       "file_type": "code",
       "id": "cashierauthdialog_test_submitlockedcashierpin",
       "label": "submitLockedCashierPin()",
@@ -257764,7 +257842,7 @@
       "source_location": "L208"
     },
     {
-      "community": 580,
+      "community": 581,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_test_tsx",
       "label": "CashierAuthDialog.test.tsx",
@@ -257773,7 +257851,7 @@
       "source_location": "L1"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "ordersummary_test_getbalancedueamount",
       "label": "getBalanceDueAmount()",
@@ -257782,7 +257860,7 @@
       "source_location": "L49"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "ordersummary_test_getbalanceduelabel",
       "label": "getBalanceDueLabel()",
@@ -257791,7 +257869,7 @@
       "source_location": "L66"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "ordersummary_test_getbalanceduepanel",
       "label": "getBalanceDuePanel()",
@@ -257800,7 +257878,7 @@
       "source_location": "L75"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "ordersummary_test_stripwhitespace",
       "label": "stripWhitespace()",
@@ -257809,7 +257887,7 @@
       "source_location": "L45"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_ordersummary_test_tsx",
       "label": "OrderSummary.test.tsx",
@@ -257818,7 +257896,7 @@
       "source_location": "L1"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_test_tsx",
       "label": "POSSettingsView.test.tsx",
@@ -257827,7 +257905,7 @@
       "source_location": "L1"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "possettingsview_test_findtrigger",
       "label": "findTrigger()",
@@ -257836,7 +257914,7 @@
       "source_location": "L185"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "possettingsview_test_selectcontent",
       "label": "SelectContent()",
@@ -257845,7 +257923,7 @@
       "source_location": "L160"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "possettingsview_test_selectitem",
       "label": "SelectItem()",
@@ -257854,7 +257932,7 @@
       "source_location": "L163"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "possettingsview_test_selecttrigger",
       "label": "SelectTrigger()",
@@ -257863,7 +257941,7 @@
       "source_location": "L165"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productslistview_tsx",
       "label": "ProductsListView.tsx",
@@ -257872,7 +257950,7 @@
       "source_location": "L1"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "productslistview_handlecategorypageindexchange",
       "label": "handleCategoryPageIndexChange()",
@@ -257881,7 +257959,7 @@
       "source_location": "L220"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "productslistview_handleclearcache",
       "label": "handleClearCache()",
@@ -257890,7 +257968,7 @@
       "source_location": "L108"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "productslistview_handlestorefrontvisibilitychange",
       "label": "handleStorefrontVisibilityChange()",
@@ -257899,7 +257977,7 @@
       "source_location": "L87"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "productslistview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -257908,7 +257986,7 @@
       "source_location": "L33"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeview_tsx",
       "label": "PromoCodeView.tsx",
@@ -257917,7 +257995,7 @@
       "source_location": "L1"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "promocodeview_handleaddpromocode",
       "label": "handleAddPromoCode()",
@@ -257926,7 +258004,7 @@
       "source_location": "L158"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "promocodeview_handleupdatepromocode",
       "label": "handleUpdatePromoCode()",
@@ -257935,7 +258013,7 @@
       "source_location": "L231"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "promocodeview_updatehomepagediscountcode",
       "label": "updateHomepageDiscountCode()",
@@ -257944,7 +258022,7 @@
       "source_location": "L324"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "promocodeview_updateleaveareviewdiscountcode",
       "label": "updateLeaveAReviewDiscountCode()",
@@ -257953,7 +258031,7 @@
       "source_location": "L379"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportsoverviewview_test_tsx",
       "label": "ReportsOverviewView.test.tsx",
@@ -257962,7 +258040,7 @@
       "source_location": "L1"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "reportsoverviewview_test_expectanimatedmetrics",
       "label": "expectAnimatedMetrics()",
@@ -257971,7 +258049,7 @@
       "source_location": "L414"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "reportsoverviewview_test_harness",
       "label": "Harness()",
@@ -257980,7 +258058,7 @@
       "source_location": "L173"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "reportsoverviewview_test_linkedrange",
       "label": "linkedRange()",
@@ -257989,7 +258067,7 @@
       "source_location": "L548"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "reportsoverviewview_test_snapshot",
       "label": "snapshot()",
@@ -257998,7 +258076,7 @@
       "source_location": "L87"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportroutesearch_ts",
       "label": "reportRouteSearch.ts",
@@ -258007,7 +258085,7 @@
       "source_location": "L1"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "reportroutesearch_overviewsearchfromweeklyreturn",
       "label": "overviewSearchFromWeeklyReturn()",
@@ -258016,7 +258094,7 @@
       "source_location": "L148"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "reportroutesearch_parseunitssheetfocussearch",
       "label": "parseUnitsSheetFocusSearch()",
@@ -258025,7 +258103,7 @@
       "source_location": "L81"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "reportroutesearch_unitssheetfocussearchvalue",
       "label": "unitsSheetFocusSearchValue()",
@@ -258034,7 +258112,7 @@
       "source_location": "L72"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "reportroutesearch_weeklyreturnsearchfromoverview",
       "label": "weeklyReturnSearchFromOverview()",
@@ -258043,7 +258121,7 @@
       "source_location": "L125"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_pulse_storepulsesummaryview_tsx",
       "label": "StorePulseSummaryView.tsx",
@@ -258052,7 +258130,7 @@
       "source_location": "L1"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "storepulsesummaryview_formatcomparisonhelper",
       "label": "formatComparisonHelper()",
@@ -258061,7 +258139,7 @@
       "source_location": "L165"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "storepulsesummaryview_formatxaxistick",
       "label": "formatXAxisTick()",
@@ -258070,7 +258148,7 @@
       "source_location": "L379"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "storepulsesummaryview_gettrendvalue",
       "label": "getTrendValue()",
@@ -258079,7 +258157,7 @@
       "source_location": "L312"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "storepulsesummaryview_helper",
       "label": "helper()",
@@ -258088,7 +258166,7 @@
       "source_location": "L202"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "date_time_picker_handleclear",
       "label": "handleClear()",
@@ -258097,7 +258175,7 @@
       "source_location": "L101"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "date_time_picker_handledateselect",
       "label": "handleDateSelect()",
@@ -258106,7 +258184,7 @@
       "source_location": "L55"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "date_time_picker_handletimeblur",
       "label": "handleTimeBlur()",
@@ -258115,7 +258193,7 @@
       "source_location": "L77"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "date_time_picker_handletimechange",
       "label": "handleTimeChange()",
@@ -258124,57 +258202,12 @@
       "source_location": "L65"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
       "label": "date-time-picker.tsx",
       "norm_label": "date-time-picker.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/date-time-picker.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "custom_modal_example_basicmodalexample",
-      "label": "BasicModalExample()",
-      "norm_label": "basicmodalexample()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
-      "source_location": "L7"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "custom_modal_example_customclosebuttonexample",
-      "label": "CustomCloseButtonExample()",
-      "norm_label": "customclosebuttonexample()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
-      "source_location": "L69"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "custom_modal_example_custompositionmodalexample",
-      "label": "CustomPositionModalExample()",
-      "norm_label": "custompositionmodalexample()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
-      "source_location": "L44"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "custom_modal_example_fullscreenmodalexample",
-      "label": "FullScreenModalExample()",
-      "norm_label": "fullscreenmodalexample()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
-      "source_location": "L103"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_example_tsx",
-      "label": "custom-modal-example.tsx",
-      "norm_label": "custom-modal-example.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L1"
     },
     {
@@ -258414,46 +258447,46 @@
     {
       "community": 590,
       "file_type": "code",
-      "id": "config_getruntimeorigin",
-      "label": "getRuntimeOrigin()",
-      "norm_label": "getruntimeorigin()",
-      "source_file": "packages/athena-webapp/src/config.ts",
-      "source_location": "L12"
+      "id": "custom_modal_example_basicmodalexample",
+      "label": "BasicModalExample()",
+      "norm_label": "basicmodalexample()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
+      "source_location": "L7"
     },
     {
       "community": 590,
       "file_type": "code",
-      "id": "config_islocalhost",
-      "label": "isLocalHost()",
-      "norm_label": "islocalhost()",
-      "source_file": "packages/athena-webapp/src/config.ts",
-      "source_location": "L20"
+      "id": "custom_modal_example_customclosebuttonexample",
+      "label": "CustomCloseButtonExample()",
+      "norm_label": "customclosebuttonexample()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
+      "source_location": "L69"
     },
     {
       "community": 590,
       "file_type": "code",
-      "id": "config_resolvestorefronturl",
-      "label": "resolveStoreFrontUrl()",
-      "norm_label": "resolvestorefronturl()",
-      "source_file": "packages/athena-webapp/src/config.ts",
-      "source_location": "L24"
+      "id": "custom_modal_example_custompositionmodalexample",
+      "label": "CustomPositionModalExample()",
+      "norm_label": "custompositionmodalexample()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
+      "source_location": "L44"
     },
     {
       "community": 590,
       "file_type": "code",
-      "id": "config_trimtrailingslash",
-      "label": "trimTrailingSlash()",
-      "norm_label": "trimtrailingslash()",
-      "source_file": "packages/athena-webapp/src/config.ts",
-      "source_location": "L8"
+      "id": "custom_modal_example_fullscreenmodalexample",
+      "label": "FullScreenModalExample()",
+      "norm_label": "fullscreenmodalexample()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
+      "source_location": "L103"
     },
     {
       "community": 590,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_config_ts",
-      "label": "config.ts",
-      "norm_label": "config.ts",
-      "source_file": "packages/athena-webapp/src/config.ts",
+      "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_example_tsx",
+      "label": "custom-modal-example.tsx",
+      "norm_label": "custom-modal-example.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L1"
     },
     {
@@ -264246,42 +264279,6 @@
     {
       "community": 674,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_register_test_ts",
-      "label": "register.test.ts",
-      "norm_label": "register.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 674,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_public_register_test_ts",
-      "label": "register.test.ts",
-      "norm_label": "register.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 674,
-      "file_type": "code",
-      "id": "register_test_buildctx",
-      "label": "buildCtx()",
-      "norm_label": "buildctx()",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 674,
-      "file_type": "code",
-      "id": "register_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 675,
-      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
       "label": "register.ts",
       "norm_label": "register.ts",
@@ -264289,7 +264286,7 @@
       "source_location": "L1"
     },
     {
-      "community": 675,
+      "community": 674,
       "file_type": "code",
       "id": "register_mapopendrawerusererror",
       "label": "mapOpenDrawerUserError()",
@@ -264298,7 +264295,7 @@
       "source_location": "L34"
     },
     {
-      "community": 675,
+      "community": 674,
       "file_type": "code",
       "id": "register_normalizeregisternumber",
       "label": "normalizeRegisterNumber()",
@@ -264307,7 +264304,7 @@
       "source_location": "L29"
     },
     {
-      "community": 675,
+      "community": 674,
       "file_type": "code",
       "id": "register_opendrawer",
       "label": "openDrawer()",
@@ -264316,7 +264313,7 @@
       "source_location": "L56"
     },
     {
-      "community": 676,
+      "community": 675,
       "file_type": "code",
       "id": "opendrawer_test_createdbgetmock",
       "label": "createDbGetMock()",
@@ -264325,7 +264322,7 @@
       "source_location": "L39"
     },
     {
-      "community": 676,
+      "community": 675,
       "file_type": "code",
       "id": "opendrawer_test_createdbmock",
       "label": "createDbMock()",
@@ -264334,7 +264331,7 @@
       "source_location": "L99"
     },
     {
-      "community": 676,
+      "community": 675,
       "file_type": "code",
       "id": "opendrawer_test_createdbquerymock",
       "label": "createDbQueryMock()",
@@ -264343,7 +264340,7 @@
       "source_location": "L74"
     },
     {
-      "community": 676,
+      "community": 675,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_opendrawer_test_ts",
       "label": "openDrawer.test.ts",
@@ -264352,7 +264349,7 @@
       "source_location": "L1"
     },
     {
-      "community": 677,
+      "community": 676,
       "file_type": "code",
       "id": "getregisterstate_buildregisterstate",
       "label": "buildRegisterState()",
@@ -264361,7 +264358,7 @@
       "source_location": "L21"
     },
     {
-      "community": 677,
+      "community": 676,
       "file_type": "code",
       "id": "getregisterstate_getactivesessionconflictforregisterstate",
       "label": "getActiveSessionConflictForRegisterState()",
@@ -264370,7 +264367,7 @@
       "source_location": "L42"
     },
     {
-      "community": 677,
+      "community": 676,
       "file_type": "code",
       "id": "getregisterstate_getregisterstate",
       "label": "getRegisterState()",
@@ -264379,7 +264376,7 @@
       "source_location": "L80"
     },
     {
-      "community": 677,
+      "community": 676,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
       "label": "getRegisterState.ts",
@@ -264388,7 +264385,7 @@
       "source_location": "L1"
     },
     {
-      "community": 678,
+      "community": 677,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_storepulse_test_ts",
       "label": "storePulse.test.ts",
@@ -264397,7 +264394,7 @@
       "source_location": "L1"
     },
     {
-      "community": 678,
+      "community": 677,
       "file_type": "code",
       "id": "storepulse_test_createdb",
       "label": "createDb()",
@@ -264406,7 +264403,7 @@
       "source_location": "L12"
     },
     {
-      "community": 678,
+      "community": 677,
       "file_type": "code",
       "id": "storepulse_test_item",
       "label": "item()",
@@ -264415,7 +264412,7 @@
       "source_location": "L127"
     },
     {
-      "community": 678,
+      "community": 677,
       "file_type": "code",
       "id": "storepulse_test_transaction",
       "label": "transaction()",
@@ -264424,7 +264421,7 @@
       "source_location": "L99"
     },
     {
-      "community": 679,
+      "community": 678,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_posregistersessionactivity_test_ts",
       "label": "posRegisterSessionActivity.test.ts",
@@ -264433,7 +264430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 679,
+      "community": 678,
       "file_type": "code",
       "id": "posregistersessionactivity_test_buildactivity",
       "label": "buildActivity()",
@@ -264442,7 +264439,7 @@
       "source_location": "L457"
     },
     {
-      "community": 679,
+      "community": 678,
       "file_type": "code",
       "id": "posregistersessionactivity_test_buildreport",
       "label": "buildReport()",
@@ -264451,13 +264448,49 @@
       "source_location": "L436"
     },
     {
-      "community": 679,
+      "community": 678,
       "file_type": "code",
       "id": "posregistersessionactivity_test_createfakerepository",
       "label": "createFakeRepository()",
       "norm_label": "createfakerepository()",
       "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
       "source_location": "L476"
+    },
+    {
+      "community": 679,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_sync_registercatalogrevision_ts",
+      "label": "registerCatalogRevision.ts",
+      "norm_label": "registercatalogrevision.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerCatalogRevision.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 679,
+      "file_type": "code",
+      "id": "registercatalogrevision_advanceregistercatalogrevision",
+      "label": "advanceRegisterCatalogRevision()",
+      "norm_label": "advanceregistercatalogrevision()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerCatalogRevision.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 679,
+      "file_type": "code",
+      "id": "registercatalogrevision_readregistercatalogrevision",
+      "label": "readRegisterCatalogRevision()",
+      "norm_label": "readregistercatalogrevision()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerCatalogRevision.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 679,
+      "file_type": "code",
+      "id": "registercatalogrevision_readregistercatalogrevisionrow",
+      "label": "readRegisterCatalogRevisionRow()",
+      "norm_label": "readregistercatalogrevisionrow()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerCatalogRevision.ts",
+      "source_location": "L6"
     },
     {
       "community": 68,
@@ -264678,42 +264711,6 @@
     {
       "community": 680,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sync_registercatalogrevision_ts",
-      "label": "registerCatalogRevision.ts",
-      "norm_label": "registercatalogrevision.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerCatalogRevision.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 680,
-      "file_type": "code",
-      "id": "registercatalogrevision_advanceregistercatalogrevision",
-      "label": "advanceRegisterCatalogRevision()",
-      "norm_label": "advanceregistercatalogrevision()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerCatalogRevision.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 680,
-      "file_type": "code",
-      "id": "registercatalogrevision_readregistercatalogrevision",
-      "label": "readRegisterCatalogRevision()",
-      "norm_label": "readregistercatalogrevision()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerCatalogRevision.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 680,
-      "file_type": "code",
-      "id": "registercatalogrevision_readregistercatalogrevisionrow",
-      "label": "readRegisterCatalogRevisionRow()",
-      "norm_label": "readregistercatalogrevisionrow()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerCatalogRevision.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 681,
-      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_sequencegappolicy_ts",
       "label": "sequenceGapPolicy.ts",
       "norm_label": "sequencegappolicy.ts",
@@ -264721,7 +264718,7 @@
       "source_location": "L1"
     },
     {
-      "community": 681,
+      "community": 680,
       "file_type": "code",
       "id": "sequencegappolicy_decidesequencegapaction",
       "label": "decideSequenceGapAction()",
@@ -264730,7 +264727,7 @@
       "source_location": "L115"
     },
     {
-      "community": 681,
+      "community": 680,
       "file_type": "code",
       "id": "sequencegappolicy_issequencegapresolved",
       "label": "isSequenceGapResolved()",
@@ -264739,7 +264736,7 @@
       "source_location": "L219"
     },
     {
-      "community": 681,
+      "community": 680,
       "file_type": "code",
       "id": "sequencegappolicy_recordsequencegapobservation",
       "label": "recordSequenceGapObservation()",
@@ -264748,7 +264745,7 @@
       "source_location": "L190"
     },
     {
-      "community": 682,
+      "community": 681,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_staffproof_ts",
       "label": "staffProof.ts",
@@ -264757,7 +264754,7 @@
       "source_location": "L1"
     },
     {
-      "community": 682,
+      "community": 681,
       "file_type": "code",
       "id": "staffproof_createposlocalstaffprooftoken",
       "label": "createPosLocalStaffProofToken()",
@@ -264766,7 +264763,7 @@
       "source_location": "L10"
     },
     {
-      "community": 682,
+      "community": 681,
       "file_type": "code",
       "id": "staffproof_hashposlocalstaffprooftoken",
       "label": "hashPosLocalStaffProofToken()",
@@ -264775,7 +264772,7 @@
       "source_location": "L16"
     },
     {
-      "community": 682,
+      "community": 681,
       "file_type": "code",
       "id": "staffproof_tohex",
       "label": "toHex()",
@@ -264784,7 +264781,7 @@
       "source_location": "L4"
     },
     {
-      "community": 683,
+      "community": 682,
       "file_type": "code",
       "id": "cloudrepairpolicy_test_buildconflict",
       "label": "buildConflict()",
@@ -264793,7 +264790,7 @@
       "source_location": "L387"
     },
     {
-      "community": 683,
+      "community": 682,
       "file_type": "code",
       "id": "cloudrepairpolicy_test_buildevent",
       "label": "buildEvent()",
@@ -264802,7 +264799,7 @@
       "source_location": "L407"
     },
     {
-      "community": 683,
+      "community": 682,
       "file_type": "code",
       "id": "cloudrepairpolicy_test_createrepairprojectionrepository",
       "label": "createRepairProjectionRepository()",
@@ -264811,7 +264808,7 @@
       "source_location": "L282"
     },
     {
-      "community": 683,
+      "community": 682,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_cloudrepairpolicy_test_ts",
       "label": "cloudRepairPolicy.test.ts",
@@ -264820,7 +264817,7 @@
       "source_location": "L1"
     },
     {
-      "community": 684,
+      "community": 683,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_terminalcommandservice_test_ts",
       "label": "terminalCommandService.test.ts",
@@ -264829,7 +264826,7 @@
       "source_location": "L1"
     },
     {
-      "community": 684,
+      "community": 683,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildcommand",
       "label": "buildCommand()",
@@ -264838,7 +264835,7 @@
       "source_location": "L1731"
     },
     {
-      "community": 684,
+      "community": 683,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildrepository",
       "label": "buildRepository()",
@@ -264847,7 +264844,7 @@
       "source_location": "L1666"
     },
     {
-      "community": 684,
+      "community": 683,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildruntimestatus",
       "label": "buildRuntimeStatus()",
@@ -264856,7 +264853,7 @@
       "source_location": "L1755"
     },
     {
-      "community": 685,
+      "community": 684,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
       "label": "sessionCommandRepository.ts",
@@ -264865,7 +264862,7 @@
       "source_location": "L1"
     },
     {
-      "community": 685,
+      "community": 684,
       "file_type": "code",
       "id": "sessioncommandrepository_collectsessionitemsfrompages",
       "label": "collectSessionItemsFromPages()",
@@ -264874,7 +264871,7 @@
       "source_location": "L177"
     },
     {
-      "community": 685,
+      "community": 684,
       "file_type": "code",
       "id": "sessioncommandrepository_createsessioncommandrepository",
       "label": "createSessionCommandRepository()",
@@ -264883,13 +264880,49 @@
       "source_location": "L68"
     },
     {
-      "community": 685,
+      "community": 684,
       "file_type": "code",
       "id": "sessioncommandrepository_scansessionitembyskuinpages",
       "label": "scanSessionItemBySkuInPages()",
       "norm_label": "scansessionitembyskuinpages()",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
       "source_location": "L195"
+    },
+    {
+      "community": 685,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_register_test_ts",
+      "label": "register.test.ts",
+      "norm_label": "register.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 685,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_public_register_test_ts",
+      "label": "register.test.ts",
+      "norm_label": "register.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 685,
+      "file_type": "code",
+      "id": "register_test_buildctx",
+      "label": "buildCtx()",
+      "norm_label": "buildctx()",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 685,
+      "file_type": "code",
+      "id": "register_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L38"
     },
     {
       "community": 686,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2850
-- Graph nodes: 11927
-- Graph edges: 14588
+- Graph nodes: 11928
+- Graph edges: 14590
 - Communities: 2775
 
 ## Graph Hotspots

--- a/packages/athena-webapp/convex/emails/ApprovalRequestPending.test.tsx
+++ b/packages/athena-webapp/convex/emails/ApprovalRequestPending.test.tsx
@@ -16,7 +16,7 @@ const baseProps: ApprovalRequestPendingProps = {
   },
   identifier: "TXN-1048",
   queueUrl:
-    "https://athena.wigclub.store/wigclub/store/wigclub/operations/approvals",
+    "https://athena-os.app/wigclub/store/wigclub/operations/approvals",
   reason: "Cash refund exceeded the register's approval threshold.",
   requestType: "pos_transaction_void",
   requesterName: "Ama Mensah",

--- a/packages/athena-webapp/convex/emails/ApprovalRequestPending.tsx
+++ b/packages/athena-webapp/convex/emails/ApprovalRequestPending.tsx
@@ -187,7 +187,7 @@ export const approvalRequestPendingPreviewProps = {
   },
   identifier: "#532108",
   queueUrl:
-    "https://athena.wigclub.store/wigclub/store/wigclub/operations/approvals",
+    "https://athena-os.app/wigclub/store/wigclub/operations/approvals",
   reason: "This transaction void requires manager approval.",
   requestType: "pos_transaction_void",
   requesterName: "Ama Mensah",

--- a/packages/athena-webapp/convex/emails/DailyManagerReport.test.tsx
+++ b/packages/athena-webapp/convex/emails/DailyManagerReport.test.tsx
@@ -17,7 +17,7 @@ const baseProps: DailyManagerReportProps = {
   completedBy: "Athena",
   storeCurrency: "GHS",
   status: "applied",
-  reportUrl: "https://athena.wigclub.store/wigclub/store/wigclub/operations",
+  reportUrl: "https://athena-os.app/wigclub/store/wigclub/operations",
   reviewedItems: [],
   carryForwardItems: [],
   blockers: [],
@@ -39,7 +39,7 @@ const baseProps: DailyManagerReportProps = {
     { name: "HD Lace Closure", detail: "HDLC-14", unitsSold: 4 },
   ],
   topItemsUrl:
-    "https://athena.wigclub.store/wigclub/store/wigclub/reports?daysStart=2026-07-03&daysEnd=2026-07-03&daysTableStart=2026-07-03&daysTableEnd=2026-07-03&selectedDay=2026-07-03&units=true",
+    "https://athena-os.app/wigclub/store/wigclub/reports?daysStart=2026-07-03&daysEnd=2026-07-03&daysTableStart=2026-07-03&daysTableEnd=2026-07-03&selectedDay=2026-07-03&units=true",
 };
 
 describe("DailyManagerReport", () => {
@@ -103,7 +103,7 @@ describe("DailyManagerReport", () => {
         completedBy="Athena"
         storeCurrency="GHS"
         status="prepared"
-        reportUrl="https://athena.wigclub.store/wigclub/store/wigclub/operations"
+        reportUrl="https://athena-os.app/wigclub/store/wigclub/operations"
       />,
     );
 
@@ -152,7 +152,7 @@ describe("DailyManagerReport", () => {
           completedBy: "Athena",
           operatingDate: "Friday, July 3",
           reportUrl:
-            "https://athena.wigclub.store/wigclub/store/wigclub/operations",
+            "https://athena-os.app/wigclub/store/wigclub/operations",
           storeName: "Wigclub East Legon",
         } as DailyManagerReportProps)}
       />,

--- a/packages/athena-webapp/convex/emails/DailyManagerReport.tsx
+++ b/packages/athena-webapp/convex/emails/DailyManagerReport.tsx
@@ -139,7 +139,7 @@ export const dailyManagerReportPreviewProps = {
   operatingDate: "Saturday, Aug 8",
   paymentTotals: samplePaymentTotalsFor(previewMoney),
   reportUrl:
-    "https://athena.wigclub.store/wigclub/store/wigclub/operations/daily-close?operatingDate=2026-08-08",
+    "https://athena-os.app/wigclub/store/wigclub/operations/daily-close?operatingDate=2026-08-08",
   reviewedItems: sampleReviewedItemsFor(previewMoney),
   status: "applied",
   storeCurrency: "GHS",
@@ -151,7 +151,7 @@ export const dailyManagerReportPreviewProps = {
     { name: "HD Lace Closure", detail: "HDLC-14", unitsSold: 4 },
   ],
   topItemsUrl:
-    "https://athena.wigclub.store/wigclub/store/wigclub/reports?daysStart=2026-08-08&daysEnd=2026-08-08&daysTableStart=2026-08-08&daysTableEnd=2026-08-08&selectedDay=2026-08-08&units=true",
+    "https://athena-os.app/wigclub/store/wigclub/reports?daysStart=2026-08-08&daysEnd=2026-08-08&daysTableStart=2026-08-08&daysTableEnd=2026-08-08&selectedDay=2026-08-08&units=true",
 } satisfies DailyManagerReportProps;
 
 const statusCopy: Record<DailyReportStatus, DailyReportStatusCopy> = {

--- a/packages/athena-webapp/convex/emails/DailyManagerReportComparisonPreview.tsx
+++ b/packages/athena-webapp/convex/emails/DailyManagerReportComparisonPreview.tsx
@@ -55,7 +55,7 @@ export default function DailyManagerReportComparisonPreview() {
           transactionCountComparison: "67% lower vs prior day",
         },
       ]}
-      reportUrl="https://athena.wigclub.store/wigclub/store/wigclub/operations/daily-close?operatingDate=2026-08-08"
+      reportUrl="https://athena-os.app/wigclub/store/wigclub/operations/daily-close?operatingDate=2026-08-08"
       reviewedItems={[]}
       status="applied"
       storeCurrency="GHS"

--- a/packages/athena-webapp/convex/emails/PosTerminalHealthAlert.tsx
+++ b/packages/athena-webapp/convex/emails/PosTerminalHealthAlert.tsx
@@ -25,7 +25,7 @@ export const posTerminalHealthAlertPreviewProps = {
     "Storage is almost full. New offline sales may not be saved reliably.",
   ],
   healthUrl:
-    "https://athena.wigclub.store/wigclub/store/wigclub/pos/terminals/terminal-1",
+    "https://athena-os.app/wigclub/store/wigclub/pos/terminals/terminal-1",
   observedAtLabel: "Saturday, Aug 8 · Reported at 8:47 PM",
   storeName: "Wigclub",
   terminalLabel: "Front counter / Register 2",

--- a/packages/athena-webapp/convex/emails/RegisterCloseoutVarianceAlert.test.tsx
+++ b/packages/athena-webapp/convex/emails/RegisterCloseoutVarianceAlert.test.tsx
@@ -16,7 +16,7 @@ const baseProps: RegisterCloseoutVarianceAlertProps = {
   reason: "Variance exceeded the closeout approval threshold.",
   registerLabel: "Front counter / Register 2",
   reviewUrl:
-    "https://athena.wigclub.store/wigclub/store/wigclub/cash-controls/registers/register-session-1",
+    "https://athena-os.app/wigclub/store/wigclub/cash-controls/registers/register-session-1",
   storeName: "Wigclub East Legon",
   submittedAt: "8:42 PM",
   submittedBy: "Ama Mensah",
@@ -146,7 +146,7 @@ describe("RegisterCloseoutVarianceAlert", () => {
           operatingDate: "Friday, July 3",
           registerLabel: "Front counter / Register 2",
           reviewUrl:
-            "https://athena.wigclub.store/wigclub/store/wigclub/cash-controls/registers/register-session-1",
+            "https://athena-os.app/wigclub/store/wigclub/cash-controls/registers/register-session-1",
           storeName: "Wigclub East Legon",
           submittedAt: "8:42 PM",
           submittedBy: "Ama Mensah",

--- a/packages/athena-webapp/convex/emails/RegisterCloseoutVarianceAlert.tsx
+++ b/packages/athena-webapp/convex/emails/RegisterCloseoutVarianceAlert.tsx
@@ -49,7 +49,7 @@ export const registerCloseoutVarianceAlertPreviewProps = {
   reason: "Variance exceeded the closeout approval threshold.",
   registerLabel: "Front counter / Register 2",
   reviewUrl:
-    "https://athena.wigclub.store/wigclub/store/wigclub/cash-controls/registers/register-session-1",
+    "https://athena-os.app/wigclub/store/wigclub/cash-controls/registers/register-session-1",
   storeName: "Wigclub",
   submittedAt: "8:47 PM",
   submittedBy: "Ama Mensah",

--- a/packages/athena-webapp/convex/emails/WeeklyManagerReport.tsx
+++ b/packages/athena-webapp/convex/emails/WeeklyManagerReport.tsx
@@ -57,7 +57,7 @@ export const weeklyManagerReportPreviewProps = {
     timestampDate: "Aug 8",
   },
   reportUrl:
-    "https://athena.wigclub.store/wigclub/store/wigclub/reports/weekly?reportId=week%3A2026-08-03",
+    "https://athena-os.app/wigclub/store/wigclub/reports/weekly?reportId=week%3A2026-08-03",
   reportSections: [
     {
       title: "Close variance",
@@ -133,7 +133,7 @@ export const weeklyManagerReportPreviewProps = {
     { name: "HD Lace Closure", detail: "HDLC-14", unitsSold: 24 },
   ],
   topItemsUrl:
-    "https://athena.wigclub.store/wigclub/store/wigclub/reports/weekly?reportId=week%3A2026-08-03&units=true",
+    "https://athena-os.app/wigclub/store/wigclub/reports/weekly?reportId=week%3A2026-08-03&units=true",
 } satisfies DailyManagerReportProps;
 
 export function WeeklyManagerReport(props: DailyManagerReportProps) {

--- a/packages/athena-webapp/convex/mailersend/index.tsx
+++ b/packages/athena-webapp/convex/mailersend/index.tsx
@@ -162,7 +162,7 @@ export const sendNewOrderEmail = async (params: {
 }) => {
   const appUrl =
     process.env.STAGE == "prod"
-      ? "https://athena.wigclub.store"
+      ? "https://athena-os.app"
       : "http://localhost:5173";
 
   const orderUrl = `${appUrl}/wigclub/store/wigclub/orders/${params.order_id}`;

--- a/packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts
@@ -70,7 +70,7 @@ describe("daily manager report email URLs", () => {
     process.env.SITE_URL = "https://storefront.example.com";
     process.env.STAGE = "prod";
 
-    expect(resolveAppUrl()).toBe("https://athena.wigclub.store");
+    expect(resolveAppUrl()).toBe("https://athena-os.app");
   });
 
   it("omits voids from operating summary when there are no voids", () => {

--- a/packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts
+++ b/packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts
@@ -1181,7 +1181,7 @@ export function resolveAppUrl() {
     return trimTrailingSlash(explicitAthenaUrl);
   }
 
-  if (process.env.STAGE === "prod") return "https://athena.wigclub.store";
+  if (process.env.STAGE === "prod") return "https://athena-os.app";
 
   return "http://localhost:5173";
 }

--- a/packages/athena-webapp/convex/sendgrid/index.tsx
+++ b/packages/athena-webapp/convex/sendgrid/index.tsx
@@ -124,7 +124,7 @@ export const sendNewOrderEmail = async (params: {
 }) => {
   const appUrl =
     process.env.STAGE == "prod"
-      ? "https://athena.wigclub.store"
+      ? "https://athena-os.app"
       : "http://localhost:5173";
 
   const message = {

--- a/packages/athena-webapp/index.html
+++ b/packages/athena-webapp/index.html
@@ -14,7 +14,7 @@
     <link rel="icon" href="/favicon-16x16.png" sizes="16x16" type="image/png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" sizes="180x180" />
     <link rel="manifest" href="/site.webmanifest" />
-    <link rel="canonical" href="https://athena.wigclub.store/" />
+    <link rel="canonical" href="https://athena-os.app/" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Athena" />
     <meta
@@ -25,7 +25,7 @@
       property="og:description"
       content="See today's sales, understand what moved, and keep the history behind your business close."
     />
-    <meta property="og:url" content="https://athena.wigclub.store/" />
+    <meta property="og:url" content="https://athena-os.app/" />
   </head>
   <body>
     <div id="app"></div>

--- a/packages/athena-webapp/playwright.prod.config.ts
+++ b/packages/athena-webapp/playwright.prod.config.ts
@@ -6,7 +6,7 @@ const baseURL =
   process.env.ATHENA_POS_E2E_BASE_URL ||
   (runLocalCandidateBuild
     ? `http://127.0.0.1:${port}`
-    : process.env.ATHENA_PROD_URL || "https://athena.wigclub.store");
+    : process.env.ATHENA_PROD_URL || "https://athena-os.app");
 const convexUrl =
   process.env.ATHENA_PROD_CONVEX_URL ||
   process.env.VITE_CONVEX_URL ||

--- a/packages/athena-webapp/src/config.test.ts
+++ b/packages/athena-webapp/src/config.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { resolveStoreFrontUrl } from "./config";
 
 describe("resolveStoreFrontUrl", () => {
@@ -10,12 +10,34 @@ describe("resolveStoreFrontUrl", () => {
     ).toBe("https://qa.wigclub.store");
   });
 
-  it("routes production Athena to the production storefront", () => {
+  it("routes the legacy production Athena host to the production storefront", () => {
     expect(
       resolveStoreFrontUrl({
         origin: "https://athena.wigclub.store",
       }),
     ).toBe("https://wigclub.store");
+  });
+
+  it("uses the configured storefront URL on the primary admin host", () => {
+    expect(
+      resolveStoreFrontUrl({
+        configuredUrl: "https://wigclub.store",
+        origin: "https://athena-os.app",
+      }),
+    ).toBe("https://wigclub.store");
+  });
+
+  it("warns and falls back when the primary admin host has no configured URL", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(resolveStoreFrontUrl({ origin: "https://athena-os.app" })).toBe(
+      "http://localhost:5174",
+    );
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("VITE_STOREFRONT_URL"),
+    );
+
+    warn.mockRestore();
   });
 
   it("routes local Athena dev to the local storefront dev server", () => {

--- a/packages/athena-webapp/src/config.ts
+++ b/packages/athena-webapp/src/config.ts
@@ -21,6 +21,33 @@ function isLocalHost(hostname: string) {
   return hostname === "localhost" || hostname === "127.0.0.1";
 }
 
+// Hosts whose storefront hostname is a mechanical transform of the admin
+// hostname. `athena-os.app` is deliberately absent: the admin app is no longer
+// named after the storefront it administers, so there is nothing to derive.
+// Builds served from it rely on VITE_STOREFRONT_URL, which every deploy path
+// sets.
+function deriveStoreFrontFromAdminHost(adminUrl: URL) {
+  const { hostname, protocol } = adminUrl;
+
+  if (hostname === "athena-qa.wigclub.store") {
+    return `${protocol}//qa.wigclub.store`;
+  }
+
+  if (hostname === "athena.wigclub.store") {
+    return `${protocol}//wigclub.store`;
+  }
+
+  if (hostname.startsWith("athena-qa.")) {
+    return `${protocol}//${hostname.replace(/^athena-qa\./, "qa.")}`;
+  }
+
+  if (hostname.startsWith("athena.")) {
+    return `${protocol}//${hostname.replace(/^athena\./, "")}`;
+  }
+
+  return undefined;
+}
+
 export function resolveStoreFrontUrl({
   configuredUrl,
   origin,
@@ -46,24 +73,18 @@ export function resolveStoreFrontUrl({
     return `${adminUrl.protocol}//${adminUrl.hostname}:5174`;
   }
 
-  if (adminUrl.hostname === "athena-qa.wigclub.store") {
-    return `${adminUrl.protocol}//qa.wigclub.store`;
+  const derived = deriveStoreFrontFromAdminHost(adminUrl);
+  if (derived) {
+    return derived;
   }
 
-  if (adminUrl.hostname === "athena.wigclub.store") {
-    return `${adminUrl.protocol}//wigclub.store`;
-  }
-
-  if (adminUrl.hostname.startsWith("athena-qa.")) {
-    return `${adminUrl.protocol}//${adminUrl.hostname.replace(
-      /^athena-qa\./,
-      "qa.",
-    )}`;
-  }
-
-  if (adminUrl.hostname.startsWith("athena.")) {
-    return `${adminUrl.protocol}//${adminUrl.hostname.replace(/^athena\./, "")}`;
-  }
+  // Reaching here on a deployed host means the build is missing
+  // VITE_STOREFRONT_URL. Say so, rather than silently pointing every storefront
+  // link in the admin app at a dev server nobody is running.
+  console.warn(
+    `[config] No storefront URL configured for ${adminUrl.hostname}. ` +
+      `Set VITE_STOREFRONT_URL at build time. Falling back to ${LOCAL_STOREFRONT_URL}.`,
+  );
 
   return LOCAL_STOREFRONT_URL;
 }

--- a/packages/athena-webapp/src/static-product-metadata.test.ts
+++ b/packages/athena-webapp/src/static-product-metadata.test.ts
@@ -26,7 +26,7 @@ describe("static product-page metadata", () => {
     expect(document.querySelectorAll('link[rel="canonical"]')).toHaveLength(1);
     expect(
       document.querySelector('link[rel="canonical"]')?.getAttribute("href"),
-    ).toBe("https://athena.wigclub.store/");
+    ).toBe("https://athena-os.app/");
   });
 
   it("keeps Open Graph metadata aligned with the canonical public page", () => {
@@ -44,6 +44,6 @@ describe("static product-page metadata", () => {
         .querySelector('meta[name="description"]')
         ?.getAttribute("content"),
     );
-    expect(content("og:url")).toBe("https://athena.wigclub.store/");
+    expect(content("og:url")).toBe("https://athena-os.app/");
   });
 });

--- a/packages/athena-webapp/vite.config.ts
+++ b/packages/athena-webapp/vite.config.ts
@@ -8,7 +8,7 @@ import { athenaDocsContentPlugin } from "./vite-docs-content-plugin";
 export default defineConfig(({ mode }) => ({
   base: "/",
   server: {
-    allowedHosts: ["athena-qa.wigclub.store"],
+    allowedHosts: ["athena-qa.wigclub.store", "qa.athena-os.app"],
   },
   optimizeDeps: {
     // Generated Storybook output can coexist with the app in local worktrees.

--- a/scripts/deploy-qa-vps.test.ts
+++ b/scripts/deploy-qa-vps.test.ts
@@ -59,7 +59,12 @@ describe("VPS QA deploy contract", () => {
     expect(setupScript).toContain(
       "proxy_pass http://127.0.0.1:$STOREFRONT_QA_PORT;",
     );
-    expect(setupScript).toContain("server_name $ATHENA_QA_HOST;");
+    expect(setupScript).toContain(
+      'ATHENA_QA_ALT_HOST="${ATHENA_QA_ALT_HOST:-qa.athena-os.app}"',
+    );
+    expect(setupScript).toContain(
+      "server_name $ATHENA_QA_HOST $ATHENA_QA_ALT_HOST;",
+    );
     expect(setupScript).toContain(
       "proxy_pass http://127.0.0.1:$ATHENA_QA_PORT;",
     );

--- a/scripts/deploy-vps.sh
+++ b/scripts/deploy-vps.sh
@@ -18,6 +18,10 @@ DEV_CONVEX_CLOUD="${DEV_CONVEX_CLOUD:-https://jovial-wildebeest-179.convex.cloud
 DEV_CONVEX_SITE="${DEV_CONVEX_SITE:-https://jovial-wildebeest-179.convex.site}"
 DEV_API_URL="${DEV_API_URL:-https://dev.wigclub.store}"
 STOREFRONT_URL="${STOREFRONT_URL:-https://wigclub.store}"
+# The QA admin app is reachable on hosts the storefront URL cannot be derived
+# from (qa.athena-os.app), so pass it explicitly rather than relying on the
+# hostname fallback in src/config.ts.
+QA_STOREFRONT_URL="${QA_STOREFRONT_URL:-https://$STOREFRONT_QA_HOST}"
 VITE_WALKTHROUGH_PRIVACY_CONTACT="${VITE_WALKTHROUGH_PRIVACY_CONTACT:-Kwamina.0x00@gmail.com}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -396,7 +400,7 @@ REMOTE_SCRIPT
 }
 
 deploy_athena_qa() {
-  remote_script "$REMOTE_SOURCE_DIR" "$ATHENA_QA_PORT" "$DEV_CONVEX_CLOUD" "$DEV_CONVEX_SITE" "$ATHENA_QA_HOST" "$VITE_WALKTHROUGH_PRIVACY_CONTACT" <<'REMOTE_SCRIPT'
+  remote_script "$REMOTE_SOURCE_DIR" "$ATHENA_QA_PORT" "$DEV_CONVEX_CLOUD" "$DEV_CONVEX_SITE" "$ATHENA_QA_HOST" "$VITE_WALKTHROUGH_PRIVACY_CONTACT" "$QA_STOREFRONT_URL" <<'REMOTE_SCRIPT'
 set -euo pipefail
 
 REMOTE_SOURCE_DIR="$1"
@@ -405,6 +409,7 @@ DEV_CONVEX_CLOUD="$3"
 DEV_CONVEX_SITE="$4"
 ATHENA_QA_HOST="$5"
 VITE_WALKTHROUGH_PRIVACY_CONTACT="${6:-}"
+QA_STOREFRONT_URL="${7:-}"
 
 export BUN_INSTALL="${BUN_INSTALL:-/root/.bun}"
 export PATH="$BUN_INSTALL/bin:$PATH"
@@ -417,6 +422,7 @@ fi
 
 VITE_CONVEX_URL="$DEV_CONVEX_CLOUD" \
 VITE_API_GATEWAY_URL="$DEV_CONVEX_SITE" \
+VITE_STOREFRONT_URL="$QA_STOREFRONT_URL" \
 VITE_WALKTHROUGH_PRIVACY_CONTACT="$VITE_WALKTHROUGH_PRIVACY_CONTACT" \
   pm2 start bun --name athena-qa -- run dev -- --host 127.0.0.1 --port "$ATHENA_QA_PORT" --strictPort
 

--- a/scripts/setup-production-vps.sh
+++ b/scripts/setup-production-vps.sh
@@ -6,9 +6,19 @@ PROD_CONVEX_SITE="${PROD_CONVEX_SITE:-https://colorless-cardinal-870.convex.site
 DEV_CONVEX_SITE="${DEV_CONVEX_SITE:-https://jovial-wildebeest-179.convex.site}"
 STOREFRONT_HOST="${STOREFRONT_HOST:-wigclub.store}"
 STOREFRONT_WWW_HOST="${STOREFRONT_WWW_HOST:-www.wigclub.store}"
-ATHENA_HOST="${ATHENA_HOST:-athena.wigclub.store}"
+ATHENA_HOST="${ATHENA_HOST:-athena-os.app}"
+# Served alongside ATHENA_HOST from the same document root, not redirected to it.
+# The production POS terminal is bookmarked here and its offline state
+# (IndexedDB, app-shell service worker cache, auth session) is origin-scoped, so
+# a redirect would strand unsynced sales. Retire only after that terminal has
+# drained and been re-onboarded on ATHENA_HOST.
+ATHENA_LEGACY_HOST="${ATHENA_LEGACY_HOST:-athena.wigclub.store}"
 STOREFRONT_QA_HOST="${STOREFRONT_QA_HOST:-qa.wigclub.store}"
 ATHENA_QA_HOST="${ATHENA_QA_HOST:-athena-qa.wigclub.store}"
+ATHENA_QA_ALT_HOST="${ATHENA_QA_ALT_HOST:-qa.athena-os.app}"
+# Redirected to ATHENA_HOST rather than serving the app a second time, so the
+# admin app has exactly one origin and one session store.
+ATHENA_WWW_HOST="${ATHENA_WWW_HOST:-www.athena-os.app}"
 ATHENA_QA_PORT="${ATHENA_QA_PORT:-${QA_PORT:-5175}}"
 STOREFRONT_QA_PORT="${STOREFRONT_QA_PORT:-5176}"
 API_HOST="${API_HOST:-api.wigclub.store}"
@@ -62,7 +72,7 @@ server {
 
 server {
     listen 80;
-    server_name $ATHENA_HOST;
+    server_name $ATHENA_HOST $ATHENA_LEGACY_HOST;
     root $ATHENA_ROOT/athena-webapp/current;
     index index.html;
 
@@ -101,7 +111,7 @@ server {
 
 server {
     listen 80;
-    server_name $ATHENA_QA_HOST;
+    server_name $ATHENA_QA_HOST $ATHENA_QA_ALT_HOST;
 
     # Keep QA walkthrough responses out of search results under the same path
     # boundary as production, including query strings and nested SPA URLs.
@@ -209,6 +219,15 @@ server {
 }
 NGINX
 
+# Separate file so the redirect survives a rewrite of wigclub.conf.
+cat >/etc/nginx/conf.d/athena-os-www.conf <<NGINX
+server {
+    listen 80;
+    server_name $ATHENA_WWW_HOST;
+    return 301 https://$ATHENA_HOST\$request_uri;
+}
+NGINX
+
 nginx -t
 systemctl enable --now nginx
 systemctl enable --now valkey-server
@@ -217,3 +236,4 @@ systemctl enable pm2-root
 
 echo "Base VPS setup complete."
 echo "Next: install cloudflared credentials, add the VPS GitHub deploy key, run scripts/deploy-vps.sh, then configure the Cloudflare Tunnel hostnames."
+echo "The Athena admin app is served on both $ATHENA_HOST and $ATHENA_LEGACY_HOST; both need a tunnel hostname and DNS route."

--- a/tools/screen-redact-extension/README.md
+++ b/tools/screen-redact-extension/README.md
@@ -13,7 +13,7 @@ Chrome extension for recording the admin app. It does two things, independently:
 
 1. Chrome → `chrome://extensions` → enable **Developer mode**.
 2. **Load unpacked** → select this folder (`tools/screen-redact-extension`).
-3. Open https://athena.wigclub.store, click the extension icon, tick **Mask amounts**.
+3. Open https://athena-os.app (or the legacy https://athena.wigclub.store — both are supported), click the extension icon, tick **Mask amounts**.
 4. Confirm the small `REDACTED` badge is showing bottom-right before you hit record.
 
 Toggle at any time with **Alt+Shift+M** (works mid-recording).

--- a/tools/screen-redact-extension/manifest.json
+++ b/tools/screen-redact-extension/manifest.json
@@ -5,6 +5,7 @@
   "description": "Masks currency amounts and hides demo-only chrome so the admin app can be screen-recorded safely.",
   "permissions": ["storage", "scripting", "activeTab"],
   "host_permissions": [
+    "https://athena-os.app/*",
     "https://athena.wigclub.store/*",
     "http://localhost/*"
   ],
@@ -21,7 +22,11 @@
   "background": { "service_worker": "background.js" },
   "content_scripts": [
     {
-      "matches": ["https://athena.wigclub.store/*", "http://localhost/*"],
+      "matches": [
+        "https://athena-os.app/*",
+        "https://athena.wigclub.store/*",
+        "http://localhost/*"
+      ],
       "js": ["content.js"],
       "css": ["content.css"],
       "run_at": "document_start",


### PR DESCRIPTION
Moves the Athena admin app's primary URL to `athena-os.app` while keeping `athena.wigclub.store` serving the same document root.

## Why it's an alias, not a redirect

The production POS terminal is bookmarked to the legacy host and is offline-capable. Its unsynced sales (`athena-pos-local` IndexedDB), app-shell service worker cache, and auth session are all **origin-scoped**. A 301 would move the browser to an origin where none of that exists and make the old one unreachable, stranding any sale not yet synced.

Both hosts are therefore served from one nginx block. `ATHENA_LEGACY_HOST` names the alias and carries a comment recording why it must not become a redirect. It retires only once that terminal has drained and been re-onboarded.

## Changes

- **nginx** — `server_name $ATHENA_HOST $ATHENA_LEGACY_HOST`; `www.athena-os.app` 301s to the apex from its own conf file so it survives a `wigclub.conf` rewrite; `qa.athena-os.app` joins the QA block
- **Storefront URL resolution** — the legacy `athena*.wigclub.store` derivations move into a named helper and are kept. Any unrecognised deployed host now **warns** that `VITE_STOREFRONT_URL` is missing instead of silently falling back to `http://localhost:5174`. No `athena-os.app → wigclub.store` mapping was added; that would hardcode tenant identity into the platform host.
- **Primary-host references** — `index.html` canonical/`og:url`, the three Convex `STAGE=prod` email URLs plus template previews, the Playwright prod default
- **Rollback workflow** — smoke-checks both admin hosts; a rollback leaving either broken is a failed rollback
- **QA** — `qa.athena-os.app` added to Vite `allowedHosts` (Vite 403s unknown `Host` headers) and the QA deploy now passes `VITE_STOREFRONT_URL`, which cannot be derived from that hostname
- **screen-redact extension** — matches both origins so it doesn't go dark on the legacy terminal

## Already live

The infrastructure half was applied to the VPS and Cloudflare during this work. Verified externally: `athena-os.app` returns 200 serving the app with no Squarespace markers, `www` 301s to the apex, `athena.wigclub.store` still returns 200. `qa.athena-os.app` returns Vite's 403 until this merges and QA redeploys — that 403 confirms the Cloudflare → tunnel → nginx → dev-server path is intact.

This PR makes the repo match that state and fixes the two things a deploy still owns: the canonical/`og:url` tags and the Convex email links, both of which still point at the legacy host in the running build.

## Verification

`bun run pr:athena` green — all five phases pass, proof recorded for `f01ed243`.

Solution note: `docs/solutions/architecture-patterns/athena-dual-origin-admin-hosts-2026-08-10.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)