### PR TITLE
fix(reports): align daily close and weekly review

### DIFF
--- a/docs/reports/2026-08-12-store-day-sales-parity-weekly-review-report.html
+++ b/docs/reports/2026-08-12-store-day-sales-parity-weekly-review-report.html
@@ -1,0 +1,215 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Store-Day Sales Parity and Weekly Review Refinement</title>
+</head>
+<body>
+    <article data-athena-landed-change-report="v2" data-athena-report-diff-fingerprint="4d79178e4438fa24d1e3e7bff0b559a670a413e7f889bf6e072714b429e16a5e">
+  <header data-report-section="header">
+    <h1>Store-Day Sales Parity and Weekly Review Refinement</h1>
+    <p>Why Daily Close now agrees with channel-complete reporting</p>
+    <ul data-report-pills>
+      <li>Delivery candidate</li>
+      <li>Branch codex/eod-storefront-net-sales</li>
+      <li>Focused validation complete</li>
+      <li>Production deploy pending</li>
+    </ul>
+    <dl data-report-meta>
+      <dt>Source</dt><dd>61e91573</dd>
+      <dt>Status</dt><dd>Delivery candidate</dd>
+      <dt>Root alignment</dt><dd>Pending merge</dd>
+      <dt>Production</dt><dd>Pending merge</dd>
+    </dl>
+  </header>
+  <section data-report-section="summary">
+    <h2>Executive summary</h2>
+      <p>Daily Close now includes completed storefront orders in the same store-day sales total used for POS activity. The accepted close can therefore carry channel-complete sales evidence into reporting instead of freezing a lower POS-only total.</p>
+      <p>The weekly workspace also communicates evidence and sort choices more efficiently: shared coverage is stated once, empty payment mix is omitted, expense rankings use one reusable segmented control, and historical weeks offer an explicit return to the current period.</p>
+  </section>
+  <section data-report-section="problem">
+    <h2>The mismatch</h2>
+      <p>Reports folded fulfilled online orders, while End of Day Review counted only completed POS transactions. Both surfaces were internally consistent with their own source sets, but they answered the same store-day question with different totals.</p>
+      <p>A safe repair had to include money, counts, inspectable rows, legacy documents, source caps, and Convex read cost together.</p>
+  </section>
+  <section data-report-section="mental-model">
+    <h2>Mental model</h2>
+      <p>Think of Daily Close as the store-day envelope. POS and storefront are separate sales lanes entering that envelope. Reports may transform the accepted evidence later, but the envelope cannot omit a lane that reports already recognizes.</p>
+      <p>For current online orders, the parent row now carries the charged paymentDue and compact itemCount needed by the envelope. Older rows use a bounded reconstruction path.</p>
+  </section>
+  <section data-report-section="before-after">
+    <h2>Before and after</h2>
+      <p>Before: completed POS transactions fed Daily Close totals, while fulfilled online orders entered reporting facts independently. A day containing online revenue produced a lower EOD number.</p>
+      <p>After: delivered and picked-up orders in the operating-day range contribute paymentDue and one transaction each, create linked ready evidence, and participate in source completeness. Accepted Daily Close facts then flow through the existing dirty-day and weekly projection pipeline.</p>
+  </section>
+  <section data-report-section="changes">
+    <h2>What changed</h2>
+      <p>POS payment totals, POS cash totals, cash transaction counts, report acceptance semantics, and frozen historical close snapshots remain unchanged. Only delivered and picked-up storefront statuses are included.</p>
+      <ul>
+        <li>Online-order creation snapshots itemCount beside the existing authoritative paymentDue.</li>
+        <li>Daily Close reads fulfilled orders through the store/status/completed-time index and uses the parent projection without child queries for current data.</li>
+        <li>Legacy orders reconstruct inline or split item rows under one 200-line evidence budget and fail closed when completeness cannot be proven.</li>
+        <li>Weekly payment, cash, and expense coverage collapses into one Daily Close evidence line only when the three lanes agree.</li>
+        <li>Payment mix and expense sort controls disappear when there is no corresponding data.</li>
+        <li>Overview, Units Moved, and weekly expense rankings reuse ReportSegmentedTabs.</li>
+        <li>Historical weekly selection can return to the current week while clearing period-owned sheet state.</li>
+      </ul>
+  </section>
+  <section data-report-section="failure-boundaries">
+    <h2>Failure boundaries</h2>
+      <p>More than 200 qualifying orders or more than 200 reconstructed legacy lines marks source evidence incomplete. The visible snapshot may contain provisional partial totals and rows, but existing completion guards prevent the operator or automation from accepting that unproven close. Escalate the cap breach for engineering remediation, such as a bounded pagination or cap change, then rebuild the snapshot; do not delete or exclude valid sales evidence.</p>
+      <p>Current orders avoid read amplification. Legacy child reads are sequential and constrained by the remaining shared budget.</p>
+      <p>Already completed historical snapshots are not rewritten. The correction applies when the store-day snapshot is built before acceptance or rebuilt after reopening.</p>
+  </section>
+  <section data-report-section="validation">
+    <h2>Validation and review</h2>
+      <p>The repository merge gate must be rerun after adding this report and solution note. Merge, local-main alignment, Convex deployment, and Athena frontend deployment are still pending and must not be inferred from this candidate report.</p>
+      <ul>
+        <li><code>bun run test -- convex/operations/dailyClose.test.ts</code>: 95 tests passed.</li>
+        <li><code>bun run test -- convex/storeFront/onlineOrder.test.ts</code>: 13 tests passed.</li>
+        <li><code>bun run test -- ReportsWeeklyView.test.tsx</code>: 42 tests passed.</li>
+        <li><code>bun run test -- weekly.lifecycle.test.tsx</code>: 28 tests passed.</li>
+        <li><code>bun run typecheck</code> passed. <code>bun run lint:frontend:changed</code> passed with only 4 Fast Refresh warnings.</li>
+        <li>Final candidate review artifacts under <code>/tmp/compound-engineering/ce-code-review/reports-20260812-final/</code> are clean for correctness, testing, TypeScript, adversarial behavior, agent-native parity, and performance. Maintainability records one non-blocking P3 consolidation note.</li>
+      </ul>
+  </section>
+  <section data-report-section="guidance">
+    <h2>Next-time guidance</h2>
+      <ul>
+        <li>When adding a sales channel to reports, update Daily Close total, count, evidence rows, and completeness together.</li>
+        <li>Persist compact parent projections for hot aggregate reads; keep child reconstruction bounded and legacy-only.</li>
+        <li>Use the shared segmented report control for mutually exclusive report orderings.</li>
+        <li>Treat empty analytical sections as absent when they offer neither data nor an operator action.</li>
+      </ul>
+  </section>
+  <section data-report-section="key-files">
+    <h2>Key files</h2>
+    <table>
+      <thead><tr><th>File</th><th>Why it matters</th></tr></thead>
+      <tbody>
+        <tr><td><code>packages/athena-webapp/convex/operations/dailyClose.ts</code></td><td>Owns the store-day source reads, completeness, ready evidence, and combined sales summary.</td></tr>
+        <tr><td><code>packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts</code></td><td>Snapshots itemCount beside paymentDue when current orders are created.</td></tr>
+        <tr><td><code>packages/athena-webapp/convex/schemas/storeFront/onlineOrder/onlineOrder.ts</code></td><td>Keeps itemCount optional so old documents remain readable.</td></tr>
+        <tr><td><code>packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx</code></td><td>Presents shared coverage, conditional sections, and tabbed expense rankings.</td></tr>
+        <tr><td><code>packages/athena-webapp/src/components/reports/ReportSegmentedTabs.tsx</code></td><td>Centralizes segmented-control styling across report surfaces.</td></tr>
+        <tr><td><code>packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports/weekly.tsx</code></td><td>Owns historical-week selection and return-to-current route state.</td></tr>
+      </tbody>
+    </table>
+  </section>
+  <section data-report-section="quiz" data-quiz-pass-threshold="8">
+    <h2>Comprehension quiz</h2>
+    <p>Pass required: 8 of 10.</p>
+    <ol data-quiz>
+      <li data-quiz-question>
+        <p data-quiz-prompt>A store day has POS sales and one picked-up online order. Why was Reports higher than the old EOD total?</p>
+        <ol data-quiz-options>
+          <li>Daily Close included the order but excluded the POS sale</li>
+          <li data-quiz-correct>Daily Close omitted fulfilled storefront orders</li>
+          <li>Reports treated the picked-up order as cash tender</li>
+          <li>Daily Close counted the order only in transactionCount</li>
+        </ol>
+        <p data-quiz-explanation>Reports included storefront facts while Daily Close originally summarized only POS transactions.</p>
+      </li>
+      <li data-quiz-question>
+        <p data-quiz-prompt>Which storefront statuses now contribute to Daily Close?</p>
+        <ol data-quiz-options>
+          <li>Every non-cancelled status</li>
+          <li>Open and ready</li>
+          <li data-quiz-correct>Delivered and picked-up</li>
+          <li>Refunded only</li>
+        </ol>
+        <p data-quiz-explanation>Terminal fulfillment, represented by delivered or picked-up, is the inclusion boundary.</p>
+      </li>
+      <li data-quiz-question>
+        <p data-quiz-prompt>What is the current-order fast path?</p>
+        <ol data-quiz-options>
+          <li>Scan every order item concurrently</li>
+          <li data-quiz-correct>Use paymentDue and itemCount on the parent order</li>
+          <li>Trust the client subtotal</li>
+          <li>Read report facts back into Daily Close</li>
+        </ol>
+        <p data-quiz-explanation>The parent projection supplies the charged total and evidence count without child queries.</p>
+      </li>
+      <li data-quiz-question>
+        <p data-quiz-prompt>How are older orders handled?</p>
+        <ol data-quiz-options>
+          <li>They are ignored</li>
+          <li>They are migrated during every read</li>
+          <li data-quiz-correct>They use bounded inline or split-row reconstruction</li>
+          <li>They always use amount without discounts</li>
+        </ol>
+        <p data-quiz-explanation>Optional parent fields preserve compatibility, while bounded reconstruction keeps historical totals accurate.</p>
+      </li>
+      <li data-quiz-question>
+        <p data-quiz-prompt>An order-source cap is exceeded and the snapshot shows some rows. May the close be accepted?</p>
+        <ol data-quiz-options>
+          <li>Yes, because every displayed row is individually valid</li>
+          <li>Yes, after a manager acknowledges the partial total</li>
+          <li data-quiz-correct>No; displayed totals remain provisional and incomplete evidence blocks acceptance</li>
+          <li>No, but the provisional total is persisted as a completed snapshot</li>
+        </ol>
+        <p data-quiz-explanation>Completeness metadata prevents an unproven store-day close from being accepted.</p>
+      </li>
+      <li data-quiz-question>
+        <p data-quiz-prompt>Which totals remain POS-only?</p>
+        <ol data-quiz-options>
+          <li>Sales total and transaction count</li>
+          <li data-quiz-correct>Payment totals and cash totals</li>
+          <li>All weekly totals</li>
+          <li>Expense totals</li>
+        </ol>
+        <p data-quiz-explanation>Storefront revenue joins sales, but POS tender and cash attribution remain in their existing lanes.</p>
+      </li>
+      <li data-quiz-question>
+        <p data-quiz-prompt>When is the shared Daily Close evidence line shown?</p>
+        <ol data-quiz-options>
+          <li>Whenever any lane is complete</li>
+          <li data-quiz-correct>Only when payment, cash, and expense coverage agree</li>
+          <li>Only for historical weeks</li>
+          <li>Whenever payment mix is empty</li>
+        </ol>
+        <p data-quiz-explanation>A single line is safe only when all three coverage values match and are available.</p>
+      </li>
+      <li data-quiz-question>
+        <p data-quiz-prompt>What happens to Payment mix with zero rows?</p>
+        <ol data-quiz-options>
+          <li>It shows a certified-zero card</li>
+          <li>It renders loading copy</li>
+          <li data-quiz-correct>The section is omitted</li>
+          <li>It becomes a modal</li>
+        </ol>
+        <p data-quiz-explanation>The weekly view no longer renders a section with no payment methods to compare.</p>
+      </li>
+      <li data-quiz-question>
+        <p data-quiz-prompt>What state changes when Return to current week is selected?</p>
+        <ol data-quiz-options>
+          <li>Every report preference, including the Overview window</li>
+          <li>Only the selected report id; history pagination remains</li>
+          <li data-quiz-correct>The historical report, history cursors, and Units Moved sheet/tab/page/return state clear; the Overview window remains</li>
+          <li>The active store and report tab reset</li>
+        </ol>
+        <p data-quiz-explanation>The action exits the selected historical period while preserving unrelated report context.</p>
+      </li>
+      <li data-quiz-question>
+        <p data-quiz-prompt>What does this delivery-candidate report prove about production status?</p>
+        <ol data-quiz-options>
+          <li>It proves Convex and Athena are already deployed</li>
+          <li data-quiz-correct>It proves neither merge nor deployment; those finish-line steps remain pending</li>
+          <li>It proves the branch may deploy directly without merging</li>
+          <li>It proves only the storefront surface needs deployment</li>
+        </ol>
+        <p data-quiz-explanation>This report describes a delivery candidate; merge and post-merge deployment are still pending.</p>
+      </li>
+    </ol>
+  </section>
+  <section data-report-section="subagent-evidence">
+    <h2>Subagent evidence</h2>
+    <dl>
+      <dt>session context historian</dt><dd>Searched prior sessions and repo artifacts, then reconstructed the decision and review history from source evidence when no extractable prior transcript remained.</dd>
+      <dt>delivered diff explorer</dt><dd>Mapped backend, projection, presentation, navigation, test, and generated-artifact changes plus unchanged boundaries and risks.</dd>
+      <dt>final candidate review personas</dt><dd>Correctness, testing, TypeScript, adversarial, agent-native, standards, maintainability, and performance reviewers challenged the candidate; blocking findings were fixed and re-reviewed.</dd>
+    </dl>
+  </section>
+</article>
+</body>
+</html>

--- a/docs/solutions/logic-errors/daily-close-storefront-sales-parity-2026-08-12.md
+++ b/docs/solutions/logic-errors/daily-close-storefront-sales-parity-2026-08-12.md
@@ -1,0 +1,94 @@
+---
+title: Daily Close Must Include Every Completed Sales Channel
+date: 2026-08-12
+category: logic-errors
+module: athena-webapp-reporting
+problem_type: logic_error
+component: database
+symptoms:
+  - "End of day review net sales are lower than the Reports workspace for the same store day"
+  - "Completed storefront orders appear in reporting facts but not in Daily Close totals"
+root_cause: missing_include
+resolution_type: code_fix
+severity: high
+related_components:
+  - reports-workspace
+  - storefront-orders
+  - daily-close
+tags:
+  - daily-close
+  - storefront
+  - net-sales
+  - source-completeness
+  - convex
+delivery_diff_fingerprint: 4d79178e4438fa24d1e3e7bff0b559a670a413e7f889bf6e072714b429e16a5e
+---
+
+# Daily Close Must Include Every Completed Sales Channel
+
+## Problem
+
+Daily Close treated completed POS transactions as the entire store-day sales
+boundary. The Reports workspace also folds fulfilled storefront orders, so a
+day with online revenue produced two internally valid but different net-sales
+figures.
+
+## Symptoms
+
+- The EOD Review sales total omitted fulfilled online orders.
+- The Reports workspace showed the higher channel-complete figure.
+- Simply adding order totals risked inconsistent transaction counts, legacy
+  discount errors, and unbounded per-order line queries.
+
+## What Didn't Work
+
+- Adding storefront totals without changing `transactionCount` made the summary
+  internally inconsistent.
+- Reading only `onlineOrderItem` rows dropped older orders that retain inline
+  `order.items`.
+- Launching one 201-row probe per order concurrently could exceed Convex read
+  limits before the aggregate 200-line completeness budget was applied.
+- Sequentially loading current-format child rows preserved the cap but put an
+  N+1 query path on the live Daily Close snapshot.
+
+## Solution
+
+Treat fulfilled storefront orders as first-class Daily Close sales evidence:
+
+- Read `delivered` and `picked-up` orders through the
+  `by_storeId_status_completedAt` index for the operating-day range.
+- Add their authoritative `paymentDue` to `salesTotal` and count each order in
+  `transactionCount`.
+- Persist a compact `itemCount` when a new online order is created. Current
+  orders can then populate EOD evidence from the parent row without child
+  queries.
+- For older orders, reconstruct lines from inline `order.items` or bounded
+  `onlineOrderItem` rows. Record incomplete source evidence when the shared
+  200-line probe is exceeded.
+- Emit a linked `Completed online order` ready item so the total remains
+  inspectable by operators.
+
+## Why This Works
+
+The parent order already owns the charged total in `paymentDue`; copying only
+the derived item count at creation gives Daily Close the two values it needs
+without creating a competing money calculation. Optional fields preserve old
+documents, while the legacy fallback maintains historical accuracy and fails
+closed when it cannot prove completeness.
+
+## Prevention
+
+- When a new sales channel contributes reporting facts, add it to the
+  store-day close boundary or explicitly document why it is excluded.
+- Keep totals, counts, visible evidence rows, and source-completeness entries in
+  the same change.
+- Prefer compact parent-row projections for hot aggregate reads; reserve child
+  reconstruction for bounded legacy fallback paths.
+- Test mixed POS/storefront days, legacy inline discounts, and both parent and
+  child source caps.
+
+## Related Issues
+
+- [Athena Daily Close Is A Store-Day Boundary](athena-daily-close-store-day-boundary-2026-05-07.md)
+- [Athena Convex Read Amplification](../performance/athena-convex-read-amplification-2026-06-29.md)
+- [Athena Reporting Fact Projection Boundary](../architecture/athena-reporting-fact-projection-boundary-2026-07-09.md)

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 2866 files · ~0 words
+- 2868 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 12053 nodes · 14785 edges · 2791 communities detected
+- 12055 nodes · 14787 edges · 2793 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2801,10 +2801,12 @@
 - [[_COMMUNITY_Community 2788|Community 2788]]
 - [[_COMMUNITY_Community 2789|Community 2789]]
 - [[_COMMUNITY_Community 2790|Community 2790]]
+- [[_COMMUNITY_Community 2791|Community 2791]]
+- [[_COMMUNITY_Community 2792|Community 2792]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
-2. `buildDailyCloseSnapshotWithCtx()` - 35 edges
+2. `buildDailyCloseSnapshotWithCtx()` - 37 edges
 3. `collectConvexQueryWriteBoundaryFindings()` - 28 edges
 4. `projectLocalRegisterReadModel()` - 27 edges
 5. `applyInventoryEffectWithCtx()` - 22 edges
@@ -2830,7 +2832,7 @@
 
 ### Community 0 - "Community 0"
 Cohesion: 0.05
-Nodes (86): approvalBelongsToRange(), approvalRequestTypeLabel(), asCarryForwardItem(), buildApprovalRequestsById(), buildDailyCloseExpenseProductEvidence(), buildDailyCloseLifecycleGateWithCtx(), buildDailyCloseReportSnapshot(), buildDailyCloseSnapshotWithCtx() (+78 more)
+Nodes (88): approvalBelongsToRange(), approvalRequestTypeLabel(), asCarryForwardItem(), buildApprovalRequestsById(), buildCompletedOnlineOrderTotals(), buildDailyCloseExpenseProductEvidence(), buildDailyCloseLifecycleGateWithCtx(), buildDailyCloseReportSnapshot() (+80 more)
 
 ### Community 1 - "Community 1"
 Cohesion: 0.03
@@ -3273,128 +3275,128 @@ Cohesion: 0.18
 Nodes (14): cleanValue(), drawColumnHeaders(), drawReportFooter(), drawReportHeader(), drawReportRow(), exportOpenWorkInventoryPdf(), formatOpenWorkInventoryReportEyebrow(), formatOpenWorkInventoryReportItemCount() (+6 more)
 
 ### Community 111 - "Community 111"
-Cohesion: 0.13
-Nodes (4): formatReportMoney(), money(), quantityLabel(), valuesFor()
-
-### Community 112 - "Community 112"
 Cohesion: 0.25
 Nodes (15): applyTheme(), emitThemeChange(), getStorage(), getStoredDarkThemeVariant(), getStoredThemeMode(), getSystemTheme(), getThemeSnapshot(), initializeAthenaTheme() (+7 more)
 
-### Community 113 - "Community 113"
+### Community 112 - "Community 112"
 Cohesion: 0.25
 Nodes (16): buildStorefrontContextEvent(), buildStorefrontIdempotencyKey(), compactScalarPayload(), createStorefrontContextTrackingEnvelope(), createStorefrontRouteViewedContextEvent(), getCartChange(), getCartContextEventInput(), getCheckoutBlocker() (+8 more)
 
-### Community 114 - "Community 114"
+### Community 113 - "Community 113"
 Cohesion: 0.22
 Nodes (16): buildDegreeIndex(), buildHotspotLines(), buildPackagePage(), buildRootIndexPage(), collectRepoCodeFiles(), compareHotspots(), countCommunities(), fileExists() (+8 more)
 
-### Community 115 - "Community 115"
+### Community 114 - "Community 114"
 Cohesion: 0.23
 Nodes (17): assertPrAthenaProofReady(), classifySnapshotError(), collectFilesUnder(), collectProofSnapshot(), collectUnstagedFiles(), collectUntrackedFiles(), collectValidationFingerprintPaths(), evaluatePrePushValidationProof() (+9 more)
 
-### Community 116 - "Community 116"
+### Community 115 - "Community 115"
 Cohesion: 0.22
 Nodes (14): assertActorMatchesStore(), buildCompiledContextBundle(), buildStoreInsightsContextBundleFromContextEvents(), buildUserInsightsContextBundleFromContextEvents(), compileContextEvent(), compileContextEventsWithReport(), getDataWindow(), getStoreFrontActorById() (+6 more)
 
-### Community 117 - "Community 117"
+### Community 116 - "Community 116"
 Cohesion: 0.19
 Nodes (10): canListRegisterSessionSyncConflicts(), filterPendingCompletedSaleVoidApprovals(), filterPendingTransactionItemAdjustmentApprovals(), getNumberMetadata(), getPendingItemAdjustmentCashDelta(), getStringMetadata(), listPendingCompletedSaleVoidApprovals(), listPendingRegisterSessionApprovalRequests() (+2 more)
 
-### Community 118 - "Community 118"
+### Community 117 - "Community 117"
 Cohesion: 0.2
 Nodes (13): computePendingRanges(), DayCapExceeded, expireRangeResults(), foldAndReplaceDay(), loadAcceptedClose(), markDayDirty(), openPolicyForReason(), parseStoreAllowlist() (+5 more)
 
-### Community 119 - "Community 119"
+### Community 118 - "Community 118"
 Cohesion: 0.22
 Nodes (15): buildSameElapsedOperatingComparison(), elapsedOperatingTime(), latestEffectiveSchedule(), operatingDuration(), reportingDateAt(), resolveReportingCalendarReferenceWithCtx(), resolveReportingFinancialPeriod(), resolveReportingFinancialPeriodWithCtx() (+7 more)
 
-### Community 120 - "Community 120"
+### Community 119 - "Community 119"
 Cohesion: 0.24
 Nodes (14): arrayLength(), asRecord(), canReportPosRegisterSessionLocalActivityType(), cashDirection(), classifyPosRegisterSessionLocalEventType(), compactMetadata(), finiteNumber(), labelFromToken() (+6 more)
 
-### Community 121 - "Community 121"
+### Community 120 - "Community 120"
 Cohesion: 0.12
 Nodes (1): DataTableViewOptions()
 
-### Community 122 - "Community 122"
+### Community 121 - "Community 121"
 Cohesion: 0.13
 Nodes (4): DailyCloseHistoryView(), getDailyCloseHistoryApi(), getHistoryRecordSnapshot(), normalizeHistorySnapshot()
 
-### Community 123 - "Community 123"
+### Community 122 - "Community 122"
 Cohesion: 0.15
 Nodes (7): formatOperatingDate(), formatOptionalMoney(), formatReportDateRange(), formatReportMoney(), formatReportProfit(), reportDaySettlementPresentation(), reportOldestUnreconciledPresentation()
 
-### Community 124 - "Community 124"
+### Community 123 - "Community 123"
 Cohesion: 0.25
 Nodes (14): addGroupedError(), auditHarnessGateObligationContract(), collectLiveSurfaceEntries(), fileExists(), formatGroupedErrors(), formatMissingValidationPathError(), hasAnyHarnessDocs(), inferGroupFromError() (+6 more)
 
-### Community 125 - "Community 125"
+### Community 124 - "Community 124"
 Cohesion: 0.19
 Nodes (13): compareSnapshots(), fileExists(), formatArtifactList(), formatDetailLines(), formatError(), formatHarnessJanitorReport(), readUtf8OrNull(), runCheckStep() (+5 more)
 
-### Community 126 - "Community 126"
+### Community 125 - "Community 125"
 Cohesion: 0.21
 Nodes (14): buildNumericTrendStats(), buildRegressionWarnings(), buildRuntimeTrendOutput(), buildScenarioTrend(), collectHarnessRuntimeTrends(), formatMs(), formatPercent(), parseHarnessBehaviorReportLines() (+6 more)
 
-### Community 127 - "Community 127"
+### Community 126 - "Community 126"
 Cohesion: 0.18
 Nodes (11): assertAllowedGateEventSequence(), buildGitProcessEnv(), clearRecordedProof(), consumeHarnessGateDecisionEvents(), nonEmpty(), parseGateDecisionEvent(), parseProviderSkippedEvents(), resolveDecisionEventsDir() (+3 more)
 
-### Community 128 - "Community 128"
+### Community 127 - "Community 127"
 Cohesion: 0.23
 Nodes (13): buildAbusePartitionKey(), buildServerContextTrackingEnvelope(), deriveBrowserFamily(), deriveContextEnvironment(), deriveOsFamily(), derivePrimarySubject(), isAcceptedSyntheticContext(), isRecord() (+5 more)
 
-### Community 129 - "Community 129"
+### Community 128 - "Community 128"
 Cohesion: 0.19
 Nodes (10): buildLatestRunDebugPayload(), getBoundedDebugRunsByCapability(), getLatestDebugRunByCapability(), getLatestDebugRunBySubject(), isActiveRunStale(), isActiveRunStatus(), selectLatestDebugRunFromCandidates(), shouldRecoverActiveRun() (+2 more)
 
-### Community 130 - "Community 130"
+### Community 129 - "Community 129"
 Cohesion: 0.19
 Nodes (13): ConstructionScopeError, costOverlayConstructionIdentity(), digest(), heartbeatConstructionOrThrow(), loadAnchors(), loadSource(), materializeCostOverlayRows(), normalizeOutcome() (+5 more)
 
-### Community 131 - "Community 131"
+### Community 130 - "Community 130"
 Cohesion: 0.18
 Nodes (8): buildCtx(), buildFrozenClose(), buildObservedCtx(), createDb(), frozenFinancialCompleteness(), frozenFinancialCompletenessForRange(), frozenFinancialCompletenessWithExpenseOverride(), operatingDateRange()
 
-### Community 132 - "Community 132"
+### Community 131 - "Community 131"
 Cohesion: 0.24
 Nodes (12): canonicalSyncedSaleInventoryReviewSkuId(), compareOperationalWorkItems(), compareStrings(), groupKey(), joinSourceIdentity(), operationalWorkActionableTimestamp(), operationalWorkMetadataString(), priorityBucket() (+4 more)
 
-### Community 133 - "Community 133"
+### Community 132 - "Community 132"
 Cohesion: 0.32
 Nodes (15): adjustRegisterSessionExpectedCashForPaymentCorrection(), applyPaymentMethodCorrection(), buildPaymentMethodCorrectionApprovalRequirement(), consumePaymentMethodCorrectionApprovalProof(), correctTransactionCustomer(), correctTransactionPaymentMethod(), createPaymentMethodCorrectionApprovalRequest(), getPaymentMethodCashContribution() (+7 more)
 
-### Community 134 - "Community 134"
+### Community 133 - "Community 133"
 Cohesion: 0.3
 Nodes (15): buildPosOperatorSnapshot(), buildRecentDayBuckets(), buildSummaryTrendBucket(), buildTransactionDateBuckets(), calculateDeltaPercent(), formatHourLabel(), formatPaymentMethodLabel(), formatShortDate() (+7 more)
 
-### Community 135 - "Community 135"
+### Community 134 - "Community 134"
 Cohesion: 0.18
 Nodes (7): buildPendingCheckoutFinalizationPayloadHash(), buildPendingCheckoutSaleEvidenceFingerprint(), buildTrustedSkuFingerprint(), listPendingCheckoutProductPageBindingWithCtx(), reviewedPosVisibleFor(), stableStringify(), validateReviewedTrustedInventoryFields()
 
-### Community 136 - "Community 136"
+### Community 135 - "Community 135"
 Cohesion: 0.19
 Nodes (9): admitOne(), allow(), completedMix(), drive(), ensure(), headerByKey(), seedSkus(), seedStore() (+1 more)
 
-### Community 137 - "Community 137"
+### Community 136 - "Community 136"
 Cohesion: 0.18
 Nodes (10): buildServiceCase(), createServiceCaseWithCtx(), deriveServiceCasePaymentStatus(), listServiceCaseAllocationsWithCtx(), listServiceCaseLineItemsWithCtx(), listServiceInventoryUsageWithCtx(), resolveServiceReturnBasisWithCtx(), roundServiceReturnCost() (+2 more)
 
-### Community 138 - "Community 138"
+### Community 137 - "Community 137"
 Cohesion: 0.27
 Nodes (15): assertValidOnlineOrderStatusTransition(), getOnlineOrderPaymentAmount(), getOnlineOrderPaymentMethodLabel(), getOnlineOrderStatusEventType(), getStoreOrganizationId(), isPaymentOnDeliveryOrder(), recordOnlineOrderCreatedEvent(), recordOnlineOrderFulfillmentMovement() (+7 more)
 
-### Community 139 - "Community 139"
+### Community 138 - "Community 138"
 Cohesion: 0.19
 Nodes (9): allocateMinorAmounts(), appendTransition(), applyOnlineOrderUpdate(), buildStorefrontFulfillmentSaleFacts(), buildStorefrontRefundFacts(), buildStorefrontReturnFacts(), getOnlineOrderWithCtx(), getWorkflowTraceIdForLookup() (+1 more)
 
-### Community 140 - "Community 140"
+### Community 139 - "Community 139"
 Cohesion: 0.12
 Nodes (0):
 
-### Community 141 - "Community 141"
+### Community 140 - "Community 140"
 Cohesion: 0.22
 Nodes (13): createRequestIdentity(), formatCost(), formatSignedCost(), handleAbandon(), handleApply(), handleBulkDecision(), handleCreate(), handleDecisionChange() (+5 more)
+
+### Community 141 - "Community 141"
+Cohesion: 0.13
+Nodes (2): formatReportMoney(), money()
 
 ### Community 142 - "Community 142"
 Cohesion: 0.17
@@ -4065,24 +4067,24 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 309 - "Community 309"
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
+
+### Community 310 - "Community 310"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 310 - "Community 310"
+### Community 311 - "Community 311"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 311 - "Community 311"
+### Community 312 - "Community 312"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 312 - "Community 312"
-Cohesion: 0.31
-Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
-
 ### Community 313 - "Community 313"
 Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
+Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
 
 ### Community 314 - "Community 314"
 Cohesion: 0.39
@@ -5557,40 +5559,40 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 682 - "Community 682"
-Cohesion: 0.5
-Nodes (1): buildCtx()
-
-### Community 683 - "Community 683"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 684 - "Community 684"
+### Community 683 - "Community 683"
 Cohesion: 0.83
 Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
-### Community 685 - "Community 685"
+### Community 684 - "Community 684"
 Cohesion: 0.83
 Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
-### Community 686 - "Community 686"
+### Community 685 - "Community 685"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 687 - "Community 687"
+### Community 686 - "Community 686"
 Cohesion: 0.67
 Nodes (2): buildActivity(), buildReport()
 
-### Community 688 - "Community 688"
+### Community 687 - "Community 687"
 Cohesion: 0.83
 Nodes (3): advanceRegisterCatalogRevision(), readRegisterCatalogRevision(), readRegisterCatalogRevisionRow()
 
-### Community 689 - "Community 689"
+### Community 688 - "Community 688"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 690 - "Community 690"
+### Community 689 - "Community 689"
 Cohesion: 0.83
 Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
+
+### Community 690 - "Community 690"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 691 - "Community 691"
 Cohesion: 0.5
@@ -5602,7 +5604,7 @@ Nodes (0):
 
 ### Community 693 - "Community 693"
 Cohesion: 0.5
-Nodes (0):
+Nodes (1): buildCtx()
 
 ### Community 694 - "Community 694"
 Cohesion: 0.5
@@ -13992,6 +13994,14 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 2791 - "Community 2791"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 2792 - "Community 2792"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **3 isolated node(s):** `StaleConstructionError`, `FakeMessageChannel`, `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
@@ -16477,923 +16487,927 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 2331`** (1 nodes): `ReportDateRangeField.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2332`** (1 nodes): `ReportSkuMixChart.test.tsx`
+- **Thin community `Community 2332`** (1 nodes): `ReportSegmentedTabs.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2333`** (1 nodes): `reportFormat.test.ts`
+- **Thin community `Community 2333`** (1 nodes): `ReportSegmentedTabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2334`** (1 nodes): `reportPeriodKeys.test.ts`
+- **Thin community `Community 2334`** (1 nodes): `ReportSkuMixChart.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2335`** (1 nodes): `reportRouteSearch.test.ts`
+- **Thin community `Community 2335`** (1 nodes): `reportFormat.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2336`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 2336`** (1 nodes): `reportPeriodKeys.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2337`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 2337`** (1 nodes): `reportRouteSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2338`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 2338`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2339`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 2339`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2340`** (1 nodes): `SharedDemoExperience.test.tsx`
+- **Thin community `Community 2340`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2341`** (1 nodes): `SharedDemoRestoreOverlay.test.tsx`
+- **Thin community `Community 2341`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2342`** (1 nodes): `sharedDemoLocalBootstrap.test.ts`
+- **Thin community `Community 2342`** (1 nodes): `SharedDemoExperience.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2343`** (1 nodes): `sharedDemoRestoreOverlay.test.ts`
+- **Thin community `Community 2343`** (1 nodes): `SharedDemoRestoreOverlay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2344`** (1 nodes): `sharedDemoRestoreOverlay.tsx`
+- **Thin community `Community 2344`** (1 nodes): `sharedDemoLocalBootstrap.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2345`** (1 nodes): `index.tsx`
+- **Thin community `Community 2345`** (1 nodes): `sharedDemoRestoreOverlay.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2346`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 2346`** (1 nodes): `sharedDemoRestoreOverlay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2347`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 2347`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2348`** (1 nodes): `NotFound.test.tsx`
+- **Thin community `Community 2348`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2349`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 2349`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2350`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 2350`** (1 nodes): `NotFound.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2351`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 2351`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2352`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 2352`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2353`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 2353`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2354`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 2354`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2355`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
+- **Thin community `Community 2355`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2356`** (1 nodes): `index.tsx`
+- **Thin community `Community 2356`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2357`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 2357`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2358`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 2358`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2359`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 2359`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2360`** (1 nodes): `button.tsx`
+- **Thin community `Community 2360`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2361`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 2361`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2362`** (1 nodes): `card.tsx`
+- **Thin community `Community 2362`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2363`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 2363`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2364`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 2364`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2365`** (1 nodes): `command.tsx`
+- **Thin community `Community 2365`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2366`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 2366`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2367`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 2367`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2368`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 2368`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2369`** (1 nodes): `form.tsx`
+- **Thin community `Community 2369`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2370`** (1 nodes): `icons.tsx`
+- **Thin community `Community 2370`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2371`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 2371`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2372`** (1 nodes): `input.test.tsx`
+- **Thin community `Community 2372`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2373`** (1 nodes): `input.tsx`
+- **Thin community `Community 2373`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2374`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 2374`** (1 nodes): `input.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2375`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 2375`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2376`** (1 nodes): `popover.tsx`
+- **Thin community `Community 2376`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2377`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 2377`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2378`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 2378`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2379`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 2379`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2380`** (1 nodes): `select.tsx`
+- **Thin community `Community 2380`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2381`** (1 nodes): `separator.tsx`
+- **Thin community `Community 2381`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2382`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 2382`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2383`** (1 nodes): `switch.tsx`
+- **Thin community `Community 2383`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2384`** (1 nodes): `table.test.tsx`
+- **Thin community `Community 2384`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2385`** (1 nodes): `table.tsx`
+- **Thin community `Community 2385`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2386`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 2386`** (1 nodes): `table.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2387`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 2387`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2388`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 2388`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2389`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 2389`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2390`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 2390`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2391`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 2391`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2392`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 2392`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2393`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2393`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2394`** (1 nodes): `constants.ts`
+- **Thin community `Community 2394`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2395`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2395`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2396`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2396`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2397`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2397`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2398`** (1 nodes): `data.ts`
+- **Thin community `Community 2398`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2399`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 2399`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2400`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 2400`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2401`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2401`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2402`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2402`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2403`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2403`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2404`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2404`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2405`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2405`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2406`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 2406`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2407`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 2407`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2408`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 2408`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2409`** (1 nodes): `index.ts`
+- **Thin community `Community 2409`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2410`** (1 nodes): `config.test.ts`
+- **Thin community `Community 2410`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2411`** (1 nodes): `docsWorkspaceTracking.test.ts`
+- **Thin community `Community 2411`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2412`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 2412`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2413`** (1 nodes): `onlineOrderSessionOverlay.test.ts`
+- **Thin community `Community 2413`** (1 nodes): `docsWorkspaceTracking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2414`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 2414`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2415`** (1 nodes): `use-pagination-persistence.test.ts`
+- **Thin community `Community 2415`** (1 nodes): `onlineOrderSessionOverlay.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2416`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 2416`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2417`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 2417`** (1 nodes): `use-pagination-persistence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2418`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 2418`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2419`** (1 nodes): `useGetActiveStore.test.ts`
+- **Thin community `Community 2419`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2420`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 2420`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2421`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 2421`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2422`** (1 nodes): `usePOSProducts.test.ts`
+- **Thin community `Community 2422`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2423`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 2423`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2424`** (1 nodes): `useSharedDemoContext.test.ts`
+- **Thin community `Community 2424`** (1 nodes): `usePOSProducts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2425`** (1 nodes): `useStoreOperatingClock.test.tsx`
+- **Thin community `Community 2425`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2426`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 2426`** (1 nodes): `useSharedDemoContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2427`** (1 nodes): `AppMessagesContext.ts`
+- **Thin community `Community 2427`** (1 nodes): `useStoreOperatingClock.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2428`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
+- **Thin community `Community 2428`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2429`** (1 nodes): `index.ts`
+- **Thin community `Community 2429`** (1 nodes): `AppMessagesContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2430`** (1 nodes): `appUpdateActions.ts`
+- **Thin community `Community 2430`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 2431`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2432`** (1 nodes): `updateCommunicationPreferenceContext.ts`
+- **Thin community `Community 2432`** (1 nodes): `appUpdateActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2433`** (1 nodes): `updateCoordinator.test.ts`
+- **Thin community `Community 2433`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2434`** (1 nodes): `aws.ts`
+- **Thin community `Community 2434`** (1 nodes): `updateCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2435`** (1 nodes): `constants.ts`
+- **Thin community `Community 2435`** (1 nodes): `updateCoordinator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2436`** (1 nodes): `countries.ts`
+- **Thin community `Community 2436`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2437`** (1 nodes): `access.test.ts`
+- **Thin community `Community 2437`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2438`** (1 nodes): `content.test.ts`
+- **Thin community `Community 2438`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2439`** (1 nodes): `navigation.test.ts`
+- **Thin community `Community 2439`** (1 nodes): `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2440`** (1 nodes): `parsing.test.ts`
+- **Thin community `Community 2440`** (1 nodes): `content.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2441`** (1 nodes): `reportContract.test.ts`
+- **Thin community `Community 2441`** (1 nodes): `navigation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2442`** (1 nodes): `scrollProgress.test.ts`
+- **Thin community `Community 2442`** (1 nodes): `parsing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2443`** (1 nodes): `virtual-docs-index.d.ts`
+- **Thin community `Community 2443`** (1 nodes): `reportContract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2444`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 2444`** (1 nodes): `scrollProgress.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2445`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 2445`** (1 nodes): `virtual-docs-index.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2446`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 2446`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2447`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 2447`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2448`** (1 nodes): `ghana.ts`
+- **Thin community `Community 2448`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2449`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 2449`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2450`** (1 nodes): `inventoryImportParser.test.ts`
+- **Thin community `Community 2450`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2451`** (1 nodes): `landingFunnelClient.test.ts`
+- **Thin community `Community 2451`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2452`** (1 nodes): `walkthroughPrivacy.ts`
+- **Thin community `Community 2452`** (1 nodes): `inventoryImportParser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2453`** (1 nodes): `walkthroughRequestClient.test.ts`
+- **Thin community `Community 2453`** (1 nodes): `landingFunnelClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2454`** (1 nodes): `appEntryRoutes.test.ts`
+- **Thin community `Community 2454`** (1 nodes): `walkthroughPrivacy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2455`** (1 nodes): `storeEntryRoute.test.ts`
+- **Thin community `Community 2455`** (1 nodes): `walkthroughRequestClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2456`** (1 nodes): `operatingDate.test.ts`
+- **Thin community `Community 2456`** (1 nodes): `appEntryRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2457`** (1 nodes): `dto.ts`
+- **Thin community `Community 2457`** (1 nodes): `storeEntryRoute.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2458`** (1 nodes): `ports.ts`
+- **Thin community `Community 2458`** (1 nodes): `operatingDate.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2459`** (1 nodes): `posLocalStorePort.ts`
+- **Thin community `Community 2459`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2460`** (1 nodes): `results.test.ts`
+- **Thin community `Community 2460`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2461`** (1 nodes): `constants.ts`
+- **Thin community `Community 2461`** (1 nodes): `posLocalStorePort.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2462`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 2462`** (1 nodes): `results.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2463`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 2463`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2464`** (1 nodes): `index.ts`
+- **Thin community `Community 2464`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2465`** (1 nodes): `session.test.ts`
+- **Thin community `Community 2465`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2466`** (1 nodes): `types.ts`
+- **Thin community `Community 2466`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2467`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 2467`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2468`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 2468`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2469`** (1 nodes): `registerLifecycleAuthorityGateway.test.ts`
+- **Thin community `Community 2469`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2470`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 2470`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2471`** (1 nodes): `drawerAuthorityReconciliation.test.ts`
+- **Thin community `Community 2471`** (1 nodes): `registerLifecycleAuthorityGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2472`** (1 nodes): `indexedDbPosLocalStorageEngine.test.ts`
+- **Thin community `Community 2472`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2473`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 2473`** (1 nodes): `drawerAuthorityReconciliation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2474`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 2474`** (1 nodes): `indexedDbPosLocalStorageEngine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2475`** (1 nodes): `posLocalLedgerPolicy.test.ts`
+- **Thin community `Community 2475`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2476`** (1 nodes): `posLocalStorageHealth.test.ts`
+- **Thin community `Community 2476`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2477`** (1 nodes): `posLocalStorageRuntime.test.ts`
+- **Thin community `Community 2477`** (1 nodes): `posLocalLedgerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2478`** (1 nodes): `posLocalStoreInitialization.test.ts`
+- **Thin community `Community 2478`** (1 nodes): `posLocalStorageHealth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2479`** (1 nodes): `posLocalStoreMaintenance.test.ts`
+- **Thin community `Community 2479`** (1 nodes): `posLocalStorageRuntime.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2480`** (1 nodes): `posLocalStoreMigrations.test.ts`
+- **Thin community `Community 2480`** (1 nodes): `posLocalStoreInitialization.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2481`** (1 nodes): `posLocalStoreSnapshot.test.ts`
+- **Thin community `Community 2481`** (1 nodes): `posLocalStoreMaintenance.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2482`** (1 nodes): `registerCatalogPinRuntime.test.ts`
+- **Thin community `Community 2482`** (1 nodes): `posLocalStoreMigrations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2483`** (1 nodes): `registerLifecycleAuthorityRollout.test.ts`
+- **Thin community `Community 2483`** (1 nodes): `posLocalStoreSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2484`** (1 nodes): `registerSessionAuthorityBootstrap.test.ts`
+- **Thin community `Community 2484`** (1 nodes): `registerCatalogPinRuntime.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2485`** (1 nodes): `saleBlockerPolicy.test.ts`
+- **Thin community `Community 2485`** (1 nodes): `registerLifecycleAuthorityRollout.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2486`** (1 nodes): `syncGapDiagnosis.test.ts`
+- **Thin community `Community 2486`** (1 nodes): `registerSessionAuthorityBootstrap.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2487`** (1 nodes): `printAttemptTelemetry.test.ts`
+- **Thin community `Community 2487`** (1 nodes): `saleBlockerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2488`** (1 nodes): `runtimeCounters.test.ts`
+- **Thin community `Community 2488`** (1 nodes): `syncGapDiagnosis.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2489`** (1 nodes): `telemetryBuffer.test.ts`
+- **Thin community `Community 2489`** (1 nodes): `printAttemptTelemetry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2490`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 2490`** (1 nodes): `runtimeCounters.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2491`** (1 nodes): `catalogSearchPresentation.test.ts`
+- **Thin community `Community 2491`** (1 nodes): `telemetryBuffer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2492`** (1 nodes): `registerCashierPresence.test.ts`
+- **Thin community `Community 2492`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2493`** (1 nodes): `registerCheckoutProjection.test.ts`
+- **Thin community `Community 2493`** (1 nodes): `catalogSearchPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2494`** (1 nodes): `registerUiState.test.ts`
+- **Thin community `Community 2494`** (1 nodes): `registerCashierPresence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2495`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
+- **Thin community `Community 2495`** (1 nodes): `registerCheckoutProjection.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2496`** (1 nodes): `registerSessionCode.test.ts`
+- **Thin community `Community 2496`** (1 nodes): `registerUiState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2497`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 2497`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2498`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 2498`** (1 nodes): `registerSessionCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2499`** (1 nodes): `contract.test.ts`
+- **Thin community `Community 2499`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2500`** (1 nodes): `guardrails.test.ts`
+- **Thin community `Community 2500`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2501`** (1 nodes): `index.ts`
+- **Thin community `Community 2501`** (1 nodes): `contract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2502`** (1 nodes): `runtimeBuildMetadata.test.ts`
+- **Thin community `Community 2502`** (1 nodes): `guardrails.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2503`** (1 nodes): `category.ts`
+- **Thin community `Community 2503`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2504`** (1 nodes): `product.ts`
+- **Thin community `Community 2504`** (1 nodes): `runtimeBuildMetadata.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2505`** (1 nodes): `store.ts`
+- **Thin community `Community 2505`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2506`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 2506`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2507`** (1 nodes): `user.ts`
+- **Thin community `Community 2507`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2508`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 2508`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2509`** (1 nodes): `sheetReturn.test.ts`
+- **Thin community `Community 2509`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2510`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 2510`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2511`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 2511`** (1 nodes): `sheetReturn.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2512`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 2512`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2513`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2513`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2514`** (1 nodes): `main.tsx`
+- **Thin community `Community 2514`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2515`** (1 nodes): `posAppShellReadiness.test.ts`
+- **Thin community `Community 2515`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2516`** (1 nodes): `posAppShellRoutes.test.ts`
+- **Thin community `Community 2516`** (1 nodes): `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2517`** (1 nodes): `posOfflineReadiness.test.ts`
+- **Thin community `Community 2517`** (1 nodes): `posAppShellReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2518`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
+- **Thin community `Community 2518`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2519`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 2519`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2520`** (1 nodes): `-app-entry-route.tsx`
+- **Thin community `Community 2520`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2521`** (1 nodes): `-privacy-page.tsx`
+- **Thin community `Community 2521`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2522`** (1 nodes): `-root-page-search.ts`
+- **Thin community `Community 2522`** (1 nodes): `-app-entry-route.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2523`** (1 nodes): `-shared-demo-entry.tsx`
+- **Thin community `Community 2523`** (1 nodes): `-privacy-page.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2524`** (1 nodes): `-walkthrough-page.tsx`
+- **Thin community `Community 2524`** (1 nodes): `-root-page-search.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2525`** (1 nodes): `__root.test.ts`
+- **Thin community `Community 2525`** (1 nodes): `-shared-demo-entry.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2526`** (1 nodes): `index.tsx`
+- **Thin community `Community 2526`** (1 nodes): `-walkthrough-page.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2527`** (1 nodes): `index.tsx`
+- **Thin community `Community 2527`** (1 nodes): `__root.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 2528`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2529`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 2529`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2530`** (1 nodes): `app-settings.tsx`
+- **Thin community `Community 2530`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2531`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 2531`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2532`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 2532`** (1 nodes): `app-settings.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2533`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 2533`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2534`** (1 nodes): `index.tsx`
+- **Thin community `Community 2534`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2535`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 2535`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2536`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 2536`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2537`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 2537`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2538`** (1 nodes): `home.tsx`
+- **Thin community `Community 2538`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2539`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 2539`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2540`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 2540`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2541`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 2541`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2542`** (1 nodes): `index.test.ts`
+- **Thin community `Community 2542`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2543`** (1 nodes): `-cost-overlay-search.ts`
+- **Thin community `Community 2543`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2544`** (1 nodes): `cost-overlay.test.ts`
+- **Thin community `Community 2544`** (1 nodes): `index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2545`** (1 nodes): `cost-overlay.tsx`
+- **Thin community `Community 2545`** (1 nodes): `-cost-overlay-search.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2546`** (1 nodes): `review.tsx`
+- **Thin community `Community 2546`** (1 nodes): `cost-overlay.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2547`** (1 nodes): `inventory-import.test.tsx`
+- **Thin community `Community 2547`** (1 nodes): `cost-overlay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2548`** (1 nodes): `inventory-import.tsx`
+- **Thin community `Community 2548`** (1 nodes): `review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2549`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 2549`** (1 nodes): `inventory-import.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2550`** (1 nodes): `index.tsx`
+- **Thin community `Community 2550`** (1 nodes): `inventory-import.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2551`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 2551`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2552`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 2552`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2553`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 2553`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2554`** (1 nodes): `index.tsx`
+- **Thin community `Community 2554`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2555`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 2555`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2556`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 2556`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2557`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 2557`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2558`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 2558`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2559`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 2559`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2560`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 2560`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2561`** (1 nodes): `expense.index.test.tsx`
+- **Thin community `Community 2561`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2562`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 2562`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2563`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 2563`** (1 nodes): `expense.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2564`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 2564`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2565`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 2565`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2566`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 2566`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2567`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 2567`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2568`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 2568`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2569`** (1 nodes): `edit.tsx`
+- **Thin community `Community 2569`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2570`** (1 nodes): `index.tsx`
+- **Thin community `Community 2570`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2571`** (1 nodes): `archived.tsx`
+- **Thin community `Community 2571`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2572`** (1 nodes): `new.tsx`
+- **Thin community `Community 2572`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2573`** (1 nodes): `new.tsx`
+- **Thin community `Community 2573`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2574`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 2574`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2575`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 2575`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2576`** (1 nodes): `index.tsx`
+- **Thin community `Community 2576`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2577`** (1 nodes): `new.tsx`
+- **Thin community `Community 2577`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2578`** (1 nodes): `$productSkuId.test.ts`
+- **Thin community `Community 2578`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2579`** (1 nodes): `index.test.ts`
+- **Thin community `Community 2579`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2580`** (1 nodes): `items.tsx`
+- **Thin community `Community 2580`** (1 nodes): `$productSkuId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2581`** (1 nodes): `weekly.test.ts`
+- **Thin community `Community 2581`** (1 nodes): `index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2582`** (1 nodes): `reports.tsx`
+- **Thin community `Community 2582`** (1 nodes): `items.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2583`** (1 nodes): `index.tsx`
+- **Thin community `Community 2583`** (1 nodes): `weekly.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2584`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 2584`** (1 nodes): `reports.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2585`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 2585`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2586`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 2586`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2587`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 2587`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2588`** (1 nodes): `index.tsx`
+- **Thin community `Community 2588`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2589`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 2589`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2590`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 2590`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2591`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 2591`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2592`** (1 nodes): `index.tsx`
+- **Thin community `Community 2592`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2593`** (1 nodes): `_authed-shell.test.tsx`
+- **Thin community `Community 2593`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2594`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 2594`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2595`** (1 nodes): `app.route.test.tsx`
+- **Thin community `Community 2595`** (1 nodes): `_authed-shell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2596`** (1 nodes): `app.test.tsx`
+- **Thin community `Community 2596`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2597`** (1 nodes): `app.tsx`
+- **Thin community `Community 2597`** (1 nodes): `app.route.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2598`** (1 nodes): `demo.test.tsx`
+- **Thin community `Community 2598`** (1 nodes): `app.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2599`** (1 nodes): `demo.tsx`
+- **Thin community `Community 2599`** (1 nodes): `app.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2600`** (1 nodes): `docs.index.tsx`
+- **Thin community `Community 2600`** (1 nodes): `demo.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2601`** (1 nodes): `docs.reports.$slug.tsx`
+- **Thin community `Community 2601`** (1 nodes): `demo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2602`** (1 nodes): `docs.solutions.$category.$slug.test.tsx`
+- **Thin community `Community 2602`** (1 nodes): `docs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2603`** (1 nodes): `docs.tsx`
+- **Thin community `Community 2603`** (1 nodes): `docs.reports.$slug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2604`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 2604`** (1 nodes): `docs.solutions.$category.$slug.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2605`** (1 nodes): `index.tsx`
+- **Thin community `Community 2605`** (1 nodes): `docs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2606`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 2606`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2607`** (1 nodes): `landing.tsx`
+- **Thin community `Community 2607`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2608`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 2608`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2609`** (1 nodes): `_layout.index.tsx`
+- **Thin community `Community 2609`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2610`** (1 nodes): `_layout.tsx`
+- **Thin community `Community 2610`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2611`** (1 nodes): `privacy.test.tsx`
+- **Thin community `Community 2611`** (1 nodes): `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2612`** (1 nodes): `privacy.tsx`
+- **Thin community `Community 2612`** (1 nodes): `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2613`** (1 nodes): `register-interest.tsx`
+- **Thin community `Community 2613`** (1 nodes): `privacy.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2614`** (1 nodes): `walkthrough.test.tsx`
+- **Thin community `Community 2614`** (1 nodes): `privacy.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2615`** (1 nodes): `walkthrough.tsx`
+- **Thin community `Community 2615`** (1 nodes): `register-interest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2616`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 2616`** (1 nodes): `walkthrough.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2617`** (1 nodes): `expenseStore.test.ts`
+- **Thin community `Community 2617`** (1 nodes): `walkthrough.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2618`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 2618`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2619`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 2619`** (1 nodes): `expenseStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2620`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 2620`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2621`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 2621`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2622`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 2622`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2623`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 2623`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2624`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 2624`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2625`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 2625`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2626`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 2626`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2627`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 2627`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2628`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 2628`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2629`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 2629`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2630`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 2630`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2631`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 2631`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2632`** (1 nodes): `eodReviewFixtures.ts`
+- **Thin community `Community 2632`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2633`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 2633`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2634`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 2634`** (1 nodes): `eodReviewFixtures.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2635`** (1 nodes): `setup.ts`
+- **Thin community `Community 2635`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2636`** (1 nodes): `vite-env.d.ts`
+- **Thin community `Community 2636`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2637`** (1 nodes): `viteConfig.test.ts`
+- **Thin community `Community 2637`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2638`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 2638`** (1 nodes): `vite-env.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2639`** (1 nodes): `types.ts`
+- **Thin community `Community 2639`** (1 nodes): `viteConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2640`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 2640`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2641`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 2641`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2642`** (1 nodes): `global.d.ts`
+- **Thin community `Community 2642`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2643`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 2643`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2644`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 2644`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2645`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 2645`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2646`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 2646`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2647`** (1 nodes): `types.ts`
+- **Thin community `Community 2647`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2648`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 2648`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2649`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 2649`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2650`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 2650`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2651`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 2651`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2652`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 2652`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2653`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 2653`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2654`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 2654`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2655`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 2655`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2656`** (1 nodes): `schema.ts`
+- **Thin community `Community 2656`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2657`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 2657`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2658`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 2658`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2659`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 2659`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2660`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 2660`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2661`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 2661`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2662`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 2662`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2663`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 2663`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2664`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 2664`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2665`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 2665`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2666`** (1 nodes): `types.ts`
+- **Thin community `Community 2666`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2667`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2667`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2668`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 2668`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2669`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 2669`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2670`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 2670`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2671`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 2671`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2672`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 2672`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2673`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 2673`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2674`** (1 nodes): `constants.ts`
+- **Thin community `Community 2674`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2675`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 2675`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2676`** (1 nodes): `About.tsx`
+- **Thin community `Community 2676`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2677`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 2677`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2678`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 2678`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2679`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 2679`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2680`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 2680`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2681`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 2681`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2682`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 2682`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2683`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 2683`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2684`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 2684`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2685`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 2685`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2686`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 2686`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2687`** (1 nodes): `types.ts`
+- **Thin community `Community 2687`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2688`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 2688`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2689`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 2689`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2690`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 2690`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2691`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 2691`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2692`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 2692`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2693`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 2693`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2694`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 2694`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2695`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 2695`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2696`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 2696`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2697`** (1 nodes): `alert.tsx`
+- **Thin community `Community 2697`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2698`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 2698`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2699`** (1 nodes): `button.tsx`
+- **Thin community `Community 2699`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2700`** (1 nodes): `card.tsx`
+- **Thin community `Community 2700`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2701`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 2701`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2702`** (1 nodes): `command.tsx`
+- **Thin community `Community 2702`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2703`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 2703`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2704`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 2704`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2705`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 2705`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2706`** (1 nodes): `form.tsx`
+- **Thin community `Community 2706`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2707`** (1 nodes): `icons.tsx`
+- **Thin community `Community 2707`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2708`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 2708`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2709`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 2709`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2710`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 2710`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2711`** (1 nodes): `input.tsx`
+- **Thin community `Community 2711`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2712`** (1 nodes): `label.tsx`
+- **Thin community `Community 2712`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2713`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 2713`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2714`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 2714`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2715`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 2715`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2716`** (1 nodes): `index.ts`
+- **Thin community `Community 2716`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2717`** (1 nodes): `types.ts`
+- **Thin community `Community 2717`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2718`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 2718`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2719`** (1 nodes): `popover.tsx`
+- **Thin community `Community 2719`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2720`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 2720`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2721`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 2721`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2722`** (1 nodes): `select.tsx`
+- **Thin community `Community 2722`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2723`** (1 nodes): `separator.tsx`
+- **Thin community `Community 2723`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2724`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 2724`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2725`** (1 nodes): `table.tsx`
+- **Thin community `Community 2725`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2726`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 2726`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2727`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 2727`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2728`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 2728`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2729`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 2729`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2730`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 2730`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2731`** (1 nodes): `config.ts`
+- **Thin community `Community 2731`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2732`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
+- **Thin community `Community 2732`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2733`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 2733`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2734`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 2734`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2735`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 2735`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2736`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 2736`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2737`** (1 nodes): `constants.ts`
+- **Thin community `Community 2737`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2738`** (1 nodes): `countries.ts`
+- **Thin community `Community 2738`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2739`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 2739`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2740`** (1 nodes): `ghana.ts`
+- **Thin community `Community 2740`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2741`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 2741`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2742`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 2742`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2743`** (1 nodes): `index.ts`
+- **Thin community `Community 2743`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2744`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 2744`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2745`** (1 nodes): `store.ts`
+- **Thin community `Community 2745`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2746`** (1 nodes): `bag.ts`
+- **Thin community `Community 2746`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2747`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 2747`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2748`** (1 nodes): `category.ts`
+- **Thin community `Community 2748`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2749`** (1 nodes): `organization.ts`
+- **Thin community `Community 2749`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2750`** (1 nodes): `product.ts`
+- **Thin community `Community 2750`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2751`** (1 nodes): `store.ts`
+- **Thin community `Community 2751`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2752`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 2752`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2753`** (1 nodes): `user.ts`
+- **Thin community `Community 2753`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2754`** (1 nodes): `states.ts`
+- **Thin community `Community 2754`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2755`** (1 nodes): `storefrontContextEvents.test.ts`
+- **Thin community `Community 2755`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2756`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 2756`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2757`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 2757`** (1 nodes): `storefrontContextEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2758`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2758`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2759`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 2759`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2760`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 2760`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2761`** (1 nodes): `__root.tsx`
+- **Thin community `Community 2761`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2762`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 2762`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2763`** (1 nodes): `index.tsx`
+- **Thin community `Community 2763`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2764`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 2764`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 2765`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2766`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 2766`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2767`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 2767`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2768`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 2768`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2769`** (1 nodes): `complete.tsx`
+- **Thin community `Community 2769`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2770`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 2770`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2771`** (1 nodes): `index.tsx`
+- **Thin community `Community 2771`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2772`** (1 nodes): `pending.tsx`
+- **Thin community `Community 2772`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2773`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 2773`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2774`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 2774`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2775`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 2775`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2776`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 2776`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2777`** (1 nodes): `index.js`
+- **Thin community `Community 2777`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2778`** (1 nodes): `check-register-session-authority-writers.test.ts`
+- **Thin community `Community 2778`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2779`** (1 nodes): `delivery-documentation-check.test.ts`
+- **Thin community `Community 2779`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2780`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 2780`** (1 nodes): `check-register-session-authority-writers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2781`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 2781`** (1 nodes): `delivery-documentation-check.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2782`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 2782`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2783`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 2783`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2784`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 2784`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2785`** (1 nodes): `harness-execution-context.test.ts`
+- **Thin community `Community 2785`** (1 nodes): `valkey-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2786`** (1 nodes): `harness-gate-registry.test.ts`
+- **Thin community `Community 2786`** (1 nodes): `harness-behavior-scenarios.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2787`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 2787`** (1 nodes): `harness-execution-context.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2788`** (1 nodes): `operational-work-repair.test.ts`
+- **Thin community `Community 2788`** (1 nodes): `harness-gate-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2789`** (1 nodes): `background.js`
+- **Thin community `Community 2789`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2790`** (1 nodes): `popup.js`
+- **Thin community `Community 2790`** (1 nodes): `operational-work-repair.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2791`** (1 nodes): `background.js`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2792`** (1 nodes): `popup.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -9803,7 +9803,7 @@
       "relation": "calls",
       "source": "dailyclose_isinrange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1501",
+      "source_location": "L1503",
       "target": "dailyclose_approvalbelongstorange",
       "weight": 1
     },
@@ -9815,7 +9815,7 @@
       "relation": "calls",
       "source": "dailyclose_registersessionbelongstorange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1518",
+      "source_location": "L1520",
       "target": "dailyclose_approvalbelongstorange",
       "weight": 1
     },
@@ -9827,7 +9827,7 @@
       "relation": "calls",
       "source": "dailyclose_formatpaymentmethodlabel",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L838",
+      "source_location": "L840",
       "target": "dailyclose_approvalrequesttypelabel",
       "weight": 1
     },
@@ -9839,7 +9839,7 @@
       "relation": "calls",
       "source": "dailyclose_ascarryforwarditem",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L979",
+      "source_location": "L981",
       "target": "dailyclose_carryforwardbusinessdate",
       "weight": 1
     },
@@ -9851,7 +9851,7 @@
       "relation": "calls",
       "source": "dailyclose_ascarryforwarditem",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L983",
+      "source_location": "L985",
       "target": "dailyclose_carryforwardsourceid",
       "weight": 1
     },
@@ -9863,8 +9863,20 @@
       "relation": "calls",
       "source": "dailyclose_ascarryforwarditem",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L981",
+      "source_location": "L983",
       "target": "dailyclose_stringfrommetadata",
+      "weight": 1
+    },
+    {
+      "_src": "dailyclose_buildcompletedonlineordertotals",
+      "_tgt": "dailyclose_sourcecompletenessentry",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailyclose_sourcecompletenessentry",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L1842",
+      "target": "dailyclose_buildcompletedonlineordertotals",
       "weight": 1
     },
     {
@@ -9875,7 +9887,7 @@
       "relation": "calls",
       "source": "dailyclose_getdailyclosefordate",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1174",
+      "source_location": "L1176",
       "target": "dailyclose_builddailycloselifecyclegatewithctx",
       "weight": 1
     },
@@ -9887,7 +9899,7 @@
       "relation": "calls",
       "source": "dailyclose_resolveoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1165",
+      "source_location": "L1167",
       "target": "dailyclose_builddailycloselifecyclegatewithctx",
       "weight": 1
     },
@@ -9899,7 +9911,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosereportsnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2240",
+      "source_location": "L2351",
       "target": "dailyclose_snapshotrevieweditems",
       "weight": 1
     },
@@ -9911,7 +9923,7 @@
       "relation": "calls",
       "source": "dailyclose_uniquedailycloseitems",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2170",
+      "source_location": "L2281",
       "target": "dailyclose_builddailyclosereportsnapshot",
       "weight": 1
     },
@@ -9923,7 +9935,19 @@
       "relation": "calls",
       "source": "dailyclose_buildapprovalrequestsbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2773",
+      "source_location": "L2896",
+      "target": "dailyclose_builddailyclosesnapshotwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "dailyclose_builddailyclosesnapshotwithctx",
+      "_tgt": "dailyclose_buildcompletedonlineordertotals",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailyclose_buildcompletedonlineordertotals",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L2830",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -9935,7 +9959,7 @@
       "relation": "calls",
       "source": "dailyclose_buildexpensesessionsbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2827",
+      "source_location": "L2950",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -9947,7 +9971,7 @@
       "relation": "calls",
       "source": "dailyclose_buildexpensetransactionitemcountsbytransactionid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2722",
+      "source_location": "L2843",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -9959,7 +9983,7 @@
       "relation": "calls",
       "source": "dailyclose_buildreadiness",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3538",
+      "source_location": "L3698",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -9971,7 +9995,7 @@
       "relation": "calls",
       "source": "dailyclose_buildregistersessionsbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2820",
+      "source_location": "L2943",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -9983,7 +10007,7 @@
       "relation": "calls",
       "source": "dailyclose_buildstaffnamesbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2648",
+      "source_location": "L2759",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -9995,7 +10019,7 @@
       "relation": "calls",
       "source": "dailyclose_buildterminallabelsbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2842",
+      "source_location": "L2965",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10007,7 +10031,7 @@
       "relation": "calls",
       "source": "dailyclose_buildtransactionitemcountsbytransactionid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2717",
+      "source_location": "L2838",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10019,7 +10043,7 @@
       "relation": "calls",
       "source": "dailyclose_cashdeltasbyregistersessionid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2817",
+      "source_location": "L2940",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10031,7 +10055,7 @@
       "relation": "calls",
       "source": "dailyclose_completesourcecompleteness",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2626",
+      "source_location": "L2737",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10043,7 +10067,7 @@
       "relation": "calls",
       "source": "dailyclose_emptysummary",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2620",
+      "source_location": "L2731",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10055,7 +10079,7 @@
       "relation": "calls",
       "source": "dailyclose_filterregistersessionsbelongingtorange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2761",
+      "source_location": "L2884",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10067,7 +10091,7 @@
       "relation": "calls",
       "source": "dailyclose_frozensyncedsaleinventoryreviewgroups",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3620",
+      "source_location": "L3780",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10079,7 +10103,7 @@
       "relation": "calls",
       "source": "dailyclose_getdailyclosecompletioneventstaffprofileid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2644",
+      "source_location": "L2755",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10091,7 +10115,7 @@
       "relation": "calls",
       "source": "dailyclose_getdailyclosefordate",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2639",
+      "source_location": "L2750",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10103,7 +10127,7 @@
       "relation": "calls",
       "source": "dailyclose_getpriorcompleteddailyclose",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2651",
+      "source_location": "L2762",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10115,7 +10139,7 @@
       "relation": "calls",
       "source": "dailyclose_getstore",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2576",
+      "source_location": "L2687",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10127,7 +10151,19 @@
       "relation": "calls",
       "source": "dailyclose_listactiveoversizedoperationalworkrepairs",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2693",
+      "source_location": "L2805",
+      "target": "dailyclose_builddailyclosesnapshotwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "dailyclose_builddailyclosesnapshotwithctx",
+      "_tgt": "dailyclose_listcompletedonlineordersforday",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailyclose_listcompletedonlineordersforday",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L2811",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10139,7 +10175,7 @@
       "relation": "calls",
       "source": "dailyclose_listdepositsforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2709",
+      "source_location": "L2825",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10151,7 +10187,7 @@
       "relation": "calls",
       "source": "dailyclose_listexpensesforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2708",
+      "source_location": "L2824",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10163,7 +10199,7 @@
       "relation": "calls",
       "source": "dailyclose_listopenoperationalworkitems",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2692",
+      "source_location": "L2804",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10175,7 +10211,7 @@
       "relation": "calls",
       "source": "dailyclose_listopenpossessions",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2691",
+      "source_location": "L2803",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10187,7 +10223,7 @@
       "relation": "calls",
       "source": "dailyclose_listpendingcloseoutapprovals",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2690",
+      "source_location": "L2802",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10199,7 +10235,7 @@
       "relation": "calls",
       "source": "dailyclose_listregistersessionsfordailyclose",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2685",
+      "source_location": "L2797",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10211,7 +10247,7 @@
       "relation": "calls",
       "source": "dailyclose_listtransactionsforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2694",
+      "source_location": "L2806",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10223,7 +10259,7 @@
       "relation": "calls",
       "source": "dailyclose_mayberedactdailyclosesnapshotforbroadview",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2662",
+      "source_location": "L2773",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10235,7 +10271,7 @@
       "relation": "calls",
       "source": "dailyclose_mergesourcecompleteness",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2747",
+      "source_location": "L2868",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10247,7 +10283,7 @@
       "relation": "calls",
       "source": "dailyclose_normalizecompleteddailyclosesnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2652",
+      "source_location": "L2763",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10259,7 +10295,7 @@
       "relation": "calls",
       "source": "dailyclose_normalizedailyclosesummary",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3609",
+      "source_location": "L3769",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10271,7 +10307,7 @@
       "relation": "calls",
       "source": "dailyclose_resolveoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2575",
+      "source_location": "L2686",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10283,7 +10319,7 @@
       "relation": "calls",
       "source": "dailyclose_sortdailycloseblockers",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3537",
+      "source_location": "L3697",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10295,7 +10331,7 @@
       "relation": "calls",
       "source": "dailyclose_uniquesourcesubjects",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3626",
+      "source_location": "L3786",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10307,7 +10343,7 @@
       "relation": "calls",
       "source": "dailyclose_buildexpensetransactionitemcountsbytransactionid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1850",
+      "source_location": "L1961",
       "target": "dailyclose_builddailycloseexpenseproductevidence",
       "weight": 1
     },
@@ -10319,7 +10355,7 @@
       "relation": "calls",
       "source": "dailyclose_stringfrommetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3731",
+      "source_location": "L3891",
       "target": "dailyclose_carryforwardbusinessdate",
       "weight": 1
     },
@@ -10331,7 +10367,7 @@
       "relation": "calls",
       "source": "dailyclose_carryforwardbusinessdate",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3763",
+      "source_location": "L3923",
       "target": "dailyclose_carryforwardmetadatamatches",
       "weight": 1
     },
@@ -10343,7 +10379,7 @@
       "relation": "calls",
       "source": "dailyclose_carryforwardsourceid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3764",
+      "source_location": "L3924",
       "target": "dailyclose_carryforwardmetadatamatches",
       "weight": 1
     },
@@ -10355,7 +10391,7 @@
       "relation": "calls",
       "source": "dailyclose_stringfrommetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3740",
+      "source_location": "L3900",
       "target": "dailyclose_carryforwardsourceid",
       "weight": 1
     },
@@ -10367,7 +10403,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosereportsnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4684",
+      "source_location": "L4844",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10379,7 +10415,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosesnapshotwithctx",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4497",
+      "source_location": "L4657",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10391,7 +10427,7 @@
       "relation": "calls",
       "source": "dailyclose_getnonactivedailyclosefordate",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4529",
+      "source_location": "L4689",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10403,7 +10439,7 @@
       "relation": "calls",
       "source": "dailyclose_getstore",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4472",
+      "source_location": "L4632",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10415,7 +10451,7 @@
       "relation": "calls",
       "source": "dailyclose_incompletesourcecompletenessentries",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4564",
+      "source_location": "L4724",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10427,7 +10463,7 @@
       "relation": "calls",
       "source": "dailyclose_logicalcarryforwardselectioncount",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4638",
+      "source_location": "L4798",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10439,7 +10475,7 @@
       "relation": "calls",
       "source": "dailyclose_markotherdailyclosesnotcurrent",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4715",
+      "source_location": "L4875",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10451,7 +10487,7 @@
       "relation": "calls",
       "source": "dailyclose_patchdailyclosecarryforwardworkitemmetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4745",
+      "source_location": "L4905",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10463,7 +10499,7 @@
       "relation": "calls",
       "source": "dailyclose_recorddailyclosecompletedevent",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4751",
+      "source_location": "L4911",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10475,7 +10511,7 @@
       "relation": "calls",
       "source": "dailyclose_recorddailyclosecompletedreportfacts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4740",
+      "source_location": "L4900",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10487,7 +10523,7 @@
       "relation": "calls",
       "source": "dailyclose_resolveoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4488",
+      "source_location": "L4648",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10499,7 +10535,7 @@
       "relation": "calls",
       "source": "dailyclose_validateautomationcarryforwardworkitems",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4618",
+      "source_location": "L4778",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10511,7 +10547,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosereportsnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4357",
+      "source_location": "L4517",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10523,7 +10559,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosesnapshotwithctx",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4183",
+      "source_location": "L4343",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10535,7 +10571,7 @@
       "relation": "calls",
       "source": "dailyclose_createcarryforwardworkitems",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4280",
+      "source_location": "L4440",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10547,7 +10583,7 @@
       "relation": "calls",
       "source": "dailyclose_getstore",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4158",
+      "source_location": "L4318",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10559,7 +10595,7 @@
       "relation": "calls",
       "source": "dailyclose_incompletesourcecompletenessentries",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4206",
+      "source_location": "L4366",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10571,7 +10607,7 @@
       "relation": "calls",
       "source": "dailyclose_logicalcarryforwardselectioncount",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4317",
+      "source_location": "L4477",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10583,7 +10619,7 @@
       "relation": "calls",
       "source": "dailyclose_markotherdailyclosesnotcurrent",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4390",
+      "source_location": "L4550",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10595,7 +10631,7 @@
       "relation": "calls",
       "source": "dailyclose_patchdailyclosecarryforwardworkitemmetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4419",
+      "source_location": "L4579",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10607,7 +10643,7 @@
       "relation": "calls",
       "source": "dailyclose_recorddailyclosecompletedevent",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4425",
+      "source_location": "L4585",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10619,7 +10655,7 @@
       "relation": "calls",
       "source": "dailyclose_recorddailyclosecompletedreportfacts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4414",
+      "source_location": "L4574",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10631,7 +10667,7 @@
       "relation": "calls",
       "source": "dailyclose_resolveoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4174",
+      "source_location": "L4334",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10643,7 +10679,7 @@
       "relation": "calls",
       "source": "dailyclose_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4316",
+      "source_location": "L4476",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10655,7 +10691,7 @@
       "relation": "calls",
       "source": "dailyclose_uniqueoperationalworkitemids",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4226",
+      "source_location": "L4386",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10667,7 +10703,7 @@
       "relation": "calls",
       "source": "dailyclose_validatecarryforwardworkitemids",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4243",
+      "source_location": "L4403",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10679,7 +10715,7 @@
       "relation": "calls",
       "source": "dailyclose_validateselectedcarryforwardgroups",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4229",
+      "source_location": "L4389",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10691,7 +10727,7 @@
       "relation": "calls",
       "source": "dailyclose_findcurrentcarryforwardworkitembysource",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3919",
+      "source_location": "L4079",
       "target": "dailyclose_createcarryforwardworkitems",
       "weight": 1
     },
@@ -10703,7 +10739,7 @@
       "relation": "calls",
       "source": "dailyclose_sourceidfromcarryforwardinput",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3916",
+      "source_location": "L4076",
       "target": "dailyclose_createcarryforwardworkitems",
       "weight": 1
     },
@@ -10715,7 +10751,7 @@
       "relation": "calls",
       "source": "dailyclose_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3907",
+      "source_location": "L4067",
       "target": "dailyclose_createcarryforwardworkitems",
       "weight": 1
     },
@@ -10727,7 +10763,7 @@
       "relation": "calls",
       "source": "dailyclose_buildapprovalrequestsbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L936",
+      "source_location": "L938",
       "target": "dailyclose_filterregistersessionsbelongingtorange",
       "weight": 1
     },
@@ -10739,7 +10775,7 @@
       "relation": "calls",
       "source": "dailyclose_buildstaffnamesbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5445",
+      "source_location": "L5605",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -10751,7 +10787,7 @@
       "relation": "calls",
       "source": "dailyclose_completionattributionfordailyclose",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5448",
+      "source_location": "L5608",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -10763,7 +10799,7 @@
       "relation": "calls",
       "source": "dailyclose_getdailyclosecompletioneventstaffprofileid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5441",
+      "source_location": "L5601",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -10775,7 +10811,7 @@
       "relation": "calls",
       "source": "dailyclose_redactdailyclosereportsnapshotforbroadview",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5471",
+      "source_location": "L5631",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -10787,7 +10823,7 @@
       "relation": "calls",
       "source": "dailyclose_getpriorcompleteddailyclose",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5313",
+      "source_location": "L5473",
       "target": "dailyclose_getdailycloseopeningcontextwithctx",
       "weight": 1
     },
@@ -10799,7 +10835,7 @@
       "relation": "calls",
       "source": "dailyclose_sourcecompletenessentry",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1671",
+      "source_location": "L1673",
       "target": "dailyclose_listactiveoversizedoperationalworkrepairs",
       "weight": 1
     },
@@ -10811,8 +10847,20 @@
       "relation": "calls",
       "source": "dailyclose_buildstaffnamesbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5401",
+      "source_location": "L5561",
       "target": "dailyclose_listcompleteddailyclosehistorywithctx",
+      "weight": 1
+    },
+    {
+      "_src": "dailyclose_listcompletedonlineordersforday",
+      "_tgt": "dailyclose_sourcecompletenessentry",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailyclose_sourcecompletenessentry",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L1774",
+      "target": "dailyclose_listcompletedonlineordersforday",
       "weight": 1
     },
     {
@@ -10823,7 +10871,7 @@
       "relation": "calls",
       "source": "dailyclose_sourcecompletenessentry",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1996",
+      "source_location": "L2107",
       "target": "dailyclose_listdepositsforday",
       "weight": 1
     },
@@ -10835,7 +10883,7 @@
       "relation": "calls",
       "source": "dailyclose_sourcecompletenessentry",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1765",
+      "source_location": "L1876",
       "target": "dailyclose_listexpensesforday",
       "weight": 1
     },
@@ -10847,7 +10895,7 @@
       "relation": "calls",
       "source": "dailyclose_sourcecompletenessentry",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1634",
+      "source_location": "L1636",
       "target": "dailyclose_listopenoperationalworkitems",
       "weight": 1
     },
@@ -10859,7 +10907,7 @@
       "relation": "calls",
       "source": "dailyclose_sourcecompletenessentry",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1599",
+      "source_location": "L1601",
       "target": "dailyclose_listopenpossessions",
       "weight": 1
     },
@@ -10871,7 +10919,7 @@
       "relation": "calls",
       "source": "dailyclose_sourcecompletenessentry",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1559",
+      "source_location": "L1561",
       "target": "dailyclose_listpendingcloseoutapprovals",
       "weight": 1
     },
@@ -10883,7 +10931,7 @@
       "relation": "calls",
       "source": "dailyclose_completesourcecompleteness",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1366",
+      "source_location": "L1368",
       "target": "dailyclose_listregistersessionsfordailyclose",
       "weight": 1
     },
@@ -10895,7 +10943,7 @@
       "relation": "calls",
       "source": "dailyclose_sourcecompletenessentry",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1411",
+      "source_location": "L1413",
       "target": "dailyclose_listregistersessionsfordailyclose",
       "weight": 1
     },
@@ -10907,7 +10955,7 @@
       "relation": "calls",
       "source": "dailyclose_readcappedsource",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1723",
+      "source_location": "L1725",
       "target": "dailyclose_listtransactionsforday",
       "weight": 1
     },
@@ -10919,7 +10967,7 @@
       "relation": "calls",
       "source": "dailyclose_ascarryforwarditem",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1056",
+      "source_location": "L1058",
       "target": "dailyclose_logicalgroupascarryforwarditem",
       "weight": 1
     },
@@ -10931,7 +10979,7 @@
       "relation": "calls",
       "source": "dailyclose_mayberedactdailyclosesnapshotforbroadview",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2457",
+      "source_location": "L2568",
       "target": "dailyclose_emptysummary",
       "weight": 1
     },
@@ -10943,7 +10991,7 @@
       "relation": "calls",
       "source": "dailyclose_redactdailyclosesummaryforbroadview",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2458",
+      "source_location": "L2569",
       "target": "dailyclose_mayberedactdailyclosesnapshotforbroadview",
       "weight": 1
     },
@@ -10955,7 +11003,7 @@
       "relation": "calls",
       "source": "dailyclose_completesourcecompleteness",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L493",
+      "source_location": "L495",
       "target": "dailyclose_mergesourcecompleteness",
       "weight": 1
     },
@@ -10967,7 +11015,7 @@
       "relation": "calls",
       "source": "dailyclose_normalizecompleteddailyclosesnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L447",
+      "source_location": "L449",
       "target": "dailyclose_completesourcecompleteness",
       "weight": 1
     },
@@ -10979,7 +11027,7 @@
       "relation": "calls",
       "source": "dailyclose_normalizecompleteddailyclosesnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L387",
+      "source_location": "L389",
       "target": "dailyclose_completionattributionfordailyclose",
       "weight": 1
     },
@@ -10991,7 +11039,7 @@
       "relation": "calls",
       "source": "dailyclose_normalizecompleteddailyclosesnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L428",
+      "source_location": "L430",
       "target": "dailyclose_normalizedailyclosesummary",
       "weight": 1
     },
@@ -11003,7 +11051,7 @@
       "relation": "calls",
       "source": "dailyclose_normalizedailyclosesummary",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L517",
+      "source_location": "L519",
       "target": "dailyclose_emptysummary",
       "weight": 1
     },
@@ -11015,7 +11063,7 @@
       "relation": "calls",
       "source": "dailyclose_patchdailyclosecarryforwardworkitemmetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1101",
+      "source_location": "L1103",
       "target": "dailyclose_carryforwardbusinessdate",
       "weight": 1
     },
@@ -11027,7 +11075,7 @@
       "relation": "calls",
       "source": "dailyclose_patchdailyclosecarryforwardworkitemmetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1102",
+      "source_location": "L1104",
       "target": "dailyclose_carryforwardsourceid",
       "weight": 1
     },
@@ -11039,7 +11087,7 @@
       "relation": "calls",
       "source": "dailyclose_sourcecompletenessentry",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1700",
+      "source_location": "L1702",
       "target": "dailyclose_readcappedsource",
       "weight": 1
     },
@@ -11051,7 +11099,7 @@
       "relation": "calls",
       "source": "dailyclose_markreportdaydirty",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4146",
+      "source_location": "L4306",
       "target": "dailyclose_recorddailyclosecompletedreportfacts",
       "weight": 1
     },
@@ -11063,7 +11111,7 @@
       "relation": "calls",
       "source": "dailyclose_redactdailyclosesummaryforbroadview",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2417",
+      "source_location": "L2528",
       "target": "dailyclose_redactdailyclosereportsnapshotforbroadview",
       "weight": 1
     },
@@ -11075,7 +11123,7 @@
       "relation": "calls",
       "source": "dailyclose_normalizedailyclosesummary",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2380",
+      "source_location": "L2491",
       "target": "dailyclose_redactdailyclosesummaryforbroadview",
       "weight": 1
     },
@@ -11087,7 +11135,7 @@
       "relation": "calls",
       "source": "dailyclose_isinrange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1463",
+      "source_location": "L1465",
       "target": "dailyclose_registersessionbelongstorange",
       "weight": 1
     },
@@ -11099,7 +11147,7 @@
       "relation": "calls",
       "source": "dailyclose_registersessioncloseoutoperatingat",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1457",
+      "source_location": "L1459",
       "target": "dailyclose_registersessionbelongstorange",
       "weight": 1
     },
@@ -11111,7 +11159,7 @@
       "relation": "calls",
       "source": "dailyclose_registersessionintersectsrange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1466",
+      "source_location": "L1468",
       "target": "dailyclose_registersessionbelongstorange",
       "weight": 1
     },
@@ -11123,7 +11171,7 @@
       "relation": "calls",
       "source": "dailyclose_registersessioncloseoutoperatingat",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L753",
+      "source_location": "L755",
       "target": "dailyclose_issubmittedvariancecloseout",
       "weight": 1
     },
@@ -11135,7 +11183,7 @@
       "relation": "calls",
       "source": "dailyclose_markotherdailyclosesnotcurrent",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5241",
+      "source_location": "L5401",
       "target": "dailyclose_reopendailyclosewithctx",
       "weight": 1
     },
@@ -11147,7 +11195,7 @@
       "relation": "calls",
       "source": "dailyclose_markreportdaydirty",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5292",
+      "source_location": "L5452",
       "target": "dailyclose_reopendailyclosewithctx",
       "weight": 1
     },
@@ -11159,7 +11207,7 @@
       "relation": "calls",
       "source": "dailyclose_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5078",
+      "source_location": "L5238",
       "target": "dailyclose_reopendailyclosewithctx",
       "weight": 1
     },
@@ -11171,7 +11219,7 @@
       "relation": "calls",
       "source": "dailyclose_carryforwardbusinessdate",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4896",
+      "source_location": "L5056",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -11183,7 +11231,7 @@
       "relation": "calls",
       "source": "dailyclose_carryforwardresolutionvalidationerror",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4847",
+      "source_location": "L5007",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -11195,7 +11243,7 @@
       "relation": "calls",
       "source": "dailyclose_carryforwardsourceid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4923",
+      "source_location": "L5083",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -11207,7 +11255,7 @@
       "relation": "calls",
       "source": "dailyclose_getstore",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4821",
+      "source_location": "L4981",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -11219,7 +11267,7 @@
       "relation": "calls",
       "source": "dailyclose_listdailyopeninghandoffsforcarryforward",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4968",
+      "source_location": "L5128",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -11231,7 +11279,7 @@
       "relation": "calls",
       "source": "dailyclose_stringfrommetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4905",
+      "source_location": "L5065",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -11243,7 +11291,7 @@
       "relation": "calls",
       "source": "dailyclose_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4812",
+      "source_location": "L4972",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -11255,7 +11303,7 @@
       "relation": "calls",
       "source": "dailyclose_isvalidoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L731",
+      "source_location": "L733",
       "target": "dailyclose_resolveoperatingdaterange",
       "weight": 1
     },
@@ -11267,7 +11315,7 @@
       "relation": "calls",
       "source": "dailyclose_safeoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L725",
+      "source_location": "L727",
       "target": "dailyclose_resolveoperatingdaterange",
       "weight": 1
     },
@@ -11279,7 +11327,7 @@
       "relation": "calls",
       "source": "dailyclose_stringfrommetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3752",
+      "source_location": "L3912",
       "target": "dailyclose_sourceidfromcarryforwardinput",
       "weight": 1
     },
@@ -11291,7 +11339,7 @@
       "relation": "calls",
       "source": "dailyclose_test_completeddailyclosesnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L465",
+      "source_location": "L467",
       "target": "dailyclose_test_completeddailycloserow",
       "weight": 1
     },
@@ -11303,7 +11351,7 @@
       "relation": "calls",
       "source": "dailyclose_completionattributionfordailyclose",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2470",
+      "source_location": "L2581",
       "target": "dailyclose_todailyclosehistorylistitem",
       "weight": 1
     },
@@ -11315,7 +11363,7 @@
       "relation": "calls",
       "source": "dailyclose_redactdailyclosesummaryforbroadview",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2499",
+      "source_location": "L2610",
       "target": "dailyclose_todailyclosehistorylistitem",
       "weight": 1
     },
@@ -11327,7 +11375,7 @@
       "relation": "calls",
       "source": "dailyclose_formatpaymentmethodlabel",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L817",
+      "source_location": "L819",
       "target": "dailyclose_transactionpaymentsummary",
       "weight": 1
     },
@@ -30899,7 +30947,7 @@
       "relation": "calls",
       "source": "onlineorder_clearbagitems",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L329",
+      "source_location": "L333",
       "target": "onlineorder_createorderfromcheckoutsession",
       "weight": 1
     },
@@ -30911,7 +30959,7 @@
       "relation": "calls",
       "source": "onlineorder_generateordernumber",
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
-      "source_location": "L257",
+      "source_location": "L261",
       "target": "onlineorder_createorderfromcheckoutsession",
       "weight": 1
     },
@@ -48563,7 +48611,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L74",
+      "source_location": "L76",
       "target": "dailyclose_test_compareindexedvalue",
       "weight": 1
     },
@@ -48575,7 +48623,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L464",
+      "source_location": "L466",
       "target": "dailyclose_test_completeddailycloserow",
       "weight": 1
     },
@@ -48587,7 +48635,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L410",
+      "source_location": "L412",
       "target": "dailyclose_test_completeddailyclosesnapshot",
       "weight": 1
     },
@@ -48599,7 +48647,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L6123",
+      "source_location": "L6309",
       "target": "dailyclose_test_createcommandargs",
       "weight": 1
     },
@@ -48611,7 +48659,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L82",
+      "source_location": "L84",
       "target": "dailyclose_test_createdb",
       "weight": 1
     },
@@ -48623,7 +48671,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L354",
+      "source_location": "L356",
       "target": "dailyclose_test_dailycloseapprovalproof",
       "weight": 1
     },
@@ -48635,7 +48683,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L390",
+      "source_location": "L392",
       "target": "dailyclose_test_dailyclosecarryforwardapprovalproof",
       "weight": 1
     },
@@ -48647,7 +48695,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L372",
+      "source_location": "L374",
       "target": "dailyclose_test_dailyclosereopenapprovalproof",
       "weight": 1
     },
@@ -48659,7 +48707,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L329",
+      "source_location": "L331",
       "target": "dailyclose_test_dailyclosesummary",
       "weight": 1
     },
@@ -48671,7 +48719,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L69",
+      "source_location": "L71",
       "target": "dailyclose_test_gethandler",
       "weight": 1
     },
@@ -48683,7 +48731,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L497",
+      "source_location": "L499",
       "target": "dailyclose_test_mockdailyclosesnapshotaccess",
       "weight": 1
     },
@@ -48695,7 +48743,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L311",
+      "source_location": "L313",
       "target": "dailyclose_test_openoperationalworkitems",
       "weight": 1
     },
@@ -48707,7 +48755,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L4144",
+      "source_location": "L4330",
       "target": "dailyclose_test_syncedreview",
       "weight": 1
     },
@@ -48719,7 +48767,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1485",
+      "source_location": "L1487",
       "target": "dailyclose_approvalbelongstorange",
       "weight": 1
     },
@@ -48731,7 +48779,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L825",
+      "source_location": "L827",
       "target": "dailyclose_approvalrequesttypelabel",
       "weight": 1
     },
@@ -48743,7 +48791,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L970",
+      "source_location": "L972",
       "target": "dailyclose_ascarryforwarditem",
       "weight": 1
     },
@@ -48755,8 +48803,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L901",
+      "source_location": "L903",
       "target": "dailyclose_buildapprovalrequestsbyid",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_operations_dailyclose_ts",
+      "_tgt": "dailyclose_buildcompletedonlineordertotals",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L1787",
+      "target": "dailyclose_buildcompletedonlineordertotals",
       "weight": 1
     },
     {
@@ -48767,7 +48827,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1860",
+      "source_location": "L1971",
       "target": "dailyclose_builddailycloseexpenseproductevidence",
       "weight": 1
     },
@@ -48779,7 +48839,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1156",
+      "source_location": "L1158",
       "target": "dailyclose_builddailycloselifecyclegatewithctx",
       "weight": 1
     },
@@ -48791,7 +48851,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2130",
+      "source_location": "L2241",
       "target": "dailyclose_builddailyclosereportsnapshot",
       "weight": 1
     },
@@ -48803,7 +48863,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2563",
+      "source_location": "L2674",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -48815,7 +48875,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L950",
+      "source_location": "L952",
       "target": "dailyclose_buildexpensesessionsbyid",
       "weight": 1
     },
@@ -48827,7 +48887,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1806",
+      "source_location": "L1917",
       "target": "dailyclose_buildexpensetransactionitemcountsbytransactionid",
       "weight": 1
     },
@@ -48839,7 +48899,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2027",
+      "source_location": "L2138",
       "target": "dailyclose_buildreadiness",
       "weight": 1
     },
@@ -48851,7 +48911,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L881",
+      "source_location": "L883",
       "target": "dailyclose_buildregistersessionsbyid",
       "weight": 1
     },
@@ -48863,7 +48923,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L861",
+      "source_location": "L863",
       "target": "dailyclose_buildstaffnamesbyid",
       "weight": 1
     },
@@ -48875,7 +48935,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L841",
+      "source_location": "L843",
       "target": "dailyclose_buildterminallabelsbyid",
       "weight": 1
     },
@@ -48887,7 +48947,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1778",
+      "source_location": "L1889",
       "target": "dailyclose_buildtransactionitemcountsbytransactionid",
       "weight": 1
     },
@@ -48899,7 +48959,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3727",
+      "source_location": "L3887",
       "target": "dailyclose_carryforwardbusinessdate",
       "weight": 1
     },
@@ -48911,7 +48971,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3757",
+      "source_location": "L3917",
       "target": "dailyclose_carryforwardmetadatamatches",
       "weight": 1
     },
@@ -48923,7 +48983,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4801",
+      "source_location": "L4961",
       "target": "dailyclose_carryforwardresolutionvalidationerror",
       "weight": 1
     },
@@ -48935,7 +48995,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3736",
+      "source_location": "L3896",
       "target": "dailyclose_carryforwardsourceid",
       "weight": 1
     },
@@ -48947,7 +49007,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3801",
+      "source_location": "L3961",
       "target": "dailyclose_carryforwardworkitemidfromitem",
       "weight": 1
     },
@@ -48959,7 +49019,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2009",
+      "source_location": "L2120",
       "target": "dailyclose_cashdeltasbyregistersessionid",
       "weight": 1
     },
@@ -48971,7 +49031,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L921",
+      "source_location": "L923",
       "target": "dailyclose_closeoutapprovalforregistersession",
       "weight": 1
     },
@@ -48983,7 +49043,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4466",
+      "source_location": "L4626",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -48995,7 +49055,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4154",
+      "source_location": "L4314",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -49007,7 +49067,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L451",
+      "source_location": "L453",
       "target": "dailyclose_completesourcecompleteness",
       "weight": 1
     },
@@ -49019,7 +49079,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2291",
+      "source_location": "L2402",
       "target": "dailyclose_completionattributionfordailyclose",
       "weight": 1
     },
@@ -49031,7 +49091,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3892",
+      "source_location": "L4052",
       "target": "dailyclose_createcarryforwardworkitems",
       "weight": 1
     },
@@ -49043,7 +49103,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2530",
+      "source_location": "L2641",
       "target": "dailyclose_emptysummary",
       "weight": 1
     },
@@ -49055,7 +49115,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L933",
+      "source_location": "L935",
       "target": "dailyclose_filterregistersessionsbelongingtorange",
       "weight": 1
     },
@@ -49067,7 +49127,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3768",
+      "source_location": "L3928",
       "target": "dailyclose_findcurrentcarryforwardworkitembysource",
       "weight": 1
     },
@@ -49079,7 +49139,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L797",
+      "source_location": "L799",
       "target": "dailyclose_formatpaymentmethodlabel",
       "weight": 1
     },
@@ -49091,7 +49151,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2103",
+      "source_location": "L2214",
       "target": "dailyclose_frozensyncedsaleinventoryreviewgroups",
       "weight": 1
     },
@@ -49103,7 +49163,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5420",
+      "source_location": "L5580",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -49115,7 +49175,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2503",
+      "source_location": "L2614",
       "target": "dailyclose_getdailyclosecompletioneventstaffprofileid",
       "weight": 1
     },
@@ -49127,7 +49187,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1117",
+      "source_location": "L1119",
       "target": "dailyclose_getdailyclosefordate",
       "weight": 1
     },
@@ -49139,7 +49199,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5306",
+      "source_location": "L5466",
       "target": "dailyclose_getdailycloseopeningcontextwithctx",
       "weight": 1
     },
@@ -49151,7 +49211,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3991",
+      "source_location": "L4151",
       "target": "dailyclose_getnonactivedailyclosefordate",
       "weight": 1
     },
@@ -49163,7 +49223,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1192",
+      "source_location": "L1194",
       "target": "dailyclose_getpriorcompleteddailyclose",
       "weight": 1
     },
@@ -49175,7 +49235,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1110",
+      "source_location": "L1112",
       "target": "dailyclose_getstore",
       "weight": 1
     },
@@ -49187,7 +49247,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2287",
+      "source_location": "L2398",
       "target": "dailyclose_incompletesourcecompletenessentries",
       "weight": 1
     },
@@ -49199,7 +49259,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L741",
+      "source_location": "L743",
       "target": "dailyclose_isinrange",
       "weight": 1
     },
@@ -49211,7 +49271,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L765",
+      "source_location": "L767",
       "target": "dailyclose_issubmittedvariancecloseout",
       "weight": 1
     },
@@ -49223,7 +49283,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L709",
+      "source_location": "L711",
       "target": "dailyclose_isvalidoperatingdaterange",
       "weight": 1
     },
@@ -49235,7 +49295,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1651",
+      "source_location": "L1653",
       "target": "dailyclose_listactiveoversizedoperationalworkrepairs",
       "weight": 1
     },
@@ -49247,8 +49307,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5367",
+      "source_location": "L5527",
       "target": "dailyclose_listcompleteddailyclosehistorywithctx",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_operations_dailyclose_ts",
+      "_tgt": "dailyclose_listcompletedonlineordersforday",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L1744",
+      "target": "dailyclose_listcompletedonlineordersforday",
       "weight": 1
     },
     {
@@ -49259,7 +49331,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4772",
+      "source_location": "L4932",
       "target": "dailyclose_listdailyopeninghandoffsforcarryforward",
       "weight": 1
     },
@@ -49271,7 +49343,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1971",
+      "source_location": "L2082",
       "target": "dailyclose_listdepositsforday",
       "weight": 1
     },
@@ -49283,7 +49355,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1742",
+      "source_location": "L1853",
       "target": "dailyclose_listexpensesforday",
       "weight": 1
     },
@@ -49295,7 +49367,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1614",
+      "source_location": "L1616",
       "target": "dailyclose_listopenoperationalworkitems",
       "weight": 1
     },
@@ -49307,7 +49379,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1571",
+      "source_location": "L1573",
       "target": "dailyclose_listopenpossessions",
       "weight": 1
     },
@@ -49319,7 +49391,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1525",
+      "source_location": "L1527",
       "target": "dailyclose_listpendingcloseoutapprovals",
       "weight": 1
     },
@@ -49331,7 +49403,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1225",
+      "source_location": "L1227",
       "target": "dailyclose_listregistersessionsfordailyclose",
       "weight": 1
     },
@@ -49343,7 +49415,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1712",
+      "source_location": "L1714",
       "target": "dailyclose_listtransactionsforday",
       "weight": 1
     },
@@ -49355,7 +49427,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3686",
+      "source_location": "L3846",
       "target": "dailyclose_logicalcarryforwardselectioncount",
       "weight": 1
     },
@@ -49367,7 +49439,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1018",
+      "source_location": "L1020",
       "target": "dailyclose_logicalgroupascarryforwarditem",
       "weight": 1
     },
@@ -49379,7 +49451,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3968",
+      "source_location": "L4128",
       "target": "dailyclose_markotherdailyclosesnotcurrent",
       "weight": 1
     },
@@ -49391,7 +49463,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4075",
+      "source_location": "L4235",
       "target": "dailyclose_markreportdaydirty",
       "weight": 1
     },
@@ -49403,7 +49475,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2429",
+      "source_location": "L2540",
       "target": "dailyclose_mayberedactdailyclosesnapshotforbroadview",
       "weight": 1
     },
@@ -49415,7 +49487,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L488",
+      "source_location": "L490",
       "target": "dailyclose_mergesourcecompleteness",
       "weight": 1
     },
@@ -49427,7 +49499,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L821",
+      "source_location": "L823",
       "target": "dailyclose_nonzerovariancemetadata",
       "weight": 1
     },
@@ -49439,7 +49511,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2340",
+      "source_location": "L2451",
       "target": "dailyclose_normalizebroadviewmetadatalabel",
       "weight": 1
     },
@@ -49451,7 +49523,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L375",
+      "source_location": "L377",
       "target": "dailyclose_normalizecompleteddailyclosesnapshot",
       "weight": 1
     },
@@ -49463,7 +49535,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L500",
+      "source_location": "L502",
       "target": "dailyclose_normalizedailyclosesummary",
       "weight": 1
     },
@@ -49475,7 +49547,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1085",
+      "source_location": "L1087",
       "target": "dailyclose_patchdailyclosecarryforwardworkitemmetadata",
       "weight": 1
     },
@@ -49487,7 +49559,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1469",
+      "source_location": "L1471",
       "target": "dailyclose_possessionintersectsrange",
       "weight": 1
     },
@@ -49499,7 +49571,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1688",
+      "source_location": "L1690",
       "target": "dailyclose_readcappedsource",
       "weight": 1
     },
@@ -49511,7 +49583,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4014",
+      "source_location": "L4174",
       "target": "dailyclose_recorddailyclosecompletedevent",
       "weight": 1
     },
@@ -49523,7 +49595,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4108",
+      "source_location": "L4268",
       "target": "dailyclose_recorddailyclosecompletedreportfacts",
       "weight": 1
     },
@@ -49535,7 +49607,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2344",
+      "source_location": "L2455",
       "target": "dailyclose_redactdailycloseitemforbroadview",
       "weight": 1
     },
@@ -49547,7 +49619,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5342",
+      "source_location": "L5502",
       "target": "dailyclose_redactdailycloseopeningcontextforbroadview",
       "weight": 1
     },
@@ -49559,7 +49631,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2397",
+      "source_location": "L2508",
       "target": "dailyclose_redactdailyclosereportsnapshotforbroadview",
       "weight": 1
     },
@@ -49571,7 +49643,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2377",
+      "source_location": "L2488",
       "target": "dailyclose_redactdailyclosesummaryforbroadview",
       "weight": 1
     },
@@ -49583,7 +49655,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L784",
+      "source_location": "L786",
       "target": "dailyclose_registermetadatalabel",
       "weight": 1
     },
@@ -49595,7 +49667,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1452",
+      "source_location": "L1454",
       "target": "dailyclose_registersessionbelongstorange",
       "weight": 1
     },
@@ -49607,7 +49679,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L745",
+      "source_location": "L747",
       "target": "dailyclose_registersessioncloseoutoperatingat",
       "weight": 1
     },
@@ -49619,7 +49691,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1442",
+      "source_location": "L1444",
       "target": "dailyclose_registersessionintersectsrange",
       "weight": 1
     },
@@ -49631,7 +49703,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L776",
+      "source_location": "L778",
       "target": "dailyclose_registersessionlabel",
       "weight": 1
     },
@@ -49643,7 +49715,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5074",
+      "source_location": "L5234",
       "target": "dailyclose_reopendailyclosewithctx",
       "weight": 1
     },
@@ -49655,7 +49727,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4808",
+      "source_location": "L4968",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -49667,7 +49739,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L720",
+      "source_location": "L722",
       "target": "dailyclose_resolveoperatingdaterange",
       "weight": 1
     },
@@ -49679,7 +49751,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L692",
+      "source_location": "L694",
       "target": "dailyclose_safeoperatingdaterange",
       "weight": 1
     },
@@ -49691,7 +49763,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2273",
+      "source_location": "L2384",
       "target": "dailyclose_snapshotrevieweditems",
       "weight": 1
     },
@@ -49703,7 +49775,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L321",
+      "source_location": "L323",
       "target": "dailyclose_sortdailycloseblockers",
       "weight": 1
     },
@@ -49715,7 +49787,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L460",
+      "source_location": "L462",
       "target": "dailyclose_sourcecompletenessentry",
       "weight": 1
     },
@@ -49727,7 +49799,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3746",
+      "source_location": "L3906",
       "target": "dailyclose_sourceidfromcarryforwardinput",
       "weight": 1
     },
@@ -49739,7 +49811,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3718",
+      "source_location": "L3878",
       "target": "dailyclose_stringfrommetadata",
       "weight": 1
     },
@@ -49751,7 +49823,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2464",
+      "source_location": "L2575",
       "target": "dailyclose_todailyclosehistorylistitem",
       "weight": 1
     },
@@ -49763,7 +49835,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L803",
+      "source_location": "L805",
       "target": "dailyclose_transactionpaymentsummary",
       "weight": 1
     },
@@ -49775,7 +49847,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L687",
+      "source_location": "L689",
       "target": "dailyclose_trimoptional",
       "weight": 1
     },
@@ -49787,7 +49859,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2065",
+      "source_location": "L2176",
       "target": "dailyclose_trustedsyncedsaleinventoryreviewunits",
       "weight": 1
     },
@@ -49799,7 +49871,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2057",
+      "source_location": "L2168",
       "target": "dailyclose_uniquedailycloseitems",
       "weight": 1
     },
@@ -49811,7 +49883,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3712",
+      "source_location": "L3872",
       "target": "dailyclose_uniqueoperationalworkitemids",
       "weight": 1
     },
@@ -49823,7 +49895,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2047",
+      "source_location": "L2158",
       "target": "dailyclose_uniquesourcesubjects",
       "weight": 1
     },
@@ -49835,7 +49907,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3811",
+      "source_location": "L3971",
       "target": "dailyclose_validateautomationcarryforwardworkitems",
       "weight": 1
     },
@@ -49847,7 +49919,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3632",
+      "source_location": "L3792",
       "target": "dailyclose_validatecarryforwardworkitemids",
       "weight": 1
     },
@@ -49859,7 +49931,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3660",
+      "source_location": "L3820",
       "target": "dailyclose_validateselectedcarryforwardgroups",
       "weight": 1
     },
@@ -102023,7 +102095,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportsoverviewview_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsOverviewView.tsx",
-      "source_location": "L131",
+      "source_location": "L135",
       "target": "reportsoverviewview_cn",
       "weight": 1
     },
@@ -102035,7 +102107,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportsoverviewview_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsOverviewView.tsx",
-      "source_location": "L28",
+      "source_location": "L32",
       "target": "reportsoverviewview_comparisonfor",
       "weight": 1
     },
@@ -102095,7 +102167,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportsweeklyview_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L280",
+      "source_location": "L286",
       "target": "reportsweeklyview_closeevidencecoveragelabel",
       "weight": 1
     },
@@ -102107,7 +102179,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportsweeklyview_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L249",
+      "source_location": "L255",
       "target": "reportsweeklyview_comparabilitylabel",
       "weight": 1
     },
@@ -102119,7 +102191,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportsweeklyview_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L223",
+      "source_location": "L229",
       "target": "reportsweeklyview_completenesslabel",
       "weight": 1
     },
@@ -102131,7 +102203,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportsweeklyview_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L1200",
+      "source_location": "L1218",
       "target": "reportsweeklyview_formatreportmoney",
       "weight": 1
     },
@@ -102143,7 +102215,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportsweeklyview_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L589",
+      "source_location": "L621",
       "target": "reportsweeklyview_formatreporttimestamp",
       "weight": 1
     },
@@ -102155,7 +102227,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportsweeklyview_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L323",
+      "source_location": "L352",
       "target": "reportsweeklyview_metriclist",
       "weight": 1
     },
@@ -102167,7 +102239,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportsweeklyview_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L506",
+      "source_location": "L538",
       "target": "reportsweeklyview_money",
       "weight": 1
     },
@@ -102179,7 +102251,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportsweeklyview_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L510",
+      "source_location": "L542",
       "target": "reportsweeklyview_optionalmoney",
       "weight": 1
     },
@@ -102191,20 +102263,8 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportsweeklyview_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L345",
+      "source_location": "L374",
       "target": "reportsweeklyview_ownerroutelink",
-      "weight": 1
-    },
-    {
-      "_src": "packages_athena_webapp_src_components_reports_reportsweeklyview_tsx",
-      "_tgt": "reportsweeklyview_productcountlabel",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "contains",
-      "source": "packages_athena_webapp_src_components_reports_reportsweeklyview_tsx",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L1241",
-      "target": "reportsweeklyview_productcountlabel",
       "weight": 1
     },
     {
@@ -102215,20 +102275,8 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportsweeklyview_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L514",
+      "source_location": "L546",
       "target": "reportsweeklyview_profit",
-      "weight": 1
-    },
-    {
-      "_src": "packages_athena_webapp_src_components_reports_reportsweeklyview_tsx",
-      "_tgt": "reportsweeklyview_quantitylabel",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "contains",
-      "source": "packages_athena_webapp_src_components_reports_reportsweeklyview_tsx",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L1243",
-      "target": "reportsweeklyview_quantitylabel",
       "weight": 1
     },
     {
@@ -102239,8 +102287,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportsweeklyview_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L304",
+      "source_location": "L333",
       "target": "reportsweeklyview_section",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_reports_reportsweeklyview_tsx",
+      "_tgt": "reportsweeklyview_sharedcloseevidencecoverage",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_reports_reportsweeklyview_tsx",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
+      "source_location": "L296",
+      "target": "reportsweeklyview_sharedcloseevidencecoverage",
       "weight": 1
     },
     {
@@ -102251,20 +102311,8 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportsweeklyview_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L518",
+      "source_location": "L550",
       "target": "reportsweeklyview_units",
-      "weight": 1
-    },
-    {
-      "_src": "packages_athena_webapp_src_components_reports_reportsweeklyview_tsx",
-      "_tgt": "reportsweeklyview_valuesfor",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "contains",
-      "source": "packages_athena_webapp_src_components_reports_reportsweeklyview_tsx",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L1245",
-      "target": "reportsweeklyview_valuesfor",
       "weight": 1
     },
     {
@@ -102275,7 +102323,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportsweeklyview_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L270",
+      "source_location": "L276",
       "target": "reportsweeklyview_variancecoveragelabel",
       "weight": 1
     },
@@ -102287,7 +102335,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportsweeklyview_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L290",
+      "source_location": "L319",
       "target": "reportsweeklyview_weeklypaymentmix",
       "weight": 1
     },
@@ -102395,7 +102443,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportunitsmovedchartsheet_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
-      "source_location": "L340",
+      "source_location": "L339",
       "target": "reportunitsmovedchartsheet_capturescrollposition",
       "weight": 1
     },
@@ -102407,7 +102455,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportunitsmovedchartsheet_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
-      "source_location": "L86",
+      "source_location": "L85",
       "target": "reportunitsmovedchartsheet_formatnetunitsmoved",
       "weight": 1
     },
@@ -102419,7 +102467,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportunitsmovedchartsheet_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
-      "source_location": "L530",
+      "source_location": "L529",
       "target": "reportunitsmovedchartsheet_handleretry",
       "weight": 1
     },
@@ -102431,7 +102479,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportunitsmovedchartsheet_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
-      "source_location": "L598",
+      "source_location": "L597",
       "target": "reportunitsmovedchartsheet_handleskulinkclick",
       "weight": 1
     },
@@ -102443,7 +102491,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportunitsmovedchartsheet_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
-      "source_location": "L103",
+      "source_location": "L102",
       "target": "reportunitsmovedchartsheet_movementbarradius",
       "weight": 1
     },
@@ -102455,7 +102503,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportunitsmovedchartsheet_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
-      "source_location": "L110",
+      "source_location": "L109",
       "target": "reportunitsmovedchartsheet_movementchartdomain",
       "weight": 1
     },
@@ -102467,7 +102515,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportunitsmovedchartsheet_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
-      "source_location": "L93",
+      "source_location": "L92",
       "target": "reportunitsmovedchartsheet_netunitsmovedaccessiblephrase",
       "weight": 1
     },
@@ -102479,7 +102527,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportunitsmovedchartsheet_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
-      "source_location": "L332",
+      "source_location": "L331",
       "target": "reportunitsmovedchartsheet_setactivetab",
       "weight": 1
     },
@@ -102491,7 +102539,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportunitsmovedchartsheet_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
-      "source_location": "L336",
+      "source_location": "L335",
       "target": "reportunitsmovedchartsheet_setgranularpage",
       "weight": 1
     },
@@ -102503,7 +102551,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportunitsmovedchartsheet_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
-      "source_location": "L318",
+      "source_location": "L317",
       "target": "reportunitsmovedchartsheet_setisopen",
       "weight": 1
     },
@@ -102515,7 +102563,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportunitsmovedchartsheet_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
-      "source_location": "L133",
+      "source_location": "L132",
       "target": "reportunitsmovedchartsheet_unitmovementmetadata",
       "weight": 1
     },
@@ -124931,7 +124979,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_weekly_tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports/weekly.tsx",
-      "source_location": "L93",
+      "source_location": "L94",
       "target": "weekly_unavailableweeklycopy",
       "weight": 1
     },
@@ -124943,7 +124991,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_weekly_tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports/weekly.tsx",
-      "source_location": "L39",
+      "source_location": "L40",
       "target": "weekly_weeklystatusrow",
       "weight": 1
     },
@@ -146087,32 +146135,8 @@
       "relation": "calls",
       "source": "reportsweeklyview_money",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L509",
+      "source_location": "L541",
       "target": "reportsweeklyview_formatreportmoney",
-      "weight": 1
-    },
-    {
-      "_src": "reportsweeklyview_valuesfor",
-      "_tgt": "reportsweeklyview_formatreportmoney",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "calls",
-      "source": "reportsweeklyview_formatreportmoney",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L1247",
-      "target": "reportsweeklyview_valuesfor",
-      "weight": 1
-    },
-    {
-      "_src": "reportsweeklyview_valuesfor",
-      "_tgt": "reportsweeklyview_quantitylabel",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "calls",
-      "source": "reportsweeklyview_quantitylabel",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L1247",
-      "target": "reportsweeklyview_valuesfor",
       "weight": 1
     },
     {
@@ -177433,7 +177457,7 @@
       "label": "approvalBelongsToRange()",
       "norm_label": "approvalbelongstorange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1485"
+      "source_location": "L1487"
     },
     {
       "community": 0,
@@ -177442,7 +177466,7 @@
       "label": "approvalRequestTypeLabel()",
       "norm_label": "approvalrequesttypelabel()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L825"
+      "source_location": "L827"
     },
     {
       "community": 0,
@@ -177451,7 +177475,7 @@
       "label": "asCarryForwardItem()",
       "norm_label": "ascarryforwarditem()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L970"
+      "source_location": "L972"
     },
     {
       "community": 0,
@@ -177460,7 +177484,16 @@
       "label": "buildApprovalRequestsById()",
       "norm_label": "buildapprovalrequestsbyid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L901"
+      "source_location": "L903"
+    },
+    {
+      "community": 0,
+      "file_type": "code",
+      "id": "dailyclose_buildcompletedonlineordertotals",
+      "label": "buildCompletedOnlineOrderTotals()",
+      "norm_label": "buildcompletedonlineordertotals()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L1787"
     },
     {
       "community": 0,
@@ -177469,7 +177502,7 @@
       "label": "buildDailyCloseExpenseProductEvidence()",
       "norm_label": "builddailycloseexpenseproductevidence()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1860"
+      "source_location": "L1971"
     },
     {
       "community": 0,
@@ -177478,7 +177511,7 @@
       "label": "buildDailyCloseLifecycleGateWithCtx()",
       "norm_label": "builddailycloselifecyclegatewithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1156"
+      "source_location": "L1158"
     },
     {
       "community": 0,
@@ -177487,7 +177520,7 @@
       "label": "buildDailyCloseReportSnapshot()",
       "norm_label": "builddailyclosereportsnapshot()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2130"
+      "source_location": "L2241"
     },
     {
       "community": 0,
@@ -177496,7 +177529,7 @@
       "label": "buildDailyCloseSnapshotWithCtx()",
       "norm_label": "builddailyclosesnapshotwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2563"
+      "source_location": "L2674"
     },
     {
       "community": 0,
@@ -177505,7 +177538,7 @@
       "label": "buildExpenseSessionsById()",
       "norm_label": "buildexpensesessionsbyid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L950"
+      "source_location": "L952"
     },
     {
       "community": 0,
@@ -177514,7 +177547,7 @@
       "label": "buildExpenseTransactionItemCountsByTransactionId()",
       "norm_label": "buildexpensetransactionitemcountsbytransactionid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1806"
+      "source_location": "L1917"
     },
     {
       "community": 0,
@@ -177523,7 +177556,7 @@
       "label": "buildReadiness()",
       "norm_label": "buildreadiness()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2027"
+      "source_location": "L2138"
     },
     {
       "community": 0,
@@ -177532,7 +177565,7 @@
       "label": "buildRegisterSessionsById()",
       "norm_label": "buildregistersessionsbyid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L881"
+      "source_location": "L883"
     },
     {
       "community": 0,
@@ -177541,7 +177574,7 @@
       "label": "buildStaffNamesById()",
       "norm_label": "buildstaffnamesbyid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L861"
+      "source_location": "L863"
     },
     {
       "community": 0,
@@ -177550,7 +177583,7 @@
       "label": "buildTerminalLabelsById()",
       "norm_label": "buildterminallabelsbyid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L841"
+      "source_location": "L843"
     },
     {
       "community": 0,
@@ -177559,7 +177592,7 @@
       "label": "buildTransactionItemCountsByTransactionId()",
       "norm_label": "buildtransactionitemcountsbytransactionid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1778"
+      "source_location": "L1889"
     },
     {
       "community": 0,
@@ -177568,7 +177601,7 @@
       "label": "carryForwardBusinessDate()",
       "norm_label": "carryforwardbusinessdate()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3727"
+      "source_location": "L3887"
     },
     {
       "community": 0,
@@ -177577,7 +177610,7 @@
       "label": "carryForwardMetadataMatches()",
       "norm_label": "carryforwardmetadatamatches()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3757"
+      "source_location": "L3917"
     },
     {
       "community": 0,
@@ -177586,7 +177619,7 @@
       "label": "carryForwardResolutionValidationError()",
       "norm_label": "carryforwardresolutionvalidationerror()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4801"
+      "source_location": "L4961"
     },
     {
       "community": 0,
@@ -177595,7 +177628,7 @@
       "label": "carryForwardSourceId()",
       "norm_label": "carryforwardsourceid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3736"
+      "source_location": "L3896"
     },
     {
       "community": 0,
@@ -177604,7 +177637,7 @@
       "label": "carryForwardWorkItemIdFromItem()",
       "norm_label": "carryforwardworkitemidfromitem()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3801"
+      "source_location": "L3961"
     },
     {
       "community": 0,
@@ -177613,7 +177646,7 @@
       "label": "cashDeltasByRegisterSessionId()",
       "norm_label": "cashdeltasbyregistersessionid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2009"
+      "source_location": "L2120"
     },
     {
       "community": 0,
@@ -177622,7 +177655,7 @@
       "label": "closeoutApprovalForRegisterSession()",
       "norm_label": "closeoutapprovalforregistersession()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L921"
+      "source_location": "L923"
     },
     {
       "community": 0,
@@ -177631,7 +177664,7 @@
       "label": "completeDailyCloseForAutomationWithCtx()",
       "norm_label": "completedailycloseforautomationwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4466"
+      "source_location": "L4626"
     },
     {
       "community": 0,
@@ -177640,7 +177673,7 @@
       "label": "completeDailyCloseWithCtx()",
       "norm_label": "completedailyclosewithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4154"
+      "source_location": "L4314"
     },
     {
       "community": 0,
@@ -177649,7 +177682,7 @@
       "label": "completeSourceCompleteness()",
       "norm_label": "completesourcecompleteness()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L451"
+      "source_location": "L453"
     },
     {
       "community": 0,
@@ -177658,7 +177691,7 @@
       "label": "completionAttributionForDailyClose()",
       "norm_label": "completionattributionfordailyclose()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2291"
+      "source_location": "L2402"
     },
     {
       "community": 0,
@@ -177667,7 +177700,7 @@
       "label": "createCarryForwardWorkItems()",
       "norm_label": "createcarryforwardworkitems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3892"
+      "source_location": "L4052"
     },
     {
       "community": 0,
@@ -177676,7 +177709,7 @@
       "label": "emptySummary()",
       "norm_label": "emptysummary()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2530"
+      "source_location": "L2641"
     },
     {
       "community": 0,
@@ -177685,7 +177718,7 @@
       "label": "filterRegisterSessionsBelongingToRange()",
       "norm_label": "filterregistersessionsbelongingtorange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L933"
+      "source_location": "L935"
     },
     {
       "community": 0,
@@ -177694,7 +177727,7 @@
       "label": "findCurrentCarryForwardWorkItemBySource()",
       "norm_label": "findcurrentcarryforwardworkitembysource()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3768"
+      "source_location": "L3928"
     },
     {
       "community": 0,
@@ -177703,7 +177736,7 @@
       "label": "formatPaymentMethodLabel()",
       "norm_label": "formatpaymentmethodlabel()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L797"
+      "source_location": "L799"
     },
     {
       "community": 0,
@@ -177712,7 +177745,7 @@
       "label": "frozenSyncedSaleInventoryReviewGroups()",
       "norm_label": "frozensyncedsaleinventoryreviewgroups()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2103"
+      "source_location": "L2214"
     },
     {
       "community": 0,
@@ -177721,7 +177754,7 @@
       "label": "getCompletedDailyCloseHistoryDetailWithCtx()",
       "norm_label": "getcompleteddailyclosehistorydetailwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5420"
+      "source_location": "L5580"
     },
     {
       "community": 0,
@@ -177730,7 +177763,7 @@
       "label": "getDailyCloseCompletionEventStaffProfileId()",
       "norm_label": "getdailyclosecompletioneventstaffprofileid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2503"
+      "source_location": "L2614"
     },
     {
       "community": 0,
@@ -177739,7 +177772,7 @@
       "label": "getDailyCloseForDate()",
       "norm_label": "getdailyclosefordate()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1117"
+      "source_location": "L1119"
     },
     {
       "community": 0,
@@ -177748,7 +177781,7 @@
       "label": "getDailyCloseOpeningContextWithCtx()",
       "norm_label": "getdailycloseopeningcontextwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5306"
+      "source_location": "L5466"
     },
     {
       "community": 0,
@@ -177757,7 +177790,7 @@
       "label": "getNonActiveDailyCloseForDate()",
       "norm_label": "getnonactivedailyclosefordate()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3991"
+      "source_location": "L4151"
     },
     {
       "community": 0,
@@ -177766,7 +177799,7 @@
       "label": "getPriorCompletedDailyClose()",
       "norm_label": "getpriorcompleteddailyclose()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1192"
+      "source_location": "L1194"
     },
     {
       "community": 0,
@@ -177775,7 +177808,7 @@
       "label": "getStore()",
       "norm_label": "getstore()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1110"
+      "source_location": "L1112"
     },
     {
       "community": 0,
@@ -177784,7 +177817,7 @@
       "label": "incompleteSourceCompletenessEntries()",
       "norm_label": "incompletesourcecompletenessentries()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2287"
+      "source_location": "L2398"
     },
     {
       "community": 0,
@@ -177793,7 +177826,7 @@
       "label": "isInRange()",
       "norm_label": "isinrange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L741"
+      "source_location": "L743"
     },
     {
       "community": 0,
@@ -177802,7 +177835,7 @@
       "label": "isSubmittedVarianceCloseout()",
       "norm_label": "issubmittedvariancecloseout()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L765"
+      "source_location": "L767"
     },
     {
       "community": 0,
@@ -177811,7 +177844,7 @@
       "label": "isValidOperatingDateRange()",
       "norm_label": "isvalidoperatingdaterange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L709"
+      "source_location": "L711"
     },
     {
       "community": 0,
@@ -177820,7 +177853,7 @@
       "label": "listActiveOversizedOperationalWorkRepairs()",
       "norm_label": "listactiveoversizedoperationalworkrepairs()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1651"
+      "source_location": "L1653"
     },
     {
       "community": 0,
@@ -177829,7 +177862,16 @@
       "label": "listCompletedDailyCloseHistoryWithCtx()",
       "norm_label": "listcompleteddailyclosehistorywithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5367"
+      "source_location": "L5527"
+    },
+    {
+      "community": 0,
+      "file_type": "code",
+      "id": "dailyclose_listcompletedonlineordersforday",
+      "label": "listCompletedOnlineOrdersForDay()",
+      "norm_label": "listcompletedonlineordersforday()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L1744"
     },
     {
       "community": 0,
@@ -177838,7 +177880,7 @@
       "label": "listDailyOpeningHandoffsForCarryForward()",
       "norm_label": "listdailyopeninghandoffsforcarryforward()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4772"
+      "source_location": "L4932"
     },
     {
       "community": 0,
@@ -177847,7 +177889,7 @@
       "label": "listDepositsForDay()",
       "norm_label": "listdepositsforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1971"
+      "source_location": "L2082"
     },
     {
       "community": 0,
@@ -177856,7 +177898,7 @@
       "label": "listExpensesForDay()",
       "norm_label": "listexpensesforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1742"
+      "source_location": "L1853"
     },
     {
       "community": 0,
@@ -177865,7 +177907,7 @@
       "label": "listOpenOperationalWorkItems()",
       "norm_label": "listopenoperationalworkitems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1614"
+      "source_location": "L1616"
     },
     {
       "community": 0,
@@ -177874,7 +177916,7 @@
       "label": "listOpenPosSessions()",
       "norm_label": "listopenpossessions()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1571"
+      "source_location": "L1573"
     },
     {
       "community": 0,
@@ -177883,7 +177925,7 @@
       "label": "listPendingCloseoutApprovals()",
       "norm_label": "listpendingcloseoutapprovals()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1525"
+      "source_location": "L1527"
     },
     {
       "community": 0,
@@ -177892,7 +177934,7 @@
       "label": "listRegisterSessionsForDailyClose()",
       "norm_label": "listregistersessionsfordailyclose()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1225"
+      "source_location": "L1227"
     },
     {
       "community": 0,
@@ -177901,7 +177943,7 @@
       "label": "listTransactionsForDay()",
       "norm_label": "listtransactionsforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1712"
+      "source_location": "L1714"
     },
     {
       "community": 0,
@@ -177910,7 +177952,7 @@
       "label": "logicalCarryForwardSelectionCount()",
       "norm_label": "logicalcarryforwardselectioncount()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3686"
+      "source_location": "L3846"
     },
     {
       "community": 0,
@@ -177919,7 +177961,7 @@
       "label": "logicalGroupAsCarryForwardItem()",
       "norm_label": "logicalgroupascarryforwarditem()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1018"
+      "source_location": "L1020"
     },
     {
       "community": 0,
@@ -177928,7 +177970,7 @@
       "label": "markOtherDailyClosesNotCurrent()",
       "norm_label": "markotherdailyclosesnotcurrent()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3968"
+      "source_location": "L4128"
     },
     {
       "community": 0,
@@ -177937,7 +177979,7 @@
       "label": "markReportDayDirty()",
       "norm_label": "markreportdaydirty()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4075"
+      "source_location": "L4235"
     },
     {
       "community": 0,
@@ -177946,7 +177988,7 @@
       "label": "maybeRedactDailyCloseSnapshotForBroadView()",
       "norm_label": "mayberedactdailyclosesnapshotforbroadview()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2429"
+      "source_location": "L2540"
     },
     {
       "community": 0,
@@ -177955,7 +177997,7 @@
       "label": "mergeSourceCompleteness()",
       "norm_label": "mergesourcecompleteness()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L488"
+      "source_location": "L490"
     },
     {
       "community": 0,
@@ -177964,7 +178006,7 @@
       "label": "nonZeroVarianceMetadata()",
       "norm_label": "nonzerovariancemetadata()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L821"
+      "source_location": "L823"
     },
     {
       "community": 0,
@@ -177973,7 +178015,7 @@
       "label": "normalizeBroadViewMetadataLabel()",
       "norm_label": "normalizebroadviewmetadatalabel()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2340"
+      "source_location": "L2451"
     },
     {
       "community": 0,
@@ -177982,7 +178024,7 @@
       "label": "normalizeCompletedDailyCloseSnapshot()",
       "norm_label": "normalizecompleteddailyclosesnapshot()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L375"
+      "source_location": "L377"
     },
     {
       "community": 0,
@@ -177991,7 +178033,7 @@
       "label": "normalizeDailyCloseSummary()",
       "norm_label": "normalizedailyclosesummary()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L500"
+      "source_location": "L502"
     },
     {
       "community": 0,
@@ -178000,7 +178042,7 @@
       "label": "patchDailyCloseCarryForwardWorkItemMetadata()",
       "norm_label": "patchdailyclosecarryforwardworkitemmetadata()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1085"
+      "source_location": "L1087"
     },
     {
       "community": 0,
@@ -178009,7 +178051,7 @@
       "label": "posSessionIntersectsRange()",
       "norm_label": "possessionintersectsrange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1469"
+      "source_location": "L1471"
     },
     {
       "community": 0,
@@ -178018,7 +178060,7 @@
       "label": "readCappedSource()",
       "norm_label": "readcappedsource()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1688"
+      "source_location": "L1690"
     },
     {
       "community": 0,
@@ -178027,7 +178069,7 @@
       "label": "recordDailyCloseCompletedEvent()",
       "norm_label": "recorddailyclosecompletedevent()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4014"
+      "source_location": "L4174"
     },
     {
       "community": 0,
@@ -178036,7 +178078,7 @@
       "label": "recordDailyCloseCompletedReportFacts()",
       "norm_label": "recorddailyclosecompletedreportfacts()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4108"
+      "source_location": "L4268"
     },
     {
       "community": 0,
@@ -178045,7 +178087,7 @@
       "label": "redactDailyCloseItemForBroadView()",
       "norm_label": "redactdailycloseitemforbroadview()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2344"
+      "source_location": "L2455"
     },
     {
       "community": 0,
@@ -178054,7 +178096,7 @@
       "label": "redactDailyCloseOpeningContextForBroadView()",
       "norm_label": "redactdailycloseopeningcontextforbroadview()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5342"
+      "source_location": "L5502"
     },
     {
       "community": 0,
@@ -178063,7 +178105,7 @@
       "label": "redactDailyCloseReportSnapshotForBroadView()",
       "norm_label": "redactdailyclosereportsnapshotforbroadview()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2397"
+      "source_location": "L2508"
     },
     {
       "community": 0,
@@ -178072,7 +178114,7 @@
       "label": "redactDailyCloseSummaryForBroadView()",
       "norm_label": "redactdailyclosesummaryforbroadview()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2377"
+      "source_location": "L2488"
     },
     {
       "community": 0,
@@ -178081,7 +178123,7 @@
       "label": "registerMetadataLabel()",
       "norm_label": "registermetadatalabel()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L784"
+      "source_location": "L786"
     },
     {
       "community": 0,
@@ -178090,7 +178132,7 @@
       "label": "registerSessionBelongsToRange()",
       "norm_label": "registersessionbelongstorange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1452"
+      "source_location": "L1454"
     },
     {
       "community": 0,
@@ -178099,7 +178141,7 @@
       "label": "registerSessionCloseoutOperatingAt()",
       "norm_label": "registersessioncloseoutoperatingat()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L745"
+      "source_location": "L747"
     },
     {
       "community": 0,
@@ -178108,7 +178150,7 @@
       "label": "registerSessionIntersectsRange()",
       "norm_label": "registersessionintersectsrange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1442"
+      "source_location": "L1444"
     },
     {
       "community": 0,
@@ -178117,7 +178159,7 @@
       "label": "registerSessionLabel()",
       "norm_label": "registersessionlabel()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L776"
+      "source_location": "L778"
     },
     {
       "community": 0,
@@ -178126,7 +178168,7 @@
       "label": "reopenDailyCloseWithCtx()",
       "norm_label": "reopendailyclosewithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5074"
+      "source_location": "L5234"
     },
     {
       "community": 0,
@@ -178135,7 +178177,7 @@
       "label": "resolveDailyCloseCarryForwardWithCtx()",
       "norm_label": "resolvedailyclosecarryforwardwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4808"
+      "source_location": "L4968"
     },
     {
       "community": 0,
@@ -178144,7 +178186,7 @@
       "label": "resolveOperatingDateRange()",
       "norm_label": "resolveoperatingdaterange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L720"
+      "source_location": "L722"
     },
     {
       "community": 0,
@@ -178153,7 +178195,7 @@
       "label": "safeOperatingDateRange()",
       "norm_label": "safeoperatingdaterange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L692"
+      "source_location": "L694"
     },
     {
       "community": 0,
@@ -178162,7 +178204,7 @@
       "label": "snapshotReviewedItems()",
       "norm_label": "snapshotrevieweditems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2273"
+      "source_location": "L2384"
     },
     {
       "community": 0,
@@ -178171,7 +178213,7 @@
       "label": "sortDailyCloseBlockers()",
       "norm_label": "sortdailycloseblockers()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L321"
+      "source_location": "L323"
     },
     {
       "community": 0,
@@ -178180,7 +178222,7 @@
       "label": "sourceCompletenessEntry()",
       "norm_label": "sourcecompletenessentry()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L460"
+      "source_location": "L462"
     },
     {
       "community": 0,
@@ -178189,7 +178231,7 @@
       "label": "sourceIdFromCarryForwardInput()",
       "norm_label": "sourceidfromcarryforwardinput()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3746"
+      "source_location": "L3906"
     },
     {
       "community": 0,
@@ -178198,7 +178240,7 @@
       "label": "stringFromMetadata()",
       "norm_label": "stringfrommetadata()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3718"
+      "source_location": "L3878"
     },
     {
       "community": 0,
@@ -178207,7 +178249,7 @@
       "label": "toDailyCloseHistoryListItem()",
       "norm_label": "todailyclosehistorylistitem()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2464"
+      "source_location": "L2575"
     },
     {
       "community": 0,
@@ -178216,7 +178258,7 @@
       "label": "transactionPaymentSummary()",
       "norm_label": "transactionpaymentsummary()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L803"
+      "source_location": "L805"
     },
     {
       "community": 0,
@@ -178225,7 +178267,7 @@
       "label": "trimOptional()",
       "norm_label": "trimoptional()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L687"
+      "source_location": "L689"
     },
     {
       "community": 0,
@@ -178234,7 +178276,7 @@
       "label": "trustedSyncedSaleInventoryReviewUnits()",
       "norm_label": "trustedsyncedsaleinventoryreviewunits()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2065"
+      "source_location": "L2176"
     },
     {
       "community": 0,
@@ -178243,7 +178285,7 @@
       "label": "uniqueDailyCloseItems()",
       "norm_label": "uniquedailycloseitems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2057"
+      "source_location": "L2168"
     },
     {
       "community": 0,
@@ -178252,7 +178294,7 @@
       "label": "uniqueOperationalWorkItemIds()",
       "norm_label": "uniqueoperationalworkitemids()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3712"
+      "source_location": "L3872"
     },
     {
       "community": 0,
@@ -178261,7 +178303,7 @@
       "label": "uniqueSourceSubjects()",
       "norm_label": "uniquesourcesubjects()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2047"
+      "source_location": "L2158"
     },
     {
       "community": 0,
@@ -178270,7 +178312,7 @@
       "label": "validateAutomationCarryForwardWorkItems()",
       "norm_label": "validateautomationcarryforwardworkitems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3811"
+      "source_location": "L3971"
     },
     {
       "community": 0,
@@ -178279,7 +178321,7 @@
       "label": "validateCarryForwardWorkItemIds()",
       "norm_label": "validatecarryforwardworkitemids()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3632"
+      "source_location": "L3792"
     },
     {
       "community": 0,
@@ -178288,7 +178330,7 @@
       "label": "validateSelectedCarryForwardGroups()",
       "norm_label": "validateselectedcarryforwardgroups()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3660"
+      "source_location": "L3820"
     },
     {
       "community": 0,
@@ -181735,7 +181777,7 @@
       "label": "unavailableWeeklyCopy()",
       "norm_label": "unavailableweeklycopy()",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports/weekly.tsx",
-      "source_location": "L93"
+      "source_location": "L94"
     },
     {
       "community": 1047,
@@ -181744,7 +181786,7 @@
       "label": "WeeklyStatusRow()",
       "norm_label": "weeklystatusrow()",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports/weekly.tsx",
-      "source_location": "L39"
+      "source_location": "L40"
     },
     {
       "community": 1048,
@@ -184818,164 +184860,164 @@
     {
       "community": 111,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reports_reportsweeklyview_tsx",
-      "label": "ReportsWeeklyView.tsx",
-      "norm_label": "reportsweeklyview.tsx",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
+      "id": "packages_athena_webapp_src_lib_theme_ts",
+      "label": "theme.ts",
+      "norm_label": "theme.ts",
+      "source_file": "packages/athena-webapp/src/lib/theme.ts",
       "source_location": "L1"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "reportsweeklyview_closeevidencecoveragelabel",
-      "label": "closeEvidenceCoverageLabel()",
-      "norm_label": "closeevidencecoveragelabel()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L280"
+      "id": "theme_applytheme",
+      "label": "applyTheme()",
+      "norm_label": "applytheme()",
+      "source_file": "packages/athena-webapp/src/lib/theme.ts",
+      "source_location": "L92"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "reportsweeklyview_comparabilitylabel",
-      "label": "comparabilityLabel()",
-      "norm_label": "comparabilitylabel()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L249"
+      "id": "theme_emitthemechange",
+      "label": "emitThemeChange()",
+      "norm_label": "emitthemechange()",
+      "source_file": "packages/athena-webapp/src/lib/theme.ts",
+      "source_location": "L114"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "reportsweeklyview_completenesslabel",
-      "label": "completenessLabel()",
-      "norm_label": "completenesslabel()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L223"
+      "id": "theme_getstorage",
+      "label": "getStorage()",
+      "norm_label": "getstorage()",
+      "source_file": "packages/athena-webapp/src/lib/theme.ts",
+      "source_location": "L41"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "reportsweeklyview_formatreportmoney",
-      "label": "formatReportMoney()",
-      "norm_label": "formatreportmoney()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L606"
+      "id": "theme_getstoreddarkthemevariant",
+      "label": "getStoredDarkThemeVariant()",
+      "norm_label": "getstoreddarkthemevariant()",
+      "source_file": "packages/athena-webapp/src/lib/theme.ts",
+      "source_location": "L60"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "reportsweeklyview_formatreporttimestamp",
-      "label": "formatReportTimestamp()",
-      "norm_label": "formatreporttimestamp()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L589"
+      "id": "theme_getstoredthememode",
+      "label": "getStoredThemeMode()",
+      "norm_label": "getstoredthememode()",
+      "source_file": "packages/athena-webapp/src/lib/theme.ts",
+      "source_location": "L53"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "reportsweeklyview_metriclist",
-      "label": "MetricList()",
-      "norm_label": "metriclist()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L323"
+      "id": "theme_getsystemtheme",
+      "label": "getSystemTheme()",
+      "norm_label": "getsystemtheme()",
+      "source_file": "packages/athena-webapp/src/lib/theme.ts",
+      "source_location": "L70"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "reportsweeklyview_money",
-      "label": "money()",
-      "norm_label": "money()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L506"
+      "id": "theme_getthemesnapshot",
+      "label": "getThemeSnapshot()",
+      "norm_label": "getthemesnapshot()",
+      "source_file": "packages/athena-webapp/src/lib/theme.ts",
+      "source_location": "L212"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "reportsweeklyview_optionalmoney",
-      "label": "optionalMoney()",
-      "norm_label": "optionalmoney()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L510"
+      "id": "theme_initializeathenatheme",
+      "label": "initializeAthenaTheme()",
+      "norm_label": "initializeathenatheme()",
+      "source_file": "packages/athena-webapp/src/lib/theme.ts",
+      "source_location": "L122"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "reportsweeklyview_ownerroutelink",
-      "label": "OwnerRouteLink()",
-      "norm_label": "ownerroutelink()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L345"
+      "id": "theme_isdarkthemevariant",
+      "label": "isDarkThemeVariant()",
+      "norm_label": "isdarkthemevariant()",
+      "source_file": "packages/athena-webapp/src/lib/theme.ts",
+      "source_location": "L33"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "reportsweeklyview_productcountlabel",
-      "label": "productCountLabel()",
-      "norm_label": "productcountlabel()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L1241"
+      "id": "theme_isthememode",
+      "label": "isThemeMode()",
+      "norm_label": "isthememode()",
+      "source_file": "packages/athena-webapp/src/lib/theme.ts",
+      "source_location": "L29"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "reportsweeklyview_profit",
-      "label": "profit()",
-      "norm_label": "profit()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L514"
+      "id": "theme_prefersreducedmotion",
+      "label": "prefersReducedMotion()",
+      "norm_label": "prefersreducedmotion()",
+      "source_file": "packages/athena-webapp/src/lib/theme.ts",
+      "source_location": "L81"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "reportsweeklyview_quantitylabel",
-      "label": "quantityLabel()",
-      "norm_label": "quantitylabel()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L1243"
+      "id": "theme_resolvetheme",
+      "label": "resolveTheme()",
+      "norm_label": "resolvetheme()",
+      "source_file": "packages/athena-webapp/src/lib/theme.ts",
+      "source_location": "L88"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "reportsweeklyview_section",
-      "label": "Section()",
-      "norm_label": "section()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L304"
+      "id": "theme_setathenadarkthemevariant",
+      "label": "setAthenaDarkThemeVariant()",
+      "norm_label": "setathenadarkthemevariant()",
+      "source_file": "packages/athena-webapp/src/lib/theme.ts",
+      "source_location": "L158"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "reportsweeklyview_units",
-      "label": "units()",
-      "norm_label": "units()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L518"
+      "id": "theme_setathenathememode",
+      "label": "setAthenaThemeMode()",
+      "norm_label": "setathenathememode()",
+      "source_file": "packages/athena-webapp/src/lib/theme.ts",
+      "source_location": "L145"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "reportsweeklyview_valuesfor",
-      "label": "valuesFor()",
-      "norm_label": "valuesfor()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L1245"
+      "id": "theme_setathenathememodewithtransition",
+      "label": "setAthenaThemeModeWithTransition()",
+      "norm_label": "setathenathememodewithtransition()",
+      "source_file": "packages/athena-webapp/src/lib/theme.ts",
+      "source_location": "L166"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "reportsweeklyview_variancecoveragelabel",
-      "label": "varianceCoverageLabel()",
-      "norm_label": "variancecoveragelabel()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L270"
+      "id": "theme_subscribetothemestore",
+      "label": "subscribeToThemeStore()",
+      "norm_label": "subscribetothemestore()",
+      "source_file": "packages/athena-webapp/src/lib/theme.ts",
+      "source_location": "L185"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "reportsweeklyview_weeklypaymentmix",
-      "label": "weeklyPaymentMix()",
-      "norm_label": "weeklypaymentmix()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
-      "source_location": "L290"
+      "id": "theme_useathenatheme",
+      "label": "useAthenaTheme()",
+      "norm_label": "useathenatheme()",
+      "source_file": "packages/athena-webapp/src/lib/theme.ts",
+      "source_location": "L221"
     },
     {
       "community": 1110,
@@ -185160,164 +185202,164 @@
     {
       "community": 112,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_theme_ts",
-      "label": "theme.ts",
-      "norm_label": "theme.ts",
-      "source_file": "packages/athena-webapp/src/lib/theme.ts",
+      "id": "packages_storefront_webapp_src_lib_storefrontcontextevents_ts",
+      "label": "storefrontContextEvents.ts",
+      "norm_label": "storefrontcontextevents.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
       "source_location": "L1"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "theme_applytheme",
-      "label": "applyTheme()",
-      "norm_label": "applytheme()",
-      "source_file": "packages/athena-webapp/src/lib/theme.ts",
-      "source_location": "L92"
+      "id": "storefrontcontextevents_buildstorefrontcontextevent",
+      "label": "buildStorefrontContextEvent()",
+      "norm_label": "buildstorefrontcontextevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
+      "source_location": "L95"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "theme_emitthemechange",
-      "label": "emitThemeChange()",
-      "norm_label": "emitthemechange()",
-      "source_file": "packages/athena-webapp/src/lib/theme.ts",
-      "source_location": "L114"
+      "id": "storefrontcontextevents_buildstorefrontidempotencykey",
+      "label": "buildStorefrontIdempotencyKey()",
+      "norm_label": "buildstorefrontidempotencykey()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
+      "source_location": "L454"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "theme_getstorage",
-      "label": "getStorage()",
-      "norm_label": "getstorage()",
-      "source_file": "packages/athena-webapp/src/lib/theme.ts",
-      "source_location": "L41"
+      "id": "storefrontcontextevents_compactscalarpayload",
+      "label": "compactScalarPayload()",
+      "norm_label": "compactscalarpayload()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
+      "source_location": "L425"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "theme_getstoreddarkthemevariant",
-      "label": "getStoredDarkThemeVariant()",
-      "norm_label": "getstoreddarkthemevariant()",
-      "source_file": "packages/athena-webapp/src/lib/theme.ts",
-      "source_location": "L60"
+      "id": "storefrontcontextevents_createstorefrontcontexttrackingenvelope",
+      "label": "createStorefrontContextTrackingEnvelope()",
+      "norm_label": "createstorefrontcontexttrackingenvelope()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
+      "source_location": "L131"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "theme_getstoredthememode",
-      "label": "getStoredThemeMode()",
-      "norm_label": "getstoredthememode()",
-      "source_file": "packages/athena-webapp/src/lib/theme.ts",
-      "source_location": "L53"
+      "id": "storefrontcontextevents_createstorefrontrouteviewedcontextevent",
+      "label": "createStorefrontRouteViewedContextEvent()",
+      "norm_label": "createstorefrontrouteviewedcontextevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
+      "source_location": "L113"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "theme_getsystemtheme",
-      "label": "getSystemTheme()",
-      "norm_label": "getsystemtheme()",
-      "source_file": "packages/athena-webapp/src/lib/theme.ts",
-      "source_location": "L70"
+      "id": "storefrontcontextevents_getcartchange",
+      "label": "getCartChange()",
+      "norm_label": "getcartchange()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
+      "source_location": "L332"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "theme_getthemesnapshot",
-      "label": "getThemeSnapshot()",
-      "norm_label": "getthemesnapshot()",
-      "source_file": "packages/athena-webapp/src/lib/theme.ts",
-      "source_location": "L212"
+      "id": "storefrontcontextevents_getcartcontexteventinput",
+      "label": "getCartContextEventInput()",
+      "norm_label": "getcartcontexteventinput()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
+      "source_location": "L255"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "theme_initializeathenatheme",
-      "label": "initializeAthenaTheme()",
-      "norm_label": "initializeathenatheme()",
-      "source_file": "packages/athena-webapp/src/lib/theme.ts",
-      "source_location": "L122"
+      "id": "storefrontcontextevents_getcheckoutblocker",
+      "label": "getCheckoutBlocker()",
+      "norm_label": "getcheckoutblocker()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
+      "source_location": "L380"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "theme_isdarkthemevariant",
-      "label": "isDarkThemeVariant()",
-      "norm_label": "isdarkthemevariant()",
-      "source_file": "packages/athena-webapp/src/lib/theme.ts",
-      "source_location": "L33"
+      "id": "storefrontcontextevents_getcheckoutcontexteventinput",
+      "label": "getCheckoutContextEventInput()",
+      "norm_label": "getcheckoutcontexteventinput()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
+      "source_location": "L288"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "theme_isthememode",
-      "label": "isThemeMode()",
-      "norm_label": "isthememode()",
-      "source_file": "packages/athena-webapp/src/lib/theme.ts",
-      "source_location": "L29"
+      "id": "storefrontcontextevents_getcheckoutstate",
+      "label": "getCheckoutState()",
+      "norm_label": "getcheckoutstate()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
+      "source_location": "L345"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "theme_prefersreducedmotion",
-      "label": "prefersReducedMotion()",
-      "norm_label": "prefersreducedmotion()",
-      "source_file": "packages/athena-webapp/src/lib/theme.ts",
-      "source_location": "L81"
+      "id": "storefrontcontextevents_getnumber",
+      "label": "getNumber()",
+      "norm_label": "getnumber()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
+      "source_location": "L450"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "theme_resolvetheme",
-      "label": "resolveTheme()",
-      "norm_label": "resolvetheme()",
-      "source_file": "packages/athena-webapp/src/lib/theme.ts",
-      "source_location": "L88"
+      "id": "storefrontcontextevents_getstorefrontcontexteventinput",
+      "label": "getStorefrontContextEventInput()",
+      "norm_label": "getstorefrontcontexteventinput()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
+      "source_location": "L167"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "theme_setathenadarkthemevariant",
-      "label": "setAthenaDarkThemeVariant()",
-      "norm_label": "setathenadarkthemevariant()",
-      "source_file": "packages/athena-webapp/src/lib/theme.ts",
-      "source_location": "L158"
+      "id": "storefrontcontextevents_getstring",
+      "label": "getString()",
+      "norm_label": "getstring()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
+      "source_location": "L446"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "theme_setathenathememode",
-      "label": "setAthenaThemeMode()",
-      "norm_label": "setathenathememode()",
-      "source_file": "packages/athena-webapp/src/lib/theme.ts",
-      "source_location": "L145"
+      "id": "storefrontcontextevents_issafescalarcontextvalue",
+      "label": "isSafeScalarContextValue()",
+      "norm_label": "issafescalarcontextvalue()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
+      "source_location": "L436"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "theme_setathenathememodewithtransition",
-      "label": "setAthenaThemeModeWithTransition()",
-      "norm_label": "setathenathememodewithtransition()",
-      "source_file": "packages/athena-webapp/src/lib/theme.ts",
-      "source_location": "L166"
+      "id": "storefrontcontextevents_normalizekeypart",
+      "label": "normalizeKeyPart()",
+      "norm_label": "normalizekeypart()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
+      "source_location": "L468"
     },
     {
       "community": 112,
       "file_type": "code",
-      "id": "theme_subscribetothemestore",
-      "label": "subscribeToThemeStore()",
-      "norm_label": "subscribetothemestore()",
-      "source_file": "packages/athena-webapp/src/lib/theme.ts",
-      "source_location": "L185"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "theme_useathenatheme",
-      "label": "useAthenaTheme()",
-      "norm_label": "useathenatheme()",
-      "source_file": "packages/athena-webapp/src/lib/theme.ts",
+      "id": "storefrontcontextevents_trackstorefrontcontextevent",
+      "label": "trackStorefrontContextEvent()",
+      "norm_label": "trackstorefrontcontextevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
       "source_location": "L221"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "storefrontcontextevents_validatestorefrontcontextpayload",
+      "label": "validateStorefrontContextPayload()",
+      "norm_label": "validatestorefrontcontextpayload()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
+      "source_location": "L397"
     },
     {
       "community": 1120,
@@ -185502,164 +185544,164 @@
     {
       "community": 113,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontcontextevents_ts",
-      "label": "storefrontContextEvents.ts",
-      "norm_label": "storefrontcontextevents.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
-      "source_location": "L1"
+      "id": "graphify_wiki_builddegreeindex",
+      "label": "buildDegreeIndex()",
+      "norm_label": "builddegreeindex()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L152"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "storefrontcontextevents_buildstorefrontcontextevent",
-      "label": "buildStorefrontContextEvent()",
-      "norm_label": "buildstorefrontcontextevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
-      "source_location": "L95"
+      "id": "graphify_wiki_buildhotspotlines",
+      "label": "buildHotspotLines()",
+      "norm_label": "buildhotspotlines()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L190"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "storefrontcontextevents_buildstorefrontidempotencykey",
-      "label": "buildStorefrontIdempotencyKey()",
-      "norm_label": "buildstorefrontidempotencykey()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
-      "source_location": "L454"
+      "id": "graphify_wiki_buildpackagepage",
+      "label": "buildPackagePage()",
+      "norm_label": "buildpackagepage()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L272"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "storefrontcontextevents_compactscalarpayload",
-      "label": "compactScalarPayload()",
-      "norm_label": "compactscalarpayload()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
-      "source_location": "L425"
+      "id": "graphify_wiki_buildrootindexpage",
+      "label": "buildRootIndexPage()",
+      "norm_label": "buildrootindexpage()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L227"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "storefrontcontextevents_createstorefrontcontexttrackingenvelope",
-      "label": "createStorefrontContextTrackingEnvelope()",
-      "norm_label": "createstorefrontcontexttrackingenvelope()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
+      "id": "graphify_wiki_collectrepocodefiles",
+      "label": "collectRepoCodeFiles()",
+      "norm_label": "collectrepocodefiles()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L88"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "graphify_wiki_comparehotspots",
+      "label": "compareHotspots()",
+      "norm_label": "comparehotspots()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L170"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "graphify_wiki_countcommunities",
+      "label": "countCommunities()",
+      "norm_label": "countcommunities()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L148"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "graphify_wiki_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L79"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "graphify_wiki_formatlist",
+      "label": "formatList()",
+      "norm_label": "formatlist()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L144"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "graphify_wiki_generategraphifywikipages",
+      "label": "generateGraphifyWikiPages()",
+      "norm_label": "generategraphifywikipages()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L339"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "graphify_wiki_loadgraphifygraph",
+      "label": "loadGraphifyGraph()",
+      "norm_label": "loadgraphifygraph()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L213"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "graphify_wiki_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L127"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "graphify_wiki_readdir",
+      "label": "readDir()",
+      "norm_label": "readdir()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L122"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "graphify_wiki_scorenode",
+      "label": "scoreNode()",
+      "norm_label": "scorenode()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L163"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "graphify_wiki_tomarkdownlink",
+      "label": "toMarkdownLink()",
+      "norm_label": "tomarkdownlink()",
+      "source_file": "scripts/graphify-wiki.ts",
       "source_location": "L131"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "storefrontcontextevents_createstorefrontrouteviewedcontextevent",
-      "label": "createStorefrontRouteViewedContextEvent()",
-      "norm_label": "createstorefrontrouteviewedcontextevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
-      "source_location": "L113"
+      "id": "graphify_wiki_tosourcelink",
+      "label": "toSourceLink()",
+      "norm_label": "tosourcelink()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L139"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "storefrontcontextevents_getcartchange",
-      "label": "getCartChange()",
-      "norm_label": "getcartchange()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
-      "source_location": "L332"
+      "id": "graphify_wiki_writegraphifywikipages",
+      "label": "writeGraphifyWikiPages()",
+      "norm_label": "writegraphifywikipages()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L371"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "storefrontcontextevents_getcartcontexteventinput",
-      "label": "getCartContextEventInput()",
-      "norm_label": "getcartcontexteventinput()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
-      "source_location": "L255"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "storefrontcontextevents_getcheckoutblocker",
-      "label": "getCheckoutBlocker()",
-      "norm_label": "getcheckoutblocker()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
-      "source_location": "L380"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "storefrontcontextevents_getcheckoutcontexteventinput",
-      "label": "getCheckoutContextEventInput()",
-      "norm_label": "getcheckoutcontexteventinput()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
-      "source_location": "L288"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "storefrontcontextevents_getcheckoutstate",
-      "label": "getCheckoutState()",
-      "norm_label": "getcheckoutstate()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
-      "source_location": "L345"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "storefrontcontextevents_getnumber",
-      "label": "getNumber()",
-      "norm_label": "getnumber()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
-      "source_location": "L450"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "storefrontcontextevents_getstorefrontcontexteventinput",
-      "label": "getStorefrontContextEventInput()",
-      "norm_label": "getstorefrontcontexteventinput()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
-      "source_location": "L167"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "storefrontcontextevents_getstring",
-      "label": "getString()",
-      "norm_label": "getstring()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
-      "source_location": "L446"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "storefrontcontextevents_issafescalarcontextvalue",
-      "label": "isSafeScalarContextValue()",
-      "norm_label": "issafescalarcontextvalue()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
-      "source_location": "L436"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "storefrontcontextevents_normalizekeypart",
-      "label": "normalizeKeyPart()",
-      "norm_label": "normalizekeypart()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
-      "source_location": "L468"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "storefrontcontextevents_trackstorefrontcontextevent",
-      "label": "trackStorefrontContextEvent()",
-      "norm_label": "trackstorefrontcontextevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
-      "source_location": "L221"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "storefrontcontextevents_validatestorefrontcontextpayload",
-      "label": "validateStorefrontContextPayload()",
-      "norm_label": "validatestorefrontcontextpayload()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
-      "source_location": "L397"
+      "id": "scripts_graphify_wiki_ts",
+      "label": "graphify-wiki.ts",
+      "norm_label": "graphify-wiki.ts",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L1"
     },
     {
       "community": 1130,
@@ -185844,163 +185886,163 @@
     {
       "community": 114,
       "file_type": "code",
-      "id": "graphify_wiki_builddegreeindex",
-      "label": "buildDegreeIndex()",
-      "norm_label": "builddegreeindex()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L152"
+      "id": "pre_push_validation_proof_assertprathenaproofready",
+      "label": "assertPrAthenaProofReady()",
+      "norm_label": "assertprathenaproofready()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L165"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "graphify_wiki_buildhotspotlines",
-      "label": "buildHotspotLines()",
-      "norm_label": "buildhotspotlines()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L190"
+      "id": "pre_push_validation_proof_classifysnapshoterror",
+      "label": "classifySnapshotError()",
+      "norm_label": "classifysnapshoterror()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L397"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "graphify_wiki_buildpackagepage",
-      "label": "buildPackagePage()",
-      "norm_label": "buildpackagepage()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L272"
+      "id": "pre_push_validation_proof_collectfilesunder",
+      "label": "collectFilesUnder()",
+      "norm_label": "collectfilesunder()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L221"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "graphify_wiki_buildrootindexpage",
-      "label": "buildRootIndexPage()",
-      "norm_label": "buildrootindexpage()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L227"
+      "id": "pre_push_validation_proof_collectproofsnapshot",
+      "label": "collectProofSnapshot()",
+      "norm_label": "collectproofsnapshot()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L327"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "graphify_wiki_collectrepocodefiles",
-      "label": "collectRepoCodeFiles()",
-      "norm_label": "collectrepocodefiles()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L88"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "graphify_wiki_comparehotspots",
-      "label": "compareHotspots()",
-      "norm_label": "comparehotspots()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L170"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "graphify_wiki_countcommunities",
-      "label": "countCommunities()",
-      "norm_label": "countcommunities()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L148"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "graphify_wiki_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L79"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "graphify_wiki_formatlist",
-      "label": "formatList()",
-      "norm_label": "formatlist()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L144"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "graphify_wiki_generategraphifywikipages",
-      "label": "generateGraphifyWikiPages()",
-      "norm_label": "generategraphifywikipages()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L339"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "graphify_wiki_loadgraphifygraph",
-      "label": "loadGraphifyGraph()",
-      "norm_label": "loadgraphifygraph()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L213"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "graphify_wiki_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L127"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "graphify_wiki_readdir",
-      "label": "readDir()",
-      "norm_label": "readdir()",
-      "source_file": "scripts/graphify-wiki.ts",
+      "id": "pre_push_validation_proof_collectunstagedfiles",
+      "label": "collectUnstagedFiles()",
+      "norm_label": "collectunstagedfiles()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
       "source_location": "L122"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "graphify_wiki_scorenode",
-      "label": "scoreNode()",
-      "norm_label": "scorenode()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L163"
+      "id": "pre_push_validation_proof_collectuntrackedfiles",
+      "label": "collectUntrackedFiles()",
+      "norm_label": "collectuntrackedfiles()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L149"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "graphify_wiki_tomarkdownlink",
-      "label": "toMarkdownLink()",
-      "norm_label": "tomarkdownlink()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L131"
+      "id": "pre_push_validation_proof_collectvalidationfingerprintpaths",
+      "label": "collectValidationFingerprintPaths()",
+      "norm_label": "collectvalidationfingerprintpaths()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L257"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "graphify_wiki_tosourcelink",
-      "label": "toSourceLink()",
-      "norm_label": "tosourcelink()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L139"
+      "id": "pre_push_validation_proof_evaluateprepushvalidationproof",
+      "label": "evaluatePrePushValidationProof()",
+      "norm_label": "evaluateprepushvalidationproof()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L410"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "graphify_wiki_writegraphifywikipages",
-      "label": "writeGraphifyWikiPages()",
-      "norm_label": "writegraphifywikipages()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L371"
+      "id": "pre_push_validation_proof_formatpathlist",
+      "label": "formatPathList()",
+      "norm_label": "formatpathlist()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L118"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "scripts_graphify_wiki_ts",
-      "label": "graphify-wiki.ts",
-      "norm_label": "graphify-wiki.ts",
-      "source_file": "scripts/graphify-wiki.ts",
+      "id": "pre_push_validation_proof_hashvalidationwiring",
+      "label": "hashValidationWiring()",
+      "norm_label": "hashvalidationwiring()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L286"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "pre_push_validation_proof_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "pre_push_validation_proof_parseporcelainpaths",
+      "label": "parsePorcelainPaths()",
+      "norm_label": "parseporcelainpaths()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L109"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "pre_push_validation_proof_readprathenascript",
+      "label": "readPrAthenaScript()",
+      "norm_label": "readprathenascript()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L310"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "pre_push_validation_proof_recordprepushvalidationproof",
+      "label": "recordPrePushValidationProof()",
+      "norm_label": "recordprepushvalidationproof()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L497"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "pre_push_validation_proof_runcommand",
+      "label": "runCommand()",
+      "norm_label": "runcommand()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "pre_push_validation_proof_sortuniquepaths",
+      "label": "sortUniquePaths()",
+      "norm_label": "sortuniquepaths()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "pre_push_validation_proof_validateproofshape",
+      "label": "validateProofShape()",
+      "norm_label": "validateproofshape()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L377"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "scripts_pre_push_validation_proof_ts",
+      "label": "pre-push-validation-proof.ts",
+      "norm_label": "pre-push-validation-proof.ts",
+      "source_file": "scripts/pre-push-validation-proof.ts",
       "source_location": "L1"
     },
     {
@@ -186186,163 +186228,154 @@
     {
       "community": 115,
       "file_type": "code",
-      "id": "pre_push_validation_proof_assertprathenaproofready",
-      "label": "assertPrAthenaProofReady()",
-      "norm_label": "assertprathenaproofready()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L165"
+      "id": "contextbundles_assertactormatchesstore",
+      "label": "assertActorMatchesStore()",
+      "norm_label": "assertactormatchesstore()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/contextBundles.ts",
+      "source_location": "L297"
     },
     {
       "community": 115,
       "file_type": "code",
-      "id": "pre_push_validation_proof_classifysnapshoterror",
-      "label": "classifySnapshotError()",
-      "norm_label": "classifysnapshoterror()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L397"
+      "id": "contextbundles_buildcompiledcontextbundle",
+      "label": "buildCompiledContextBundle()",
+      "norm_label": "buildcompiledcontextbundle()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/contextBundles.ts",
+      "source_location": "L112"
     },
     {
       "community": 115,
       "file_type": "code",
-      "id": "pre_push_validation_proof_collectfilesunder",
-      "label": "collectFilesUnder()",
-      "norm_label": "collectfilesunder()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L221"
+      "id": "contextbundles_buildstoreinsightscontextbundlefromcontextevents",
+      "label": "buildStoreInsightsContextBundleFromContextEvents()",
+      "norm_label": "buildstoreinsightscontextbundlefromcontextevents()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/contextBundles.ts",
+      "source_location": "L72"
     },
     {
       "community": 115,
       "file_type": "code",
-      "id": "pre_push_validation_proof_collectproofsnapshot",
-      "label": "collectProofSnapshot()",
-      "norm_label": "collectproofsnapshot()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L327"
+      "id": "contextbundles_builduserinsightscontextbundlefromcontextevents",
+      "label": "buildUserInsightsContextBundleFromContextEvents()",
+      "norm_label": "builduserinsightscontextbundlefromcontextevents()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/contextBundles.ts",
+      "source_location": "L91"
     },
     {
       "community": 115,
       "file_type": "code",
-      "id": "pre_push_validation_proof_collectunstagedfiles",
-      "label": "collectUnstagedFiles()",
-      "norm_label": "collectunstagedfiles()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L122"
+      "id": "contextbundles_compilecontextevent",
+      "label": "compileContextEvent()",
+      "norm_label": "compilecontextevent()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/contextBundles.ts",
+      "source_location": "L171"
     },
     {
       "community": 115,
       "file_type": "code",
-      "id": "pre_push_validation_proof_collectuntrackedfiles",
-      "label": "collectUntrackedFiles()",
-      "norm_label": "collectuntrackedfiles()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L149"
+      "id": "contextbundles_compilecontexteventswithreport",
+      "label": "compileContextEventsWithReport()",
+      "norm_label": "compilecontexteventswithreport()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/contextBundles.ts",
+      "source_location": "L146"
     },
     {
       "community": 115,
       "file_type": "code",
-      "id": "pre_push_validation_proof_collectvalidationfingerprintpaths",
-      "label": "collectValidationFingerprintPaths()",
-      "norm_label": "collectvalidationfingerprintpaths()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L257"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "pre_push_validation_proof_evaluateprepushvalidationproof",
-      "label": "evaluatePrePushValidationProof()",
-      "norm_label": "evaluateprepushvalidationproof()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L410"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "pre_push_validation_proof_formatpathlist",
-      "label": "formatPathList()",
-      "norm_label": "formatpathlist()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L118"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "pre_push_validation_proof_hashvalidationwiring",
-      "label": "hashValidationWiring()",
-      "norm_label": "hashvalidationwiring()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
+      "id": "contextbundles_contexteventmatchesactor",
+      "label": "contextEventMatchesActor()",
+      "norm_label": "contexteventmatchesactor()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/contextBundles.ts",
       "source_location": "L286"
     },
     {
       "community": 115,
       "file_type": "code",
-      "id": "pre_push_validation_proof_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L74"
+      "id": "contextbundles_getdatawindow",
+      "label": "getDataWindow()",
+      "norm_label": "getdatawindow()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/contextBundles.ts",
+      "source_location": "L333"
     },
     {
       "community": 115,
       "file_type": "code",
-      "id": "pre_push_validation_proof_parseporcelainpaths",
-      "label": "parsePorcelainPaths()",
-      "norm_label": "parseporcelainpaths()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L109"
+      "id": "contextbundles_getstorefrontactorbyid",
+      "label": "getStoreFrontActorById()",
+      "norm_label": "getstorefrontactorbyid()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/contextBundles.ts",
+      "source_location": "L315"
     },
     {
       "community": 115,
       "file_type": "code",
-      "id": "pre_push_validation_proof_readprathenascript",
-      "label": "readPrAthenaScript()",
-      "norm_label": "readprathenascript()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L310"
+      "id": "contextbundles_getstorefrontactortable",
+      "label": "getStorefrontActorTable()",
+      "norm_label": "getstorefrontactortable()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/contextBundles.ts",
+      "source_location": "L308"
     },
     {
       "community": 115,
       "file_type": "code",
-      "id": "pre_push_validation_proof_recordprepushvalidationproof",
-      "label": "recordPrePushValidationProof()",
-      "norm_label": "recordprepushvalidationproof()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L497"
+      "id": "contextbundles_ishistoricalcontextevent",
+      "label": "isHistoricalContextEvent()",
+      "norm_label": "ishistoricalcontextevent()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/contextBundles.ts",
+      "source_location": "L274"
     },
     {
       "community": 115,
       "file_type": "code",
-      "id": "pre_push_validation_proof_runcommand",
-      "label": "runCommand()",
-      "norm_label": "runcommand()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L84"
+      "id": "contextbundles_ispromptsafepayloadvalue",
+      "label": "isPromptSafePayloadValue()",
+      "norm_label": "ispromptsafepayloadvalue()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/contextBundles.ts",
+      "source_location": "L265"
     },
     {
       "community": 115,
       "file_type": "code",
-      "id": "pre_push_validation_proof_sortuniquepaths",
-      "label": "sortUniquePaths()",
-      "norm_label": "sortuniquepaths()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L78"
+      "id": "contextbundles_sanitizecontexteventpayload",
+      "label": "sanitizeContextEventPayload()",
+      "norm_label": "sanitizecontexteventpayload()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/contextBundles.ts",
+      "source_location": "L215"
     },
     {
       "community": 115,
       "file_type": "code",
-      "id": "pre_push_validation_proof_validateproofshape",
-      "label": "validateProofShape()",
-      "norm_label": "validateproofshape()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L377"
+      "id": "contextbundles_sanitizecontexteventpayloadvalue",
+      "label": "sanitizeContextEventPayloadValue()",
+      "norm_label": "sanitizecontexteventpayloadvalue()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/contextBundles.ts",
+      "source_location": "L233"
     },
     {
       "community": 115,
       "file_type": "code",
-      "id": "scripts_pre_push_validation_proof_ts",
-      "label": "pre-push-validation-proof.ts",
-      "norm_label": "pre-push-validation-proof.ts",
-      "source_file": "scripts/pre-push-validation-proof.ts",
+      "id": "contextbundles_sanitizeorigin",
+      "label": "sanitizeOrigin()",
+      "norm_label": "sanitizeorigin()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/contextBundles.ts",
+      "source_location": "L255"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "contextbundles_sanitizepathname",
+      "label": "sanitizePathname()",
+      "norm_label": "sanitizepathname()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/contextBundles.ts",
+      "source_location": "L245"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_contexttracking_contextbundles_ts",
+      "label": "contextBundles.ts",
+      "norm_label": "contextbundles.ts",
+      "source_file": "packages/athena-webapp/convex/contextTracking/contextBundles.ts",
       "source_location": "L1"
     },
     {
@@ -186528,155 +186561,155 @@
     {
       "community": 116,
       "file_type": "code",
-      "id": "contextbundles_assertactormatchesstore",
-      "label": "assertActorMatchesStore()",
-      "norm_label": "assertactormatchesstore()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/contextBundles.ts",
-      "source_location": "L297"
+      "id": "packages_athena_webapp_convex_pos_application_sync_registersessioncloseoutholds_ts",
+      "label": "registerSessionCloseoutHolds.ts",
+      "norm_label": "registersessioncloseoutholds.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts",
+      "source_location": "L1"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "contextbundles_buildcompiledcontextbundle",
-      "label": "buildCompiledContextBundle()",
-      "norm_label": "buildcompiledcontextbundle()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/contextBundles.ts",
-      "source_location": "L112"
+      "id": "registersessioncloseoutholds_buildpendingcompletedsalevoidapprovalsummary",
+      "label": "buildPendingCompletedSaleVoidApprovalSummary()",
+      "norm_label": "buildpendingcompletedsalevoidapprovalsummary()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts",
+      "source_location": "L192"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "contextbundles_buildstoreinsightscontextbundlefromcontextevents",
-      "label": "buildStoreInsightsContextBundleFromContextEvents()",
-      "norm_label": "buildstoreinsightscontextbundlefromcontextevents()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/contextBundles.ts",
-      "source_location": "L72"
+      "id": "registersessioncloseoutholds_canlistregistersessionsyncconflicts",
+      "label": "canListRegisterSessionSyncConflicts()",
+      "norm_label": "canlistregistersessionsyncconflicts()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts",
+      "source_location": "L240"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "contextbundles_builduserinsightscontextbundlefromcontextevents",
-      "label": "buildUserInsightsContextBundleFromContextEvents()",
-      "norm_label": "builduserinsightscontextbundlefromcontextevents()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/contextBundles.ts",
-      "source_location": "L91"
+      "id": "registersessioncloseoutholds_filterpendingcompletedsalevoidapprovals",
+      "label": "filterPendingCompletedSaleVoidApprovals()",
+      "norm_label": "filterpendingcompletedsalevoidapprovals()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts",
+      "source_location": "L76"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "contextbundles_compilecontextevent",
-      "label": "compileContextEvent()",
-      "norm_label": "compilecontextevent()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/contextBundles.ts",
+      "id": "registersessioncloseoutholds_filterpendingtransactionitemadjustmentapprovals",
+      "label": "filterPendingTransactionItemAdjustmentApprovals()",
+      "norm_label": "filterpendingtransactionitemadjustmentapprovals()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts",
+      "source_location": "L86"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "registersessioncloseoutholds_getapprovalrequesttransactionid",
+      "label": "getApprovalRequestTransactionId()",
+      "norm_label": "getapprovalrequesttransactionid()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts",
+      "source_location": "L120"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "registersessioncloseoutholds_getapprovalrequesttransactionnumber",
+      "label": "getApprovalRequestTransactionNumber()",
+      "norm_label": "getapprovalrequesttransactionnumber()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts",
+      "source_location": "L126"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "registersessioncloseoutholds_getcloseoutholdoperatormessage",
+      "label": "getCloseoutHoldOperatorMessage()",
+      "norm_label": "getcloseoutholdoperatormessage()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts",
+      "source_location": "L332"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "registersessioncloseoutholds_getnumbermetadata",
+      "label": "getNumberMetadata()",
+      "norm_label": "getnumbermetadata()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts",
+      "source_location": "L155"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "registersessioncloseoutholds_getpendingitemadjustmentcashdelta",
+      "label": "getPendingItemAdjustmentCashDelta()",
+      "norm_label": "getpendingitemadjustmentcashdelta()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts",
       "source_location": "L171"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "contextbundles_compilecontexteventswithreport",
-      "label": "compileContextEventsWithReport()",
-      "norm_label": "compilecontexteventswithreport()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/contextBundles.ts",
-      "source_location": "L146"
+      "id": "registersessioncloseoutholds_getstringmetadata",
+      "label": "getStringMetadata()",
+      "norm_label": "getstringmetadata()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts",
+      "source_location": "L163"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "contextbundles_contexteventmatchesactor",
-      "label": "contextEventMatchesActor()",
-      "norm_label": "contexteventmatchesactor()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/contextBundles.ts",
-      "source_location": "L286"
+      "id": "registersessioncloseoutholds_gettransactionpendingvoidcashamount",
+      "label": "getTransactionPendingVoidCashAmount()",
+      "norm_label": "gettransactionpendingvoidcashamount()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts",
+      "source_location": "L134"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "contextbundles_getdatawindow",
-      "label": "getDataWindow()",
-      "norm_label": "getdatawindow()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/contextBundles.ts",
-      "source_location": "L333"
+      "id": "registersessioncloseoutholds_hascashaffectingcloseoutholds",
+      "label": "hasCashAffectingCloseoutHolds()",
+      "norm_label": "hascashaffectingcloseoutholds()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts",
+      "source_location": "L39"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "contextbundles_getstorefrontactorbyid",
-      "label": "getStoreFrontActorById()",
-      "norm_label": "getstorefrontactorbyid()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/contextBundles.ts",
-      "source_location": "L315"
+      "id": "registersessioncloseoutholds_listpendingcompletedsalevoidapprovals",
+      "label": "listPendingCompletedSaleVoidApprovals()",
+      "norm_label": "listpendingcompletedsalevoidapprovals()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts",
+      "source_location": "L96"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "contextbundles_getstorefrontactortable",
-      "label": "getStorefrontActorTable()",
-      "norm_label": "getstorefrontactortable()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/contextBundles.ts",
-      "source_location": "L308"
+      "id": "registersessioncloseoutholds_listpendingregistersessionapprovalrequests",
+      "label": "listPendingRegisterSessionApprovalRequests()",
+      "norm_label": "listpendingregistersessionapprovalrequests()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts",
+      "source_location": "L45"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "contextbundles_ishistoricalcontextevent",
-      "label": "isHistoricalContextEvent()",
-      "norm_label": "ishistoricalcontextevent()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/contextBundles.ts",
-      "source_location": "L274"
+      "id": "registersessioncloseoutholds_listpendingtransactionitemadjustmentapprovals",
+      "label": "listPendingTransactionItemAdjustmentApprovals()",
+      "norm_label": "listpendingtransactionitemadjustmentapprovals()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts",
+      "source_location": "L108"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "contextbundles_ispromptsafepayloadvalue",
-      "label": "isPromptSafePayloadValue()",
-      "norm_label": "ispromptsafepayloadvalue()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/contextBundles.ts",
-      "source_location": "L265"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "contextbundles_sanitizecontexteventpayload",
-      "label": "sanitizeContextEventPayload()",
-      "norm_label": "sanitizecontexteventpayload()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/contextBundles.ts",
-      "source_location": "L215"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "contextbundles_sanitizecontexteventpayloadvalue",
-      "label": "sanitizeContextEventPayloadValue()",
-      "norm_label": "sanitizecontexteventpayloadvalue()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/contextBundles.ts",
-      "source_location": "L233"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "contextbundles_sanitizeorigin",
-      "label": "sanitizeOrigin()",
-      "norm_label": "sanitizeorigin()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/contextBundles.ts",
-      "source_location": "L255"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "contextbundles_sanitizepathname",
-      "label": "sanitizePathname()",
-      "norm_label": "sanitizepathname()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/contextBundles.ts",
-      "source_location": "L245"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_contexttracking_contextbundles_ts",
-      "label": "contextBundles.ts",
-      "norm_label": "contextbundles.ts",
-      "source_file": "packages/athena-webapp/convex/contextTracking/contextBundles.ts",
-      "source_location": "L1"
+      "id": "registersessioncloseoutholds_listregistersessioncloseoutholds",
+      "label": "listRegisterSessionCloseoutHolds()",
+      "norm_label": "listregistersessioncloseoutholds()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts",
+      "source_location": "L262"
     },
     {
       "community": 1160,
@@ -186861,155 +186894,155 @@
     {
       "community": 117,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sync_registersessioncloseoutholds_ts",
-      "label": "registerSessionCloseoutHolds.ts",
-      "norm_label": "registersessioncloseoutholds.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts",
+      "id": "packages_athena_webapp_convex_reports_sweeper_ts",
+      "label": "sweeper.ts",
+      "norm_label": "sweeper.ts",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
       "source_location": "L1"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "registersessioncloseoutholds_buildpendingcompletedsalevoidapprovalsummary",
-      "label": "buildPendingCompletedSaleVoidApprovalSummary()",
-      "norm_label": "buildpendingcompletedsalevoidapprovalsummary()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts",
-      "source_location": "L192"
+      "id": "sweeper_computependingranges",
+      "label": "computePendingRanges()",
+      "norm_label": "computependingranges()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L541"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "registersessioncloseoutholds_canlistregistersessionsyncconflicts",
-      "label": "canListRegisterSessionSyncConflicts()",
-      "norm_label": "canlistregistersessionsyncconflicts()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts",
-      "source_location": "L240"
+      "id": "sweeper_daycapexceeded",
+      "label": "DayCapExceeded",
+      "norm_label": "daycapexceeded",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L122"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "registersessioncloseoutholds_filterpendingcompletedsalevoidapprovals",
-      "label": "filterPendingCompletedSaleVoidApprovals()",
-      "norm_label": "filterpendingcompletedsalevoidapprovals()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts",
-      "source_location": "L76"
+      "id": "sweeper_daycapexceeded_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L123"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "registersessioncloseoutholds_filterpendingtransactionitemadjustmentapprovals",
-      "label": "filterPendingTransactionItemAdjustmentApprovals()",
-      "norm_label": "filterpendingtransactionitemadjustmentapprovals()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts",
-      "source_location": "L86"
+      "id": "sweeper_expirerangeresults",
+      "label": "expireRangeResults()",
+      "norm_label": "expirerangeresults()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L579"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "registersessioncloseoutholds_getapprovalrequesttransactionid",
-      "label": "getApprovalRequestTransactionId()",
-      "norm_label": "getapprovalrequesttransactionid()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts",
-      "source_location": "L120"
+      "id": "sweeper_findopenoperatingdate",
+      "label": "findOpenOperatingDate()",
+      "norm_label": "findopenoperatingdate()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L524"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "registersessioncloseoutholds_getapprovalrequesttransactionnumber",
-      "label": "getApprovalRequestTransactionNumber()",
-      "norm_label": "getapprovalrequesttransactionnumber()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts",
-      "source_location": "L126"
+      "id": "sweeper_foldandreplaceday",
+      "label": "foldAndReplaceDay()",
+      "norm_label": "foldandreplaceday()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L294"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "registersessioncloseoutholds_getcloseoutholdoperatormessage",
-      "label": "getCloseoutHoldOperatorMessage()",
-      "norm_label": "getcloseoutholdoperatormessage()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts",
-      "source_location": "L332"
+      "id": "sweeper_loadacceptedclose",
+      "label": "loadAcceptedClose()",
+      "norm_label": "loadacceptedclose()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L243"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "registersessioncloseoutholds_getnumbermetadata",
-      "label": "getNumberMetadata()",
-      "norm_label": "getnumbermetadata()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts",
+      "id": "sweeper_markdaydirty",
+      "label": "markDayDirty()",
+      "norm_label": "markdaydirty()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L488"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "sweeper_openpolicyforreason",
+      "label": "openPolicyForReason()",
+      "norm_label": "openpolicyforreason()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L267"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "sweeper_parsestoreallowlist",
+      "label": "parseStoreAllowlist()",
+      "norm_label": "parsestoreallowlist()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L145"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "sweeper_rangesnapshotkindconfigs",
+      "label": "rangeSnapshotKindConfigs()",
+      "norm_label": "rangesnapshotkindconfigs()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L611"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "sweeper_readstoreallowlist",
+      "label": "readStoreAllowlist()",
+      "norm_label": "readstoreallowlist()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
       "source_location": "L155"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "registersessioncloseoutholds_getpendingitemadjustmentcashdelta",
-      "label": "getPendingItemAdjustmentCashDelta()",
-      "norm_label": "getpendingitemadjustmentcashdelta()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts",
-      "source_location": "L171"
+      "id": "sweeper_selectacceptedclose",
+      "label": "selectAcceptedClose()",
+      "norm_label": "selectacceptedclose()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L207"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "registersessioncloseoutholds_getstringmetadata",
-      "label": "getStringMetadata()",
-      "norm_label": "getstringmetadata()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts",
+      "id": "sweeper_sweepwithctx",
+      "label": "sweepWithCtx()",
+      "norm_label": "sweepwithctx()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L615"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "sweeper_tocloseref",
+      "label": "toCloseRef()",
+      "norm_label": "tocloseref()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L223"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "sweeper_tofoldfact",
+      "label": "toFoldFact()",
+      "norm_label": "tofoldfact()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
       "source_location": "L163"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "registersessioncloseoutholds_gettransactionpendingvoidcashamount",
-      "label": "getTransactionPendingVoidCashAmount()",
-      "norm_label": "gettransactionpendingvoidcashamount()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts",
-      "source_location": "L134"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "registersessioncloseoutholds_hascashaffectingcloseoutholds",
-      "label": "hasCashAffectingCloseoutHolds()",
-      "norm_label": "hascashaffectingcloseoutholds()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts",
-      "source_location": "L39"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "registersessioncloseoutholds_listpendingcompletedsalevoidapprovals",
-      "label": "listPendingCompletedSaleVoidApprovals()",
-      "norm_label": "listpendingcompletedsalevoidapprovals()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "registersessioncloseoutholds_listpendingregistersessionapprovalrequests",
-      "label": "listPendingRegisterSessionApprovalRequests()",
-      "norm_label": "listpendingregistersessionapprovalrequests()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "registersessioncloseoutholds_listpendingtransactionitemadjustmentapprovals",
-      "label": "listPendingTransactionItemAdjustmentApprovals()",
-      "norm_label": "listpendingtransactionitemadjustmentapprovals()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts",
-      "source_location": "L108"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "registersessioncloseoutholds_listregistersessioncloseoutholds",
-      "label": "listRegisterSessionCloseoutHolds()",
-      "norm_label": "listregistersessioncloseoutholds()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionCloseoutHolds.ts",
-      "source_location": "L262"
     },
     {
       "community": 1170,
@@ -187194,155 +187227,155 @@
     {
       "community": 118,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_sweeper_ts",
-      "label": "sweeper.ts",
-      "norm_label": "sweeper.ts",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L1"
+      "id": "operatingperiods_buildsameelapsedoperatingcomparison",
+      "label": "buildSameElapsedOperatingComparison()",
+      "norm_label": "buildsameelapsedoperatingcomparison()",
+      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
+      "source_location": "L202"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "sweeper_computependingranges",
-      "label": "computePendingRanges()",
-      "norm_label": "computependingranges()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L541"
+      "id": "operatingperiods_elapsedoperatingtime",
+      "label": "elapsedOperatingTime()",
+      "norm_label": "elapsedoperatingtime()",
+      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
+      "source_location": "L168"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "sweeper_daycapexceeded",
-      "label": "DayCapExceeded",
-      "norm_label": "daycapexceeded",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L122"
+      "id": "operatingperiods_latesteffectiveschedule",
+      "label": "latestEffectiveSchedule()",
+      "norm_label": "latesteffectiveschedule()",
+      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
+      "source_location": "L340"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "sweeper_daycapexceeded_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L123"
+      "id": "operatingperiods_operatingduration",
+      "label": "operatingDuration()",
+      "norm_label": "operatingduration()",
+      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
+      "source_location": "L161"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "sweeper_expirerangeresults",
-      "label": "expireRangeResults()",
-      "norm_label": "expirerangeresults()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L579"
+      "id": "operatingperiods_reportingdateat",
+      "label": "reportingDateAt()",
+      "norm_label": "reportingdateat()",
+      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
+      "source_location": "L20"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "sweeper_findopenoperatingdate",
-      "label": "findOpenOperatingDate()",
-      "norm_label": "findopenoperatingdate()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L524"
+      "id": "operatingperiods_resolvereportingcalendardaterangewithctx",
+      "label": "resolveReportingCalendarDateRangeWithCtx()",
+      "norm_label": "resolvereportingcalendardaterangewithctx()",
+      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
+      "source_location": "L440"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "sweeper_foldandreplaceday",
-      "label": "foldAndReplaceDay()",
-      "norm_label": "foldandreplaceday()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L294"
+      "id": "operatingperiods_resolvereportingcalendarreferencewithctx",
+      "label": "resolveReportingCalendarReferenceWithCtx()",
+      "norm_label": "resolvereportingcalendarreferencewithctx()",
+      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
+      "source_location": "L414"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "sweeper_loadacceptedclose",
-      "label": "loadAcceptedClose()",
-      "norm_label": "loadacceptedclose()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L243"
+      "id": "operatingperiods_resolvereportingfinancialperiod",
+      "label": "resolveReportingFinancialPeriod()",
+      "norm_label": "resolvereportingfinancialperiod()",
+      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
+      "source_location": "L33"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "sweeper_markdaydirty",
-      "label": "markDayDirty()",
-      "norm_label": "markdaydirty()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L488"
+      "id": "operatingperiods_resolvereportingfinancialperiodwithctx",
+      "label": "resolveReportingFinancialPeriodWithCtx()",
+      "norm_label": "resolvereportingfinancialperiodwithctx()",
+      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
+      "source_location": "L107"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "sweeper_openpolicyforreason",
-      "label": "openPolicyForReason()",
-      "norm_label": "openpolicyforreason()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L267"
+      "id": "operatingperiods_resolvereportingoperatingdaterangewithctx",
+      "label": "resolveReportingOperatingDateRangeWithCtx()",
+      "norm_label": "resolvereportingoperatingdaterangewithctx()",
+      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
+      "source_location": "L475"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "sweeper_parsestoreallowlist",
-      "label": "parseStoreAllowlist()",
-      "norm_label": "parsestoreallowlist()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L145"
+      "id": "operatingperiods_resolvereportingoperatingperiod",
+      "label": "resolveReportingOperatingPeriod()",
+      "norm_label": "resolvereportingoperatingperiod()",
+      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
+      "source_location": "L258"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "sweeper_rangesnapshotkindconfigs",
-      "label": "rangeSnapshotKindConfigs()",
-      "norm_label": "rangesnapshotkindconfigs()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L611"
+      "id": "operatingperiods_resolvereportingoperatingperiodwithctx",
+      "label": "resolveReportingOperatingPeriodWithCtx()",
+      "norm_label": "resolvereportingoperatingperiodwithctx()",
+      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
+      "source_location": "L355"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "sweeper_readstoreallowlist",
-      "label": "readStoreAllowlist()",
-      "norm_label": "readstoreallowlist()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "id": "operatingperiods_resolvereportingreferenceperiod",
+      "label": "resolveReportingReferencePeriod()",
+      "norm_label": "resolvereportingreferenceperiod()",
+      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
+      "source_location": "L307"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "operatingperiods_resolvereportingreferenceperiodwithctx",
+      "label": "resolveReportingReferencePeriodWithCtx()",
+      "norm_label": "resolvereportingreferenceperiodwithctx()",
+      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
+      "source_location": "L379"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "operatingperiods_shiftdate",
+      "label": "shiftDate()",
+      "norm_label": "shiftdate()",
+      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
       "source_location": "L155"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "sweeper_selectacceptedclose",
-      "label": "selectAcceptedClose()",
-      "norm_label": "selectacceptedclose()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L207"
+      "id": "operatingperiods_takeoperatingtime",
+      "label": "takeOperatingTime()",
+      "norm_label": "takeoperatingtime()",
+      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
+      "source_location": "L181"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "sweeper_sweepwithctx",
-      "label": "sweepWithCtx()",
-      "norm_label": "sweepwithctx()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L615"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "sweeper_tocloseref",
-      "label": "toCloseRef()",
-      "norm_label": "tocloseref()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L223"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "sweeper_tofoldfact",
-      "label": "toFoldFact()",
-      "norm_label": "tofoldfact()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L163"
+      "id": "packages_athena_webapp_convex_storetime_operatingperiods_ts",
+      "label": "operatingPeriods.ts",
+      "norm_label": "operatingperiods.ts",
+      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
+      "source_location": "L1"
     },
     {
       "community": 1180,
@@ -187527,155 +187560,155 @@
     {
       "community": 119,
       "file_type": "code",
-      "id": "operatingperiods_buildsameelapsedoperatingcomparison",
-      "label": "buildSameElapsedOperatingComparison()",
-      "norm_label": "buildsameelapsedoperatingcomparison()",
-      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
-      "source_location": "L202"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "operatingperiods_elapsedoperatingtime",
-      "label": "elapsedOperatingTime()",
-      "norm_label": "elapsedoperatingtime()",
-      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
-      "source_location": "L168"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "operatingperiods_latesteffectiveschedule",
-      "label": "latestEffectiveSchedule()",
-      "norm_label": "latesteffectiveschedule()",
-      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
-      "source_location": "L340"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "operatingperiods_operatingduration",
-      "label": "operatingDuration()",
-      "norm_label": "operatingduration()",
-      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
-      "source_location": "L161"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "operatingperiods_reportingdateat",
-      "label": "reportingDateAt()",
-      "norm_label": "reportingdateat()",
-      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "operatingperiods_resolvereportingcalendardaterangewithctx",
-      "label": "resolveReportingCalendarDateRangeWithCtx()",
-      "norm_label": "resolvereportingcalendardaterangewithctx()",
-      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
-      "source_location": "L440"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "operatingperiods_resolvereportingcalendarreferencewithctx",
-      "label": "resolveReportingCalendarReferenceWithCtx()",
-      "norm_label": "resolvereportingcalendarreferencewithctx()",
-      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
-      "source_location": "L414"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "operatingperiods_resolvereportingfinancialperiod",
-      "label": "resolveReportingFinancialPeriod()",
-      "norm_label": "resolvereportingfinancialperiod()",
-      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "operatingperiods_resolvereportingfinancialperiodwithctx",
-      "label": "resolveReportingFinancialPeriodWithCtx()",
-      "norm_label": "resolvereportingfinancialperiodwithctx()",
-      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "operatingperiods_resolvereportingoperatingdaterangewithctx",
-      "label": "resolveReportingOperatingDateRangeWithCtx()",
-      "norm_label": "resolvereportingoperatingdaterangewithctx()",
-      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
-      "source_location": "L475"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "operatingperiods_resolvereportingoperatingperiod",
-      "label": "resolveReportingOperatingPeriod()",
-      "norm_label": "resolvereportingoperatingperiod()",
-      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
-      "source_location": "L258"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "operatingperiods_resolvereportingoperatingperiodwithctx",
-      "label": "resolveReportingOperatingPeriodWithCtx()",
-      "norm_label": "resolvereportingoperatingperiodwithctx()",
-      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
-      "source_location": "L355"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "operatingperiods_resolvereportingreferenceperiod",
-      "label": "resolveReportingReferencePeriod()",
-      "norm_label": "resolvereportingreferenceperiod()",
-      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
-      "source_location": "L307"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "operatingperiods_resolvereportingreferenceperiodwithctx",
-      "label": "resolveReportingReferencePeriodWithCtx()",
-      "norm_label": "resolvereportingreferenceperiodwithctx()",
-      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
-      "source_location": "L379"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "operatingperiods_shiftdate",
-      "label": "shiftDate()",
-      "norm_label": "shiftdate()",
-      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
-      "source_location": "L155"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "operatingperiods_takeoperatingtime",
-      "label": "takeOperatingTime()",
-      "norm_label": "takeoperatingtime()",
-      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
-      "source_location": "L181"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storetime_operatingperiods_ts",
-      "label": "operatingPeriods.ts",
-      "norm_label": "operatingperiods.ts",
-      "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.ts",
+      "id": "packages_athena_webapp_shared_posregistersessionactivitycontract_ts",
+      "label": "posRegisterSessionActivityContract.ts",
+      "norm_label": "posregistersessionactivitycontract.ts",
+      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "posregistersessionactivitycontract_arraylength",
+      "label": "arrayLength()",
+      "norm_label": "arraylength()",
+      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
+      "source_location": "L409"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "posregistersessionactivitycontract_asrecord",
+      "label": "asRecord()",
+      "norm_label": "asrecord()",
+      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
+      "source_location": "L397"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "posregistersessionactivitycontract_canreportposregistersessionlocalactivitytype",
+      "label": "canReportPosRegisterSessionLocalActivityType()",
+      "norm_label": "canreportposregistersessionlocalactivitytype()",
+      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
+      "source_location": "L246"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "posregistersessionactivitycontract_cashdirection",
+      "label": "cashDirection()",
+      "norm_label": "cashdirection()",
+      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
+      "source_location": "L462"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "posregistersessionactivitycontract_classifyposregistersessionlocaleventtype",
+      "label": "classifyPosRegisterSessionLocalEventType()",
+      "norm_label": "classifyposregistersessionlocaleventtype()",
+      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
+      "source_location": "L240"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "posregistersessionactivitycontract_compactmetadata",
+      "label": "compactMetadata()",
+      "norm_label": "compactmetadata()",
+      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
+      "source_location": "L389"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "posregistersessionactivitycontract_finitenumber",
+      "label": "finiteNumber()",
+      "norm_label": "finitenumber()",
+      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
+      "source_location": "L403"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "posregistersessionactivitycontract_isposregistersessionactivitystatus",
+      "label": "isPosRegisterSessionActivityStatus()",
+      "norm_label": "isposregistersessionactivitystatus()",
+      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
+      "source_location": "L250"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "posregistersessionactivitycontract_labelfromtoken",
+      "label": "labelFromToken()",
+      "norm_label": "labelfromtoken()",
+      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
+      "source_location": "L438"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "posregistersessionactivitycontract_paymentmethodssummary",
+      "label": "paymentMethodsSummary()",
+      "norm_label": "paymentmethodssummary()",
+      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
+      "source_location": "L448"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "posregistersessionactivitycontract_safelabel",
+      "label": "safeLabel()",
+      "norm_label": "safelabel()",
+      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
+      "source_location": "L426"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "posregistersessionactivitycontract_safetoken",
+      "label": "safeToken()",
+      "norm_label": "safetoken()",
+      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
+      "source_location": "L432"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "posregistersessionactivitycontract_sanitizemetadataforlocalevent",
+      "label": "sanitizeMetadataForLocalEvent()",
+      "norm_label": "sanitizemetadataforlocalevent()",
+      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
+      "source_location": "L314"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "posregistersessionactivitycontract_sanitizeposregistersessionlocalactivity",
+      "label": "sanitizePosRegisterSessionLocalActivity()",
+      "norm_label": "sanitizeposregistersessionlocalactivity()",
+      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
+      "source_location": "L267"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "posregistersessionactivitycontract_sumamountarray",
+      "label": "sumAmountArray()",
+      "norm_label": "sumamountarray()",
+      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
+      "source_location": "L413"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "posregistersessionactivitycontract_toposregistersessionactivitystatuslabel",
+      "label": "toPosRegisterSessionActivityStatusLabel()",
+      "norm_label": "toposregistersessionactivitystatuslabel()",
+      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
+      "source_location": "L261"
     },
     {
       "community": 1190,
@@ -188292,155 +188325,155 @@
     {
       "community": 120,
       "file_type": "code",
-      "id": "packages_athena_webapp_shared_posregistersessionactivitycontract_ts",
-      "label": "posRegisterSessionActivityContract.ts",
-      "norm_label": "posregistersessionactivitycontract.ts",
-      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
+      "id": "data_table_view_options_datatableviewoptions",
+      "label": "DataTableViewOptions()",
+      "norm_label": "datatableviewoptions()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-view-options.tsx",
       "source_location": "L1"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "posregistersessionactivitycontract_arraylength",
-      "label": "arrayLength()",
-      "norm_label": "arraylength()",
-      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
-      "source_location": "L409"
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "posregistersessionactivitycontract_asrecord",
-      "label": "asRecord()",
-      "norm_label": "asrecord()",
-      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
-      "source_location": "L397"
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "posregistersessionactivitycontract_canreportposregistersessionlocalactivitytype",
-      "label": "canReportPosRegisterSessionLocalActivityType()",
-      "norm_label": "canreportposregistersessionlocalactivitytype()",
-      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
-      "source_location": "L246"
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "posregistersessionactivitycontract_cashdirection",
-      "label": "cashDirection()",
-      "norm_label": "cashdirection()",
-      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
-      "source_location": "L462"
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "posregistersessionactivitycontract_classifyposregistersessionlocaleventtype",
-      "label": "classifyPosRegisterSessionLocalEventType()",
-      "norm_label": "classifyposregistersessionlocaleventtype()",
-      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
-      "source_location": "L240"
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "posregistersessionactivitycontract_compactmetadata",
-      "label": "compactMetadata()",
-      "norm_label": "compactmetadata()",
-      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
-      "source_location": "L389"
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "posregistersessionactivitycontract_finitenumber",
-      "label": "finiteNumber()",
-      "norm_label": "finitenumber()",
-      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
-      "source_location": "L403"
+      "id": "packages_athena_webapp_src_components_base_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "posregistersessionactivitycontract_isposregistersessionactivitystatus",
-      "label": "isPosRegisterSessionActivityStatus()",
-      "norm_label": "isposregistersessionactivitystatus()",
-      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
-      "source_location": "L250"
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "posregistersessionactivitycontract_labelfromtoken",
-      "label": "labelFromToken()",
-      "norm_label": "labelfromtoken()",
-      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
-      "source_location": "L438"
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "posregistersessionactivitycontract_paymentmethodssummary",
-      "label": "paymentMethodsSummary()",
-      "norm_label": "paymentmethodssummary()",
-      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
-      "source_location": "L448"
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "posregistersessionactivitycontract_safelabel",
-      "label": "safeLabel()",
-      "norm_label": "safelabel()",
-      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
-      "source_location": "L426"
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "posregistersessionactivitycontract_safetoken",
-      "label": "safeToken()",
-      "norm_label": "safetoken()",
-      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
-      "source_location": "L432"
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "posregistersessionactivitycontract_sanitizemetadataforlocalevent",
-      "label": "sanitizeMetadataForLocalEvent()",
-      "norm_label": "sanitizemetadataforlocalevent()",
-      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
-      "source_location": "L314"
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "posregistersessionactivitycontract_sanitizeposregistersessionlocalactivity",
-      "label": "sanitizePosRegisterSessionLocalActivity()",
-      "norm_label": "sanitizeposregistersessionlocalactivity()",
-      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
-      "source_location": "L267"
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "posregistersessionactivitycontract_sumamountarray",
-      "label": "sumAmountArray()",
-      "norm_label": "sumamountarray()",
-      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
-      "source_location": "L413"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "posregistersessionactivitycontract_toposregistersessionactivitystatuslabel",
-      "label": "toPosRegisterSessionActivityStatusLabel()",
-      "norm_label": "toposregistersessionactivitystatuslabel()",
-      "source_file": "packages/athena-webapp/shared/posRegisterSessionActivityContract.ts",
-      "source_location": "L261"
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_view_options_tsx",
+      "label": "data-table-view-options.tsx",
+      "norm_label": "data-table-view-options.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
+      "source_location": "L1"
     },
     {
       "community": 1200,
@@ -188625,154 +188658,154 @@
     {
       "community": 121,
       "file_type": "code",
-      "id": "data_table_view_options_datatableviewoptions",
-      "label": "DataTableViewOptions()",
-      "norm_label": "datatableviewoptions()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
-      "source_location": "L18"
+      "id": "dailyclosehistoryview_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L444"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "dailyclosehistoryview_dailyclosehistoryapipendingview",
+      "label": "DailyCloseHistoryApiPendingView()",
+      "norm_label": "dailyclosehistoryapipendingview()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L245"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "dailyclosehistoryview_dailyclosehistoryview",
+      "label": "DailyCloseHistoryView()",
+      "norm_label": "dailyclosehistoryview()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L270"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "dailyclosehistoryview_formatcount",
+      "label": "formatCount()",
+      "norm_label": "formatcount()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L228"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "dailyclosehistoryview_getdailyclosehistoryapi",
+      "label": "getDailyCloseHistoryApi()",
+      "norm_label": "getdailyclosehistoryapi()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L107"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "dailyclosehistoryview_gethistorylifecyclelabel",
+      "label": "getHistoryLifecycleLabel()",
+      "norm_label": "gethistorylifecyclelabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L156"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "dailyclosehistoryview_gethistoryrecordcompletedat",
+      "label": "getHistoryRecordCompletedAt()",
+      "norm_label": "gethistoryrecordcompletedat()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L140"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "dailyclosehistoryview_gethistoryrecordcompletedby",
+      "label": "getHistoryRecordCompletedBy()",
+      "norm_label": "gethistoryrecordcompletedby()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L144"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "dailyclosehistoryview_gethistoryrecordid",
+      "label": "getHistoryRecordId()",
+      "norm_label": "gethistoryrecordid()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L128"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "dailyclosehistoryview_gethistoryrecords",
+      "label": "getHistoryRecords()",
+      "norm_label": "gethistoryrecords()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L117"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "dailyclosehistoryview_gethistoryrecordsnapshot",
+      "label": "getHistoryRecordSnapshot()",
+      "norm_label": "gethistoryrecordsnapshot()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L210"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "dailyclosehistoryview_gethistoryrecordsummary",
+      "label": "getHistoryRecordSummary()",
+      "norm_label": "gethistoryrecordsummary()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L152"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "dailyclosehistoryview_getsearchstring",
+      "label": "getSearchString()",
+      "norm_label": "getsearchstring()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L241"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "dailyclosehistoryview_iscompletedhistoryrecord",
+      "label": "isCompletedHistoryRecord()",
+      "norm_label": "iscompletedhistoryrecord()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L134"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "dailyclosehistoryview_normalizehistorysnapshot",
+      "label": "normalizeHistorySnapshot()",
+      "norm_label": "normalizehistorysnapshot()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L168"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-view-options.tsx",
-      "source_location": "L1"
+      "id": "dailyclosehistoryview_sortnewestfirst",
+      "label": "sortNewestFirst()",
+      "norm_label": "sortnewestfirst()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "source_location": "L234"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_view_options_tsx",
-      "label": "data-table-view-options.tsx",
-      "norm_label": "data-table-view-options.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
+      "id": "packages_athena_webapp_src_components_operations_dailyclosehistoryview_tsx",
+      "label": "DailyCloseHistoryView.tsx",
+      "norm_label": "dailyclosehistoryview.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
       "source_location": "L1"
     },
     {
@@ -188958,155 +188991,155 @@
     {
       "community": 122,
       "file_type": "code",
-      "id": "dailyclosehistoryview_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L444"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "dailyclosehistoryview_dailyclosehistoryapipendingview",
-      "label": "DailyCloseHistoryApiPendingView()",
-      "norm_label": "dailyclosehistoryapipendingview()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L245"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "dailyclosehistoryview_dailyclosehistoryview",
-      "label": "DailyCloseHistoryView()",
-      "norm_label": "dailyclosehistoryview()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L270"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "dailyclosehistoryview_formatcount",
-      "label": "formatCount()",
-      "norm_label": "formatcount()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L228"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "dailyclosehistoryview_getdailyclosehistoryapi",
-      "label": "getDailyCloseHistoryApi()",
-      "norm_label": "getdailyclosehistoryapi()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L107"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "dailyclosehistoryview_gethistorylifecyclelabel",
-      "label": "getHistoryLifecycleLabel()",
-      "norm_label": "gethistorylifecyclelabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L156"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "dailyclosehistoryview_gethistoryrecordcompletedat",
-      "label": "getHistoryRecordCompletedAt()",
-      "norm_label": "gethistoryrecordcompletedat()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L140"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "dailyclosehistoryview_gethistoryrecordcompletedby",
-      "label": "getHistoryRecordCompletedBy()",
-      "norm_label": "gethistoryrecordcompletedby()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L144"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "dailyclosehistoryview_gethistoryrecordid",
-      "label": "getHistoryRecordId()",
-      "norm_label": "gethistoryrecordid()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L128"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "dailyclosehistoryview_gethistoryrecords",
-      "label": "getHistoryRecords()",
-      "norm_label": "gethistoryrecords()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L117"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "dailyclosehistoryview_gethistoryrecordsnapshot",
-      "label": "getHistoryRecordSnapshot()",
-      "norm_label": "gethistoryrecordsnapshot()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L210"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "dailyclosehistoryview_gethistoryrecordsummary",
-      "label": "getHistoryRecordSummary()",
-      "norm_label": "gethistoryrecordsummary()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L152"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "dailyclosehistoryview_getsearchstring",
-      "label": "getSearchString()",
-      "norm_label": "getsearchstring()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L241"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "dailyclosehistoryview_iscompletedhistoryrecord",
-      "label": "isCompletedHistoryRecord()",
-      "norm_label": "iscompletedhistoryrecord()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L134"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "dailyclosehistoryview_normalizehistorysnapshot",
-      "label": "normalizeHistorySnapshot()",
-      "norm_label": "normalizehistorysnapshot()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L168"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "dailyclosehistoryview_sortnewestfirst",
-      "label": "sortNewestFirst()",
-      "norm_label": "sortnewestfirst()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
-      "source_location": "L234"
-    },
-    {
-      "community": 122,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_dailyclosehistoryview_tsx",
-      "label": "DailyCloseHistoryView.tsx",
-      "norm_label": "dailyclosehistoryview.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx",
+      "id": "packages_athena_webapp_src_components_reports_reportformat_ts",
+      "label": "reportFormat.ts",
+      "norm_label": "reportformat.ts",
+      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "reportformat_formatbasispoints",
+      "label": "formatBasisPoints()",
+      "norm_label": "formatbasispoints()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
+      "source_location": "L113"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "reportformat_formatbasketsize",
+      "label": "formatBasketSize()",
+      "norm_label": "formatbasketsize()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "reportformat_formatcompactreportmoney",
+      "label": "formatCompactReportMoney()",
+      "norm_label": "formatcompactreportmoney()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
+      "source_location": "L91"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "reportformat_formatoperatingdate",
+      "label": "formatOperatingDate()",
+      "norm_label": "formatoperatingdate()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
+      "source_location": "L141"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "reportformat_formatoperatingdatelist",
+      "label": "formatOperatingDateList()",
+      "norm_label": "formatoperatingdatelist()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
+      "source_location": "L162"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "reportformat_formatoptionalmoney",
+      "label": "formatOptionalMoney()",
+      "norm_label": "formatoptionalmoney()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "reportformat_formatreportdaterange",
+      "label": "formatReportDateRange()",
+      "norm_label": "formatreportdaterange()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
+      "source_location": "L179"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "reportformat_formatreportmoney",
+      "label": "formatReportMoney()",
+      "norm_label": "formatreportmoney()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "reportformat_formatreportprofit",
+      "label": "formatReportProfit()",
+      "norm_label": "formatreportprofit()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "reportformat_formatskudisplayname",
+      "label": "formatSkuDisplayName()",
+      "norm_label": "formatskudisplayname()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
+      "source_location": "L338"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "reportformat_formatskusubtitle",
+      "label": "formatSkuSubtitle()",
+      "norm_label": "formatskusubtitle()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
+      "source_location": "L320"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "reportformat_formatunits",
+      "label": "formatUnits()",
+      "norm_label": "formatunits()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "reportformat_reportdaysettlementpresentation",
+      "label": "reportDaySettlementPresentation()",
+      "norm_label": "reportdaysettlementpresentation()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
+      "source_location": "L242"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "reportformat_reportdaystatuspresentation",
+      "label": "reportDayStatusPresentation()",
+      "norm_label": "reportdaystatuspresentation()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
+      "source_location": "L132"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "reportformat_reportoldestunreconciledpresentation",
+      "label": "reportOldestUnreconciledPresentation()",
+      "norm_label": "reportoldestunreconciledpresentation()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
+      "source_location": "L360"
+    },
+    {
+      "community": 122,
+      "file_type": "code",
+      "id": "reportformat_reportprofithelper",
+      "label": "reportProfitHelper()",
+      "norm_label": "reportprofithelper()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
+      "source_location": "L46"
     },
     {
       "community": 1220,
@@ -189291,155 +189324,155 @@
     {
       "community": 123,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reports_reportformat_ts",
-      "label": "reportFormat.ts",
-      "norm_label": "reportformat.ts",
-      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
+      "id": "harness_audit_addgroupederror",
+      "label": "addGroupedError()",
+      "norm_label": "addgroupederror()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L219"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "harness_audit_auditharnessgateobligationcontract",
+      "label": "auditHarnessGateObligationContract()",
+      "norm_label": "auditharnessgateobligationcontract()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "harness_audit_collectlivesurfaceentries",
+      "label": "collectLiveSurfaceEntries()",
+      "norm_label": "collectlivesurfaceentries()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L262"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "harness_audit_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L174"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "harness_audit_formatgroupederrors",
+      "label": "formatGroupedErrors()",
+      "norm_label": "formatgroupederrors()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L495"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "harness_audit_formatmissingvalidationpatherror",
+      "label": "formatMissingValidationPathError()",
+      "norm_label": "formatmissingvalidationpatherror()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L233"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "harness_audit_hasanyharnessdocs",
+      "label": "hasAnyHarnessDocs()",
+      "norm_label": "hasanyharnessdocs()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L183"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "harness_audit_infergroupfromerror",
+      "label": "inferGroupFromError()",
+      "norm_label": "infergroupfromerror()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L243"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "harness_audit_loadaudittarget",
+      "label": "loadAuditTarget()",
+      "norm_label": "loadaudittarget()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L291"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "harness_audit_matchespathprefix",
+      "label": "matchesPathPrefix()",
+      "norm_label": "matchespathprefix()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L160"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "harness_audit_normalizebehaviorscenarioname",
+      "label": "normalizeBehaviorScenarioName()",
+      "norm_label": "normalizebehaviorscenarioname()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L215"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "harness_audit_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L156"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "harness_audit_normalizevalidationcommand",
+      "label": "normalizeValidationCommand()",
+      "norm_label": "normalizevalidationcommand()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L207"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "harness_audit_readjsonfile",
+      "label": "readJsonFile()",
+      "norm_label": "readjsonfile()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L203"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "harness_audit_runharnessaudit",
+      "label": "runHarnessAudit()",
+      "norm_label": "runharnessaudit()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L510"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "harness_audit_shouldskipsurfaceentry",
+      "label": "shouldSkipSurfaceEntry()",
+      "norm_label": "shouldskipsurfaceentry()",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L248"
+    },
+    {
+      "community": 123,
+      "file_type": "code",
+      "id": "scripts_harness_audit_ts",
+      "label": "harness-audit.ts",
+      "norm_label": "harness-audit.ts",
+      "source_file": "scripts/harness-audit.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "reportformat_formatbasispoints",
-      "label": "formatBasisPoints()",
-      "norm_label": "formatbasispoints()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
-      "source_location": "L113"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "reportformat_formatbasketsize",
-      "label": "formatBasketSize()",
-      "norm_label": "formatbasketsize()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
-      "source_location": "L76"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "reportformat_formatcompactreportmoney",
-      "label": "formatCompactReportMoney()",
-      "norm_label": "formatcompactreportmoney()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
-      "source_location": "L91"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "reportformat_formatoperatingdate",
-      "label": "formatOperatingDate()",
-      "norm_label": "formatoperatingdate()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
-      "source_location": "L141"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "reportformat_formatoperatingdatelist",
-      "label": "formatOperatingDateList()",
-      "norm_label": "formatoperatingdatelist()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
-      "source_location": "L162"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "reportformat_formatoptionalmoney",
-      "label": "formatOptionalMoney()",
-      "norm_label": "formatoptionalmoney()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "reportformat_formatreportdaterange",
-      "label": "formatReportDateRange()",
-      "norm_label": "formatreportdaterange()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
-      "source_location": "L179"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "reportformat_formatreportmoney",
-      "label": "formatReportMoney()",
-      "norm_label": "formatreportmoney()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "reportformat_formatreportprofit",
-      "label": "formatReportProfit()",
-      "norm_label": "formatreportprofit()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "reportformat_formatskudisplayname",
-      "label": "formatSkuDisplayName()",
-      "norm_label": "formatskudisplayname()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
-      "source_location": "L338"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "reportformat_formatskusubtitle",
-      "label": "formatSkuSubtitle()",
-      "norm_label": "formatskusubtitle()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
-      "source_location": "L320"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "reportformat_formatunits",
-      "label": "formatUnits()",
-      "norm_label": "formatunits()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "reportformat_reportdaysettlementpresentation",
-      "label": "reportDaySettlementPresentation()",
-      "norm_label": "reportdaysettlementpresentation()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
-      "source_location": "L242"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "reportformat_reportdaystatuspresentation",
-      "label": "reportDayStatusPresentation()",
-      "norm_label": "reportdaystatuspresentation()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
-      "source_location": "L132"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "reportformat_reportoldestunreconciledpresentation",
-      "label": "reportOldestUnreconciledPresentation()",
-      "norm_label": "reportoldestunreconciledpresentation()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
-      "source_location": "L360"
-    },
-    {
-      "community": 123,
-      "file_type": "code",
-      "id": "reportformat_reportprofithelper",
-      "label": "reportProfitHelper()",
-      "norm_label": "reportprofithelper()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
-      "source_location": "L46"
     },
     {
       "community": 1230,
@@ -189624,154 +189657,154 @@
     {
       "community": 124,
       "file_type": "code",
-      "id": "harness_audit_addgroupederror",
-      "label": "addGroupedError()",
-      "norm_label": "addgroupederror()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L219"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "harness_audit_auditharnessgateobligationcontract",
-      "label": "auditHarnessGateObligationContract()",
-      "norm_label": "auditharnessgateobligationcontract()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "harness_audit_collectlivesurfaceentries",
-      "label": "collectLiveSurfaceEntries()",
-      "norm_label": "collectlivesurfaceentries()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L262"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "harness_audit_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L174"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "harness_audit_formatgroupederrors",
-      "label": "formatGroupedErrors()",
-      "norm_label": "formatgroupederrors()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L495"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "harness_audit_formatmissingvalidationpatherror",
-      "label": "formatMissingValidationPathError()",
-      "norm_label": "formatmissingvalidationpatherror()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L233"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "harness_audit_hasanyharnessdocs",
-      "label": "hasAnyHarnessDocs()",
-      "norm_label": "hasanyharnessdocs()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L183"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "harness_audit_infergroupfromerror",
-      "label": "inferGroupFromError()",
-      "norm_label": "infergroupfromerror()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L243"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "harness_audit_loadaudittarget",
-      "label": "loadAuditTarget()",
-      "norm_label": "loadaudittarget()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L291"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "harness_audit_matchespathprefix",
-      "label": "matchesPathPrefix()",
-      "norm_label": "matchespathprefix()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L160"
-    },
-    {
-      "community": 124,
-      "file_type": "code",
-      "id": "harness_audit_normalizebehaviorscenarioname",
-      "label": "normalizeBehaviorScenarioName()",
-      "norm_label": "normalizebehaviorscenarioname()",
-      "source_file": "scripts/harness-audit.ts",
+      "id": "harness_janitor_buildsummary",
+      "label": "buildSummary()",
+      "norm_label": "buildsummary()",
+      "source_file": "scripts/harness-janitor.ts",
       "source_location": "L215"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "harness_audit_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L156"
+      "id": "harness_janitor_comparesnapshots",
+      "label": "compareSnapshots()",
+      "norm_label": "comparesnapshots()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L107"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "harness_audit_normalizevalidationcommand",
-      "label": "normalizeValidationCommand()",
-      "norm_label": "normalizevalidationcommand()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L207"
+      "id": "harness_janitor_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L79"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "harness_audit_readjsonfile",
-      "label": "readJsonFile()",
-      "norm_label": "readjsonfile()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L203"
+      "id": "harness_janitor_formatartifactlist",
+      "label": "formatArtifactList()",
+      "norm_label": "formatartifactlist()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L131"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "harness_audit_runharnessaudit",
-      "label": "runHarnessAudit()",
-      "norm_label": "runharnessaudit()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L510"
+      "id": "harness_janitor_formatdetaillines",
+      "label": "formatDetailLines()",
+      "norm_label": "formatdetaillines()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L124"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "harness_audit_shouldskipsurfaceentry",
-      "label": "shouldSkipSurfaceEntry()",
-      "norm_label": "shouldskipsurfaceentry()",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L248"
+      "id": "harness_janitor_formaterror",
+      "label": "formatError()",
+      "norm_label": "formaterror()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L69"
     },
     {
       "community": 124,
       "file_type": "code",
-      "id": "scripts_harness_audit_ts",
-      "label": "harness-audit.ts",
-      "norm_label": "harness-audit.ts",
-      "source_file": "scripts/harness-audit.ts",
+      "id": "harness_janitor_formatharnessjanitorreport",
+      "label": "formatHarnessJanitorReport()",
+      "norm_label": "formatharnessjanitorreport()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L372"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "harness_janitor_hasfailures",
+      "label": "hasFailures()",
+      "norm_label": "hasfailures()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L242"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "harness_janitor_parseharnessjanitorcliargs",
+      "label": "parseHarnessJanitorCliArgs()",
+      "norm_label": "parseharnessjanitorcliargs()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L342"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "harness_janitor_readutf8ornull",
+      "label": "readUtf8OrNull()",
+      "norm_label": "readutf8ornull()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L88"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "harness_janitor_runcheckstep",
+      "label": "runCheckStep()",
+      "norm_label": "runcheckstep()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L163"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "harness_janitor_runharnessjanitor",
+      "label": "runHarnessJanitor()",
+      "norm_label": "runharnessjanitor()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L252"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "harness_janitor_runrepairstep",
+      "label": "runRepairStep()",
+      "norm_label": "runrepairstep()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L175"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "harness_janitor_snapshotfiles",
+      "label": "snapshotFiles()",
+      "norm_label": "snapshotfiles()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "harness_janitor_sortuniquepaths",
+      "label": "sortUniquePaths()",
+      "norm_label": "sortuniquepaths()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "harness_janitor_withcapturedconsole",
+      "label": "withCapturedConsole()",
+      "norm_label": "withcapturedconsole()",
+      "source_file": "scripts/harness-janitor.ts",
+      "source_location": "L139"
+    },
+    {
+      "community": 124,
+      "file_type": "code",
+      "id": "scripts_harness_janitor_ts",
+      "label": "harness-janitor.ts",
+      "norm_label": "harness-janitor.ts",
+      "source_file": "scripts/harness-janitor.ts",
       "source_location": "L1"
     },
     {
@@ -189957,154 +189990,154 @@
     {
       "community": 125,
       "file_type": "code",
-      "id": "harness_janitor_buildsummary",
-      "label": "buildSummary()",
-      "norm_label": "buildsummary()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L215"
+      "id": "harness_runtime_trends_buildnumerictrendstats",
+      "label": "buildNumericTrendStats()",
+      "norm_label": "buildnumerictrendstats()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L202"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "harness_janitor_comparesnapshots",
-      "label": "compareSnapshots()",
-      "norm_label": "comparesnapshots()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L107"
+      "id": "harness_runtime_trends_buildregressionwarnings",
+      "label": "buildRegressionWarnings()",
+      "norm_label": "buildregressionwarnings()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L337"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "harness_janitor_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L79"
+      "id": "harness_runtime_trends_buildruntimetrendoutput",
+      "label": "buildRuntimeTrendOutput()",
+      "norm_label": "buildruntimetrendoutput()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L409"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "harness_janitor_formatartifactlist",
-      "label": "formatArtifactList()",
-      "norm_label": "formatartifactlist()",
-      "source_file": "scripts/harness-janitor.ts",
+      "id": "harness_runtime_trends_buildscenariotrend",
+      "label": "buildScenarioTrend()",
+      "norm_label": "buildscenariotrend()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L241"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "harness_runtime_trends_collectharnessruntimetrends",
+      "label": "collectHarnessRuntimeTrends()",
+      "norm_label": "collectharnessruntimetrends()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L473"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "harness_runtime_trends_formatms",
+      "label": "formatMs()",
+      "norm_label": "formatms()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L237"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "harness_runtime_trends_formatpercent",
+      "label": "formatPercent()",
+      "norm_label": "formatpercent()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L233"
+    },
+    {
+      "community": 125,
+      "file_type": "code",
+      "id": "harness_runtime_trends_isharnessbehaviorscenarioreport",
+      "label": "isHarnessBehaviorScenarioReport()",
+      "norm_label": "isharnessbehaviorscenarioreport()",
+      "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L131"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "harness_janitor_formatdetaillines",
-      "label": "formatDetailLines()",
-      "norm_label": "formatdetaillines()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L124"
+      "id": "harness_runtime_trends_parseharnessbehaviorreportlines",
+      "label": "parseHarnessBehaviorReportLines()",
+      "norm_label": "parseharnessbehaviorreportlines()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L149"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "harness_janitor_formaterror",
-      "label": "formatError()",
-      "norm_label": "formaterror()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L69"
+      "id": "harness_runtime_trends_parseharnessruntimetrendsargs",
+      "label": "parseHarnessRuntimeTrendsArgs()",
+      "norm_label": "parseharnessruntimetrendsargs()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L509"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "harness_janitor_formatharnessjanitorreport",
-      "label": "formatHarnessJanitorReport()",
-      "norm_label": "formatharnessjanitorreport()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L372"
+      "id": "harness_runtime_trends_percentile",
+      "label": "percentile()",
+      "norm_label": "percentile()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L191"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "harness_janitor_hasfailures",
-      "label": "hasFailures()",
-      "norm_label": "hasfailures()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L242"
+      "id": "harness_runtime_trends_runharnessruntimetrends",
+      "label": "runHarnessRuntimeTrends()",
+      "norm_label": "runharnessruntimetrends()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L481"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "harness_janitor_parseharnessjanitorcliargs",
-      "label": "parseHarnessJanitorCliArgs()",
-      "norm_label": "parseharnessjanitorcliargs()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L342"
+      "id": "harness_runtime_trends_sortcountentries",
+      "label": "sortCountEntries()",
+      "norm_label": "sortcountentries()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L227"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "harness_janitor_readutf8ornull",
-      "label": "readUtf8OrNull()",
-      "norm_label": "readutf8ornull()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L88"
+      "id": "harness_runtime_trends_sortunique",
+      "label": "sortUnique()",
+      "norm_label": "sortunique()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L125"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "harness_janitor_runcheckstep",
-      "label": "runCheckStep()",
-      "norm_label": "runcheckstep()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L163"
+      "id": "harness_runtime_trends_splitinputlines",
+      "label": "splitInputLines()",
+      "norm_label": "splitinputlines()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L119"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "harness_janitor_runharnessjanitor",
-      "label": "runHarnessJanitor()",
-      "norm_label": "runharnessjanitor()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L252"
+      "id": "harness_runtime_trends_tohistoryfilestamp",
+      "label": "toHistoryFileStamp()",
+      "norm_label": "tohistoryfilestamp()",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L115"
     },
     {
       "community": 125,
       "file_type": "code",
-      "id": "harness_janitor_runrepairstep",
-      "label": "runRepairStep()",
-      "norm_label": "runrepairstep()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L175"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "harness_janitor_snapshotfiles",
-      "label": "snapshotFiles()",
-      "norm_label": "snapshotfiles()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "harness_janitor_sortuniquepaths",
-      "label": "sortUniquePaths()",
-      "norm_label": "sortuniquepaths()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "harness_janitor_withcapturedconsole",
-      "label": "withCapturedConsole()",
-      "norm_label": "withcapturedconsole()",
-      "source_file": "scripts/harness-janitor.ts",
-      "source_location": "L139"
-    },
-    {
-      "community": 125,
-      "file_type": "code",
-      "id": "scripts_harness_janitor_ts",
-      "label": "harness-janitor.ts",
-      "norm_label": "harness-janitor.ts",
-      "source_file": "scripts/harness-janitor.ts",
+      "id": "scripts_harness_runtime_trends_ts",
+      "label": "harness-runtime-trends.ts",
+      "norm_label": "harness-runtime-trends.ts",
+      "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L1"
     },
     {
@@ -190290,154 +190323,154 @@
     {
       "community": 126,
       "file_type": "code",
-      "id": "harness_runtime_trends_buildnumerictrendstats",
-      "label": "buildNumericTrendStats()",
-      "norm_label": "buildnumerictrendstats()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L202"
+      "id": "pr_athena_delivery_run_assertallowedgateeventsequence",
+      "label": "assertAllowedGateEventSequence()",
+      "norm_label": "assertallowedgateeventsequence()",
+      "source_file": "scripts/pr-athena-delivery-run.ts",
+      "source_location": "L327"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "harness_runtime_trends_buildregressionwarnings",
-      "label": "buildRegressionWarnings()",
-      "norm_label": "buildregressionwarnings()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L337"
+      "id": "pr_athena_delivery_run_buildgitprocessenv",
+      "label": "buildGitProcessEnv()",
+      "norm_label": "buildgitprocessenv()",
+      "source_file": "scripts/pr-athena-delivery-run.ts",
+      "source_location": "L139"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "harness_runtime_trends_buildruntimetrendoutput",
-      "label": "buildRuntimeTrendOutput()",
-      "norm_label": "buildruntimetrendoutput()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L409"
+      "id": "pr_athena_delivery_run_clearrecordedproof",
+      "label": "clearRecordedProof()",
+      "norm_label": "clearrecordedproof()",
+      "source_file": "scripts/pr-athena-delivery-run.ts",
+      "source_location": "L455"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "harness_runtime_trends_buildscenariotrend",
-      "label": "buildScenarioTrend()",
-      "norm_label": "buildscenariotrend()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L241"
+      "id": "pr_athena_delivery_run_commandtostring",
+      "label": "commandToString()",
+      "norm_label": "commandtostring()",
+      "source_file": "scripts/pr-athena-delivery-run.ts",
+      "source_location": "L83"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "harness_runtime_trends_collectharnessruntimetrends",
-      "label": "collectHarnessRuntimeTrends()",
-      "norm_label": "collectharnessruntimetrends()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L473"
+      "id": "pr_athena_delivery_run_consumeharnessgatedecisionevents",
+      "label": "consumeHarnessGateDecisionEvents()",
+      "norm_label": "consumeharnessgatedecisionevents()",
+      "source_file": "scripts/pr-athena-delivery-run.ts",
+      "source_location": "L369"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "harness_runtime_trends_formatms",
-      "label": "formatMs()",
-      "norm_label": "formatms()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L237"
+      "id": "pr_athena_delivery_run_interruptedexitcode",
+      "label": "interruptedExitCode()",
+      "norm_label": "interruptedexitcode()",
+      "source_file": "scripts/pr-athena-delivery-run.ts",
+      "source_location": "L467"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "harness_runtime_trends_formatpercent",
-      "label": "formatPercent()",
-      "norm_label": "formatpercent()",
-      "source_file": "scripts/harness-runtime-trends.ts",
+      "id": "pr_athena_delivery_run_interruptedreason",
+      "label": "interruptedReason()",
+      "norm_label": "interruptedreason()",
+      "source_file": "scripts/pr-athena-delivery-run.ts",
+      "source_location": "L480"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "pr_athena_delivery_run_nonempty",
+      "label": "nonEmpty()",
+      "norm_label": "nonempty()",
+      "source_file": "scripts/pr-athena-delivery-run.ts",
+      "source_location": "L229"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "pr_athena_delivery_run_parsegatedecisionevent",
+      "label": "parseGateDecisionEvent()",
+      "norm_label": "parsegatedecisionevent()",
+      "source_file": "scripts/pr-athena-delivery-run.ts",
       "source_location": "L233"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "harness_runtime_trends_isharnessbehaviorscenarioreport",
-      "label": "isHarnessBehaviorScenarioReport()",
-      "norm_label": "isharnessbehaviorscenarioreport()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L131"
+      "id": "pr_athena_delivery_run_parseproviderskippedevents",
+      "label": "parseProviderSkippedEvents()",
+      "norm_label": "parseproviderskippedevents()",
+      "source_file": "scripts/pr-athena-delivery-run.ts",
+      "source_location": "L182"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "harness_runtime_trends_parseharnessbehaviorreportlines",
-      "label": "parseHarnessBehaviorReportLines()",
-      "norm_label": "parseharnessbehaviorreportlines()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L149"
+      "id": "pr_athena_delivery_run_resolvedecisioneventsdir",
+      "label": "resolveDecisionEventsDir()",
+      "norm_label": "resolvedecisioneventsdir()",
+      "source_file": "scripts/pr-athena-delivery-run.ts",
+      "source_location": "L218"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "harness_runtime_trends_parseharnessruntimetrendsargs",
-      "label": "parseHarnessRuntimeTrendsArgs()",
-      "norm_label": "parseharnessruntimetrendsargs()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L509"
+      "id": "pr_athena_delivery_run_resolvegatedecisionexpectation",
+      "label": "resolveGateDecisionExpectation()",
+      "norm_label": "resolvegatedecisionexpectation()",
+      "source_file": "scripts/pr-athena-delivery-run.ts",
+      "source_location": "L428"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "harness_runtime_trends_percentile",
-      "label": "percentile()",
-      "norm_label": "percentile()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L191"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "harness_runtime_trends_runharnessruntimetrends",
-      "label": "runHarnessRuntimeTrends()",
-      "norm_label": "runharnessruntimetrends()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L481"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "harness_runtime_trends_sortcountentries",
-      "label": "sortCountEntries()",
-      "norm_label": "sortcountentries()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L227"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "harness_runtime_trends_sortunique",
-      "label": "sortUnique()",
-      "norm_label": "sortunique()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L125"
-    },
-    {
-      "community": 126,
-      "file_type": "code",
-      "id": "harness_runtime_trends_splitinputlines",
-      "label": "splitInputLines()",
-      "norm_label": "splitinputlines()",
-      "source_file": "scripts/harness-runtime-trends.ts",
+      "id": "pr_athena_delivery_run_rungitstdout",
+      "label": "runGitStdout()",
+      "norm_label": "rungitstdout()",
+      "source_file": "scripts/pr-athena-delivery-run.ts",
       "source_location": "L119"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "harness_runtime_trends_tohistoryfilestamp",
-      "label": "toHistoryFileStamp()",
-      "norm_label": "tohistoryfilestamp()",
-      "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L115"
+      "id": "pr_athena_delivery_run_runprathenadeliveryrun",
+      "label": "runPrAthenaDeliveryRun()",
+      "norm_label": "runprathenadeliveryrun()",
+      "source_file": "scripts/pr-athena-delivery-run.ts",
+      "source_location": "L493"
     },
     {
       "community": 126,
       "file_type": "code",
-      "id": "scripts_harness_runtime_trends_ts",
-      "label": "harness-runtime-trends.ts",
-      "norm_label": "harness-runtime-trends.ts",
-      "source_file": "scripts/harness-runtime-trends.ts",
+      "id": "pr_athena_delivery_run_runprocess",
+      "label": "runProcess()",
+      "norm_label": "runprocess()",
+      "source_file": "scripts/pr-athena-delivery-run.ts",
+      "source_location": "L91"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "pr_athena_delivery_run_writeprathenaproviderevidence",
+      "label": "writePrAthenaProviderEvidence()",
+      "norm_label": "writeprathenaproviderevidence()",
+      "source_file": "scripts/pr-athena-delivery-run.ts",
+      "source_location": "L145"
+    },
+    {
+      "community": 126,
+      "file_type": "code",
+      "id": "scripts_pr_athena_delivery_run_ts",
+      "label": "pr-athena-delivery-run.ts",
+      "norm_label": "pr-athena-delivery-run.ts",
+      "source_file": "scripts/pr-athena-delivery-run.ts",
       "source_location": "L1"
     },
     {
@@ -190623,155 +190656,146 @@
     {
       "community": 127,
       "file_type": "code",
-      "id": "pr_athena_delivery_run_assertallowedgateeventsequence",
-      "label": "assertAllowedGateEventSequence()",
-      "norm_label": "assertallowedgateeventsequence()",
-      "source_file": "scripts/pr-athena-delivery-run.ts",
-      "source_location": "L327"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "pr_athena_delivery_run_buildgitprocessenv",
-      "label": "buildGitProcessEnv()",
-      "norm_label": "buildgitprocessenv()",
-      "source_file": "scripts/pr-athena-delivery-run.ts",
-      "source_location": "L139"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "pr_athena_delivery_run_clearrecordedproof",
-      "label": "clearRecordedProof()",
-      "norm_label": "clearrecordedproof()",
-      "source_file": "scripts/pr-athena-delivery-run.ts",
-      "source_location": "L455"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "pr_athena_delivery_run_commandtostring",
-      "label": "commandToString()",
-      "norm_label": "commandtostring()",
-      "source_file": "scripts/pr-athena-delivery-run.ts",
-      "source_location": "L83"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "pr_athena_delivery_run_consumeharnessgatedecisionevents",
-      "label": "consumeHarnessGateDecisionEvents()",
-      "norm_label": "consumeharnessgatedecisionevents()",
-      "source_file": "scripts/pr-athena-delivery-run.ts",
-      "source_location": "L369"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "pr_athena_delivery_run_interruptedexitcode",
-      "label": "interruptedExitCode()",
-      "norm_label": "interruptedexitcode()",
-      "source_file": "scripts/pr-athena-delivery-run.ts",
-      "source_location": "L467"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "pr_athena_delivery_run_interruptedreason",
-      "label": "interruptedReason()",
-      "norm_label": "interruptedreason()",
-      "source_file": "scripts/pr-athena-delivery-run.ts",
-      "source_location": "L480"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "pr_athena_delivery_run_nonempty",
-      "label": "nonEmpty()",
-      "norm_label": "nonempty()",
-      "source_file": "scripts/pr-athena-delivery-run.ts",
-      "source_location": "L229"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "pr_athena_delivery_run_parsegatedecisionevent",
-      "label": "parseGateDecisionEvent()",
-      "norm_label": "parsegatedecisionevent()",
-      "source_file": "scripts/pr-athena-delivery-run.ts",
-      "source_location": "L233"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "pr_athena_delivery_run_parseproviderskippedevents",
-      "label": "parseProviderSkippedEvents()",
-      "norm_label": "parseproviderskippedevents()",
-      "source_file": "scripts/pr-athena-delivery-run.ts",
-      "source_location": "L182"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "pr_athena_delivery_run_resolvedecisioneventsdir",
-      "label": "resolveDecisionEventsDir()",
-      "norm_label": "resolvedecisioneventsdir()",
-      "source_file": "scripts/pr-athena-delivery-run.ts",
-      "source_location": "L218"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "pr_athena_delivery_run_resolvegatedecisionexpectation",
-      "label": "resolveGateDecisionExpectation()",
-      "norm_label": "resolvegatedecisionexpectation()",
-      "source_file": "scripts/pr-athena-delivery-run.ts",
-      "source_location": "L428"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "pr_athena_delivery_run_rungitstdout",
-      "label": "runGitStdout()",
-      "norm_label": "rungitstdout()",
-      "source_file": "scripts/pr-athena-delivery-run.ts",
-      "source_location": "L119"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "pr_athena_delivery_run_runprathenadeliveryrun",
-      "label": "runPrAthenaDeliveryRun()",
-      "norm_label": "runprathenadeliveryrun()",
-      "source_file": "scripts/pr-athena-delivery-run.ts",
-      "source_location": "L493"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "pr_athena_delivery_run_runprocess",
-      "label": "runProcess()",
-      "norm_label": "runprocess()",
-      "source_file": "scripts/pr-athena-delivery-run.ts",
-      "source_location": "L91"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "pr_athena_delivery_run_writeprathenaproviderevidence",
-      "label": "writePrAthenaProviderEvidence()",
-      "norm_label": "writeprathenaproviderevidence()",
-      "source_file": "scripts/pr-athena-delivery-run.ts",
-      "source_location": "L145"
-    },
-    {
-      "community": 127,
-      "file_type": "code",
-      "id": "scripts_pr_athena_delivery_run_ts",
-      "label": "pr-athena-delivery-run.ts",
-      "norm_label": "pr-athena-delivery-run.ts",
-      "source_file": "scripts/pr-athena-delivery-run.ts",
+      "id": "packages_athena_webapp_convex_http_domains_core_routes_trackingevents_ts",
+      "label": "trackingEvents.ts",
+      "norm_label": "trackingevents.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "trackingevents_buildabusepartitionkey",
+      "label": "buildAbusePartitionKey()",
+      "norm_label": "buildabusepartitionkey()",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
+      "source_location": "L225"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "trackingevents_buildservercontexttrackingenvelope",
+      "label": "buildServerContextTrackingEnvelope()",
+      "norm_label": "buildservercontexttrackingenvelope()",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "trackingevents_derivebrowserfamily",
+      "label": "deriveBrowserFamily()",
+      "norm_label": "derivebrowserfamily()",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
+      "source_location": "L148"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "trackingevents_derivecontextenvironment",
+      "label": "deriveContextEnvironment()",
+      "norm_label": "derivecontextenvironment()",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
+      "source_location": "L117"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "trackingevents_deriveosfamily",
+      "label": "deriveOsFamily()",
+      "norm_label": "deriveosfamily()",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
+      "source_location": "L159"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "trackingevents_deriveprimarysubject",
+      "label": "derivePrimarySubject()",
+      "norm_label": "deriveprimarysubject()",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
+      "source_location": "L235"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "trackingevents_isacceptedsyntheticcontext",
+      "label": "isAcceptedSyntheticContext()",
+      "norm_label": "isacceptedsyntheticcontext()",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
+      "source_location": "L195"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "trackingevents_isallowedtrackingorigin",
+      "label": "isAllowedTrackingOrigin()",
+      "norm_label": "isallowedtrackingorigin()",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
+      "source_location": "L178"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "trackingevents_isrecord",
+      "label": "isRecord()",
+      "norm_label": "isrecord()",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
+      "source_location": "L265"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "trackingevents_readpayload",
+      "label": "readPayload()",
+      "norm_label": "readpayload()",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
+      "source_location": "L205"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "trackingevents_readrequirednumber",
+      "label": "readRequiredNumber()",
+      "norm_label": "readrequirednumber()",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
+      "source_location": "L213"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "trackingevents_readrequiredstring",
+      "label": "readRequiredString()",
+      "norm_label": "readrequiredstring()",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
+      "source_location": "L209"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "trackingevents_readsubjectref",
+      "label": "readSubjectRef()",
+      "norm_label": "readsubjectref()",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
+      "source_location": "L257"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "trackingevents_readtrackingipaddress",
+      "label": "readTrackingIpAddress()",
+      "norm_label": "readtrackingipaddress()",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
+      "source_location": "L217"
+    },
+    {
+      "community": 127,
+      "file_type": "code",
+      "id": "trackingevents_readviewportbucket",
+      "label": "readViewportBucket()",
+      "norm_label": "readviewportbucket()",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
+      "source_location": "L169"
     },
     {
       "community": 1270,
@@ -190956,146 +190980,146 @@
     {
       "community": 128,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_core_routes_trackingevents_ts",
-      "label": "trackingEvents.ts",
-      "norm_label": "trackingevents.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
+      "id": "packages_athena_webapp_convex_intelligence_runs_ts",
+      "label": "runs.ts",
+      "norm_label": "runs.ts",
+      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
       "source_location": "L1"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "trackingevents_buildabusepartitionkey",
-      "label": "buildAbusePartitionKey()",
-      "norm_label": "buildabusepartitionkey()",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
-      "source_location": "L225"
+      "id": "runs_buildlatestrundebugpayload",
+      "label": "buildLatestRunDebugPayload()",
+      "norm_label": "buildlatestrundebugpayload()",
+      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
+      "source_location": "L633"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "trackingevents_buildservercontexttrackingenvelope",
-      "label": "buildServerContextTrackingEnvelope()",
-      "norm_label": "buildservercontexttrackingenvelope()",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
-      "source_location": "L67"
+      "id": "runs_getboundeddebugrunsbycapability",
+      "label": "getBoundedDebugRunsByCapability()",
+      "norm_label": "getboundeddebugrunsbycapability()",
+      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
+      "source_location": "L576"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "trackingevents_derivebrowserfamily",
-      "label": "deriveBrowserFamily()",
-      "norm_label": "derivebrowserfamily()",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
-      "source_location": "L148"
+      "id": "runs_getlatestdebugrunbycapability",
+      "label": "getLatestDebugRunByCapability()",
+      "norm_label": "getlatestdebugrunbycapability()",
+      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
+      "source_location": "L567"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "trackingevents_derivecontextenvironment",
-      "label": "deriveContextEnvironment()",
-      "norm_label": "derivecontextenvironment()",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
-      "source_location": "L117"
+      "id": "runs_getlatestdebugrunbysubject",
+      "label": "getLatestDebugRunBySubject()",
+      "norm_label": "getlatestdebugrunbysubject()",
+      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
+      "source_location": "L538"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "trackingevents_deriveosfamily",
-      "label": "deriveOsFamily()",
-      "norm_label": "deriveosfamily()",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
-      "source_location": "L159"
+      "id": "runs_isactiverunstale",
+      "label": "isActiveRunStale()",
+      "norm_label": "isactiverunstale()",
+      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
+      "source_location": "L118"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "trackingevents_deriveprimarysubject",
-      "label": "derivePrimarySubject()",
-      "norm_label": "deriveprimarysubject()",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
-      "source_location": "L235"
+      "id": "runs_isactiverunstatus",
+      "label": "isActiveRunStatus()",
+      "norm_label": "isactiverunstatus()",
+      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
+      "source_location": "L114"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "trackingevents_isacceptedsyntheticcontext",
-      "label": "isAcceptedSyntheticContext()",
-      "norm_label": "isacceptedsyntheticcontext()",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
-      "source_location": "L195"
+      "id": "runs_marksiblingartifactsstale",
+      "label": "markSiblingArtifactsStale()",
+      "norm_label": "marksiblingartifactsstale()",
+      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
+      "source_location": "L63"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "trackingevents_isallowedtrackingorigin",
-      "label": "isAllowedTrackingOrigin()",
-      "norm_label": "isallowedtrackingorigin()",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
-      "source_location": "L178"
+      "id": "runs_selectactiverunforidempotency",
+      "label": "selectActiveRunForIdempotency()",
+      "norm_label": "selectactiverunforidempotency()",
+      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
+      "source_location": "L132"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "trackingevents_isrecord",
-      "label": "isRecord()",
-      "norm_label": "isrecord()",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
-      "source_location": "L265"
+      "id": "runs_selectlatestdebugrunfromcandidates",
+      "label": "selectLatestDebugRunFromCandidates()",
+      "norm_label": "selectlatestdebugrunfromcandidates()",
+      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
+      "source_location": "L149"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "trackingevents_readpayload",
-      "label": "readPayload()",
-      "norm_label": "readpayload()",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
-      "source_location": "L205"
+      "id": "runs_shouldrecoveractiverun",
+      "label": "shouldRecoverActiveRun()",
+      "norm_label": "shouldrecoveractiverun()",
+      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
+      "source_location": "L142"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "trackingevents_readrequirednumber",
-      "label": "readRequiredNumber()",
-      "norm_label": "readrequirednumber()",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
-      "source_location": "L213"
+      "id": "runs_shouldsupersedeartifact",
+      "label": "shouldSupersedeArtifact()",
+      "norm_label": "shouldsupersedeartifact()",
+      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
+      "source_location": "L95"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "trackingevents_readrequiredstring",
-      "label": "readRequiredString()",
-      "norm_label": "readrequiredstring()",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
-      "source_location": "L209"
+      "id": "runs_summarizeerror",
+      "label": "summarizeError()",
+      "norm_label": "summarizeerror()",
+      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
+      "source_location": "L598"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "trackingevents_readsubjectref",
-      "label": "readSubjectRef()",
-      "norm_label": "readsubjectref()",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
-      "source_location": "L257"
+      "id": "runs_summarizepayload",
+      "label": "summarizePayload()",
+      "norm_label": "summarizepayload()",
+      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
+      "source_location": "L609"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "trackingevents_readtrackingipaddress",
-      "label": "readTrackingIpAddress()",
-      "norm_label": "readtrackingipaddress()",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
-      "source_location": "L217"
+      "id": "runs_summarizepayloadvalue",
+      "label": "summarizePayloadValue()",
+      "norm_label": "summarizepayloadvalue()",
+      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
+      "source_location": "L615"
     },
     {
       "community": 128,
       "file_type": "code",
-      "id": "trackingevents_readviewportbucket",
-      "label": "readViewportBucket()",
-      "norm_label": "readviewportbucket()",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/trackingEvents.ts",
-      "source_location": "L169"
+      "id": "runs_transitionrun",
+      "label": "transitionRun()",
+      "norm_label": "transitionrun()",
+      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
+      "source_location": "L40"
     },
     {
       "community": 1280,
@@ -191280,146 +191304,146 @@
     {
       "community": 129,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_intelligence_runs_ts",
-      "label": "runs.ts",
-      "norm_label": "runs.ts",
-      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
+      "id": "inventoryimportcostoverlayconstruction_constructionscopeerror",
+      "label": "ConstructionScopeError",
+      "norm_label": "constructionscopeerror",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
+      "source_location": "L156"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "inventoryimportcostoverlayconstruction_constructionscopeerror_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
+      "source_location": "L157"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "inventoryimportcostoverlayconstruction_costoverlayconstructionidentity",
+      "label": "costOverlayConstructionIdentity()",
+      "norm_label": "costoverlayconstructionidentity()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
+      "source_location": "L279"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "inventoryimportcostoverlayconstruction_digest",
+      "label": "digest()",
+      "norm_label": "digest()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
+      "source_location": "L275"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "inventoryimportcostoverlayconstruction_heartbeatconstructionorthrow",
+      "label": "heartbeatConstructionOrThrow()",
+      "norm_label": "heartbeatconstructionorthrow()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
+      "source_location": "L262"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "inventoryimportcostoverlayconstruction_loadanchors",
+      "label": "loadAnchors()",
+      "norm_label": "loadanchors()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
+      "source_location": "L646"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "inventoryimportcostoverlayconstruction_loadsource",
+      "label": "loadSource()",
+      "norm_label": "loadsource()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
+      "source_location": "L590"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "inventoryimportcostoverlayconstruction_materializecostoverlayrows",
+      "label": "materializeCostOverlayRows()",
+      "norm_label": "materializecostoverlayrows()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
+      "source_location": "L370"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "inventoryimportcostoverlayconstruction_normalizeoutcome",
+      "label": "normalizeOutcome()",
+      "norm_label": "normalizeoutcome()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
+      "source_location": "L360"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "inventoryimportcostoverlayconstruction_rawvaluefor",
+      "label": "rawValueFor()",
+      "norm_label": "rawvaluefor()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
+      "source_location": "L322"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "inventoryimportcostoverlayconstruction_safemultiply",
+      "label": "safeMultiply()",
+      "norm_label": "safemultiply()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
+      "source_location": "L300"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "inventoryimportcostoverlayconstruction_selectedcolumnfor",
+      "label": "selectedColumnFor()",
+      "norm_label": "selectedcolumnfor()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
+      "source_location": "L309"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "inventoryimportcostoverlayconstruction_serializerawvalue",
+      "label": "serializeRawValue()",
+      "norm_label": "serializerawvalue()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
+      "source_location": "L352"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "inventoryimportcostoverlayconstruction_staleconstructionerror",
+      "label": "StaleConstructionError",
+      "norm_label": "staleconstructionerror",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
+      "source_location": "L162"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "inventoryimportcostoverlayconstruction_truncateutf8",
+      "label": "truncateUtf8()",
+      "norm_label": "truncateutf8()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
+      "source_location": "L326"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_inventoryimportcostoverlayconstruction_ts",
+      "label": "inventoryImportCostOverlayConstruction.ts",
+      "norm_label": "inventoryimportcostoverlayconstruction.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "runs_buildlatestrundebugpayload",
-      "label": "buildLatestRunDebugPayload()",
-      "norm_label": "buildlatestrundebugpayload()",
-      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
-      "source_location": "L633"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "runs_getboundeddebugrunsbycapability",
-      "label": "getBoundedDebugRunsByCapability()",
-      "norm_label": "getboundeddebugrunsbycapability()",
-      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
-      "source_location": "L576"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "runs_getlatestdebugrunbycapability",
-      "label": "getLatestDebugRunByCapability()",
-      "norm_label": "getlatestdebugrunbycapability()",
-      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
-      "source_location": "L567"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "runs_getlatestdebugrunbysubject",
-      "label": "getLatestDebugRunBySubject()",
-      "norm_label": "getlatestdebugrunbysubject()",
-      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
-      "source_location": "L538"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "runs_isactiverunstale",
-      "label": "isActiveRunStale()",
-      "norm_label": "isactiverunstale()",
-      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
-      "source_location": "L118"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "runs_isactiverunstatus",
-      "label": "isActiveRunStatus()",
-      "norm_label": "isactiverunstatus()",
-      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
-      "source_location": "L114"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "runs_marksiblingartifactsstale",
-      "label": "markSiblingArtifactsStale()",
-      "norm_label": "marksiblingartifactsstale()",
-      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "runs_selectactiverunforidempotency",
-      "label": "selectActiveRunForIdempotency()",
-      "norm_label": "selectactiverunforidempotency()",
-      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
-      "source_location": "L132"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "runs_selectlatestdebugrunfromcandidates",
-      "label": "selectLatestDebugRunFromCandidates()",
-      "norm_label": "selectlatestdebugrunfromcandidates()",
-      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
-      "source_location": "L149"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "runs_shouldrecoveractiverun",
-      "label": "shouldRecoverActiveRun()",
-      "norm_label": "shouldrecoveractiverun()",
-      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
-      "source_location": "L142"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "runs_shouldsupersedeartifact",
-      "label": "shouldSupersedeArtifact()",
-      "norm_label": "shouldsupersedeartifact()",
-      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "runs_summarizeerror",
-      "label": "summarizeError()",
-      "norm_label": "summarizeerror()",
-      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
-      "source_location": "L598"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "runs_summarizepayload",
-      "label": "summarizePayload()",
-      "norm_label": "summarizepayload()",
-      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
-      "source_location": "L609"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "runs_summarizepayloadvalue",
-      "label": "summarizePayloadValue()",
-      "norm_label": "summarizepayloadvalue()",
-      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
-      "source_location": "L615"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "runs_transitionrun",
-      "label": "transitionRun()",
-      "norm_label": "transitionrun()",
-      "source_file": "packages/athena-webapp/convex/intelligence/runs.ts",
-      "source_location": "L40"
     },
     {
       "community": 1290,
@@ -192027,145 +192051,145 @@
     {
       "community": 130,
       "file_type": "code",
-      "id": "inventoryimportcostoverlayconstruction_constructionscopeerror",
-      "label": "ConstructionScopeError",
-      "norm_label": "constructionscopeerror",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
-      "source_location": "L156"
+      "id": "dailyoperations_test_buildcompletedpostransaction",
+      "label": "buildCompletedPosTransaction()",
+      "norm_label": "buildcompletedpostransaction()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
+      "source_location": "L512"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "inventoryimportcostoverlayconstruction_constructionscopeerror_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
-      "source_location": "L157"
+      "id": "dailyoperations_test_buildctx",
+      "label": "buildCtx()",
+      "norm_label": "buildctx()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
+      "source_location": "L407"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "inventoryimportcostoverlayconstruction_costoverlayconstructionidentity",
-      "label": "costOverlayConstructionIdentity()",
-      "norm_label": "costoverlayconstructionidentity()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
-      "source_location": "L279"
+      "id": "dailyoperations_test_buildfrozenclose",
+      "label": "buildFrozenClose()",
+      "norm_label": "buildfrozenclose()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
+      "source_location": "L532"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "inventoryimportcostoverlayconstruction_digest",
-      "label": "digest()",
-      "norm_label": "digest()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
-      "source_location": "L275"
+      "id": "dailyoperations_test_buildobservedctx",
+      "label": "buildObservedCtx()",
+      "norm_label": "buildobservedctx()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
+      "source_location": "L412"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "inventoryimportcostoverlayconstruction_heartbeatconstructionorthrow",
-      "label": "heartbeatConstructionOrThrow()",
-      "norm_label": "heartbeatconstructionorthrow()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
-      "source_location": "L262"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlayconstruction_loadanchors",
-      "label": "loadAnchors()",
-      "norm_label": "loadanchors()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
-      "source_location": "L646"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlayconstruction_loadsource",
-      "label": "loadSource()",
-      "norm_label": "loadsource()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
-      "source_location": "L590"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlayconstruction_materializecostoverlayrows",
-      "label": "materializeCostOverlayRows()",
-      "norm_label": "materializecostoverlayrows()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
-      "source_location": "L370"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlayconstruction_normalizeoutcome",
-      "label": "normalizeOutcome()",
-      "norm_label": "normalizeoutcome()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
-      "source_location": "L360"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlayconstruction_rawvaluefor",
-      "label": "rawValueFor()",
-      "norm_label": "rawvaluefor()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
-      "source_location": "L322"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlayconstruction_safemultiply",
-      "label": "safeMultiply()",
-      "norm_label": "safemultiply()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
-      "source_location": "L300"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlayconstruction_selectedcolumnfor",
-      "label": "selectedColumnFor()",
-      "norm_label": "selectedcolumnfor()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
-      "source_location": "L309"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlayconstruction_serializerawvalue",
-      "label": "serializeRawValue()",
-      "norm_label": "serializerawvalue()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
-      "source_location": "L352"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlayconstruction_staleconstructionerror",
-      "label": "StaleConstructionError",
-      "norm_label": "staleconstructionerror",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
-      "source_location": "L162"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlayconstruction_truncateutf8",
-      "label": "truncateUtf8()",
-      "norm_label": "truncateutf8()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
+      "id": "dailyoperations_test_buildpendingregistercountseed",
+      "label": "buildPendingRegisterCountSeed()",
+      "norm_label": "buildpendingregistercountseed()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
       "source_location": "L326"
     },
     {
       "community": 130,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_inventoryimportcostoverlayconstruction_ts",
-      "label": "inventoryImportCostOverlayConstruction.ts",
-      "norm_label": "inventoryimportcostoverlayconstruction.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayConstruction.ts",
+      "id": "dailyoperations_test_createdb",
+      "label": "createDb()",
+      "norm_label": "createdb()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "dailyoperations_test_frozenfinancialcompleteness",
+      "label": "frozenFinancialCompleteness()",
+      "norm_label": "frozenfinancialcompleteness()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
+      "source_location": "L434"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "dailyoperations_test_frozenfinancialcompletenessforrange",
+      "label": "frozenFinancialCompletenessForRange()",
+      "norm_label": "frozenfinancialcompletenessforrange()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
+      "source_location": "L485"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "dailyoperations_test_frozenfinancialcompletenesswithexpenseoverride",
+      "label": "frozenFinancialCompletenessWithExpenseOverride()",
+      "norm_label": "frozenfinancialcompletenesswithexpenseoverride()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
+      "source_location": "L496"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "dailyoperations_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
+      "source_location": "L420"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "dailyoperations_test_metricsourceobservations",
+      "label": "metricSourceObservations()",
+      "norm_label": "metricsourceobservations()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
+      "source_location": "L677"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "dailyoperations_test_mockdailyoperationsrole",
+      "label": "mockDailyOperationsRole()",
+      "norm_label": "mockdailyoperationsrole()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
+      "source_location": "L651"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "dailyoperations_test_operatingdaterange",
+      "label": "operatingDateRange()",
+      "norm_label": "operatingdaterange()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
+      "source_location": "L424"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "dailyoperations_test_review",
+      "label": "review()",
+      "norm_label": "review()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
+      "source_location": "L3535"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "dailyoperations_test_syncedsalereview",
+      "label": "syncedSaleReview()",
+      "norm_label": "syncedsalereview()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
+      "source_location": "L3440"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_dailyoperations_test_ts",
+      "label": "dailyOperations.test.ts",
+      "norm_label": "dailyoperations.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
       "source_location": "L1"
     },
     {
@@ -192351,145 +192375,145 @@
     {
       "community": 131,
       "file_type": "code",
-      "id": "dailyoperations_test_buildcompletedpostransaction",
-      "label": "buildCompletedPosTransaction()",
-      "norm_label": "buildcompletedpostransaction()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
-      "source_location": "L512"
+      "id": "logicaloperationalwork_aggregateoperationalstatus",
+      "label": "aggregateOperationalStatus()",
+      "norm_label": "aggregateoperationalstatus()",
+      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
+      "source_location": "L227"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "dailyoperations_test_buildctx",
-      "label": "buildCtx()",
-      "norm_label": "buildctx()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
-      "source_location": "L407"
+      "id": "logicaloperationalwork_canonicalsyncedsaleinventoryreviewskuid",
+      "label": "canonicalSyncedSaleInventoryReviewSkuId()",
+      "norm_label": "canonicalsyncedsaleinventoryreviewskuid()",
+      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
+      "source_location": "L167"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "dailyoperations_test_buildfrozenclose",
-      "label": "buildFrozenClose()",
-      "norm_label": "buildfrozenclose()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
-      "source_location": "L532"
+      "id": "logicaloperationalwork_compareoperationalworkitems",
+      "label": "compareOperationalWorkItems()",
+      "norm_label": "compareoperationalworkitems()",
+      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
+      "source_location": "L252"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "dailyoperations_test_buildobservedctx",
-      "label": "buildObservedCtx()",
-      "norm_label": "buildobservedctx()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
-      "source_location": "L412"
+      "id": "logicaloperationalwork_comparestrings",
+      "label": "compareStrings()",
+      "norm_label": "comparestrings()",
+      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
+      "source_location": "L248"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "dailyoperations_test_buildpendingregistercountseed",
-      "label": "buildPendingRegisterCountSeed()",
-      "norm_label": "buildpendingregistercountseed()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
-      "source_location": "L326"
+      "id": "logicaloperationalwork_groupkey",
+      "label": "groupKey()",
+      "norm_label": "groupkey()",
+      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
+      "source_location": "L270"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "dailyoperations_test_createdb",
-      "label": "createDb()",
-      "norm_label": "createdb()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
-      "source_location": "L73"
+      "id": "logicaloperationalwork_joinsourceidentity",
+      "label": "joinSourceIdentity()",
+      "norm_label": "joinsourceidentity()",
+      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
+      "source_location": "L40"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "dailyoperations_test_frozenfinancialcompleteness",
-      "label": "frozenFinancialCompleteness()",
-      "norm_label": "frozenfinancialcompleteness()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
-      "source_location": "L434"
+      "id": "logicaloperationalwork_operationalpriorityurgency",
+      "label": "operationalPriorityUrgency()",
+      "norm_label": "operationalpriorityurgency()",
+      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
+      "source_location": "L210"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "dailyoperations_test_frozenfinancialcompletenessforrange",
-      "label": "frozenFinancialCompletenessForRange()",
-      "norm_label": "frozenfinancialcompletenessforrange()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
-      "source_location": "L485"
+      "id": "logicaloperationalwork_operationalworkactionabletimestamp",
+      "label": "operationalWorkActionableTimestamp()",
+      "norm_label": "operationalworkactionabletimestamp()",
+      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
+      "source_location": "L235"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "dailyoperations_test_frozenfinancialcompletenesswithexpenseoverride",
-      "label": "frozenFinancialCompletenessWithExpenseOverride()",
-      "norm_label": "frozenfinancialcompletenesswithexpenseoverride()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
-      "source_location": "L496"
+      "id": "logicaloperationalwork_operationalworkmetadatastring",
+      "label": "operationalWorkMetadataString()",
+      "norm_label": "operationalworkmetadatastring()",
+      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
+      "source_location": "L32"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "dailyoperations_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
-      "source_location": "L420"
+      "id": "logicaloperationalwork_prioritybucket",
+      "label": "priorityBucket()",
+      "norm_label": "prioritybucket()",
+      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
+      "source_location": "L180"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "dailyoperations_test_metricsourceobservations",
-      "label": "metricSourceObservations()",
-      "norm_label": "metricsourceobservations()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
-      "source_location": "L677"
+      "id": "logicaloperationalwork_projectlogicaloperationalwork",
+      "label": "projectLogicalOperationalWork()",
+      "norm_label": "projectlogicaloperationalwork()",
+      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
+      "source_location": "L280"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "dailyoperations_test_mockdailyoperationsrole",
-      "label": "mockDailyOperationsRole()",
-      "norm_label": "mockdailyoperationsrole()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
-      "source_location": "L651"
+      "id": "logicaloperationalwork_resolvercompletenessbucket",
+      "label": "resolverCompletenessBucket()",
+      "norm_label": "resolvercompletenessbucket()",
+      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
+      "source_location": "L241"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "dailyoperations_test_operatingdaterange",
-      "label": "operatingDateRange()",
-      "norm_label": "operatingdaterange()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
-      "source_location": "L424"
+      "id": "logicaloperationalwork_stableoperationalworkitemsourceidentity",
+      "label": "stableOperationalWorkItemSourceIdentity()",
+      "norm_label": "stableoperationalworkitemsourceidentity()",
+      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
+      "source_location": "L44"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "dailyoperations_test_review",
-      "label": "review()",
-      "norm_label": "review()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
-      "source_location": "L3535"
+      "id": "logicaloperationalwork_statusurgency",
+      "label": "statusUrgency()",
+      "norm_label": "statusurgency()",
+      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
+      "source_location": "L206"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "dailyoperations_test_syncedsalereview",
-      "label": "syncedSaleReview()",
-      "norm_label": "syncedsalereview()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
-      "source_location": "L3440"
+      "id": "logicaloperationalwork_strongestoperationalpriority",
+      "label": "strongestOperationalPriority()",
+      "norm_label": "strongestoperationalpriority()",
+      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
+      "source_location": "L214"
     },
     {
       "community": 131,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_dailyoperations_test_ts",
-      "label": "dailyOperations.test.ts",
-      "norm_label": "dailyoperations.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations.test.ts",
+      "id": "packages_athena_webapp_convex_operations_logicaloperationalwork_ts",
+      "label": "logicalOperationalWork.ts",
+      "norm_label": "logicaloperationalwork.ts",
+      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
       "source_location": "L1"
     },
     {
@@ -192675,145 +192699,145 @@
     {
       "community": 132,
       "file_type": "code",
-      "id": "logicaloperationalwork_aggregateoperationalstatus",
-      "label": "aggregateOperationalStatus()",
-      "norm_label": "aggregateoperationalstatus()",
-      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
-      "source_location": "L227"
+      "id": "correcttransaction_adjustregistersessionexpectedcashforpaymentcorrection",
+      "label": "adjustRegisterSessionExpectedCashForPaymentCorrection()",
+      "norm_label": "adjustregistersessionexpectedcashforpaymentcorrection()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L260"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "logicaloperationalwork_canonicalsyncedsaleinventoryreviewskuid",
-      "label": "canonicalSyncedSaleInventoryReviewSkuId()",
-      "norm_label": "canonicalsyncedsaleinventoryreviewskuid()",
-      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
-      "source_location": "L167"
+      "id": "correcttransaction_applypaymentmethodcorrection",
+      "label": "applyPaymentMethodCorrection()",
+      "norm_label": "applypaymentmethodcorrection()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L341"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "logicaloperationalwork_compareoperationalworkitems",
-      "label": "compareOperationalWorkItems()",
-      "norm_label": "compareoperationalworkitems()",
-      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
-      "source_location": "L252"
+      "id": "correcttransaction_buildpaymentmethodcorrectionapprovalrequirement",
+      "label": "buildPaymentMethodCorrectionApprovalRequirement()",
+      "norm_label": "buildpaymentmethodcorrectionapprovalrequirement()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L66"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "logicaloperationalwork_comparestrings",
-      "label": "compareStrings()",
-      "norm_label": "comparestrings()",
-      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
-      "source_location": "L248"
+      "id": "correcttransaction_consumepaymentmethodcorrectionapprovalproof",
+      "label": "consumePaymentMethodCorrectionApprovalProof()",
+      "norm_label": "consumepaymentmethodcorrectionapprovalproof()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L310"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "logicaloperationalwork_groupkey",
-      "label": "groupKey()",
-      "norm_label": "groupkey()",
-      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
-      "source_location": "L270"
+      "id": "correcttransaction_correcttransactioncustomer",
+      "label": "correctTransactionCustomer()",
+      "norm_label": "correcttransactioncustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L482"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "logicaloperationalwork_joinsourceidentity",
-      "label": "joinSourceIdentity()",
-      "norm_label": "joinsourceidentity()",
-      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
-      "source_location": "L40"
+      "id": "correcttransaction_correcttransactionpaymentmethod",
+      "label": "correctTransactionPaymentMethod()",
+      "norm_label": "correcttransactionpaymentmethod()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L551"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "logicaloperationalwork_operationalpriorityurgency",
-      "label": "operationalPriorityUrgency()",
-      "norm_label": "operationalpriorityurgency()",
-      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
-      "source_location": "L210"
+      "id": "correcttransaction_createpaymentmethodcorrectionapprovalrequest",
+      "label": "createPaymentMethodCorrectionApprovalRequest()",
+      "norm_label": "createpaymentmethodcorrectionapprovalrequest()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L119"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "logicaloperationalwork_operationalworkactionabletimestamp",
-      "label": "operationalWorkActionableTimestamp()",
-      "norm_label": "operationalworkactionabletimestamp()",
-      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
+      "id": "correcttransaction_getpaymentmethodcashcontribution",
+      "label": "getPaymentMethodCashContribution()",
+      "norm_label": "getpaymentmethodcashcontribution()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L225"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "correcttransaction_getstringmetadata",
+      "label": "getStringMetadata()",
+      "norm_label": "getstringmetadata()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L683"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "correcttransaction_requirecompletedtransaction",
+      "label": "requireCompletedTransaction()",
+      "norm_label": "requirecompletedtransaction()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L208"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "correcttransaction_requirematchingpendingpaymentmethodcorrectionapprovalrequest",
+      "label": "requireMatchingPendingPaymentMethodCorrectionApprovalRequest()",
+      "norm_label": "requirematchingpendingpaymentmethodcorrectionapprovalrequest()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L691"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
+      "id": "correcttransaction_requireregistersessionallowspaymentcorrection",
+      "label": "requireRegisterSessionAllowsPaymentCorrection()",
+      "norm_label": "requireregistersessionallowspaymentcorrection()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
       "source_location": "L235"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "logicaloperationalwork_operationalworkmetadatastring",
-      "label": "operationalWorkMetadataString()",
-      "norm_label": "operationalworkmetadatastring()",
-      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
-      "source_location": "L32"
+      "id": "correcttransaction_resolvepaymentmethodcorrectionapprovaldecisionwithctx",
+      "label": "resolvePaymentMethodCorrectionApprovalDecisionWithCtx()",
+      "norm_label": "resolvepaymentmethodcorrectionapprovaldecisionwithctx()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L752"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "logicaloperationalwork_prioritybucket",
-      "label": "priorityBucket()",
-      "norm_label": "prioritybucket()",
-      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
-      "source_location": "L180"
+      "id": "correcttransaction_transactionlabel",
+      "label": "transactionLabel()",
+      "norm_label": "transactionlabel()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L39"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "logicaloperationalwork_projectlogicaloperationalwork",
-      "label": "projectLogicalOperationalWork()",
-      "norm_label": "projectlogicaloperationalwork()",
-      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
-      "source_location": "L280"
+      "id": "correcttransaction_transactionlabelfromapprovalrequest",
+      "label": "transactionLabelFromApprovalRequest()",
+      "norm_label": "transactionlabelfromapprovalrequest()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "source_location": "L43"
     },
     {
       "community": 132,
       "file_type": "code",
-      "id": "logicaloperationalwork_resolvercompletenessbucket",
-      "label": "resolverCompletenessBucket()",
-      "norm_label": "resolvercompletenessbucket()",
-      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
-      "source_location": "L241"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "logicaloperationalwork_stableoperationalworkitemsourceidentity",
-      "label": "stableOperationalWorkItemSourceIdentity()",
-      "norm_label": "stableoperationalworkitemsourceidentity()",
-      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
-      "source_location": "L44"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "logicaloperationalwork_statusurgency",
-      "label": "statusUrgency()",
-      "norm_label": "statusurgency()",
-      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
-      "source_location": "L206"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "logicaloperationalwork_strongestoperationalpriority",
-      "label": "strongestOperationalPriority()",
-      "norm_label": "strongestoperationalpriority()",
-      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
-      "source_location": "L214"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_logicaloperationalwork_ts",
-      "label": "logicalOperationalWork.ts",
-      "norm_label": "logicaloperationalwork.ts",
-      "source_file": "packages/athena-webapp/convex/operations/logicalOperationalWork.ts",
+      "id": "packages_athena_webapp_convex_pos_application_commands_correcttransaction_ts",
+      "label": "correctTransaction.ts",
+      "norm_label": "correcttransaction.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
       "source_location": "L1"
     },
     {
@@ -192999,146 +193023,146 @@
     {
       "community": 133,
       "file_type": "code",
-      "id": "correcttransaction_adjustregistersessionexpectedcashforpaymentcorrection",
-      "label": "adjustRegisterSessionExpectedCashForPaymentCorrection()",
-      "norm_label": "adjustregistersessionexpectedcashforpaymentcorrection()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L260"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "correcttransaction_applypaymentmethodcorrection",
-      "label": "applyPaymentMethodCorrection()",
-      "norm_label": "applypaymentmethodcorrection()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L341"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "correcttransaction_buildpaymentmethodcorrectionapprovalrequirement",
-      "label": "buildPaymentMethodCorrectionApprovalRequirement()",
-      "norm_label": "buildpaymentmethodcorrectionapprovalrequirement()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "correcttransaction_consumepaymentmethodcorrectionapprovalproof",
-      "label": "consumePaymentMethodCorrectionApprovalProof()",
-      "norm_label": "consumepaymentmethodcorrectionapprovalproof()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L310"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "correcttransaction_correcttransactioncustomer",
-      "label": "correctTransactionCustomer()",
-      "norm_label": "correcttransactioncustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L482"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "correcttransaction_correcttransactionpaymentmethod",
-      "label": "correctTransactionPaymentMethod()",
-      "norm_label": "correcttransactionpaymentmethod()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L551"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "correcttransaction_createpaymentmethodcorrectionapprovalrequest",
-      "label": "createPaymentMethodCorrectionApprovalRequest()",
-      "norm_label": "createpaymentmethodcorrectionapprovalrequest()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L119"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "correcttransaction_getpaymentmethodcashcontribution",
-      "label": "getPaymentMethodCashContribution()",
-      "norm_label": "getpaymentmethodcashcontribution()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L225"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "correcttransaction_getstringmetadata",
-      "label": "getStringMetadata()",
-      "norm_label": "getstringmetadata()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L683"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "correcttransaction_requirecompletedtransaction",
-      "label": "requireCompletedTransaction()",
-      "norm_label": "requirecompletedtransaction()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L208"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "correcttransaction_requirematchingpendingpaymentmethodcorrectionapprovalrequest",
-      "label": "requireMatchingPendingPaymentMethodCorrectionApprovalRequest()",
-      "norm_label": "requirematchingpendingpaymentmethodcorrectionapprovalrequest()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L691"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "correcttransaction_requireregistersessionallowspaymentcorrection",
-      "label": "requireRegisterSessionAllowsPaymentCorrection()",
-      "norm_label": "requireregistersessionallowspaymentcorrection()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L235"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "correcttransaction_resolvepaymentmethodcorrectionapprovaldecisionwithctx",
-      "label": "resolvePaymentMethodCorrectionApprovalDecisionWithCtx()",
-      "norm_label": "resolvepaymentmethodcorrectionapprovaldecisionwithctx()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L752"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "correcttransaction_transactionlabel",
-      "label": "transactionLabel()",
-      "norm_label": "transactionlabel()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L39"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "correcttransaction_transactionlabelfromapprovalrequest",
-      "label": "transactionLabelFromApprovalRequest()",
-      "norm_label": "transactionlabelfromapprovalrequest()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
-      "source_location": "L43"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_correcttransaction_ts",
-      "label": "correctTransaction.ts",
-      "norm_label": "correcttransaction.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/correctTransaction.ts",
+      "id": "packages_athena_webapp_convex_pos_application_queries_storepulse_ts",
+      "label": "storePulse.ts",
+      "norm_label": "storepulse.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "storepulse_buildposoperatorsnapshot",
+      "label": "buildPosOperatorSnapshot()",
+      "norm_label": "buildposoperatorsnapshot()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
+      "source_location": "L355"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "storepulse_buildrecentdaybuckets",
+      "label": "buildRecentDayBuckets()",
+      "norm_label": "buildrecentdaybuckets()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
+      "source_location": "L719"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "storepulse_buildsummarytrendbucket",
+      "label": "buildSummaryTrendBucket()",
+      "norm_label": "buildsummarytrendbucket()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
+      "source_location": "L734"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "storepulse_buildtransactiondatebuckets",
+      "label": "buildTransactionDateBuckets()",
+      "norm_label": "buildtransactiondatebuckets()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
+      "source_location": "L754"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "storepulse_calculatedeltapercent",
+      "label": "calculateDeltaPercent()",
+      "norm_label": "calculatedeltapercent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "storepulse_formathourlabel",
+      "label": "formatHourLabel()",
+      "norm_label": "formathourlabel()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
+      "source_location": "L821"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "storepulse_formatpaymentmethodlabel",
+      "label": "formatPaymentMethodLabel()",
+      "norm_label": "formatpaymentmethodlabel()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
+      "source_location": "L828"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "storepulse_formatshortdate",
+      "label": "formatShortDate()",
+      "norm_label": "formatshortdate()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
+      "source_location": "L800"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "storepulse_getfixedhistorybucketdate",
+      "label": "getFixedHistoryBucketDate()",
+      "norm_label": "getfixedhistorybucketdate()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
+      "source_location": "L787"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "storepulse_getstorepulsesummariesforoperatingdateranges",
+      "label": "getStorePulseSummariesForOperatingDateRanges()",
+      "norm_label": "getstorepulsesummariesforoperatingdateranges()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
+      "source_location": "L151"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "storepulse_getstorepulsesummaryforwindow",
+      "label": "getStorePulseSummaryForWindow()",
+      "norm_label": "getstorepulsesummaryforwindow()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "storepulse_parseoperatingdatestart",
+      "label": "parseOperatingDateStart()",
+      "norm_label": "parseoperatingdatestart()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
+      "source_location": "L712"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "storepulse_resolvepospulsewindow",
+      "label": "resolvePosPulseWindow()",
+      "norm_label": "resolvepospulsewindow()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
+      "source_location": "L583"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "storepulse_summarizepospulsetransactions",
+      "label": "summarizePosPulseTransactions()",
+      "norm_label": "summarizepospulsetransactions()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
+      "source_location": "L334"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "storepulse_toisodate",
+      "label": "toIsoDate()",
+      "norm_label": "toisodate()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
+      "source_location": "L796"
     },
     {
       "community": 1330,
@@ -193323,146 +193347,146 @@
     {
       "community": 134,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_queries_storepulse_ts",
-      "label": "storePulse.ts",
-      "norm_label": "storepulse.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
-      "source_location": "L1"
+      "id": "catalog_buildpendingcheckoutfinalizationpayloadhash",
+      "label": "buildPendingCheckoutFinalizationPayloadHash()",
+      "norm_label": "buildpendingcheckoutfinalizationpayloadhash()",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
+      "source_location": "L431"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "storepulse_buildposoperatorsnapshot",
-      "label": "buildPosOperatorSnapshot()",
-      "norm_label": "buildposoperatorsnapshot()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
-      "source_location": "L355"
+      "id": "catalog_buildpendingcheckoutsaleevidencefingerprint",
+      "label": "buildPendingCheckoutSaleEvidenceFingerprint()",
+      "norm_label": "buildpendingcheckoutsaleevidencefingerprint()",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
+      "source_location": "L322"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "storepulse_buildrecentdaybuckets",
-      "label": "buildRecentDayBuckets()",
-      "norm_label": "buildrecentdaybuckets()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
-      "source_location": "L719"
+      "id": "catalog_buildtrustedskufingerprint",
+      "label": "buildTrustedSkuFingerprint()",
+      "norm_label": "buildtrustedskufingerprint()",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
+      "source_location": "L335"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "storepulse_buildsummarytrendbucket",
-      "label": "buildSummaryTrendBucket()",
-      "norm_label": "buildsummarytrendbucket()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
-      "source_location": "L734"
+      "id": "catalog_islinkedpendingcheckoutaliasvisible",
+      "label": "isLinkedPendingCheckoutAliasVisible()",
+      "norm_label": "islinkedpendingcheckoutaliasvisible()",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
+      "source_location": "L234"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "storepulse_buildtransactiondatebuckets",
-      "label": "buildTransactionDateBuckets()",
-      "norm_label": "buildtransactiondatebuckets()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
-      "source_location": "L754"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "storepulse_calculatedeltapercent",
-      "label": "calculateDeltaPercent()",
-      "norm_label": "calculatedeltapercent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "storepulse_formathourlabel",
-      "label": "formatHourLabel()",
-      "norm_label": "formathourlabel()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
-      "source_location": "L821"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "storepulse_formatpaymentmethodlabel",
-      "label": "formatPaymentMethodLabel()",
-      "norm_label": "formatpaymentmethodlabel()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
-      "source_location": "L828"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "storepulse_formatshortdate",
-      "label": "formatShortDate()",
-      "norm_label": "formatshortdate()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
-      "source_location": "L800"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "storepulse_getfixedhistorybucketdate",
-      "label": "getFixedHistoryBucketDate()",
-      "norm_label": "getfixedhistorybucketdate()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
-      "source_location": "L787"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "storepulse_getstorepulsesummariesforoperatingdateranges",
-      "label": "getStorePulseSummariesForOperatingDateRanges()",
-      "norm_label": "getstorepulsesummariesforoperatingdateranges()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
-      "source_location": "L151"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "storepulse_getstorepulsesummaryforwindow",
-      "label": "getStorePulseSummaryForWindow()",
-      "norm_label": "getstorepulsesummaryforwindow()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "storepulse_parseoperatingdatestart",
-      "label": "parseOperatingDateStart()",
-      "norm_label": "parseoperatingdatestart()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
-      "source_location": "L712"
-    },
-    {
-      "community": 134,
-      "file_type": "code",
-      "id": "storepulse_resolvepospulsewindow",
-      "label": "resolvePosPulseWindow()",
-      "norm_label": "resolvepospulsewindow()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
+      "id": "catalog_listpendingcheckoutproductpagebindingwithctx",
+      "label": "listPendingCheckoutProductPageBindingWithCtx()",
+      "norm_label": "listpendingcheckoutproductpagebindingwithctx()",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
       "source_location": "L583"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "storepulse_summarizepospulsetransactions",
-      "label": "summarizePosPulseTransactions()",
-      "norm_label": "summarizepospulsetransactions()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
-      "source_location": "L334"
+      "id": "catalog_mappendingcheckoutreviewstatustoworkitempatch",
+      "label": "mapPendingCheckoutReviewStatusToWorkItemPatch()",
+      "norm_label": "mappendingcheckoutreviewstatustoworkitempatch()",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
+      "source_location": "L305"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "storepulse_toisodate",
-      "label": "toIsoDate()",
-      "norm_label": "toisodate()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.ts",
-      "source_location": "L796"
+      "id": "catalog_omitundefined",
+      "label": "omitUndefined()",
+      "norm_label": "omitundefined()",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
+      "source_location": "L452"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "catalog_pendingcheckoutlinkpricesmatch",
+      "label": "pendingCheckoutLinkPricesMatch()",
+      "norm_label": "pendingcheckoutlinkpricesmatch()",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
+      "source_location": "L347"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "catalog_requirependingcheckoutreviewaccess",
+      "label": "requirePendingCheckoutReviewAccess()",
+      "norm_label": "requirependingcheckoutreviewaccess()",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
+      "source_location": "L563"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "catalog_requirependingcheckoutsalecontext",
+      "label": "requirePendingCheckoutSaleContext()",
+      "norm_label": "requirependingcheckoutsalecontext()",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
+      "source_location": "L504"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "catalog_requireregistercatalogstoreaccess",
+      "label": "requireRegisterCatalogStoreAccess()",
+      "norm_label": "requireregistercatalogstoreaccess()",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
+      "source_location": "L474"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "catalog_reviewedposvisiblefor",
+      "label": "reviewedPosVisibleFor()",
+      "norm_label": "reviewedposvisiblefor()",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
+      "source_location": "L354"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "catalog_stablestringify",
+      "label": "stableStringify()",
+      "norm_label": "stablestringify()",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
+      "source_location": "L458"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "catalog_topendingcheckoutreviewitem",
+      "label": "toPendingCheckoutReviewItem()",
+      "norm_label": "topendingcheckoutreviewitem()",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
+      "source_location": "L290"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "catalog_validatereviewedtrustedinventoryfields",
+      "label": "validateReviewedTrustedInventoryFields()",
+      "norm_label": "validatereviewedtrustedinventoryfields()",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
+      "source_location": "L363"
+    },
+    {
+      "community": 134,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_public_catalog_ts",
+      "label": "catalog.ts",
+      "norm_label": "catalog.ts",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
+      "source_location": "L1"
     },
     {
       "community": 1340,
@@ -193647,146 +193671,146 @@
     {
       "community": 135,
       "file_type": "code",
-      "id": "catalog_buildpendingcheckoutfinalizationpayloadhash",
-      "label": "buildPendingCheckoutFinalizationPayloadHash()",
-      "norm_label": "buildpendingcheckoutfinalizationpayloadhash()",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
-      "source_location": "L431"
+      "id": "packages_athena_webapp_convex_reports_skumixrange_test_ts",
+      "label": "skuMixRange.test.ts",
+      "norm_label": "skumixrange.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
+      "source_location": "L1"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "catalog_buildpendingcheckoutsaleevidencefingerprint",
-      "label": "buildPendingCheckoutSaleEvidenceFingerprint()",
-      "norm_label": "buildpendingcheckoutsaleevidencefingerprint()",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
-      "source_location": "L322"
+      "id": "skumixrange_test_admitone",
+      "label": "admitOne()",
+      "norm_label": "admitone()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
+      "source_location": "L365"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "catalog_buildtrustedskufingerprint",
-      "label": "buildTrustedSkuFingerprint()",
-      "norm_label": "buildtrustedskufingerprint()",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
+      "id": "skumixrange_test_allow",
+      "label": "allow()",
+      "norm_label": "allow()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "skumixrange_test_certifyday",
+      "label": "certifyDay()",
+      "norm_label": "certifyday()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
+      "source_location": "L253"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "skumixrange_test_completedmix",
+      "label": "completedMix()",
+      "norm_label": "completedmix()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
+      "source_location": "L959"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "skumixrange_test_drive",
+      "label": "drive()",
+      "norm_label": "drive()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
       "source_location": "L335"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "catalog_islinkedpendingcheckoutaliasvisible",
-      "label": "isLinkedPendingCheckoutAliasVisible()",
-      "norm_label": "islinkedpendingcheckoutaliasvisible()",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
-      "source_location": "L234"
+      "id": "skumixrange_test_ensure",
+      "label": "ensure()",
+      "norm_label": "ensure()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
+      "source_location": "L298"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "catalog_listpendingcheckoutproductpagebindingwithctx",
-      "label": "listPendingCheckoutProductPageBindingWithCtx()",
-      "norm_label": "listpendingcheckoutproductpagebindingwithctx()",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
-      "source_location": "L583"
+      "id": "skumixrange_test_handlerof",
+      "label": "handlerOf()",
+      "norm_label": "handlerof()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
+      "source_location": "L123"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "catalog_mappendingcheckoutreviewstatustoworkitempatch",
-      "label": "mapPendingCheckoutReviewStatusToWorkItemPatch()",
-      "norm_label": "mappendingcheckoutreviewstatustoworkitempatch()",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
-      "source_location": "L305"
+      "id": "skumixrange_test_headerbykey",
+      "label": "headerByKey()",
+      "norm_label": "headerbykey()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
+      "source_location": "L319"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "catalog_omitundefined",
-      "label": "omitUndefined()",
-      "norm_label": "omitundefined()",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
-      "source_location": "L452"
+      "id": "skumixrange_test_isodateoffset",
+      "label": "isoDateOffset()",
+      "norm_label": "isodateoffset()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
+      "source_location": "L113"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "catalog_pendingcheckoutlinkpricesmatch",
-      "label": "pendingCheckoutLinkPricesMatch()",
-      "norm_label": "pendingcheckoutlinkpricesmatch()",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
-      "source_location": "L347"
+      "id": "skumixrange_test_mixchildren",
+      "label": "mixChildren()",
+      "norm_label": "mixchildren()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
+      "source_location": "L377"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "catalog_requirependingcheckoutreviewaccess",
-      "label": "requirePendingCheckoutReviewAccess()",
-      "norm_label": "requirependingcheckoutreviewaccess()",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
-      "source_location": "L563"
+      "id": "skumixrange_test_seedskus",
+      "label": "seedSkus()",
+      "norm_label": "seedskus()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
+      "source_location": "L177"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "catalog_requirependingcheckoutsalecontext",
-      "label": "requirePendingCheckoutSaleContext()",
-      "norm_label": "requirependingcheckoutsalecontext()",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
-      "source_location": "L504"
+      "id": "skumixrange_test_seedstore",
+      "label": "seedStore()",
+      "norm_label": "seedstore()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
+      "source_location": "L155"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "catalog_requireregistercatalogstoreaccess",
-      "label": "requireRegisterCatalogStoreAccess()",
-      "norm_label": "requireregistercatalogstoreaccess()",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
-      "source_location": "L474"
+      "id": "skumixrange_test_step",
+      "label": "step()",
+      "norm_label": "step()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
+      "source_location": "L1082"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "catalog_reviewedposvisiblefor",
-      "label": "reviewedPosVisibleFor()",
-      "norm_label": "reviewedposvisiblefor()",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
-      "source_location": "L354"
+      "id": "skumixrange_test_twodayfixture",
+      "label": "twoDayFixture()",
+      "norm_label": "twodayfixture()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
+      "source_location": "L1066"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "catalog_stablestringify",
-      "label": "stableStringify()",
-      "norm_label": "stablestringify()",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
-      "source_location": "L458"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "catalog_topendingcheckoutreviewitem",
-      "label": "toPendingCheckoutReviewItem()",
-      "norm_label": "topendingcheckoutreviewitem()",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
-      "source_location": "L290"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "catalog_validatereviewedtrustedinventoryfields",
-      "label": "validateReviewedTrustedInventoryFields()",
-      "norm_label": "validatereviewedtrustedinventoryfields()",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
-      "source_location": "L363"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_public_catalog_ts",
-      "label": "catalog.ts",
-      "norm_label": "catalog.ts",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.ts",
-      "source_location": "L1"
+      "id": "skumixrange_test_visible",
+      "label": "visible()",
+      "norm_label": "visible()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
+      "source_location": "L393"
     },
     {
       "community": 1350,
@@ -193971,146 +193995,146 @@
     {
       "community": 136,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_skumixrange_test_ts",
-      "label": "skuMixRange.test.ts",
-      "norm_label": "skumixrange.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
+      "id": "packages_athena_webapp_convex_serviceops_servicecases_ts",
+      "label": "serviceCases.ts",
+      "norm_label": "servicecases.ts",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
       "source_location": "L1"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "skumixrange_test_admitone",
-      "label": "admitOne()",
-      "norm_label": "admitone()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
-      "source_location": "L365"
+      "id": "servicecases_assertvalidservicecasestatustransition",
+      "label": "assertValidServiceCaseStatusTransition()",
+      "norm_label": "assertvalidservicecasestatustransition()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L357"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "skumixrange_test_allow",
-      "label": "allow()",
-      "norm_label": "allow()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
-      "source_location": "L128"
+      "id": "servicecases_buildservicecase",
+      "label": "buildServiceCase()",
+      "norm_label": "buildservicecase()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L371"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "skumixrange_test_certifyday",
-      "label": "certifyDay()",
-      "norm_label": "certifyday()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
-      "source_location": "L253"
+      "id": "servicecases_buildservicecaselineitem",
+      "label": "buildServiceCaseLineItem()",
+      "norm_label": "buildservicecaselineitem()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L400"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "skumixrange_test_completedmix",
-      "label": "completedMix()",
-      "norm_label": "completedmix()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
-      "source_location": "L959"
+      "id": "servicecases_createservicecasewithctx",
+      "label": "createServiceCaseWithCtx()",
+      "norm_label": "createservicecasewithctx()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L436"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "skumixrange_test_drive",
-      "label": "drive()",
-      "norm_label": "drive()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
-      "source_location": "L335"
+      "id": "servicecases_deriveservicecasepaymentstatus",
+      "label": "deriveServiceCasePaymentStatus()",
+      "norm_label": "deriveservicecasepaymentstatus()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L98"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "skumixrange_test_ensure",
-      "label": "ensure()",
-      "norm_label": "ensure()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
-      "source_location": "L298"
+      "id": "servicecases_getservicecasecontext",
+      "label": "getServiceCaseContext()",
+      "norm_label": "getservicecasecontext()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L322"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "skumixrange_test_handlerof",
-      "label": "handlerOf()",
-      "norm_label": "handlerof()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
-      "source_location": "L123"
+      "id": "servicecases_listpendingapprovalrequestswithctx",
+      "label": "listPendingApprovalRequestsWithCtx()",
+      "norm_label": "listpendingapprovalrequestswithctx()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L275"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "skumixrange_test_headerbykey",
-      "label": "headerByKey()",
-      "norm_label": "headerbykey()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
-      "source_location": "L319"
+      "id": "servicecases_listservicecaseallocationswithctx",
+      "label": "listServiceCaseAllocationsWithCtx()",
+      "norm_label": "listservicecaseallocationswithctx()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L262"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "skumixrange_test_isodateoffset",
-      "label": "isoDateOffset()",
-      "norm_label": "isodateoffset()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
-      "source_location": "L113"
+      "id": "servicecases_listservicecaselineitemswithctx",
+      "label": "listServiceCaseLineItemsWithCtx()",
+      "norm_label": "listservicecaselineitemswithctx()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L122"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "skumixrange_test_mixchildren",
-      "label": "mixChildren()",
-      "norm_label": "mixchildren()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
-      "source_location": "L377"
+      "id": "servicecases_listserviceinventoryusagewithctx",
+      "label": "listServiceInventoryUsageWithCtx()",
+      "norm_label": "listserviceinventoryusagewithctx()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L132"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "skumixrange_test_seedskus",
-      "label": "seedSkus()",
-      "norm_label": "seedskus()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
-      "source_location": "L177"
+      "id": "servicecases_mapservicecasestatustoworkitemstatus",
+      "label": "mapServiceCaseStatusToWorkItemStatus()",
+      "norm_label": "mapservicecasestatustoworkitemstatus()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L80"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "skumixrange_test_seedstore",
-      "label": "seedStore()",
-      "norm_label": "seedstore()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
-      "source_location": "L155"
+      "id": "servicecases_resolveservicereturnbasiswithctx",
+      "label": "resolveServiceReturnBasisWithCtx()",
+      "norm_label": "resolveservicereturnbasiswithctx()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L169"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "skumixrange_test_step",
-      "label": "step()",
-      "norm_label": "step()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
-      "source_location": "L1082"
+      "id": "servicecases_roundservicereturncost",
+      "label": "roundServiceReturnCost()",
+      "norm_label": "roundservicereturncost()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L157"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "skumixrange_test_twodayfixture",
-      "label": "twoDayFixture()",
-      "norm_label": "twodayfixture()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
-      "source_location": "L1066"
+      "id": "servicecases_syncservicecasefinancialswithctx",
+      "label": "syncServiceCaseFinancialsWithCtx()",
+      "norm_label": "syncservicecasefinancialswithctx()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L287"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "skumixrange_test_visible",
-      "label": "visible()",
-      "norm_label": "visible()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMixRange.test.ts",
-      "source_location": "L393"
+      "id": "servicecases_uncostedservicereturnbasis",
+      "label": "uncostedServiceReturnBasis()",
+      "norm_label": "uncostedservicereturnbasis()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "source_location": "L142"
     },
     {
       "community": 1360,
@@ -194295,146 +194319,146 @@
     {
       "community": 137,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_serviceops_servicecases_ts",
-      "label": "serviceCases.ts",
-      "norm_label": "servicecases.ts",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
+      "id": "orderoperations_assertvalidonlineorderstatustransition",
+      "label": "assertValidOnlineOrderStatusTransition()",
+      "norm_label": "assertvalidonlineorderstatustransition()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L41"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "orderoperations_getonlineorderpaymentamount",
+      "label": "getOnlineOrderPaymentAmount()",
+      "norm_label": "getonlineorderpaymentamount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L100"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "orderoperations_getonlineorderpaymentmethodlabel",
+      "label": "getOnlineOrderPaymentMethodLabel()",
+      "norm_label": "getonlineorderpaymentmethodlabel()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "orderoperations_getonlineorderstatuseventtype",
+      "label": "getOnlineOrderStatusEventType()",
+      "norm_label": "getonlineorderstatuseventtype()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "orderoperations_getstoreorganizationid",
+      "label": "getStoreOrganizationId()",
+      "norm_label": "getstoreorganizationid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L106"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "orderoperations_ispaymentondeliveryorder",
+      "label": "isPaymentOnDeliveryOrder()",
+      "norm_label": "ispaymentondeliveryorder()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineordercreatedevent",
+      "label": "recordOnlineOrderCreatedEvent()",
+      "norm_label": "recordonlineordercreatedevent()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L179"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderfulfillmentmovement",
+      "label": "recordOnlineOrderFulfillmentMovement()",
+      "norm_label": "recordonlineorderfulfillmentmovement()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L391"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderpaymentcollected",
+      "label": "recordOnlineOrderPaymentCollected()",
+      "norm_label": "recordonlineorderpaymentcollected()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L294"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderpaymentverified",
+      "label": "recordOnlineOrderPaymentVerified()",
+      "norm_label": "recordonlineorderpaymentverified()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L245"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderrefundallocation",
+      "label": "recordOnlineOrderRefundAllocation()",
+      "norm_label": "recordonlineorderrefundallocation()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L354"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderrestockmovement",
+      "label": "recordOnlineOrderRestockMovement()",
+      "norm_label": "recordonlineorderrestockmovement()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L419"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "orderoperations_recordonlineorderstatusevent",
+      "label": "recordOnlineOrderStatusEvent()",
+      "norm_label": "recordonlineorderstatusevent()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L206"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "orderoperations_resolvecustomerprofileforstorefrontactor",
+      "label": "resolveCustomerProfileForStoreFrontActor()",
+      "norm_label": "resolvecustomerprofileforstorefrontactor()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L114"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "orderoperations_resolveonlineordercontext",
+      "label": "resolveOnlineOrderContext()",
+      "norm_label": "resolveonlineordercontext()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "source_location": "L152"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_helpers_orderoperations_ts",
+      "label": "orderOperations.ts",
+      "norm_label": "orderoperations.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "servicecases_assertvalidservicecasestatustransition",
-      "label": "assertValidServiceCaseStatusTransition()",
-      "norm_label": "assertvalidservicecasestatustransition()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L357"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "servicecases_buildservicecase",
-      "label": "buildServiceCase()",
-      "norm_label": "buildservicecase()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L371"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "servicecases_buildservicecaselineitem",
-      "label": "buildServiceCaseLineItem()",
-      "norm_label": "buildservicecaselineitem()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L400"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "servicecases_createservicecasewithctx",
-      "label": "createServiceCaseWithCtx()",
-      "norm_label": "createservicecasewithctx()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L436"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "servicecases_deriveservicecasepaymentstatus",
-      "label": "deriveServiceCasePaymentStatus()",
-      "norm_label": "deriveservicecasepaymentstatus()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L98"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "servicecases_getservicecasecontext",
-      "label": "getServiceCaseContext()",
-      "norm_label": "getservicecasecontext()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L322"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "servicecases_listpendingapprovalrequestswithctx",
-      "label": "listPendingApprovalRequestsWithCtx()",
-      "norm_label": "listpendingapprovalrequestswithctx()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L275"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "servicecases_listservicecaseallocationswithctx",
-      "label": "listServiceCaseAllocationsWithCtx()",
-      "norm_label": "listservicecaseallocationswithctx()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L262"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "servicecases_listservicecaselineitemswithctx",
-      "label": "listServiceCaseLineItemsWithCtx()",
-      "norm_label": "listservicecaselineitemswithctx()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L122"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "servicecases_listserviceinventoryusagewithctx",
-      "label": "listServiceInventoryUsageWithCtx()",
-      "norm_label": "listserviceinventoryusagewithctx()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L132"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "servicecases_mapservicecasestatustoworkitemstatus",
-      "label": "mapServiceCaseStatusToWorkItemStatus()",
-      "norm_label": "mapservicecasestatustoworkitemstatus()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L80"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "servicecases_resolveservicereturnbasiswithctx",
-      "label": "resolveServiceReturnBasisWithCtx()",
-      "norm_label": "resolveservicereturnbasiswithctx()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L169"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "servicecases_roundservicereturncost",
-      "label": "roundServiceReturnCost()",
-      "norm_label": "roundservicereturncost()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L157"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "servicecases_syncservicecasefinancialswithctx",
-      "label": "syncServiceCaseFinancialsWithCtx()",
-      "norm_label": "syncservicecasefinancialswithctx()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L287"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "servicecases_uncostedservicereturnbasis",
-      "label": "uncostedServiceReturnBasis()",
-      "norm_label": "uncostedservicereturnbasis()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.ts",
-      "source_location": "L142"
     },
     {
       "community": 1370,
@@ -194619,145 +194643,145 @@
     {
       "community": 138,
       "file_type": "code",
-      "id": "orderoperations_assertvalidonlineorderstatustransition",
-      "label": "assertValidOnlineOrderStatusTransition()",
-      "norm_label": "assertvalidonlineorderstatustransition()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L41"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "orderoperations_getonlineorderpaymentamount",
-      "label": "getOnlineOrderPaymentAmount()",
-      "norm_label": "getonlineorderpaymentamount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L100"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "orderoperations_getonlineorderpaymentmethodlabel",
-      "label": "getOnlineOrderPaymentMethodLabel()",
-      "norm_label": "getonlineorderpaymentmethodlabel()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "orderoperations_getonlineorderstatuseventtype",
-      "label": "getOnlineOrderStatusEventType()",
-      "norm_label": "getonlineorderstatuseventtype()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "orderoperations_getstoreorganizationid",
-      "label": "getStoreOrganizationId()",
-      "norm_label": "getstoreorganizationid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "orderoperations_ispaymentondeliveryorder",
-      "label": "isPaymentOnDeliveryOrder()",
-      "norm_label": "ispaymentondeliveryorder()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineordercreatedevent",
-      "label": "recordOnlineOrderCreatedEvent()",
-      "norm_label": "recordonlineordercreatedevent()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L179"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineorderfulfillmentmovement",
-      "label": "recordOnlineOrderFulfillmentMovement()",
-      "norm_label": "recordonlineorderfulfillmentmovement()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L391"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineorderpaymentcollected",
-      "label": "recordOnlineOrderPaymentCollected()",
-      "norm_label": "recordonlineorderpaymentcollected()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L294"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineorderpaymentverified",
-      "label": "recordOnlineOrderPaymentVerified()",
-      "norm_label": "recordonlineorderpaymentverified()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L245"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineorderrefundallocation",
-      "label": "recordOnlineOrderRefundAllocation()",
-      "norm_label": "recordonlineorderrefundallocation()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L354"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineorderrestockmovement",
-      "label": "recordOnlineOrderRestockMovement()",
-      "norm_label": "recordonlineorderrestockmovement()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L419"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "orderoperations_recordonlineorderstatusevent",
-      "label": "recordOnlineOrderStatusEvent()",
-      "norm_label": "recordonlineorderstatusevent()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L206"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "orderoperations_resolvecustomerprofileforstorefrontactor",
-      "label": "resolveCustomerProfileForStoreFrontActor()",
-      "norm_label": "resolvecustomerprofileforstorefrontactor()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
-      "source_location": "L114"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "orderoperations_resolveonlineordercontext",
-      "label": "resolveOnlineOrderContext()",
-      "norm_label": "resolveonlineordercontext()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "id": "onlineorder_allocateminoramounts",
+      "label": "allocateMinorAmounts()",
+      "norm_label": "allocateminoramounts()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
       "source_location": "L152"
     },
     {
       "community": 138,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_orderoperations_ts",
-      "label": "orderOperations.ts",
-      "norm_label": "orderoperations.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderOperations.ts",
+      "id": "onlineorder_appendtransition",
+      "label": "appendTransition()",
+      "norm_label": "appendtransition()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "onlineorder_applyonlineorderupdate",
+      "label": "applyOnlineOrderUpdate()",
+      "norm_label": "applyonlineorderupdate()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L335"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "onlineorder_buildreturnexchangereplacementsourceid",
+      "label": "buildReturnExchangeReplacementSourceId()",
+      "norm_label": "buildreturnexchangereplacementsourceid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L542"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "onlineorder_buildreturnexchangereturnsourceid",
+      "label": "buildReturnExchangeReturnSourceId()",
+      "norm_label": "buildreturnexchangereturnsourceid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L550"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "onlineorder_buildstorefrontfulfillmentsalefacts",
+      "label": "buildStorefrontFulfillmentSaleFacts()",
+      "norm_label": "buildstorefrontfulfillmentsalefacts()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L184"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "onlineorder_buildstorefrontrefundfacts",
+      "label": "buildStorefrontRefundFacts()",
+      "norm_label": "buildstorefrontrefundfacts()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L249"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "onlineorder_buildstorefrontreturnfacts",
+      "label": "buildStorefrontReturnFacts()",
+      "norm_label": "buildstorefrontreturnfacts()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L306"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "onlineorder_getonlineorderwithctx",
+      "label": "getOnlineOrderWithCtx()",
+      "norm_label": "getonlineorderwithctx()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L766"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "onlineorder_getworkflowtraceidforlookup",
+      "label": "getWorkflowTraceIdForLookup()",
+      "norm_label": "getworkflowtraceidforlookup()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "onlineorder_iscommandusererror",
+      "label": "isCommandUserError()",
+      "norm_label": "iscommandusererror()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L612"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "onlineorder_listorderitems",
+      "label": "listOrderItems()",
+      "norm_label": "listorderitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L118"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "onlineorder_mapupdateordererror",
+      "label": "mapUpdateOrderError()",
+      "norm_label": "mapupdateordererror()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L557"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "onlineorder_requirenormalorderstoreaccesswithctx",
+      "label": "requireNormalOrderStoreAccessWithCtx()",
+      "norm_label": "requirenormalorderstoreaccesswithctx()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L577"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "onlineorder_returnselectedonlineorderitemstostock",
+      "label": "returnSelectedOnlineOrderItemsToStock()",
+      "norm_label": "returnselectedonlineorderitemstostock()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L2100"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
       "source_location": "L1"
     },
     {
@@ -194943,145 +194967,145 @@
     {
       "community": 139,
       "file_type": "code",
-      "id": "onlineorder_allocateminoramounts",
-      "label": "allocateMinorAmounts()",
-      "norm_label": "allocateminoramounts()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L152"
+      "id": "cashcontrolsdashboard_cashcontrolsfinancialvalue",
+      "label": "CashControlsFinancialValue()",
+      "norm_label": "cashcontrolsfinancialvalue()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L154"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "onlineorder_appendtransition",
-      "label": "appendTransition()",
-      "norm_label": "appendtransition()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L128"
+      "id": "cashcontrolsdashboard_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L382"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "onlineorder_applyonlineorderupdate",
-      "label": "applyOnlineOrderUpdate()",
-      "norm_label": "applyonlineorderupdate()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L335"
+      "id": "cashcontrolsdashboard_formatcashexposuresupporting",
+      "label": "formatCashExposureSupporting()",
+      "norm_label": "formatcashexposuresupporting()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L303"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "onlineorder_buildreturnexchangereplacementsourceid",
-      "label": "buildReturnExchangeReplacementSourceId()",
-      "norm_label": "buildreturnexchangereplacementsourceid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L542"
+      "id": "cashcontrolsdashboard_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L144"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "onlineorder_buildreturnexchangereturnsourceid",
-      "label": "buildReturnExchangeReturnSourceId()",
-      "norm_label": "buildreturnexchangereturnsourceid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L550"
+      "id": "cashcontrolsdashboard_formatposreconciliationtype",
+      "label": "formatPosReconciliationType()",
+      "norm_label": "formatposreconciliationtype()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L761"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "onlineorder_buildstorefrontfulfillmentsalefacts",
-      "label": "buildStorefrontFulfillmentSaleFacts()",
-      "norm_label": "buildstorefrontfulfillmentsalefacts()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L184"
+      "id": "cashcontrolsdashboard_formatregistername",
+      "label": "formatRegisterName()",
+      "norm_label": "formatregistername()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L178"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "onlineorder_buildstorefrontrefundfacts",
-      "label": "buildStorefrontRefundFacts()",
-      "norm_label": "buildstorefrontrefundfacts()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L249"
+      "id": "cashcontrolsdashboard_formatsessionidentifier",
+      "label": "formatSessionIdentifier()",
+      "norm_label": "formatsessionidentifier()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L189"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "onlineorder_buildstorefrontreturnfacts",
-      "label": "buildStorefrontReturnFacts()",
-      "norm_label": "buildstorefrontreturnfacts()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L306"
+      "id": "cashcontrolsdashboard_formatstatuslabel",
+      "label": "formatStatusLabel()",
+      "norm_label": "formatstatuslabel()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L172"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "onlineorder_getonlineorderwithctx",
-      "label": "getOnlineOrderWithCtx()",
-      "norm_label": "getonlineorderwithctx()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L766"
+      "id": "cashcontrolsdashboard_getsessionstatusmarkertone",
+      "label": "getSessionStatusMarkerTone()",
+      "norm_label": "getsessionstatusmarkertone()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L232"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "onlineorder_getworkflowtraceidforlookup",
-      "label": "getWorkflowTraceIdForLookup()",
-      "norm_label": "getworkflowtraceidforlookup()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L101"
+      "id": "cashcontrolsdashboard_getsnapshottotals",
+      "label": "getSnapshotTotals()",
+      "norm_label": "getsnapshottotals()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L278"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "onlineorder_iscommandusererror",
-      "label": "isCommandUserError()",
-      "norm_label": "iscommandusererror()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L612"
+      "id": "cashcontrolsdashboard_getstatusmarkerclass",
+      "label": "getStatusMarkerClass()",
+      "norm_label": "getstatusmarkerclass()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L206"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "onlineorder_listorderitems",
-      "label": "listOrderItems()",
-      "norm_label": "listorderitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L118"
+      "id": "cashcontrolsdashboard_getstatusmarkerdotclass",
+      "label": "getStatusMarkerDotClass()",
+      "norm_label": "getstatusmarkerdotclass()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L219"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "onlineorder_mapupdateordererror",
-      "label": "mapUpdateOrderError()",
-      "norm_label": "mapupdateordererror()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L557"
+      "id": "cashcontrolsdashboard_getvariancetone",
+      "label": "getVarianceTone()",
+      "norm_label": "getvariancetone()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L196"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "onlineorder_requirenormalorderstoreaccesswithctx",
-      "label": "requireNormalOrderStoreAccessWithCtx()",
-      "norm_label": "requirenormalorderstoreaccesswithctx()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L577"
+      "id": "cashcontrolsdashboard_prioritizecashcontrolssessionsforterminal",
+      "label": "prioritizeCashControlsSessionsForTerminal()",
+      "norm_label": "prioritizecashcontrolssessionsforterminal()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L132"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "onlineorder_returnselectedonlineorderitemstostock",
-      "label": "returnSelectedOnlineOrderItemsToStock()",
-      "norm_label": "returnselectedonlineorderitemstostock()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L2100"
+      "id": "cashcontrolsdashboard_statusmarker",
+      "label": "StatusMarker()",
+      "norm_label": "statusmarker()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "source_location": "L246"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_tsx",
+      "label": "CashControlsDashboard.tsx",
+      "norm_label": "cashcontrolsdashboard.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
       "source_location": "L1"
     },
     {
@@ -195681,145 +195705,145 @@
     {
       "community": 140,
       "file_type": "code",
-      "id": "cashcontrolsdashboard_cashcontrolsfinancialvalue",
-      "label": "CashControlsFinancialValue()",
-      "norm_label": "cashcontrolsfinancialvalue()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L154"
+      "id": "inventorycostoverlayview_createrequestidentity",
+      "label": "createRequestIdentity()",
+      "norm_label": "createrequestidentity()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryCostOverlayView.tsx",
+      "source_location": "L262"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "cashcontrolsdashboard_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L382"
+      "id": "inventorycostoverlayview_formatcost",
+      "label": "formatCost()",
+      "norm_label": "formatcost()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryCostOverlayView.tsx",
+      "source_location": "L210"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "cashcontrolsdashboard_formatcashexposuresupporting",
-      "label": "formatCashExposureSupporting()",
-      "norm_label": "formatcashexposuresupporting()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L303"
+      "id": "inventorycostoverlayview_formatsignedcost",
+      "label": "formatSignedCost()",
+      "norm_label": "formatsignedcost()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryCostOverlayView.tsx",
+      "source_location": "L218"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "cashcontrolsdashboard_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L144"
+      "id": "inventorycostoverlayview_getcolumnlabel",
+      "label": "getColumnLabel()",
+      "norm_label": "getcolumnlabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryCostOverlayView.tsx",
+      "source_location": "L223"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "cashcontrolsdashboard_formatposreconciliationtype",
-      "label": "formatPosReconciliationType()",
-      "norm_label": "formatposreconciliationtype()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L761"
+      "id": "inventorycostoverlayview_getcostoverlayrundescription",
+      "label": "getCostOverlayRunDescription()",
+      "norm_label": "getcostoverlayrundescription()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryCostOverlayView.tsx",
+      "source_location": "L194"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "cashcontrolsdashboard_formatregistername",
-      "label": "formatRegisterName()",
-      "norm_label": "formatregistername()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L178"
+      "id": "inventorycostoverlayview_handleabandon",
+      "label": "handleAbandon()",
+      "norm_label": "handleabandon()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryCostOverlayView.tsx",
+      "source_location": "L1446"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "cashcontrolsdashboard_formatsessionidentifier",
-      "label": "formatSessionIdentifier()",
-      "norm_label": "formatsessionidentifier()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L189"
+      "id": "inventorycostoverlayview_handleapply",
+      "label": "handleApply()",
+      "norm_label": "handleapply()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryCostOverlayView.tsx",
+      "source_location": "L1385"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "cashcontrolsdashboard_formatstatuslabel",
-      "label": "formatStatusLabel()",
-      "norm_label": "formatstatuslabel()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L172"
+      "id": "inventorycostoverlayview_handlebulkdecision",
+      "label": "handleBulkDecision()",
+      "norm_label": "handlebulkdecision()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryCostOverlayView.tsx",
+      "source_location": "L1346"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "cashcontrolsdashboard_getsessionstatusmarkertone",
-      "label": "getSessionStatusMarkerTone()",
-      "norm_label": "getsessionstatusmarkertone()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L232"
+      "id": "inventorycostoverlayview_handlecreate",
+      "label": "handleCreate()",
+      "norm_label": "handlecreate()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryCostOverlayView.tsx",
+      "source_location": "L1282"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "cashcontrolsdashboard_getsnapshottotals",
-      "label": "getSnapshotTotals()",
-      "norm_label": "getsnapshottotals()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L278"
+      "id": "inventorycostoverlayview_handledecisionchange",
+      "label": "handleDecisionChange()",
+      "norm_label": "handledecisionchange()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryCostOverlayView.tsx",
+      "source_location": "L1318"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "cashcontrolsdashboard_getstatusmarkerclass",
-      "label": "getStatusMarkerClass()",
-      "norm_label": "getstatusmarkerclass()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L206"
+      "id": "inventorycostoverlayview_handleprepare",
+      "label": "handlePrepare()",
+      "norm_label": "handleprepare()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryCostOverlayView.tsx",
+      "source_location": "L1368"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "cashcontrolsdashboard_getstatusmarkerdotclass",
-      "label": "getStatusMarkerDotClass()",
-      "norm_label": "getstatusmarkerdotclass()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L219"
+      "id": "inventorycostoverlayview_handlereopen",
+      "label": "handleReopen()",
+      "norm_label": "handlereopen()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryCostOverlayView.tsx",
+      "source_location": "L1433"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "cashcontrolsdashboard_getvariancetone",
-      "label": "getVarianceTone()",
-      "norm_label": "getvariancetone()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L196"
+      "id": "inventorycostoverlayview_handleretry",
+      "label": "handleRetry()",
+      "norm_label": "handleretry()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryCostOverlayView.tsx",
+      "source_location": "L1420"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "cashcontrolsdashboard_prioritizecashcontrolssessionsforterminal",
-      "label": "prioritizeCashControlsSessionsForTerminal()",
-      "norm_label": "prioritizecashcontrolssessionsforterminal()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L132"
+      "id": "inventorycostoverlayview_handleundo",
+      "label": "handleUndo()",
+      "norm_label": "handleundo()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryCostOverlayView.tsx",
+      "source_location": "L1402"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "cashcontrolsdashboard_statusmarker",
-      "label": "StatusMarker()",
-      "norm_label": "statusmarker()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
-      "source_location": "L246"
+      "id": "inventorycostoverlayview_normalizecostoverlayfailure",
+      "label": "normalizeCostOverlayFailure()",
+      "norm_label": "normalizecostoverlayfailure()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryCostOverlayView.tsx",
+      "source_location": "L227"
     },
     {
       "community": 140,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_tsx",
-      "label": "CashControlsDashboard.tsx",
-      "norm_label": "cashcontrolsdashboard.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx",
+      "id": "packages_athena_webapp_src_components_operations_inventorycostoverlayview_tsx",
+      "label": "InventoryCostOverlayView.tsx",
+      "norm_label": "inventorycostoverlayview.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryCostOverlayView.tsx",
       "source_location": "L1"
     },
     {
@@ -196005,146 +196029,146 @@
     {
       "community": 141,
       "file_type": "code",
-      "id": "inventorycostoverlayview_createrequestidentity",
-      "label": "createRequestIdentity()",
-      "norm_label": "createrequestidentity()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryCostOverlayView.tsx",
-      "source_location": "L262"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "inventorycostoverlayview_formatcost",
-      "label": "formatCost()",
-      "norm_label": "formatcost()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryCostOverlayView.tsx",
-      "source_location": "L210"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "inventorycostoverlayview_formatsignedcost",
-      "label": "formatSignedCost()",
-      "norm_label": "formatsignedcost()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryCostOverlayView.tsx",
-      "source_location": "L218"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "inventorycostoverlayview_getcolumnlabel",
-      "label": "getColumnLabel()",
-      "norm_label": "getcolumnlabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryCostOverlayView.tsx",
-      "source_location": "L223"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "inventorycostoverlayview_getcostoverlayrundescription",
-      "label": "getCostOverlayRunDescription()",
-      "norm_label": "getcostoverlayrundescription()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryCostOverlayView.tsx",
-      "source_location": "L194"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "inventorycostoverlayview_handleabandon",
-      "label": "handleAbandon()",
-      "norm_label": "handleabandon()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryCostOverlayView.tsx",
-      "source_location": "L1446"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "inventorycostoverlayview_handleapply",
-      "label": "handleApply()",
-      "norm_label": "handleapply()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryCostOverlayView.tsx",
-      "source_location": "L1385"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "inventorycostoverlayview_handlebulkdecision",
-      "label": "handleBulkDecision()",
-      "norm_label": "handlebulkdecision()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryCostOverlayView.tsx",
-      "source_location": "L1346"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "inventorycostoverlayview_handlecreate",
-      "label": "handleCreate()",
-      "norm_label": "handlecreate()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryCostOverlayView.tsx",
-      "source_location": "L1282"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "inventorycostoverlayview_handledecisionchange",
-      "label": "handleDecisionChange()",
-      "norm_label": "handledecisionchange()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryCostOverlayView.tsx",
-      "source_location": "L1318"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "inventorycostoverlayview_handleprepare",
-      "label": "handlePrepare()",
-      "norm_label": "handleprepare()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryCostOverlayView.tsx",
-      "source_location": "L1368"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "inventorycostoverlayview_handlereopen",
-      "label": "handleReopen()",
-      "norm_label": "handlereopen()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryCostOverlayView.tsx",
-      "source_location": "L1433"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "inventorycostoverlayview_handleretry",
-      "label": "handleRetry()",
-      "norm_label": "handleretry()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryCostOverlayView.tsx",
-      "source_location": "L1420"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "inventorycostoverlayview_handleundo",
-      "label": "handleUndo()",
-      "norm_label": "handleundo()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryCostOverlayView.tsx",
-      "source_location": "L1402"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "inventorycostoverlayview_normalizecostoverlayfailure",
-      "label": "normalizeCostOverlayFailure()",
-      "norm_label": "normalizecostoverlayfailure()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryCostOverlayView.tsx",
-      "source_location": "L227"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_inventorycostoverlayview_tsx",
-      "label": "InventoryCostOverlayView.tsx",
-      "norm_label": "inventorycostoverlayview.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryCostOverlayView.tsx",
+      "id": "packages_athena_webapp_src_components_reports_reportsweeklyview_tsx",
+      "label": "ReportsWeeklyView.tsx",
+      "norm_label": "reportsweeklyview.tsx",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "reportsweeklyview_closeevidencecoveragelabel",
+      "label": "closeEvidenceCoverageLabel()",
+      "norm_label": "closeevidencecoveragelabel()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
+      "source_location": "L286"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "reportsweeklyview_comparabilitylabel",
+      "label": "comparabilityLabel()",
+      "norm_label": "comparabilitylabel()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
+      "source_location": "L255"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "reportsweeklyview_completenesslabel",
+      "label": "completenessLabel()",
+      "norm_label": "completenesslabel()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
+      "source_location": "L229"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "reportsweeklyview_formatreportmoney",
+      "label": "formatReportMoney()",
+      "norm_label": "formatreportmoney()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
+      "source_location": "L638"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "reportsweeklyview_formatreporttimestamp",
+      "label": "formatReportTimestamp()",
+      "norm_label": "formatreporttimestamp()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
+      "source_location": "L621"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "reportsweeklyview_metriclist",
+      "label": "MetricList()",
+      "norm_label": "metriclist()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
+      "source_location": "L352"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "reportsweeklyview_money",
+      "label": "money()",
+      "norm_label": "money()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
+      "source_location": "L538"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "reportsweeklyview_optionalmoney",
+      "label": "optionalMoney()",
+      "norm_label": "optionalmoney()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
+      "source_location": "L542"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "reportsweeklyview_ownerroutelink",
+      "label": "OwnerRouteLink()",
+      "norm_label": "ownerroutelink()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
+      "source_location": "L374"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "reportsweeklyview_profit",
+      "label": "profit()",
+      "norm_label": "profit()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
+      "source_location": "L546"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "reportsweeklyview_section",
+      "label": "Section()",
+      "norm_label": "section()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
+      "source_location": "L333"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "reportsweeklyview_sharedcloseevidencecoverage",
+      "label": "sharedCloseEvidenceCoverage()",
+      "norm_label": "sharedcloseevidencecoverage()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
+      "source_location": "L296"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "reportsweeklyview_units",
+      "label": "units()",
+      "norm_label": "units()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
+      "source_location": "L550"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "reportsweeklyview_variancecoveragelabel",
+      "label": "varianceCoverageLabel()",
+      "norm_label": "variancecoveragelabel()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
+      "source_location": "L276"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "reportsweeklyview_weeklypaymentmix",
+      "label": "weeklyPaymentMix()",
+      "norm_label": "weeklypaymentmix()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx",
+      "source_location": "L319"
     },
     {
       "community": 1410,
@@ -203470,7 +203494,7 @@
       "label": "compareIndexedValue()",
       "norm_label": "compareindexedvalue()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L74"
+      "source_location": "L76"
     },
     {
       "community": 162,
@@ -203479,7 +203503,7 @@
       "label": "completedDailyCloseRow()",
       "norm_label": "completeddailycloserow()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L464"
+      "source_location": "L466"
     },
     {
       "community": 162,
@@ -203488,7 +203512,7 @@
       "label": "completedDailyCloseSnapshot()",
       "norm_label": "completeddailyclosesnapshot()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L410"
+      "source_location": "L412"
     },
     {
       "community": 162,
@@ -203497,7 +203521,7 @@
       "label": "createCommandArgs()",
       "norm_label": "createcommandargs()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L6123"
+      "source_location": "L6309"
     },
     {
       "community": 162,
@@ -203506,7 +203530,7 @@
       "label": "createDb()",
       "norm_label": "createdb()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L82"
+      "source_location": "L84"
     },
     {
       "community": 162,
@@ -203515,7 +203539,7 @@
       "label": "dailyCloseApprovalProof()",
       "norm_label": "dailycloseapprovalproof()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L354"
+      "source_location": "L356"
     },
     {
       "community": 162,
@@ -203524,7 +203548,7 @@
       "label": "dailyCloseCarryForwardApprovalProof()",
       "norm_label": "dailyclosecarryforwardapprovalproof()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L390"
+      "source_location": "L392"
     },
     {
       "community": 162,
@@ -203533,7 +203557,7 @@
       "label": "dailyCloseReopenApprovalProof()",
       "norm_label": "dailyclosereopenapprovalproof()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L372"
+      "source_location": "L374"
     },
     {
       "community": 162,
@@ -203542,7 +203566,7 @@
       "label": "dailyCloseSummary()",
       "norm_label": "dailyclosesummary()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L329"
+      "source_location": "L331"
     },
     {
       "community": 162,
@@ -203551,7 +203575,7 @@
       "label": "getHandler()",
       "norm_label": "gethandler()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L69"
+      "source_location": "L71"
     },
     {
       "community": 162,
@@ -203560,7 +203584,7 @@
       "label": "mockDailyCloseSnapshotAccess()",
       "norm_label": "mockdailyclosesnapshotaccess()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L497"
+      "source_location": "L499"
     },
     {
       "community": 162,
@@ -203569,7 +203593,7 @@
       "label": "openOperationalWorkItems()",
       "norm_label": "openoperationalworkitems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L311"
+      "source_location": "L313"
     },
     {
       "community": 162,
@@ -203578,7 +203602,7 @@
       "label": "syncedReview()",
       "norm_label": "syncedreview()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L1914"
+      "source_location": "L1916"
     },
     {
       "community": 162,
@@ -217645,7 +217669,7 @@
       "label": "captureScrollPosition()",
       "norm_label": "capturescrollposition()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
-      "source_location": "L340"
+      "source_location": "L339"
     },
     {
       "community": 212,
@@ -217654,7 +217678,7 @@
       "label": "formatNetUnitsMoved()",
       "norm_label": "formatnetunitsmoved()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
-      "source_location": "L86"
+      "source_location": "L85"
     },
     {
       "community": 212,
@@ -217663,7 +217687,7 @@
       "label": "handleRetry()",
       "norm_label": "handleretry()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
-      "source_location": "L530"
+      "source_location": "L529"
     },
     {
       "community": 212,
@@ -217672,7 +217696,7 @@
       "label": "handleSkuLinkClick()",
       "norm_label": "handleskulinkclick()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
-      "source_location": "L598"
+      "source_location": "L597"
     },
     {
       "community": 212,
@@ -217681,7 +217705,7 @@
       "label": "movementBarRadius()",
       "norm_label": "movementbarradius()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
-      "source_location": "L103"
+      "source_location": "L102"
     },
     {
       "community": 212,
@@ -217690,7 +217714,7 @@
       "label": "movementChartDomain()",
       "norm_label": "movementchartdomain()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
-      "source_location": "L110"
+      "source_location": "L109"
     },
     {
       "community": 212,
@@ -217699,7 +217723,7 @@
       "label": "netUnitsMovedAccessiblePhrase()",
       "norm_label": "netunitsmovedaccessiblephrase()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
-      "source_location": "L93"
+      "source_location": "L92"
     },
     {
       "community": 212,
@@ -217708,7 +217732,7 @@
       "label": "setActiveTab()",
       "norm_label": "setactivetab()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
-      "source_location": "L332"
+      "source_location": "L331"
     },
     {
       "community": 212,
@@ -217717,7 +217741,7 @@
       "label": "setGranularPage()",
       "norm_label": "setgranularpage()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
-      "source_location": "L336"
+      "source_location": "L335"
     },
     {
       "community": 212,
@@ -217726,7 +217750,7 @@
       "label": "setIsOpen()",
       "norm_label": "setisopen()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
-      "source_location": "L318"
+      "source_location": "L317"
     },
     {
       "community": 212,
@@ -217735,7 +217759,7 @@
       "label": "unitMovementMetadata()",
       "norm_label": "unitmovementmetadata()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
-      "source_location": "L133"
+      "source_location": "L132"
     },
     {
       "community": 2120,
@@ -222474,6 +222498,24 @@
     {
       "community": 2332,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_reports_reportsegmentedtabs_test_tsx",
+      "label": "ReportSegmentedTabs.test.tsx",
+      "norm_label": "reportsegmentedtabs.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportSegmentedTabs.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2333,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_reports_reportsegmentedtabs_tsx",
+      "label": "ReportSegmentedTabs.tsx",
+      "norm_label": "reportsegmentedtabs.tsx",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportSegmentedTabs.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2334,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportskumixchart_test_tsx",
       "label": "ReportSkuMixChart.test.tsx",
       "norm_label": "reportskumixchart.test.tsx",
@@ -222481,7 +222523,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2333,
+      "community": 2335,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportformat_test_ts",
       "label": "reportFormat.test.ts",
@@ -222490,7 +222532,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2334,
+      "community": 2336,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportperiodkeys_test_ts",
       "label": "reportPeriodKeys.test.ts",
@@ -222499,7 +222541,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2335,
+      "community": 2337,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportroutesearch_test_ts",
       "label": "reportRouteSearch.test.ts",
@@ -222508,7 +222550,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2336,
+      "community": 2338,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_ratingstars_tsx",
       "label": "RatingStars.tsx",
@@ -222517,30 +222559,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2337,
+      "community": 2339,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
       "label": "ReviewCard.tsx",
       "norm_label": "reviewcard.tsx",
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewCard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2338,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reviews_reviewmetadata_tsx",
-      "label": "ReviewMetadata.tsx",
-      "norm_label": "reviewmetadata.tsx",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewMetadata.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2339,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_serviceintakeform_tsx",
-      "label": "ServiceIntakeForm.tsx",
-      "norm_label": "serviceintakeform.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeForm.tsx",
       "source_location": "L1"
     },
     {
@@ -222645,6 +222669,24 @@
     {
       "community": 2340,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_reviews_reviewmetadata_tsx",
+      "label": "ReviewMetadata.tsx",
+      "norm_label": "reviewmetadata.tsx",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewMetadata.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2341,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_serviceintakeform_tsx",
+      "label": "ServiceIntakeForm.tsx",
+      "norm_label": "serviceintakeform.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceIntakeForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2342,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemoexperience_test_tsx",
       "label": "SharedDemoExperience.test.tsx",
       "norm_label": "shareddemoexperience.test.tsx",
@@ -222652,7 +222694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2341,
+      "community": 2343,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemorestoreoverlay_test_tsx",
       "label": "SharedDemoRestoreOverlay.test.tsx",
@@ -222661,7 +222703,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2342,
+      "community": 2344,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemolocalbootstrap_test_ts",
       "label": "sharedDemoLocalBootstrap.test.ts",
@@ -222670,7 +222712,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2343,
+      "community": 2345,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemorestoreoverlay_test_ts",
       "label": "sharedDemoRestoreOverlay.test.ts",
@@ -222679,7 +222721,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2344,
+      "community": 2346,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemorestoreoverlay_tsx",
       "label": "sharedDemoRestoreOverlay.tsx",
@@ -222688,7 +222730,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2345,
+      "community": 2347,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_index_tsx",
       "label": "index.tsx",
@@ -222697,7 +222739,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2346,
+      "community": 2348,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_auth_staffauthenticationdialog_test_tsx",
       "label": "StaffAuthenticationDialog.test.tsx",
@@ -222706,30 +222748,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2347,
+      "community": 2349,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_auth_staffpininput_tsx",
       "label": "StaffPinInput.tsx",
       "norm_label": "staffpininput.tsx",
       "source_file": "packages/athena-webapp/src/components/staff-auth/StaffPinInput.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2348,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_not_found_notfound_test_tsx",
-      "label": "NotFound.test.tsx",
-      "norm_label": "notfound.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/not-found/NotFound.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2349,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_stock_ops_skusearchfilterbar_tsx",
-      "label": "SkuSearchFilterBar.tsx",
-      "norm_label": "skusearchfilterbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/stock-ops/SkuSearchFilterBar.tsx",
       "source_location": "L1"
     },
     {
@@ -222834,6 +222858,24 @@
     {
       "community": 2350,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_not_found_notfound_test_tsx",
+      "label": "NotFound.test.tsx",
+      "norm_label": "notfound.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/not-found/NotFound.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2351,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_stock_ops_skusearchfilterbar_tsx",
+      "label": "SkuSearchFilterBar.tsx",
+      "norm_label": "skusearchfilterbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/stock-ops/SkuSearchFilterBar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2352,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_test_ts",
       "label": "FeesView.test.ts",
       "norm_label": "feesview.test.ts",
@@ -222841,7 +222883,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2351,
+      "community": 2353,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_fulfillmentview_test_tsx",
       "label": "FulfillmentView.test.tsx",
@@ -222850,7 +222892,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2352,
+      "community": 2354,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_test_tsx",
       "label": "MaintenanceView.test.tsx",
@@ -222859,7 +222901,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2353,
+      "community": 2355,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_test_tsx",
       "label": "MtnMomoView.test.tsx",
@@ -222868,7 +222910,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2354,
+      "community": 2356,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_test_tsx",
       "label": "useStoreConfigUpdate.test.tsx",
@@ -222877,7 +222919,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2355,
+      "community": 2357,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestorescheduleupdate_test_tsx",
       "label": "useStoreScheduleUpdate.test.tsx",
@@ -222886,7 +222928,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2356,
+      "community": 2358,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_index_tsx",
       "label": "index.tsx",
@@ -222895,30 +222937,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2357,
+      "community": 2359,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceview_test_tsx",
       "label": "WorkflowTraceView.test.tsx",
       "norm_label": "workflowtraceview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2358,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_accordion_tsx",
-      "label": "accordion.tsx",
-      "norm_label": "accordion.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/accordion.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2359,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_button_test_tsx",
-      "label": "button.test.tsx",
-      "norm_label": "button.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/button.test.tsx",
       "source_location": "L1"
     },
     {
@@ -223023,6 +223047,24 @@
     {
       "community": 2360,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_accordion_tsx",
+      "label": "accordion.tsx",
+      "norm_label": "accordion.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/accordion.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2361,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_button_test_tsx",
+      "label": "button.test.tsx",
+      "norm_label": "button.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/button.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2362,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
       "norm_label": "button.tsx",
@@ -223030,7 +223072,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2361,
+      "community": 2363,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
       "label": "calendar.test.tsx",
@@ -223039,7 +223081,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2362,
+      "community": 2364,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
@@ -223048,7 +223090,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2363,
+      "community": 2365,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
@@ -223057,7 +223099,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2364,
+      "community": 2366,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_collapsible_tsx",
       "label": "collapsible.tsx",
@@ -223066,7 +223108,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2365,
+      "community": 2367,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -223075,7 +223117,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2366,
+      "community": 2368,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
@@ -223084,30 +223126,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2367,
+      "community": 2369,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
       "norm_label": "dialog.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/dialog.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2368,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
-      "label": "dropdown-menu.tsx",
-      "norm_label": "dropdown-menu.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/dropdown-menu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2369,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_form_tsx",
-      "label": "form.tsx",
-      "norm_label": "form.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/form.tsx",
       "source_location": "L1"
     },
     {
@@ -223212,6 +223236,24 @@
     {
       "community": 2370,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
+      "label": "dropdown-menu.tsx",
+      "norm_label": "dropdown-menu.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/dropdown-menu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2371,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_form_tsx",
+      "label": "form.tsx",
+      "norm_label": "form.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/form.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2372,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
       "norm_label": "icons.tsx",
@@ -223219,7 +223261,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2371,
+      "community": 2373,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -223228,7 +223270,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2372,
+      "community": 2374,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_test_tsx",
       "label": "input.test.tsx",
@@ -223237,7 +223279,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2373,
+      "community": 2375,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -223246,7 +223288,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2374,
+      "community": 2376,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -223255,7 +223297,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2375,
+      "community": 2377,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_panel_header_tsx",
       "label": "panel-header.tsx",
@@ -223264,7 +223306,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2376,
+      "community": 2378,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -223273,30 +223315,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2377,
+      "community": 2379,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_primitives_test_tsx",
       "label": "primitives.test.tsx",
       "norm_label": "primitives.test.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/primitives.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2378,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
-      "label": "radio-group.tsx",
-      "norm_label": "radio-group.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/radio-group.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2379,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
-      "label": "scroll-area.tsx",
-      "norm_label": "scroll-area.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/scroll-area.tsx",
       "source_location": "L1"
     },
     {
@@ -223401,6 +223425,24 @@
     {
       "community": 2380,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
+      "label": "radio-group.tsx",
+      "norm_label": "radio-group.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/radio-group.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2381,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
+      "label": "scroll-area.tsx",
+      "norm_label": "scroll-area.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/scroll-area.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2382,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
       "norm_label": "select.tsx",
@@ -223408,7 +223450,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2381,
+      "community": 2383,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -223417,7 +223459,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2382,
+      "community": 2384,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -223426,7 +223468,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2383,
+      "community": 2385,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_switch_tsx",
       "label": "switch.tsx",
@@ -223435,7 +223477,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2384,
+      "community": 2386,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_table_test_tsx",
       "label": "table.test.tsx",
@@ -223444,7 +223486,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2385,
+      "community": 2387,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -223453,7 +223495,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2386,
+      "community": 2388,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -223462,30 +223504,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2387,
+      "community": 2389,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
       "norm_label": "textarea.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/textarea.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2388,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
-      "label": "toggle-group.tsx",
-      "norm_label": "toggle-group.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/toggle-group.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2389,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
-      "label": "toggle.tsx",
-      "norm_label": "toggle.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/toggle.tsx",
       "source_location": "L1"
     },
     {
@@ -223581,6 +223605,24 @@
     {
       "community": 2390,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
+      "label": "toggle-group.tsx",
+      "norm_label": "toggle-group.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/toggle-group.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2391,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
+      "label": "toggle.tsx",
+      "norm_label": "toggle.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/toggle.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2392,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
       "norm_label": "tooltip.tsx",
@@ -223588,7 +223630,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2391,
+      "community": 2393,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_upload_button_tsx",
       "label": "upload-button.tsx",
@@ -223597,7 +223639,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2392,
+      "community": 2394,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
       "label": "BagView.tsx",
@@ -223606,7 +223648,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2393,
+      "community": 2395,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
       "label": "columns.tsx",
@@ -223615,7 +223657,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2394,
+      "community": 2396,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
       "label": "constants.ts",
@@ -223624,7 +223666,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2395,
+      "community": 2397,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -223633,7 +223675,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2396,
+      "community": 2398,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -223642,30 +223684,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2397,
+      "community": 2399,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2398,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2399,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
-      "label": "bag-columns.tsx",
-      "norm_label": "bag-columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bag-columns.tsx",
       "source_location": "L1"
     },
     {
@@ -224112,6 +224136,24 @@
     {
       "community": 2400,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2401,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
+      "label": "bag-columns.tsx",
+      "norm_label": "bag-columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bag-columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2402,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
       "label": "bags-table.tsx",
       "norm_label": "bags-table.tsx",
@@ -224119,7 +224161,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2401,
+      "community": 2403,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
       "label": "columns.tsx",
@@ -224128,7 +224170,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2402,
+      "community": 2404,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -224137,7 +224179,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2403,
+      "community": 2405,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -224146,7 +224188,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2404,
+      "community": 2406,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -224155,7 +224197,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2405,
+      "community": 2407,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -224164,7 +224206,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2406,
+      "community": 2408,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
       "label": "LinkedAccounts.tsx",
@@ -224173,30 +224215,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2407,
+      "community": 2409,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
       "label": "TimelineEventCard.test.tsx",
       "norm_label": "timelineeventcard.test.tsx",
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2408,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
-      "label": "UserCheckoutSession.tsx",
-      "norm_label": "usercheckoutsession.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserCheckoutSession.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2409,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/index.ts",
       "source_location": "L1"
     },
     {
@@ -224292,6 +224316,24 @@
     {
       "community": 2410,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
+      "label": "UserCheckoutSession.tsx",
+      "norm_label": "usercheckoutsession.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserCheckoutSession.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2411,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2412,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_config_test_ts",
       "label": "config.test.ts",
       "norm_label": "config.test.ts",
@@ -224299,7 +224341,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2411,
+      "community": 2413,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexttracking_docsworkspacetracking_test_ts",
       "label": "docsWorkspaceTracking.test.ts",
@@ -224308,7 +224350,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2412,
+      "community": 2414,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
       "label": "ThemeContext.tsx",
@@ -224317,7 +224359,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2413,
+      "community": 2415,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_onlineordersessionoverlay_test_ts",
       "label": "onlineOrderSessionOverlay.test.ts",
@@ -224326,7 +224368,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2414,
+      "community": 2416,
       "file_type": "code",
       "id": "packages_athena_webapp_src_design_system_build_config_test_ts",
       "label": "design-system-build-config.test.ts",
@@ -224335,7 +224377,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2415,
+      "community": 2417,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_pagination_persistence_test_ts",
       "label": "use-pagination-persistence.test.ts",
@@ -224344,7 +224386,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2416,
+      "community": 2418,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
@@ -224353,30 +224395,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2417,
+      "community": 2419,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_test_tsx",
       "label": "useAuth.test.tsx",
       "norm_label": "useauth.test.tsx",
       "source_file": "packages/athena-webapp/src/hooks/useAuth.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2418,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useexpensesessions_test_ts",
-      "label": "useExpenseSessions.test.ts",
-      "norm_label": "useexpensesessions.test.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2419,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetactivestore_test_ts",
-      "label": "useGetActiveStore.test.ts",
-      "norm_label": "usegetactivestore.test.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetActiveStore.test.ts",
       "source_location": "L1"
     },
     {
@@ -224472,6 +224496,24 @@
     {
       "community": 2420,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useexpensesessions_test_ts",
+      "label": "useExpenseSessions.test.ts",
+      "norm_label": "useexpensesessions.test.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2421,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetactivestore_test_ts",
+      "label": "useGetActiveStore.test.ts",
+      "norm_label": "usegetactivestore.test.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetActiveStore.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2422,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetterminal_test_ts",
       "label": "useGetTerminal.test.ts",
       "norm_label": "usegetterminal.test.ts",
@@ -224479,7 +224521,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2421,
+      "community": 2423,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
@@ -224488,7 +224530,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2422,
+      "community": 2424,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useposproducts_test_ts",
       "label": "usePOSProducts.test.ts",
@@ -224497,7 +224539,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2423,
+      "community": 2425,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprotectedadminpagestate_test_tsx",
       "label": "useProtectedAdminPageState.test.tsx",
@@ -224506,7 +224548,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2424,
+      "community": 2426,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useshareddemocontext_test_ts",
       "label": "useSharedDemoContext.test.ts",
@@ -224515,7 +224557,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2425,
+      "community": 2427,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usestoreoperatingclock_test_tsx",
       "label": "useStoreOperatingClock.test.tsx",
@@ -224524,7 +224566,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2426,
+      "community": 2428,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_access_capabilities_test_ts",
       "label": "capabilities.test.ts",
@@ -224533,30 +224575,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2427,
+      "community": 2429,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_messages_appmessagescontext_ts",
       "label": "AppMessagesContext.ts",
       "norm_label": "appmessagescontext.ts",
       "source_file": "packages/athena-webapp/src/lib/app-messages/AppMessagesContext.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2428,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_app_messages_appmessagecommunicationpreferencecontext_ts",
-      "label": "appMessageCommunicationPreferenceContext.ts",
-      "norm_label": "appmessagecommunicationpreferencecontext.ts",
-      "source_file": "packages/athena-webapp/src/lib/app-messages/appMessageCommunicationPreferenceContext.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2429,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_app_messages_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/src/lib/app-messages/index.ts",
       "source_location": "L1"
     },
     {
@@ -224652,6 +224676,24 @@
     {
       "community": 2430,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_app_messages_appmessagecommunicationpreferencecontext_ts",
+      "label": "appMessageCommunicationPreferenceContext.ts",
+      "norm_label": "appmessagecommunicationpreferencecontext.ts",
+      "source_file": "packages/athena-webapp/src/lib/app-messages/appMessageCommunicationPreferenceContext.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2431,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_app_messages_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/src/lib/app-messages/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2432,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_update_appupdateactions_ts",
       "label": "appUpdateActions.ts",
       "norm_label": "appupdateactions.ts",
@@ -224659,7 +224701,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2431,
+      "community": 2433,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_update_index_ts",
       "label": "index.ts",
@@ -224668,7 +224710,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2432,
+      "community": 2434,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_update_updatecommunicationpreferencecontext_ts",
       "label": "updateCommunicationPreferenceContext.ts",
@@ -224677,7 +224719,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2433,
+      "community": 2435,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_update_updatecoordinator_test_ts",
       "label": "updateCoordinator.test.ts",
@@ -224686,7 +224728,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2434,
+      "community": 2436,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_aws_ts",
       "label": "aws.ts",
@@ -224695,7 +224737,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2435,
+      "community": 2437,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -224704,7 +224746,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2436,
+      "community": 2438,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -224713,30 +224755,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2437,
+      "community": 2439,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_docs_access_test_ts",
       "label": "access.test.ts",
       "norm_label": "access.test.ts",
       "source_file": "packages/athena-webapp/src/lib/docs/access.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2438,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_docs_content_test_ts",
-      "label": "content.test.ts",
-      "norm_label": "content.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/docs/content.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2439,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_docs_navigation_test_ts",
-      "label": "navigation.test.ts",
-      "norm_label": "navigation.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/docs/navigation.test.ts",
       "source_location": "L1"
     },
     {
@@ -224832,6 +224856,24 @@
     {
       "community": 2440,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_docs_content_test_ts",
+      "label": "content.test.ts",
+      "norm_label": "content.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/docs/content.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2441,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_docs_navigation_test_ts",
+      "label": "navigation.test.ts",
+      "norm_label": "navigation.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/docs/navigation.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2442,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_docs_parsing_test_ts",
       "label": "parsing.test.ts",
       "norm_label": "parsing.test.ts",
@@ -224839,7 +224881,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2441,
+      "community": 2443,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_docs_reportcontract_test_ts",
       "label": "reportContract.test.ts",
@@ -224848,7 +224890,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2442,
+      "community": 2444,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_docs_scrollprogress_test_ts",
       "label": "scrollProgress.test.ts",
@@ -224857,7 +224899,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2443,
+      "community": 2445,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_docs_virtual_docs_index_d_ts",
       "label": "virtual-docs-index.d.ts",
@@ -224866,7 +224908,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2444,
+      "community": 2446,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_operatormessages_test_ts",
       "label": "operatorMessages.test.ts",
@@ -224875,7 +224917,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2445,
+      "community": 2447,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_test_ts",
       "label": "presentCommandToast.test.ts",
@@ -224884,7 +224926,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2446,
+      "community": 2448,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_test_ts",
       "label": "presentUnexpectedErrorToast.test.ts",
@@ -224893,30 +224935,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2447,
+      "community": 2449,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_test_ts",
       "label": "runCommand.test.ts",
       "norm_label": "runcommand.test.ts",
       "source_file": "packages/athena-webapp/src/lib/errors/runCommand.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2448,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_ghana_ts",
-      "label": "ghana.ts",
-      "norm_label": "ghana.ts",
-      "source_file": "packages/athena-webapp/src/lib/ghana.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2449,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
-      "label": "ghanaRegions.ts",
-      "norm_label": "ghanaregions.ts",
-      "source_file": "packages/athena-webapp/src/lib/ghanaRegions.ts",
       "source_location": "L1"
     },
     {
@@ -225012,6 +225036,24 @@
     {
       "community": 2450,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_ghana_ts",
+      "label": "ghana.ts",
+      "norm_label": "ghana.ts",
+      "source_file": "packages/athena-webapp/src/lib/ghana.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2451,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
+      "label": "ghanaRegions.ts",
+      "norm_label": "ghanaregions.ts",
+      "source_file": "packages/athena-webapp/src/lib/ghanaRegions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2452,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_inventory_import_inventoryimportparser_test_ts",
       "label": "inventoryImportParser.test.ts",
       "norm_label": "inventoryimportparser.test.ts",
@@ -225019,7 +225061,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2451,
+      "community": 2453,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_marketing_landingfunnelclient_test_ts",
       "label": "landingFunnelClient.test.ts",
@@ -225028,7 +225070,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2452,
+      "community": 2454,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_marketing_walkthroughprivacy_ts",
       "label": "walkthroughPrivacy.ts",
@@ -225037,7 +225079,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2453,
+      "community": 2455,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_marketing_walkthroughrequestclient_test_ts",
       "label": "walkthroughRequestClient.test.ts",
@@ -225046,7 +225088,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2454,
+      "community": 2456,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_navigation_appentryroutes_test_ts",
       "label": "appEntryRoutes.test.ts",
@@ -225055,7 +225097,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2455,
+      "community": 2457,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_navigation_storeentryroute_test_ts",
       "label": "storeEntryRoute.test.ts",
@@ -225064,7 +225106,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2456,
+      "community": 2458,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_operations_operatingdate_test_ts",
       "label": "operatingDate.test.ts",
@@ -225073,30 +225115,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2457,
+      "community": 2459,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_dto_ts",
       "label": "dto.ts",
       "norm_label": "dto.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/application/dto.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2458,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_ports_ts",
-      "label": "ports.ts",
-      "norm_label": "ports.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/ports.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2459,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_poslocalstoreport_ts",
-      "label": "posLocalStorePort.ts",
-      "norm_label": "poslocalstoreport.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/posLocalStorePort.ts",
       "source_location": "L1"
     },
     {
@@ -225192,6 +225216,24 @@
     {
       "community": 2460,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_ports_ts",
+      "label": "ports.ts",
+      "norm_label": "ports.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/ports.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2461,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_poslocalstoreport_ts",
+      "label": "posLocalStorePort.ts",
+      "norm_label": "poslocalstoreport.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/posLocalStorePort.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2462,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_results_test_ts",
       "label": "results.test.ts",
       "norm_label": "results.test.ts",
@@ -225199,7 +225241,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2461,
+      "community": 2463,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_constants_ts",
       "label": "constants.ts",
@@ -225208,7 +225250,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2462,
+      "community": 2464,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
       "label": "displayAmounts.test.ts",
@@ -225217,7 +225259,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2463,
+      "community": 2465,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_cart_test_ts",
       "label": "cart.test.ts",
@@ -225226,7 +225268,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2464,
+      "community": 2466,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_index_ts",
       "label": "index.ts",
@@ -225235,7 +225277,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2465,
+      "community": 2467,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_session_test_ts",
       "label": "session.test.ts",
@@ -225244,7 +225286,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2466,
+      "community": 2468,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_types_ts",
       "label": "types.ts",
@@ -225253,30 +225295,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2467,
+      "community": 2469,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_expensereceipt_test_ts",
       "label": "expenseReceipt.test.ts",
       "norm_label": "expensereceipt.test.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/expenseReceipt.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2468,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_test_ts",
-      "label": "registerGateway.test.ts",
-      "norm_label": "registergateway.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2469,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registerlifecycleauthoritygateway_test_ts",
-      "label": "registerLifecycleAuthorityGateway.test.ts",
-      "norm_label": "registerlifecycleauthoritygateway.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerLifecycleAuthorityGateway.test.ts",
       "source_location": "L1"
     },
     {
@@ -225372,6 +225396,24 @@
     {
       "community": 2470,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_test_ts",
+      "label": "registerGateway.test.ts",
+      "norm_label": "registergateway.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2471,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registerlifecycleauthoritygateway_test_ts",
+      "label": "registerLifecycleAuthorityGateway.test.ts",
+      "norm_label": "registerlifecycleauthoritygateway.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerLifecycleAuthorityGateway.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2472,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_test_ts",
       "label": "sessionGateway.test.ts",
       "norm_label": "sessiongateway.test.ts",
@@ -225379,7 +225421,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2471,
+      "community": 2473,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_drawerauthorityreconciliation_test_ts",
       "label": "drawerAuthorityReconciliation.test.ts",
@@ -225388,7 +225430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2472,
+      "community": 2474,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_indexeddbposlocalstorageengine_test_ts",
       "label": "indexedDbPosLocalStorageEngine.test.ts",
@@ -225397,7 +225439,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2473,
+      "community": 2475,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localposentrycontext_test_ts",
       "label": "localPosEntryContext.test.ts",
@@ -225406,7 +225448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2474,
+      "community": 2476,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localposreadiness_test_ts",
       "label": "localPosReadiness.test.ts",
@@ -225415,7 +225457,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2475,
+      "community": 2477,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalledgerpolicy_test_ts",
       "label": "posLocalLedgerPolicy.test.ts",
@@ -225424,7 +225466,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2476,
+      "community": 2478,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoragehealth_test_ts",
       "label": "posLocalStorageHealth.test.ts",
@@ -225433,30 +225475,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2477,
+      "community": 2479,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstorageruntime_test_ts",
       "label": "posLocalStorageRuntime.test.ts",
       "norm_label": "poslocalstorageruntime.test.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageRuntime.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2478,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoreinitialization_test_ts",
-      "label": "posLocalStoreInitialization.test.ts",
-      "norm_label": "poslocalstoreinitialization.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStoreInitialization.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2479,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoremaintenance_test_ts",
-      "label": "posLocalStoreMaintenance.test.ts",
-      "norm_label": "poslocalstoremaintenance.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStoreMaintenance.test.ts",
       "source_location": "L1"
     },
     {
@@ -225552,6 +225576,24 @@
     {
       "community": 2480,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoreinitialization_test_ts",
+      "label": "posLocalStoreInitialization.test.ts",
+      "norm_label": "poslocalstoreinitialization.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStoreInitialization.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2481,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoremaintenance_test_ts",
+      "label": "posLocalStoreMaintenance.test.ts",
+      "norm_label": "poslocalstoremaintenance.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStoreMaintenance.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2482,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoremigrations_test_ts",
       "label": "posLocalStoreMigrations.test.ts",
       "norm_label": "poslocalstoremigrations.test.ts",
@@ -225559,7 +225601,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2481,
+      "community": 2483,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoresnapshot_test_ts",
       "label": "posLocalStoreSnapshot.test.ts",
@@ -225568,7 +225610,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2482,
+      "community": 2484,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registercatalogpinruntime_test_ts",
       "label": "registerCatalogPinRuntime.test.ts",
@@ -225577,7 +225619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2483,
+      "community": 2485,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registerlifecycleauthorityrollout_test_ts",
       "label": "registerLifecycleAuthorityRollout.test.ts",
@@ -225586,7 +225628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2484,
+      "community": 2486,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registersessionauthoritybootstrap_test_ts",
       "label": "registerSessionAuthorityBootstrap.test.ts",
@@ -225595,7 +225637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2485,
+      "community": 2487,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_saleblockerpolicy_test_ts",
       "label": "saleBlockerPolicy.test.ts",
@@ -225604,7 +225646,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2486,
+      "community": 2488,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_syncgapdiagnosis_test_ts",
       "label": "syncGapDiagnosis.test.ts",
@@ -225613,30 +225655,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2487,
+      "community": 2489,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_printattempttelemetry_test_ts",
       "label": "printAttemptTelemetry.test.ts",
       "norm_label": "printattempttelemetry.test.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2488,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_runtimecounters_test_ts",
-      "label": "runtimeCounters.test.ts",
-      "norm_label": "runtimecounters.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/runtimeCounters.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2489,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_telemetrybuffer_test_ts",
-      "label": "telemetryBuffer.test.ts",
-      "norm_label": "telemetrybuffer.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.test.ts",
       "source_location": "L1"
     },
     {
@@ -225732,6 +225756,24 @@
     {
       "community": 2490,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_runtimecounters_test_ts",
+      "label": "runtimeCounters.test.ts",
+      "norm_label": "runtimecounters.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/runtimeCounters.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2491,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_telemetrybuffer_test_ts",
+      "label": "telemetryBuffer.test.ts",
+      "norm_label": "telemetrybuffer.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2492,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearch_test_ts",
       "label": "catalogSearch.test.ts",
       "norm_label": "catalogsearch.test.ts",
@@ -225739,7 +225781,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2491,
+      "community": 2493,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearchpresentation_test_ts",
       "label": "catalogSearchPresentation.test.ts",
@@ -225748,7 +225790,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2492,
+      "community": 2494,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_registercashierpresence_test_ts",
       "label": "registerCashierPresence.test.ts",
@@ -225757,7 +225799,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2493,
+      "community": 2495,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_registercheckoutprojection_test_ts",
       "label": "registerCheckoutProjection.test.ts",
@@ -225766,7 +225808,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2494,
+      "community": 2496,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_registeruistate_test_ts",
       "label": "registerUiState.test.ts",
@@ -225775,7 +225817,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2495,
+      "community": 2497,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregistercheckoutdraftstate_test_ts",
       "label": "useRegisterCheckoutDraftState.test.ts",
@@ -225784,7 +225826,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2496,
+      "community": 2498,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_registersessioncode_test_ts",
       "label": "registerSessionCode.test.ts",
@@ -225793,30 +225835,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2497,
+      "community": 2499,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_syncstatuspresentation_test_ts",
       "label": "syncStatusPresentation.test.ts",
       "norm_label": "syncstatuspresentation.test.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2498,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_test_ts",
-      "label": "productUtils.test.ts",
-      "norm_label": "productutils.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2499,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_remote_assist_contract_test_ts",
-      "label": "contract.test.ts",
-      "norm_label": "contract.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/contract.test.ts",
       "source_location": "L1"
     },
     {
@@ -226254,6 +226278,24 @@
     {
       "community": 2500,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_productutils_test_ts",
+      "label": "productUtils.test.ts",
+      "norm_label": "productutils.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2501,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_remote_assist_contract_test_ts",
+      "label": "contract.test.ts",
+      "norm_label": "contract.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/contract.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2502,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_remote_assist_guardrails_test_ts",
       "label": "guardrails.test.ts",
       "norm_label": "guardrails.test.ts",
@@ -226261,7 +226303,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2501,
+      "community": 2503,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_remote_assist_index_ts",
       "label": "index.ts",
@@ -226270,7 +226312,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2502,
+      "community": 2504,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_runtimebuildmetadata_test_ts",
       "label": "runtimeBuildMetadata.test.ts",
@@ -226279,7 +226321,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2503,
+      "community": 2505,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -226288,7 +226330,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2504,
+      "community": 2506,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
@@ -226297,7 +226339,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2505,
+      "community": 2507,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -226306,7 +226348,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2506,
+      "community": 2508,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -226315,30 +226357,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2507,
+      "community": 2509,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
       "norm_label": "user.ts",
       "source_file": "packages/athena-webapp/src/lib/schemas/user.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2508,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_security_localpinverifier_test_ts",
-      "label": "localPinVerifier.test.ts",
-      "norm_label": "localpinverifier.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2509,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_sheetreturn_test_ts",
-      "label": "sheetReturn.test.ts",
-      "norm_label": "sheetreturn.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/sheetReturn.test.ts",
       "source_location": "L1"
     },
     {
@@ -226434,6 +226458,24 @@
     {
       "community": 2510,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_security_localpinverifier_test_ts",
+      "label": "localPinVerifier.test.ts",
+      "norm_label": "localpinverifier.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2511,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_sheetreturn_test_ts",
+      "label": "sheetReturn.test.ts",
+      "norm_label": "sheetreturn.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/sheetReturn.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2512,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_stockops_skusearch_test_ts",
       "label": "skuSearch.test.ts",
       "norm_label": "skusearch.test.ts",
@@ -226441,7 +226483,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2511,
+      "community": 2513,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
@@ -226450,7 +226492,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2512,
+      "community": 2514,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_traces_createworkflowtraceid_test_ts",
       "label": "createWorkflowTraceId.test.ts",
@@ -226459,7 +226501,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2513,
+      "community": 2515,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -226468,7 +226510,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2514,
+      "community": 2516,
       "file_type": "code",
       "id": "packages_athena_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -226477,7 +226519,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2515,
+      "community": 2517,
       "file_type": "code",
       "id": "packages_athena_webapp_src_offline_posappshellreadiness_test_ts",
       "label": "posAppShellReadiness.test.ts",
@@ -226486,7 +226528,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2516,
+      "community": 2518,
       "file_type": "code",
       "id": "packages_athena_webapp_src_offline_posappshellroutes_test_ts",
       "label": "posAppShellRoutes.test.ts",
@@ -226495,30 +226537,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2517,
+      "community": 2519,
       "file_type": "code",
       "id": "packages_athena_webapp_src_offline_posofflinereadiness_test_ts",
       "label": "posOfflineReadiness.test.ts",
       "norm_label": "posofflinereadiness.test.ts",
       "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2518,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_offline_registerposappshellserviceworker_test_ts",
-      "label": "registerPosAppShellServiceWorker.test.ts",
-      "norm_label": "registerposappshellserviceworker.test.ts",
-      "source_file": "packages/athena-webapp/src/offline/registerPosAppShellServiceWorker.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2519,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routetree_gen_ts",
-      "label": "routeTree.gen.ts",
-      "norm_label": "routetree.gen.ts",
-      "source_file": "packages/athena-webapp/src/routeTree.gen.ts",
       "source_location": "L1"
     },
     {
@@ -226614,6 +226638,24 @@
     {
       "community": 2520,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_offline_registerposappshellserviceworker_test_ts",
+      "label": "registerPosAppShellServiceWorker.test.ts",
+      "norm_label": "registerposappshellserviceworker.test.ts",
+      "source_file": "packages/athena-webapp/src/offline/registerPosAppShellServiceWorker.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2521,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routetree_gen_ts",
+      "label": "routeTree.gen.ts",
+      "norm_label": "routetree.gen.ts",
+      "source_file": "packages/athena-webapp/src/routeTree.gen.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2522,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_app_entry_route_tsx",
       "label": "-app-entry-route.tsx",
       "norm_label": "-app-entry-route.tsx",
@@ -226621,7 +226663,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2521,
+      "community": 2523,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_privacy_page_tsx",
       "label": "-privacy-page.tsx",
@@ -226630,7 +226672,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2522,
+      "community": 2524,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_root_page_search_ts",
       "label": "-root-page-search.ts",
@@ -226639,7 +226681,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2523,
+      "community": 2525,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_shared_demo_entry_tsx",
       "label": "-shared-demo-entry.tsx",
@@ -226648,7 +226690,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2524,
+      "community": 2526,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_walkthrough_page_tsx",
       "label": "-walkthrough-page.tsx",
@@ -226657,7 +226699,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2525,
+      "community": 2527,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_root_test_ts",
       "label": "__root.test.ts",
@@ -226666,7 +226708,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2526,
+      "community": 2528,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
       "label": "index.tsx",
@@ -226675,30 +226717,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2527,
+      "community": 2529,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2528,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/organization/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2529,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
-      "label": "$storeUrlSlug.tsx",
-      "norm_label": "$storeurlslug.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/stores/$storeUrlSlug.tsx",
       "source_location": "L1"
     },
     {
@@ -226794,6 +226818,24 @@
     {
       "community": 2530,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/organization/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2531,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
+      "label": "$storeUrlSlug.tsx",
+      "norm_label": "$storeurlslug.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/stores/$storeUrlSlug.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2532,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_app_settings_tsx",
       "label": "app-settings.tsx",
       "norm_label": "app-settings.tsx",
@@ -226801,7 +226843,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2531,
+      "community": 2533,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
       "label": "assets.index.tsx",
@@ -226810,7 +226852,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2532,
+      "community": 2534,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
       "label": "bags.$bagId.tsx",
@@ -226819,7 +226861,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2533,
+      "community": 2535,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
       "label": "bags.index.tsx",
@@ -226828,7 +226870,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2534,
+      "community": 2536,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
       "label": "index.tsx",
@@ -226837,7 +226879,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2535,
+      "community": 2537,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
       "label": "checkout-sessions.index.tsx",
@@ -226846,7 +226888,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2536,
+      "community": 2538,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
       "label": "configuration.index.tsx",
@@ -226855,30 +226897,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2537,
+      "community": 2539,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
       "label": "dashboard.index.tsx",
       "norm_label": "dashboard.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/dashboard.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2538,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
-      "label": "home.tsx",
-      "norm_label": "home.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/home.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2539,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
-      "label": "logs.$logId.tsx",
-      "norm_label": "logs.$logid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.$logId.tsx",
       "source_location": "L1"
     },
     {
@@ -226974,6 +226998,24 @@
     {
       "community": 2540,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
+      "label": "home.tsx",
+      "norm_label": "home.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/home.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2541,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
+      "label": "logs.$logId.tsx",
+      "norm_label": "logs.$logid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.$logId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2542,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
       "label": "logs.index.tsx",
       "norm_label": "logs.index.tsx",
@@ -226981,7 +227023,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2541,
+      "community": 2543,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
       "label": "members.index.tsx",
@@ -226990,7 +227032,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2542,
+      "community": 2544,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_test_ts",
       "label": "index.test.ts",
@@ -226999,7 +227041,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2543,
+      "community": 2545,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_inventory_import_cost_overlay_search_ts",
       "label": "-cost-overlay-search.ts",
@@ -227008,7 +227050,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2544,
+      "community": 2546,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_inventory_import_cost_overlay_test_ts",
       "label": "cost-overlay.test.ts",
@@ -227017,7 +227059,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2545,
+      "community": 2547,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_inventory_import_cost_overlay_tsx",
       "label": "cost-overlay.tsx",
@@ -227026,7 +227068,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2546,
+      "community": 2548,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_inventory_import_review_tsx",
       "label": "review.tsx",
@@ -227035,30 +227077,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2547,
+      "community": 2549,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_inventory_import_test_tsx",
       "label": "inventory-import.test.tsx",
       "norm_label": "inventory-import.test.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/inventory-import.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2548,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_inventory_import_tsx",
-      "label": "inventory-import.tsx",
-      "norm_label": "inventory-import.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/inventory-import.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2549,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_sku_activity_test_tsx",
-      "label": "sku-activity.test.tsx",
-      "norm_label": "sku-activity.test.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/sku-activity.test.tsx",
       "source_location": "L1"
     },
     {
@@ -227154,6 +227178,24 @@
     {
       "community": 2550,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_inventory_import_tsx",
+      "label": "inventory-import.tsx",
+      "norm_label": "inventory-import.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/inventory-import.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2551,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_sku_activity_test_tsx",
+      "label": "sku-activity.test.tsx",
+      "norm_label": "sku-activity.test.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/sku-activity.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2552,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
@@ -227161,7 +227203,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2551,
+      "community": 2553,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
       "label": "all.index.tsx",
@@ -227170,7 +227212,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2552,
+      "community": 2554,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
       "label": "cancelled.index.tsx",
@@ -227179,7 +227221,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2553,
+      "community": 2555,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
       "label": "completed.index.tsx",
@@ -227188,7 +227230,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2554,
+      "community": 2556,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
       "label": "index.tsx",
@@ -227197,7 +227239,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2555,
+      "community": 2557,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
       "label": "open.index.tsx",
@@ -227206,7 +227248,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2556,
+      "community": 2558,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
       "label": "out-for-delivery.index.tsx",
@@ -227215,30 +227257,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2557,
+      "community": 2559,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
       "label": "ready.index.tsx",
       "norm_label": "ready.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/ready.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2558,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
-      "label": "refunded.index.tsx",
-      "norm_label": "refunded.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/refunded.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2559,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
-      "label": "$reportId.tsx",
-      "norm_label": "$reportid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports/$reportId.tsx",
       "source_location": "L1"
     },
     {
@@ -227334,6 +227358,24 @@
     {
       "community": 2560,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
+      "label": "refunded.index.tsx",
+      "norm_label": "refunded.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/refunded.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2561,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
+      "label": "$reportId.tsx",
+      "norm_label": "$reportid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports/$reportId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2562,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
       "label": "expense-reports.index.tsx",
       "norm_label": "expense-reports.index.tsx",
@@ -227341,7 +227383,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2561,
+      "community": 2563,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_test_tsx",
       "label": "expense.index.test.tsx",
@@ -227350,7 +227392,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2562,
+      "community": 2564,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
       "label": "register.index.tsx",
@@ -227359,7 +227401,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2563,
+      "community": 2565,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_sessions_index_tsx",
       "label": "sessions.index.tsx",
@@ -227368,7 +227410,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2564,
+      "community": 2566,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_terminals_terminalid_tsx",
       "label": "$terminalId.tsx",
@@ -227377,7 +227419,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2565,
+      "community": 2567,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_terminals_index_tsx",
       "label": "terminals.index.tsx",
@@ -227386,7 +227428,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2566,
+      "community": 2568,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
       "label": "$transactionId.tsx",
@@ -227395,30 +227437,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2567,
+      "community": 2569,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
       "label": "transactions.index.tsx",
       "norm_label": "transactions.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2568,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_test_ts",
-      "label": "procurement.index.test.ts",
-      "norm_label": "procurement.index.test.ts",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2569,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
-      "label": "edit.tsx",
-      "norm_label": "edit.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/edit.tsx",
       "source_location": "L1"
     },
     {
@@ -227514,6 +227538,24 @@
     {
       "community": 2570,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_test_ts",
+      "label": "procurement.index.test.ts",
+      "norm_label": "procurement.index.test.ts",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2571,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
+      "label": "edit.tsx",
+      "norm_label": "edit.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/edit.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2572,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
@@ -227521,7 +227563,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2571,
+      "community": 2573,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_archived_tsx",
       "label": "archived.tsx",
@@ -227530,7 +227572,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2572,
+      "community": 2574,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
       "label": "new.tsx",
@@ -227539,7 +227581,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2573,
+      "community": 2575,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
       "label": "new.tsx",
@@ -227548,7 +227590,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2574,
+      "community": 2576,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
       "label": "unresolved.tsx",
@@ -227557,7 +227599,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2575,
+      "community": 2577,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
       "label": "$promoCodeSlug.tsx",
@@ -227566,7 +227608,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2576,
+      "community": 2578,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
       "label": "index.tsx",
@@ -227575,30 +227617,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2577,
+      "community": 2579,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
       "label": "new.tsx",
       "norm_label": "new.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/new.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2578,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_items_productskuid_test_ts",
-      "label": "$productSkuId.test.ts",
-      "norm_label": "$productskuid.test.ts",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports/items/$productSkuId.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2579,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_items_index_test_ts",
-      "label": "index.test.ts",
-      "norm_label": "index.test.ts",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports/items/index.test.ts",
       "source_location": "L1"
     },
     {
@@ -227694,6 +227718,24 @@
     {
       "community": 2580,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_items_productskuid_test_ts",
+      "label": "$productSkuId.test.ts",
+      "norm_label": "$productskuid.test.ts",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports/items/$productSkuId.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2581,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_items_index_test_ts",
+      "label": "index.test.ts",
+      "norm_label": "index.test.ts",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports/items/index.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2582,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_items_tsx",
       "label": "items.tsx",
       "norm_label": "items.tsx",
@@ -227701,7 +227743,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2581,
+      "community": 2583,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_weekly_test_ts",
       "label": "weekly.test.ts",
@@ -227710,7 +227752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2582,
+      "community": 2584,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_tsx",
       "label": "reports.tsx",
@@ -227719,7 +227761,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2583,
+      "community": 2585,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
       "label": "index.tsx",
@@ -227728,7 +227770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2584,
+      "community": 2586,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
       "label": "new.index.tsx",
@@ -227737,7 +227779,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2585,
+      "community": 2587,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_active_cases_index_tsx",
       "label": "active-cases.index.tsx",
@@ -227746,7 +227788,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2586,
+      "community": 2588,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_appointments_index_tsx",
       "label": "appointments.index.tsx",
@@ -227755,30 +227797,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2587,
+      "community": 2589,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_catalog_management_index_tsx",
       "label": "catalog-management.index.tsx",
       "norm_label": "catalog-management.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/catalog-management.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2588,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2589,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_intake_index_tsx",
-      "label": "intake.index.tsx",
-      "norm_label": "intake.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/intake.index.tsx",
       "source_location": "L1"
     },
     {
@@ -227874,6 +227898,24 @@
     {
       "community": 2590,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2591,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_intake_index_tsx",
+      "label": "intake.index.tsx",
+      "norm_label": "intake.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/services/intake.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2592,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_test_tsx",
       "label": "$traceId.test.tsx",
       "norm_label": "$traceid.test.tsx",
@@ -227881,7 +227923,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2591,
+      "community": 2593,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
       "label": "users.$userId.tsx",
@@ -227890,7 +227932,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2592,
+      "community": 2594,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
       "label": "index.tsx",
@@ -227899,7 +227941,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2593,
+      "community": 2595,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_shell_test_tsx",
       "label": "_authed-shell.test.tsx",
@@ -227908,7 +227950,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2594,
+      "community": 2596,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_test_tsx",
       "label": "_authed.test.tsx",
@@ -227917,7 +227959,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2595,
+      "community": 2597,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_app_route_test_tsx",
       "label": "app.route.test.tsx",
@@ -227926,7 +227968,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2596,
+      "community": 2598,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_app_test_tsx",
       "label": "app.test.tsx",
@@ -227935,30 +227977,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2597,
+      "community": 2599,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_app_tsx",
       "label": "app.tsx",
       "norm_label": "app.tsx",
       "source_file": "packages/athena-webapp/src/routes/app.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2598,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_demo_test_tsx",
-      "label": "demo.test.tsx",
-      "norm_label": "demo.test.tsx",
-      "source_file": "packages/athena-webapp/src/routes/demo.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2599,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_demo_tsx",
-      "label": "demo.tsx",
-      "norm_label": "demo.tsx",
-      "source_file": "packages/athena-webapp/src/routes/demo.tsx",
       "source_location": "L1"
     },
     {
@@ -228396,6 +228420,24 @@
     {
       "community": 2600,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_demo_test_tsx",
+      "label": "demo.test.tsx",
+      "norm_label": "demo.test.tsx",
+      "source_file": "packages/athena-webapp/src/routes/demo.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2601,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_demo_tsx",
+      "label": "demo.tsx",
+      "norm_label": "demo.tsx",
+      "source_file": "packages/athena-webapp/src/routes/demo.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2602,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_docs_index_tsx",
       "label": "docs.index.tsx",
       "norm_label": "docs.index.tsx",
@@ -228403,7 +228445,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2601,
+      "community": 2603,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_docs_reports_slug_tsx",
       "label": "docs.reports.$slug.tsx",
@@ -228412,7 +228454,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2602,
+      "community": 2604,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_docs_solutions_category_slug_test_tsx",
       "label": "docs.solutions.$category.$slug.test.tsx",
@@ -228421,7 +228463,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2603,
+      "community": 2605,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_docs_tsx",
       "label": "docs.tsx",
@@ -228430,7 +228472,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2604,
+      "community": 2606,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_test_tsx",
       "label": "index.test.tsx",
@@ -228439,7 +228481,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2605,
+      "community": 2607,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -228448,7 +228490,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2606,
+      "community": 2608,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
       "label": "join-team.index.tsx",
@@ -228457,30 +228499,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2607,
+      "community": 2609,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_landing_tsx",
       "label": "landing.tsx",
       "norm_label": "landing.tsx",
       "source_file": "packages/athena-webapp/src/routes/landing.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2608,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_login_layout_index_test_tsx",
-      "label": "_layout.index.test.tsx",
-      "norm_label": "_layout.index.test.tsx",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.index.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2609,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
-      "label": "_layout.index.tsx",
-      "norm_label": "_layout.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/login/_layout.index.tsx",
       "source_location": "L1"
     },
     {
@@ -228576,6 +228600,24 @@
     {
       "community": 2610,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_login_layout_index_test_tsx",
+      "label": "_layout.index.test.tsx",
+      "norm_label": "_layout.index.test.tsx",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.index.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2611,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
+      "label": "_layout.index.tsx",
+      "norm_label": "_layout.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/login/_layout.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2612,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_tsx",
       "label": "_layout.tsx",
       "norm_label": "_layout.tsx",
@@ -228583,7 +228625,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2611,
+      "community": 2613,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_privacy_test_tsx",
       "label": "privacy.test.tsx",
@@ -228592,7 +228634,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2612,
+      "community": 2614,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_privacy_tsx",
       "label": "privacy.tsx",
@@ -228601,7 +228643,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2613,
+      "community": 2615,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_register_interest_tsx",
       "label": "register-interest.tsx",
@@ -228610,7 +228652,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2614,
+      "community": 2616,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_walkthrough_test_tsx",
       "label": "walkthrough.test.tsx",
@@ -228619,7 +228661,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2615,
+      "community": 2617,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_walkthrough_tsx",
       "label": "walkthrough.tsx",
@@ -228628,7 +228670,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2616,
+      "community": 2618,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
       "label": "StoresSettingsAccordion.tsx",
@@ -228637,30 +228679,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2617,
+      "community": 2619,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stores_expensestore_test_ts",
       "label": "expenseStore.test.ts",
       "norm_label": "expensestore.test.ts",
       "source_file": "packages/athena-webapp/src/stores/expenseStore.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2618,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
-      "label": "Overview.stories.tsx",
-      "norm_label": "overview.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/Overview.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2619,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
-      "label": "foundations-content.test.tsx",
-      "norm_label": "foundations-content.test.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.test.tsx",
       "source_location": "L1"
     },
     {
@@ -228756,6 +228780,24 @@
     {
       "community": 2620,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
+      "label": "Overview.stories.tsx",
+      "norm_label": "overview.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/Overview.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2621,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
+      "label": "foundations-content.test.tsx",
+      "norm_label": "foundations-content.test.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2622,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
       "label": "Introduction.stories.tsx",
       "norm_label": "introduction.stories.tsx",
@@ -228763,7 +228805,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2621,
+      "community": 2623,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
       "label": "introduction-content.test.tsx",
@@ -228772,7 +228814,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2622,
+      "community": 2624,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
       "label": "introduction-content.tsx",
@@ -228781,7 +228823,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2623,
+      "community": 2625,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_adminshell_stories_tsx",
       "label": "AdminShell.stories.tsx",
@@ -228790,7 +228832,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2624,
+      "community": 2626,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_view_stories_tsx",
       "label": "View.stories.tsx",
@@ -228799,7 +228841,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2625,
+      "community": 2627,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_test_tsx",
       "label": "admin-shell-patterns.test.tsx",
@@ -228808,7 +228850,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2626,
+      "community": 2628,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_view_patterns_test_tsx",
       "label": "view-patterns.test.tsx",
@@ -228817,30 +228859,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2627,
+      "community": 2629,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_surfaces_stories_tsx",
       "label": "Surfaces.stories.tsx",
       "norm_label": "surfaces.stories.tsx",
       "source_file": "packages/athena-webapp/src/stories/Primitives/Surfaces.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2628,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
-      "label": "DashboardWorkspace.stories.tsx",
-      "norm_label": "dashboardworkspace.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/DashboardWorkspace.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2629,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
-      "label": "DataWorkspace.stories.tsx",
-      "norm_label": "dataworkspace.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/DataWorkspace.stories.tsx",
       "source_location": "L1"
     },
     {
@@ -228936,6 +228960,24 @@
     {
       "community": 2630,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
+      "label": "DashboardWorkspace.stories.tsx",
+      "norm_label": "dashboardworkspace.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/DashboardWorkspace.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2631,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
+      "label": "DataWorkspace.stories.tsx",
+      "norm_label": "dataworkspace.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/DataWorkspace.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2632,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_settingsworkspace_stories_tsx",
       "label": "SettingsWorkspace.stories.tsx",
       "norm_label": "settingsworkspace.stories.tsx",
@@ -228943,7 +228985,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2631,
+      "community": 2633,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_test_tsx",
       "label": "reference-fixtures.test.tsx",
@@ -228952,7 +228994,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2632,
+      "community": 2634,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_operations_eodreviewfixtures_ts",
       "label": "eodReviewFixtures.ts",
@@ -228961,7 +229003,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2633,
+      "community": 2635,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_config_test_ts",
       "label": "storybook-config.test.ts",
@@ -228970,7 +229012,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2634,
+      "community": 2636,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_test_ts",
       "label": "storybook-theme-decorator.test.ts",
@@ -228979,7 +229021,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2635,
+      "community": 2637,
       "file_type": "code",
       "id": "packages_athena_webapp_src_test_setup_ts",
       "label": "setup.ts",
@@ -228988,7 +229030,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2636,
+      "community": 2638,
       "file_type": "code",
       "id": "packages_athena_webapp_src_vite_env_d_ts",
       "label": "vite-env.d.ts",
@@ -228997,30 +229039,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2637,
+      "community": 2639,
       "file_type": "code",
       "id": "packages_athena_webapp_src_viteconfig_test_ts",
       "label": "viteConfig.test.ts",
       "norm_label": "viteconfig.test.ts",
       "source_file": "packages/athena-webapp/src/viteConfig.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2638,
-      "file_type": "code",
-      "id": "packages_athena_webapp_tailwind_config_js",
-      "label": "tailwind.config.js",
-      "norm_label": "tailwind.config.js",
-      "source_file": "packages/athena-webapp/tailwind.config.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 2639,
-      "file_type": "code",
-      "id": "packages_athena_webapp_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/athena-webapp/types.ts",
       "source_location": "L1"
     },
     {
@@ -229116,6 +229140,24 @@
     {
       "community": 2640,
       "file_type": "code",
+      "id": "packages_athena_webapp_tailwind_config_js",
+      "label": "tailwind.config.js",
+      "norm_label": "tailwind.config.js",
+      "source_file": "packages/athena-webapp/tailwind.config.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 2641,
+      "file_type": "code",
+      "id": "packages_athena_webapp_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/athena-webapp/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2642,
+      "file_type": "code",
       "id": "packages_athena_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
       "norm_label": "vitest.config.ts",
@@ -229123,7 +229165,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2641,
+      "community": 2643,
       "file_type": "code",
       "id": "packages_storefront_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -229132,7 +229174,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2642,
+      "community": 2644,
       "file_type": "code",
       "id": "packages_storefront_webapp_global_d_ts",
       "label": "global.d.ts",
@@ -229141,7 +229183,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2643,
+      "community": 2645,
       "file_type": "code",
       "id": "packages_storefront_webapp_playwright_config_ts",
       "label": "playwright.config.ts",
@@ -229150,7 +229192,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2644,
+      "community": 2646,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_test_ts",
       "label": "analytics.test.ts",
@@ -229159,7 +229201,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2645,
+      "community": 2647,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_homepagesnapshot_test_ts",
       "label": "homepageSnapshot.test.ts",
@@ -229168,7 +229210,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2646,
+      "community": 2648,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_trackingevents_test_ts",
       "label": "trackingEvents.test.ts",
@@ -229177,30 +229219,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2647,
+      "community": 2649,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
       "source_file": "packages/storefront-webapp/src/api/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2648,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
-      "label": "HeartIconFilled.tsx",
-      "norm_label": "hearticonfilled.tsx",
-      "source_file": "packages/storefront-webapp/src/assets/icons/HeartIconFilled.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2649,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
-      "label": "DefaultCatchBoundary.tsx",
-      "norm_label": "defaultcatchboundary.tsx",
-      "source_file": "packages/storefront-webapp/src/components/DefaultCatchBoundary.tsx",
       "source_location": "L1"
     },
     {
@@ -229296,6 +229320,24 @@
     {
       "community": 2650,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
+      "label": "HeartIconFilled.tsx",
+      "norm_label": "hearticonfilled.tsx",
+      "source_file": "packages/storefront-webapp/src/assets/icons/HeartIconFilled.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2651,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
+      "label": "DefaultCatchBoundary.tsx",
+      "norm_label": "defaultcatchboundary.tsx",
+      "source_file": "packages/storefront-webapp/src/components/DefaultCatchBoundary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2652,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
       "label": "HomePage.test.tsx",
       "norm_label": "homepage.test.tsx",
@@ -229303,7 +229345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2651,
+      "community": 2653,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
       "label": "ProductCard.test.tsx",
@@ -229312,7 +229354,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2652,
+      "community": 2654,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_upsell_tsx",
       "label": "Upsell.tsx",
@@ -229321,7 +229363,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2653,
+      "community": 2655,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_test_tsx",
       "label": "Checkout.test.tsx",
@@ -229330,7 +229372,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2654,
+      "community": 2656,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
       "label": "Checkout.tsx",
@@ -229339,7 +229381,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2655,
+      "community": 2657,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
       "label": "CustomerInfoSection.tsx",
@@ -229348,7 +229390,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2656,
+      "community": 2658,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_schema_ts",
       "label": "schema.ts",
@@ -229357,30 +229399,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2657,
+      "community": 2659,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetailssection_tsx",
       "label": "DeliveryDetailsSection.tsx",
       "norm_label": "deliverydetailssection.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetailsSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2658,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_test_ts",
-      "label": "checkoutStorage.test.ts",
-      "norm_label": "checkoutstorage.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2659,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
-      "label": "deliveryFees.test.ts",
-      "norm_label": "deliveryfees.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.test.ts",
       "source_location": "L1"
     },
     {
@@ -229476,6 +229500,24 @@
     {
       "community": 2660,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_test_ts",
+      "label": "checkoutStorage.test.ts",
+      "norm_label": "checkoutstorage.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2661,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
+      "label": "deliveryFees.test.ts",
+      "norm_label": "deliveryfees.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2662,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
       "label": "deriveCheckoutState.test.ts",
       "norm_label": "derivecheckoutstate.test.ts",
@@ -229483,7 +229525,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2661,
+      "community": 2663,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
       "label": "billingDetailsSchema.ts",
@@ -229492,7 +229534,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2662,
+      "community": 2664,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
       "label": "checkoutFormSchema.ts",
@@ -229501,7 +229543,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2663,
+      "community": 2665,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_customerdetailsschema_ts",
       "label": "customerDetailsSchema.ts",
@@ -229510,7 +229552,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2664,
+      "community": 2666,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
       "label": "deliveryDetailsSchema.ts",
@@ -229519,7 +229561,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2665,
+      "community": 2667,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
       "label": "webOrderSchema.ts",
@@ -229528,7 +229570,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2666,
+      "community": 2668,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_types_ts",
       "label": "types.ts",
@@ -229537,30 +229579,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2667,
+      "community": 2669,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_utils_test_ts",
       "label": "utils.test.ts",
       "norm_label": "utils.test.ts",
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2668,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_filter_productfilterbar_tsx",
-      "label": "ProductFilterBar.tsx",
-      "norm_label": "productfilterbar.tsx",
-      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilterBar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2669,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_bestsellerssection_test_tsx",
-      "label": "BestSellersSection.test.tsx",
-      "norm_label": "bestsellerssection.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.test.tsx",
       "source_location": "L1"
     },
     {
@@ -229656,6 +229680,24 @@
     {
       "community": 2670,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_filter_productfilterbar_tsx",
+      "label": "ProductFilterBar.tsx",
+      "norm_label": "productfilterbar.tsx",
+      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilterBar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2671,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_bestsellerssection_test_tsx",
+      "label": "BestSellersSection.test.tsx",
+      "norm_label": "bestsellerssection.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2672,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
       "label": "HomeHero.tsx",
       "norm_label": "homehero.tsx",
@@ -229663,7 +229705,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2671,
+      "community": 2673,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
       "label": "HomeHeroSection.tsx",
@@ -229672,7 +229714,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2672,
+      "community": 2674,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_test_ts",
       "label": "homePageContent.test.ts",
@@ -229681,7 +229723,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2673,
+      "community": 2675,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilemenu_tsx",
       "label": "MobileMenu.tsx",
@@ -229690,7 +229732,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2674,
+      "community": 2676,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
       "label": "constants.ts",
@@ -229699,7 +229741,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2675,
+      "community": 2677,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
       "label": "navBarConstants.ts",
@@ -229708,7 +229750,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2676,
+      "community": 2678,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_about_tsx",
       "label": "About.tsx",
@@ -229717,30 +229759,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2677,
+      "community": 2679,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_aboutproduct_tsx",
       "label": "AboutProduct.tsx",
       "norm_label": "aboutproduct.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-page/AboutProduct.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2678,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productactions_test_tsx",
-      "label": "ProductActions.test.tsx",
-      "norm_label": "productactions.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2679,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
-      "label": "ProductInfo.tsx",
-      "norm_label": "productinfo.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductInfo.tsx",
       "source_location": "L1"
     },
     {
@@ -229836,6 +229860,24 @@
     {
       "community": 2680,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productactions_test_tsx",
+      "label": "ProductActions.test.tsx",
+      "norm_label": "productactions.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2681,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
+      "label": "ProductInfo.tsx",
+      "norm_label": "productinfo.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductInfo.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2682,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
       "label": "ProductReviews.tsx",
       "norm_label": "productreviews.tsx",
@@ -229843,7 +229885,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2681,
+      "community": 2683,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
       "label": "ProductsNavigationBar.tsx",
@@ -229852,7 +229894,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2682,
+      "community": 2684,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
       "label": "ErrorMessage.tsx",
@@ -229861,7 +229903,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2683,
+      "community": 2685,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_existingreviewmessage_tsx",
       "label": "ExistingReviewMessage.tsx",
@@ -229870,7 +229912,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2684,
+      "community": 2686,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_test_tsx",
       "label": "OrderItem.test.tsx",
@@ -229879,7 +229921,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2685,
+      "community": 2687,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
       "label": "ReviewForm.tsx",
@@ -229888,7 +229930,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2686,
+      "community": 2688,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
       "label": "SuccessMessage.tsx",
@@ -229897,30 +229939,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2687,
+      "community": 2689,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
       "source_file": "packages/storefront-webapp/src/components/product-reviews/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2688,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
-      "label": "SavedBag.tsx",
-      "norm_label": "savedbag.tsx",
-      "source_file": "packages/storefront-webapp/src/components/saved-items/SavedBag.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2689,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
-      "label": "SavedIcon.tsx",
-      "norm_label": "savedicon.tsx",
-      "source_file": "packages/storefront-webapp/src/components/saved-items/SavedIcon.tsx",
       "source_location": "L1"
     },
     {
@@ -230016,6 +230040,24 @@
     {
       "community": 2690,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
+      "label": "SavedBag.tsx",
+      "norm_label": "savedbag.tsx",
+      "source_file": "packages/storefront-webapp/src/components/saved-items/SavedBag.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2691,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
+      "label": "SavedIcon.tsx",
+      "norm_label": "savedicon.tsx",
+      "source_file": "packages/storefront-webapp/src/components/saved-items/SavedIcon.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2692,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_carticon_tsx",
       "label": "CartIcon.tsx",
       "norm_label": "carticon.tsx",
@@ -230023,7 +230065,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2691,
+      "community": 2693,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
       "label": "ShoppingBag.test.tsx",
@@ -230032,7 +230074,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2692,
+      "community": 2694,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -230041,7 +230083,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2693,
+      "community": 2695,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_test_tsx",
       "label": "Maintenance.test.tsx",
@@ -230050,7 +230092,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2694,
+      "community": 2696,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_tsx",
       "label": "Maintenance.tsx",
@@ -230059,7 +230101,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2695,
+      "community": 2697,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
       "label": "AnimatedCard.tsx",
@@ -230068,7 +230110,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2696,
+      "community": 2698,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -230077,30 +230119,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2697,
+      "community": 2699,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
       "label": "alert.tsx",
       "norm_label": "alert.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/alert.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2698,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
-      "label": "breadcrumb.tsx",
-      "norm_label": "breadcrumb.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/breadcrumb.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2699,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_button_tsx",
-      "label": "button.tsx",
-      "norm_label": "button.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/button.tsx",
       "source_location": "L1"
     },
     {
@@ -230529,6 +230553,24 @@
     {
       "community": 2700,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
+      "label": "breadcrumb.tsx",
+      "norm_label": "breadcrumb.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/breadcrumb.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2701,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_button_tsx",
+      "label": "button.tsx",
+      "norm_label": "button.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/button.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2702,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
       "norm_label": "card.tsx",
@@ -230536,7 +230578,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2701,
+      "community": 2703,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
@@ -230545,7 +230587,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2702,
+      "community": 2704,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -230554,7 +230596,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2703,
+      "community": 2705,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
@@ -230563,7 +230605,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2704,
+      "community": 2706,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
@@ -230572,7 +230614,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2705,
+      "community": 2707,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
@@ -230581,7 +230623,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2706,
+      "community": 2708,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -230590,30 +230632,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2707,
+      "community": 2709,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
       "norm_label": "icons.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/icons.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2708,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
-      "label": "image-with-fallback.tsx",
-      "norm_label": "image-with-fallback.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-with-fallback.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2709,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
-      "label": "input-otp.tsx",
-      "norm_label": "input-otp.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/input-otp.tsx",
       "source_location": "L1"
     },
     {
@@ -230709,6 +230733,24 @@
     {
       "community": 2710,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
+      "label": "image-with-fallback.tsx",
+      "norm_label": "image-with-fallback.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-with-fallback.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2711,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
+      "label": "input-otp.tsx",
+      "norm_label": "input-otp.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/input-otp.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2712,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_with_end_button_tsx",
       "label": "input-with-end-button.tsx",
       "norm_label": "input-with-end-button.tsx",
@@ -230716,7 +230758,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2711,
+      "community": 2713,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -230725,7 +230767,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2712,
+      "community": 2714,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
@@ -230734,7 +230776,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2713,
+      "community": 2715,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
       "label": "LeaveAReviewModalForm.tsx",
@@ -230743,7 +230785,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2714,
+      "community": 2716,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -230752,7 +230794,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2715,
+      "community": 2717,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_animations_welcomebackmodalanimations_ts",
       "label": "welcomeBackModalAnimations.ts",
@@ -230761,7 +230803,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2716,
+      "community": 2718,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_index_ts",
       "label": "index.ts",
@@ -230770,30 +230812,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2717,
+      "community": 2719,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2718,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_navigation_menu_tsx",
-      "label": "navigation-menu.tsx",
-      "norm_label": "navigation-menu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/navigation-menu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2719,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_popover_tsx",
-      "label": "popover.tsx",
-      "norm_label": "popover.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/popover.tsx",
       "source_location": "L1"
     },
     {
@@ -230889,6 +230913,24 @@
     {
       "community": 2720,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_navigation_menu_tsx",
+      "label": "navigation-menu.tsx",
+      "norm_label": "navigation-menu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/navigation-menu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2721,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_popover_tsx",
+      "label": "popover.tsx",
+      "norm_label": "popover.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/popover.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2722,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
       "norm_label": "radio-group.tsx",
@@ -230896,7 +230938,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2721,
+      "community": 2723,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -230905,7 +230947,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2722,
+      "community": 2724,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -230914,7 +230956,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2723,
+      "community": 2725,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -230923,7 +230965,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2724,
+      "community": 2726,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -230932,7 +230974,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2725,
+      "community": 2727,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -230941,7 +230983,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2726,
+      "community": 2728,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -230950,30 +230992,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2727,
+      "community": 2729,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
       "norm_label": "textarea.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/textarea.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2728,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
-      "label": "toggle-group.tsx",
-      "norm_label": "toggle-group.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/toggle-group.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2729,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
-      "label": "toggle.tsx",
-      "norm_label": "toggle.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/toggle.tsx",
       "source_location": "L1"
     },
     {
@@ -231069,6 +231093,24 @@
     {
       "community": 2730,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
+      "label": "toggle-group.tsx",
+      "norm_label": "toggle-group.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/toggle-group.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2731,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
+      "label": "toggle.tsx",
+      "norm_label": "toggle.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/toggle.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2732,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
       "norm_label": "tooltip.tsx",
@@ -231076,7 +231118,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2731,
+      "community": 2733,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_config_ts",
       "label": "config.ts",
@@ -231085,7 +231127,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2732,
+      "community": 2734,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_test_tsx",
       "label": "StorefrontObservabilityProvider.test.tsx",
@@ -231094,7 +231136,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2733,
+      "community": 2735,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
@@ -231103,7 +231145,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2734,
+      "community": 2736,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
@@ -231112,7 +231154,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2735,
+      "community": 2737,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usequeryenabled_test_ts",
       "label": "useQueryEnabled.test.ts",
@@ -231121,7 +231163,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2736,
+      "community": 2738,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
       "label": "useStorefrontObservability.ts",
@@ -231130,30 +231172,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2737,
+      "community": 2739,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
       "source_file": "packages/storefront-webapp/src/lib/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2738,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_countries_ts",
-      "label": "countries.ts",
-      "norm_label": "countries.ts",
-      "source_file": "packages/storefront-webapp/src/lib/countries.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2739,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_feeutils_test_ts",
-      "label": "feeUtils.test.ts",
-      "norm_label": "feeutils.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/feeUtils.test.ts",
       "source_location": "L1"
     },
     {
@@ -231249,6 +231273,24 @@
     {
       "community": 2740,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_countries_ts",
+      "label": "countries.ts",
+      "norm_label": "countries.ts",
+      "source_file": "packages/storefront-webapp/src/lib/countries.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2741,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_feeutils_test_ts",
+      "label": "feeUtils.test.ts",
+      "norm_label": "feeutils.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/feeUtils.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2742,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
       "norm_label": "ghana.ts",
@@ -231256,7 +231298,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2741,
+      "community": 2743,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -231265,7 +231307,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2742,
+      "community": 2744,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
       "label": "maintenanceUtils.test.ts",
@@ -231274,7 +231316,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2743,
+      "community": 2745,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
       "label": "index.ts",
@@ -231283,7 +231325,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2744,
+      "community": 2746,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_productutils_test_ts",
       "label": "productUtils.test.ts",
@@ -231292,7 +231334,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2745,
+      "community": 2747,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_store_ts",
       "label": "store.ts",
@@ -231301,7 +231343,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2746,
+      "community": 2748,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
       "label": "bag.ts",
@@ -231310,30 +231352,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2747,
+      "community": 2749,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
       "label": "bagItem.ts",
       "norm_label": "bagitem.ts",
       "source_file": "packages/storefront-webapp/src/lib/schemas/bagItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2748,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_category_ts",
-      "label": "category.ts",
-      "norm_label": "category.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/category.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2749,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_organization_ts",
-      "label": "organization.ts",
-      "norm_label": "organization.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/organization.ts",
       "source_location": "L1"
     },
     {
@@ -231429,6 +231453,24 @@
     {
       "community": 2750,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_category_ts",
+      "label": "category.ts",
+      "norm_label": "category.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/category.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2751,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_organization_ts",
+      "label": "organization.ts",
+      "norm_label": "organization.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/organization.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2752,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
       "norm_label": "product.ts",
@@ -231436,7 +231478,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2751,
+      "community": 2753,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -231445,7 +231487,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2752,
+      "community": 2754,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -231454,7 +231496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2753,
+      "community": 2755,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -231463,7 +231505,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2754,
+      "community": 2756,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_states_ts",
       "label": "states.ts",
@@ -231472,7 +231514,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2755,
+      "community": 2757,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontcontextevents_test_ts",
       "label": "storefrontContextEvents.test.ts",
@@ -231481,7 +231523,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2756,
+      "community": 2758,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
       "label": "storefrontFailureObservability.test.ts",
@@ -231490,30 +231532,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2757,
+      "community": 2759,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
       "label": "storefrontJourneyEvents.test.ts",
       "norm_label": "storefrontjourneyevents.test.ts",
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2758,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_utils_test_ts",
-      "label": "utils.test.ts",
-      "norm_label": "utils.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/utils.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2759,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routetree_gen_ts",
-      "label": "routeTree.gen.ts",
-      "norm_label": "routetree.gen.ts",
-      "source_file": "packages/storefront-webapp/src/routeTree.gen.ts",
       "source_location": "L1"
     },
     {
@@ -231600,6 +231624,24 @@
     {
       "community": 2760,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_utils_test_ts",
+      "label": "utils.test.ts",
+      "norm_label": "utils.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/utils.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2761,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routetree_gen_ts",
+      "label": "routeTree.gen.ts",
+      "norm_label": "routetree.gen.ts",
+      "source_file": "packages/storefront-webapp/src/routeTree.gen.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2762,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_test_ts",
       "label": "-homePageLoader.test.ts",
       "norm_label": "-homepageloader.test.ts",
@@ -231607,7 +231649,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2761,
+      "community": 2763,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -231616,7 +231658,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2762,
+      "community": 2764,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_orderitemid_review_tsx",
       "label": "$orderItemId.review.tsx",
@@ -231625,7 +231667,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2763,
+      "community": 2765,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_index_tsx",
       "label": "index.tsx",
@@ -231634,7 +231676,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2764,
+      "community": 2766,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
       "label": "$subcategorySlug.tsx",
@@ -231643,7 +231685,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2765,
+      "community": 2767,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
       "label": "index.tsx",
@@ -231652,7 +231694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2766,
+      "community": 2768,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
       "label": "rewards.index.tsx",
@@ -231661,30 +231703,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2767,
+      "community": 2769,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
       "label": "shop.saved.index.tsx",
       "norm_label": "shop.saved.index.tsx",
       "source_file": "packages/storefront-webapp/src/routes/_layout/shop.saved.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2768,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
-      "label": "bag.index.tsx",
-      "norm_label": "bag.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/bag.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2769,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_complete_tsx",
-      "label": "complete.tsx",
-      "norm_label": "complete.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/complete.tsx",
       "source_location": "L1"
     },
     {
@@ -231771,6 +231795,24 @@
     {
       "community": 2770,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
+      "label": "bag.index.tsx",
+      "norm_label": "bag.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/bag.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2771,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_complete_tsx",
+      "label": "complete.tsx",
+      "norm_label": "complete.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/complete.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2772,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_incomplete_tsx",
       "label": "incomplete.tsx",
       "norm_label": "incomplete.tsx",
@@ -231778,7 +231820,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2771,
+      "community": 2773,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_index_tsx",
       "label": "index.tsx",
@@ -231787,7 +231829,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2772,
+      "community": 2774,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pending_tsx",
       "label": "pending.tsx",
@@ -231796,7 +231838,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2773,
+      "community": 2775,
       "file_type": "code",
       "id": "packages_storefront_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -231805,7 +231847,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2774,
+      "community": 2776,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_storefront_boot_e2e_ts",
       "label": "storefront-boot.e2e.ts",
@@ -231814,7 +231856,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2775,
+      "community": 2777,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -231823,7 +231865,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2776,
+      "community": 2778,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
@@ -231832,30 +231874,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2777,
+      "community": 2779,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_index_js",
       "label": "index.js",
       "norm_label": "index.js",
       "source_file": "packages/valkey-proxy-server/index.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 2778,
-      "file_type": "code",
-      "id": "scripts_check_register_session_authority_writers_test_ts",
-      "label": "check-register-session-authority-writers.test.ts",
-      "norm_label": "check-register-session-authority-writers.test.ts",
-      "source_file": "scripts/check-register-session-authority-writers.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2779,
-      "file_type": "code",
-      "id": "scripts_delivery_documentation_check_test_ts",
-      "label": "delivery-documentation-check.test.ts",
-      "norm_label": "delivery-documentation-check.test.ts",
-      "source_file": "scripts/delivery-documentation-check.test.ts",
       "source_location": "L1"
     },
     {
@@ -231942,6 +231966,24 @@
     {
       "community": 2780,
       "file_type": "code",
+      "id": "scripts_check_register_session_authority_writers_test_ts",
+      "label": "check-register-session-authority-writers.test.ts",
+      "norm_label": "check-register-session-authority-writers.test.ts",
+      "source_file": "scripts/check-register-session-authority-writers.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2781,
+      "file_type": "code",
+      "id": "scripts_delivery_documentation_check_test_ts",
+      "label": "delivery-documentation-check.test.ts",
+      "norm_label": "delivery-documentation-check.test.ts",
+      "source_file": "scripts/delivery-documentation-check.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2782,
+      "file_type": "code",
       "id": "scripts_harness_app_registry_test_ts",
       "label": "harness-app-registry.test.ts",
       "norm_label": "harness-app-registry.test.ts",
@@ -231949,7 +231991,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2781,
+      "community": 2783,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_athena_runtime_app_test_ts",
       "label": "athena-runtime-app.test.ts",
@@ -231958,7 +232000,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2782,
+      "community": 2784,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_test_ts",
       "label": "storefront-runtime-api.test.ts",
@@ -231967,7 +232009,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2783,
+      "community": 2785,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_test_ts",
       "label": "valkey-runtime-app.test.ts",
@@ -231976,7 +232018,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2784,
+      "community": 2786,
       "file_type": "code",
       "id": "scripts_harness_behavior_scenarios_test_ts",
       "label": "harness-behavior-scenarios.test.ts",
@@ -231985,7 +232027,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2785,
+      "community": 2787,
       "file_type": "code",
       "id": "scripts_harness_execution_context_test_ts",
       "label": "harness-execution-context.test.ts",
@@ -231994,7 +232036,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2786,
+      "community": 2788,
       "file_type": "code",
       "id": "scripts_harness_gate_registry_test_ts",
       "label": "harness-gate-registry.test.ts",
@@ -232003,30 +232045,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2787,
+      "community": 2789,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_test_ts",
       "label": "harness-repo-validation.test.ts",
       "norm_label": "harness-repo-validation.test.ts",
       "source_file": "scripts/harness-repo-validation.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2788,
-      "file_type": "code",
-      "id": "scripts_operational_work_repair_test_ts",
-      "label": "operational-work-repair.test.ts",
-      "norm_label": "operational-work-repair.test.ts",
-      "source_file": "scripts/operational-work-repair.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2789,
-      "file_type": "code",
-      "id": "tools_screen_redact_extension_background_js",
-      "label": "background.js",
-      "norm_label": "background.js",
-      "source_file": "tools/screen-redact-extension/background.js",
       "source_location": "L1"
     },
     {
@@ -232112,6 +232136,24 @@
     },
     {
       "community": 2790,
+      "file_type": "code",
+      "id": "scripts_operational_work_repair_test_ts",
+      "label": "operational-work-repair.test.ts",
+      "norm_label": "operational-work-repair.test.ts",
+      "source_file": "scripts/operational-work-repair.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2791,
+      "file_type": "code",
+      "id": "tools_screen_redact_extension_background_js",
+      "label": "background.js",
+      "norm_label": "background.js",
+      "source_file": "tools/screen-redact-extension/background.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 2792,
       "file_type": "code",
       "id": "tools_screen_redact_extension_popup_js",
       "label": "popup.js",
@@ -236163,83 +236205,83 @@
     {
       "community": 309,
       "file_type": "code",
-      "id": "applyremoteassistcontrolintent_applyacceptedcontrolresult",
-      "label": "applyAcceptedControlResult()",
-      "norm_label": "applyacceptedcontrolresult()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L84"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "applyremoteassistcontrolintent_applykeyevent",
-      "label": "applyKeyEvent()",
-      "norm_label": "applykeyevent()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L155"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "applyremoteassistcontrolintent_applypointerevent",
-      "label": "applyPointerEvent()",
-      "norm_label": "applypointerevent()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "applyremoteassistcontrolintent_applyremoteassistcontrolintent",
-      "label": "applyRemoteAssistControlIntent()",
-      "norm_label": "applyremoteassistcontrolintent()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "applyremoteassistcontrolintent_getrecentcontrolresult",
-      "label": "getRecentControlResult()",
-      "norm_label": "getrecentcontrolresult()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "applyremoteassistcontrolintent_getremoteassistcontroltarget",
-      "label": "getRemoteAssistControlTarget()",
-      "norm_label": "getremoteassistcontroltarget()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L145"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "applyremoteassistcontrolintent_prepareremoteassistcontrolintent",
-      "label": "prepareRemoteAssistControlIntent()",
-      "norm_label": "prepareremoteassistcontrolintent()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "applyremoteassistcontrolintent_remembercontrolresult",
-      "label": "rememberControlResult()",
-      "norm_label": "remembercontrolresult()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_remote_assist_runtime_applyremoteassistcontrolintent_ts",
-      "label": "applyRemoteAssistControlIntent.ts",
-      "norm_label": "applyremoteassistcontrolintent.ts",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "productutils_getpreferredsku",
+      "label": "getPreferredSku()",
+      "norm_label": "getpreferredsku()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L82"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "productutils_sortskusbyavailabilitythenlength",
+      "label": "sortSkusByAvailabilityThenLength()",
+      "norm_label": "sortskusbyavailabilitythenlength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L59"
     },
     {
       "community": 31,
@@ -236568,6 +236610,87 @@
     {
       "community": 310,
       "file_type": "code",
+      "id": "applyremoteassistcontrolintent_applyacceptedcontrolresult",
+      "label": "applyAcceptedControlResult()",
+      "norm_label": "applyacceptedcontrolresult()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_applykeyevent",
+      "label": "applyKeyEvent()",
+      "norm_label": "applykeyevent()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L155"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_applypointerevent",
+      "label": "applyPointerEvent()",
+      "norm_label": "applypointerevent()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L116"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_applyremoteassistcontrolintent",
+      "label": "applyRemoteAssistControlIntent()",
+      "norm_label": "applyremoteassistcontrolintent()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_getrecentcontrolresult",
+      "label": "getRecentControlResult()",
+      "norm_label": "getrecentcontrolresult()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_getremoteassistcontroltarget",
+      "label": "getRemoteAssistControlTarget()",
+      "norm_label": "getremoteassistcontroltarget()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L145"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_prepareremoteassistcontrolintent",
+      "label": "prepareRemoteAssistControlIntent()",
+      "norm_label": "prepareremoteassistcontrolintent()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_remembercontrolresult",
+      "label": "rememberControlResult()",
+      "norm_label": "remembercontrolresult()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_remote_assist_runtime_applyremoteassistcontrolintent_ts",
+      "label": "applyRemoteAssistControlIntent.ts",
+      "norm_label": "applyremoteassistcontrolintent.ts",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_offline_posofflinereadiness_ts",
       "label": "posOfflineReadiness.ts",
       "norm_label": "posofflinereadiness.ts",
@@ -236575,7 +236698,7 @@
       "source_location": "L1"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "posofflinereadiness_buildposofflinereadinesssummary",
       "label": "buildPosOfflineReadinessSummary()",
@@ -236584,7 +236707,7 @@
       "source_location": "L152"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "posofflinereadiness_buildsignal",
       "label": "buildSignal()",
@@ -236593,7 +236716,7 @@
       "source_location": "L178"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "posofflinereadiness_formatage",
       "label": "formatAge()",
@@ -236602,7 +236725,7 @@
       "source_location": "L290"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "posofflinereadiness_getsignaldescription",
       "label": "getSignalDescription()",
@@ -236611,7 +236734,7 @@
       "source_location": "L221"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "posofflinereadiness_getsignalstatus",
       "label": "getSignalStatus()",
@@ -236620,7 +236743,7 @@
       "source_location": "L201"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "posofflinereadiness_getsummarydescription",
       "label": "getSummaryDescription()",
@@ -236629,7 +236752,7 @@
       "source_location": "L262"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "posofflinereadiness_getsummarytitle",
       "label": "getSummaryTitle()",
@@ -236638,7 +236761,7 @@
       "source_location": "L256"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "posofflinereadiness_isreadylike",
       "label": "isReadyLike()",
@@ -236647,7 +236770,7 @@
       "source_location": "L286"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "foundations_content_colorrolecard",
       "label": "ColorRoleCard()",
@@ -236656,7 +236779,7 @@
       "source_location": "L222"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "foundations_content_densitycard",
       "label": "DensityCard()",
@@ -236665,7 +236788,7 @@
       "source_location": "L283"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "foundations_content_detailviewrolecard",
       "label": "DetailViewRoleCard()",
@@ -236674,7 +236797,7 @@
       "source_location": "L363"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "foundations_content_hslvar",
       "label": "hslVar()",
@@ -236683,7 +236806,7 @@
       "source_location": "L214"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "foundations_content_motioncard",
       "label": "MotionCard()",
@@ -236692,7 +236815,7 @@
       "source_location": "L342"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "foundations_content_spacetokenrow",
       "label": "SpaceTokenRow()",
@@ -236701,7 +236824,7 @@
       "source_location": "L265"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "foundations_content_textvar",
       "label": "textVar()",
@@ -236710,7 +236833,7 @@
       "source_location": "L218"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "foundations_content_typespecimencard",
       "label": "TypeSpecimenCard()",
@@ -236719,7 +236842,7 @@
       "source_location": "L246"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_foundations_content_tsx",
       "label": "foundations-content.tsx",
@@ -236728,7 +236851,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -236737,7 +236860,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -236746,7 +236869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "versionchecker_buildidfromscripts",
       "label": "buildIdFromScripts()",
@@ -236755,7 +236878,7 @@
       "source_location": "L192"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "versionchecker_createversionchecker",
       "label": "createVersionChecker()",
@@ -236764,7 +236887,7 @@
       "source_location": "L16"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "versionchecker_getinitialdeploybuildid",
       "label": "getInitialDeployBuildId()",
@@ -236773,7 +236896,7 @@
       "source_location": "L135"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "versionchecker_readdeploybuildid",
       "label": "readDeployBuildId()",
@@ -236782,7 +236905,7 @@
       "source_location": "L141"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "versionchecker_readdocumentscriptsources",
       "label": "readDocumentScriptSources()",
@@ -236791,7 +236914,7 @@
       "source_location": "L174"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "versionchecker_readentryhtmlscripts",
       "label": "readEntryHtmlScripts()",
@@ -236800,94 +236923,13 @@
       "source_location": "L151"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "versionchecker_readscriptsources",
       "label": "readScriptSources()",
       "norm_label": "readscriptsources()",
       "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
       "source_location": "L182"
-    },
-    {
-      "community": 313,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 313,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 313,
-      "file_type": "code",
-      "id": "productutils_getpreferredsku",
-      "label": "getPreferredSku()",
-      "norm_label": "getpreferredsku()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 313,
-      "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 313,
-      "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 313,
-      "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 313,
-      "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L82"
-    },
-    {
-      "community": 313,
-      "file_type": "code",
-      "id": "productutils_sortskusbyavailabilitythenlength",
-      "label": "sortSkusByAvailabilityThenLength()",
-      "norm_label": "sortskusbyavailabilitythenlength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 313,
-      "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L59"
     },
     {
       "community": 314,
@@ -268158,42 +268200,6 @@
     {
       "community": 682,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_register_test_ts",
-      "label": "register.test.ts",
-      "norm_label": "register.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 682,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_public_register_test_ts",
-      "label": "register.test.ts",
-      "norm_label": "register.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 682,
-      "file_type": "code",
-      "id": "register_test_buildctx",
-      "label": "buildCtx()",
-      "norm_label": "buildctx()",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 682,
-      "file_type": "code",
-      "id": "register_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 683,
-      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
       "label": "register.ts",
       "norm_label": "register.ts",
@@ -268201,7 +268207,7 @@
       "source_location": "L1"
     },
     {
-      "community": 683,
+      "community": 682,
       "file_type": "code",
       "id": "register_mapopendrawerusererror",
       "label": "mapOpenDrawerUserError()",
@@ -268210,7 +268216,7 @@
       "source_location": "L34"
     },
     {
-      "community": 683,
+      "community": 682,
       "file_type": "code",
       "id": "register_normalizeregisternumber",
       "label": "normalizeRegisterNumber()",
@@ -268219,7 +268225,7 @@
       "source_location": "L29"
     },
     {
-      "community": 683,
+      "community": 682,
       "file_type": "code",
       "id": "register_opendrawer",
       "label": "openDrawer()",
@@ -268228,7 +268234,7 @@
       "source_location": "L56"
     },
     {
-      "community": 684,
+      "community": 683,
       "file_type": "code",
       "id": "opendrawer_test_createdbgetmock",
       "label": "createDbGetMock()",
@@ -268237,7 +268243,7 @@
       "source_location": "L39"
     },
     {
-      "community": 684,
+      "community": 683,
       "file_type": "code",
       "id": "opendrawer_test_createdbmock",
       "label": "createDbMock()",
@@ -268246,7 +268252,7 @@
       "source_location": "L99"
     },
     {
-      "community": 684,
+      "community": 683,
       "file_type": "code",
       "id": "opendrawer_test_createdbquerymock",
       "label": "createDbQueryMock()",
@@ -268255,7 +268261,7 @@
       "source_location": "L74"
     },
     {
-      "community": 684,
+      "community": 683,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_opendrawer_test_ts",
       "label": "openDrawer.test.ts",
@@ -268264,7 +268270,7 @@
       "source_location": "L1"
     },
     {
-      "community": 685,
+      "community": 684,
       "file_type": "code",
       "id": "getregisterstate_buildregisterstate",
       "label": "buildRegisterState()",
@@ -268273,7 +268279,7 @@
       "source_location": "L21"
     },
     {
-      "community": 685,
+      "community": 684,
       "file_type": "code",
       "id": "getregisterstate_getactivesessionconflictforregisterstate",
       "label": "getActiveSessionConflictForRegisterState()",
@@ -268282,7 +268288,7 @@
       "source_location": "L42"
     },
     {
-      "community": 685,
+      "community": 684,
       "file_type": "code",
       "id": "getregisterstate_getregisterstate",
       "label": "getRegisterState()",
@@ -268291,7 +268297,7 @@
       "source_location": "L80"
     },
     {
-      "community": 685,
+      "community": 684,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
       "label": "getRegisterState.ts",
@@ -268300,7 +268306,7 @@
       "source_location": "L1"
     },
     {
-      "community": 686,
+      "community": 685,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_storepulse_test_ts",
       "label": "storePulse.test.ts",
@@ -268309,7 +268315,7 @@
       "source_location": "L1"
     },
     {
-      "community": 686,
+      "community": 685,
       "file_type": "code",
       "id": "storepulse_test_createdb",
       "label": "createDb()",
@@ -268318,7 +268324,7 @@
       "source_location": "L12"
     },
     {
-      "community": 686,
+      "community": 685,
       "file_type": "code",
       "id": "storepulse_test_item",
       "label": "item()",
@@ -268327,7 +268333,7 @@
       "source_location": "L127"
     },
     {
-      "community": 686,
+      "community": 685,
       "file_type": "code",
       "id": "storepulse_test_transaction",
       "label": "transaction()",
@@ -268336,7 +268342,7 @@
       "source_location": "L99"
     },
     {
-      "community": 687,
+      "community": 686,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_posregistersessionactivity_test_ts",
       "label": "posRegisterSessionActivity.test.ts",
@@ -268345,7 +268351,7 @@
       "source_location": "L1"
     },
     {
-      "community": 687,
+      "community": 686,
       "file_type": "code",
       "id": "posregistersessionactivity_test_buildactivity",
       "label": "buildActivity()",
@@ -268354,7 +268360,7 @@
       "source_location": "L457"
     },
     {
-      "community": 687,
+      "community": 686,
       "file_type": "code",
       "id": "posregistersessionactivity_test_buildreport",
       "label": "buildReport()",
@@ -268363,7 +268369,7 @@
       "source_location": "L436"
     },
     {
-      "community": 687,
+      "community": 686,
       "file_type": "code",
       "id": "posregistersessionactivity_test_createfakerepository",
       "label": "createFakeRepository()",
@@ -268372,7 +268378,7 @@
       "source_location": "L476"
     },
     {
-      "community": 688,
+      "community": 687,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_registercatalogrevision_ts",
       "label": "registerCatalogRevision.ts",
@@ -268381,7 +268387,7 @@
       "source_location": "L1"
     },
     {
-      "community": 688,
+      "community": 687,
       "file_type": "code",
       "id": "registercatalogrevision_advanceregistercatalogrevision",
       "label": "advanceRegisterCatalogRevision()",
@@ -268390,7 +268396,7 @@
       "source_location": "L24"
     },
     {
-      "community": 688,
+      "community": 687,
       "file_type": "code",
       "id": "registercatalogrevision_readregistercatalogrevision",
       "label": "readRegisterCatalogRevision()",
@@ -268399,7 +268405,7 @@
       "source_location": "L16"
     },
     {
-      "community": 688,
+      "community": 687,
       "file_type": "code",
       "id": "registercatalogrevision_readregistercatalogrevisionrow",
       "label": "readRegisterCatalogRevisionRow()",
@@ -268408,7 +268414,7 @@
       "source_location": "L6"
     },
     {
-      "community": 689,
+      "community": 688,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_sequencegappolicy_ts",
       "label": "sequenceGapPolicy.ts",
@@ -268417,7 +268423,7 @@
       "source_location": "L1"
     },
     {
-      "community": 689,
+      "community": 688,
       "file_type": "code",
       "id": "sequencegappolicy_decidesequencegapaction",
       "label": "decideSequenceGapAction()",
@@ -268426,7 +268432,7 @@
       "source_location": "L115"
     },
     {
-      "community": 689,
+      "community": 688,
       "file_type": "code",
       "id": "sequencegappolicy_issequencegapresolved",
       "label": "isSequenceGapResolved()",
@@ -268435,13 +268441,49 @@
       "source_location": "L219"
     },
     {
-      "community": 689,
+      "community": 688,
       "file_type": "code",
       "id": "sequencegappolicy_recordsequencegapobservation",
       "label": "recordSequenceGapObservation()",
       "norm_label": "recordsequencegapobservation()",
       "source_file": "packages/athena-webapp/convex/pos/application/sync/sequenceGapPolicy.ts",
       "source_location": "L190"
+    },
+    {
+      "community": 689,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_sync_staffproof_ts",
+      "label": "staffProof.ts",
+      "norm_label": "staffproof.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/staffProof.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 689,
+      "file_type": "code",
+      "id": "staffproof_createposlocalstaffprooftoken",
+      "label": "createPosLocalStaffProofToken()",
+      "norm_label": "createposlocalstaffprooftoken()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/staffProof.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 689,
+      "file_type": "code",
+      "id": "staffproof_hashposlocalstaffprooftoken",
+      "label": "hashPosLocalStaffProofToken()",
+      "norm_label": "hashposlocalstaffprooftoken()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/staffProof.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 689,
+      "file_type": "code",
+      "id": "staffproof_tohex",
+      "label": "toHex()",
+      "norm_label": "tohex()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/staffProof.ts",
+      "source_location": "L4"
     },
     {
       "community": 69,
@@ -268662,42 +268704,6 @@
     {
       "community": 690,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sync_staffproof_ts",
-      "label": "staffProof.ts",
-      "norm_label": "staffproof.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/staffProof.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 690,
-      "file_type": "code",
-      "id": "staffproof_createposlocalstaffprooftoken",
-      "label": "createPosLocalStaffProofToken()",
-      "norm_label": "createposlocalstaffprooftoken()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/staffProof.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 690,
-      "file_type": "code",
-      "id": "staffproof_hashposlocalstaffprooftoken",
-      "label": "hashPosLocalStaffProofToken()",
-      "norm_label": "hashposlocalstaffprooftoken()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/staffProof.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 690,
-      "file_type": "code",
-      "id": "staffproof_tohex",
-      "label": "toHex()",
-      "norm_label": "tohex()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/staffProof.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 691,
-      "file_type": "code",
       "id": "cloudrepairpolicy_test_buildconflict",
       "label": "buildConflict()",
       "norm_label": "buildconflict()",
@@ -268705,7 +268711,7 @@
       "source_location": "L387"
     },
     {
-      "community": 691,
+      "community": 690,
       "file_type": "code",
       "id": "cloudrepairpolicy_test_buildevent",
       "label": "buildEvent()",
@@ -268714,7 +268720,7 @@
       "source_location": "L407"
     },
     {
-      "community": 691,
+      "community": 690,
       "file_type": "code",
       "id": "cloudrepairpolicy_test_createrepairprojectionrepository",
       "label": "createRepairProjectionRepository()",
@@ -268723,7 +268729,7 @@
       "source_location": "L282"
     },
     {
-      "community": 691,
+      "community": 690,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_cloudrepairpolicy_test_ts",
       "label": "cloudRepairPolicy.test.ts",
@@ -268732,7 +268738,7 @@
       "source_location": "L1"
     },
     {
-      "community": 692,
+      "community": 691,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_terminalcommandservice_test_ts",
       "label": "terminalCommandService.test.ts",
@@ -268741,7 +268747,7 @@
       "source_location": "L1"
     },
     {
-      "community": 692,
+      "community": 691,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildcommand",
       "label": "buildCommand()",
@@ -268750,7 +268756,7 @@
       "source_location": "L1731"
     },
     {
-      "community": 692,
+      "community": 691,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildrepository",
       "label": "buildRepository()",
@@ -268759,7 +268765,7 @@
       "source_location": "L1666"
     },
     {
-      "community": 692,
+      "community": 691,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildruntimestatus",
       "label": "buildRuntimeStatus()",
@@ -268768,7 +268774,7 @@
       "source_location": "L1755"
     },
     {
-      "community": 693,
+      "community": 692,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
       "label": "sessionCommandRepository.ts",
@@ -268777,7 +268783,7 @@
       "source_location": "L1"
     },
     {
-      "community": 693,
+      "community": 692,
       "file_type": "code",
       "id": "sessioncommandrepository_collectsessionitemsfrompages",
       "label": "collectSessionItemsFromPages()",
@@ -268786,7 +268792,7 @@
       "source_location": "L177"
     },
     {
-      "community": 693,
+      "community": 692,
       "file_type": "code",
       "id": "sessioncommandrepository_createsessioncommandrepository",
       "label": "createSessionCommandRepository()",
@@ -268795,13 +268801,49 @@
       "source_location": "L68"
     },
     {
-      "community": 693,
+      "community": 692,
       "file_type": "code",
       "id": "sessioncommandrepository_scansessionitembyskuinpages",
       "label": "scanSessionItemBySkuInPages()",
       "norm_label": "scansessionitembyskuinpages()",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
       "source_location": "L195"
+    },
+    {
+      "community": 693,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_register_test_ts",
+      "label": "register.test.ts",
+      "norm_label": "register.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 693,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_public_register_test_ts",
+      "label": "register.test.ts",
+      "norm_label": "register.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 693,
+      "file_type": "code",
+      "id": "register_test_buildctx",
+      "label": "buildCtx()",
+      "norm_label": "buildctx()",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 693,
+      "file_type": "code",
+      "id": "register_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L38"
     },
     {
       "community": 694,
@@ -284380,7 +284422,7 @@
       "label": "cn()",
       "norm_label": "cn()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsOverviewView.tsx",
-      "source_location": "L131"
+      "source_location": "L135"
     },
     {
       "community": 963,
@@ -284389,7 +284431,7 @@
       "label": "comparisonFor()",
       "norm_label": "comparisonfor()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsOverviewView.tsx",
-      "source_location": "L28"
+      "source_location": "L32"
     },
     {
       "community": 964,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,13 +7,13 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 2866
-- Graph nodes: 12053
-- Graph edges: 14785
-- Communities: 2791
+- Code files discovered: 2868
+- Graph nodes: 12055
+- Graph edges: 14787
+- Communities: 2793
 
 ## Graph Hotspots
-- `dailyClose.ts` (96 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
+- `dailyClose.ts` (98 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `harness-inferential-review.ts` (88 edges, Community 2) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 - `posLocalStore.ts` (87 edges, Community 1) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts)
 - `dailyOperations.ts` (76 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -17,7 +17,7 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - [validation-map.json](../../../packages/athena-webapp/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `dailyClose.ts` (96 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
+- `dailyClose.ts` (98 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `posLocalStore.ts` (87 edges, Community 1) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`](../../../packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts)
 - `dailyOperations.ts` (76 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../../packages/athena-webapp/convex/operations/dailyOperations.ts)
 - `terminalHealthPresentation.ts` (76 edges, Community 4) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -20,7 +20,7 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 - `storefrontJourneyEvents.ts` (45 edges, Community 14) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 14) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `getStoreConfigV2()` (17 edges, Community 84) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
-- `storefrontContextEvents.ts` (17 edges, Community 113) - [`packages/storefront-webapp/src/lib/storefrontContextEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontContextEvents.ts)
+- `storefrontContextEvents.ts` (17 edges, Community 112) - [`packages/storefront-webapp/src/lib/storefrontContextEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontContextEvents.ts)
 - `checkoutSession.ts` (14 edges, Community 144) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 
 ## Navigation

--- a/packages/athena-webapp/convex/operations/dailyClose.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.test.ts
@@ -50,6 +50,8 @@ type TableName =
   | "expenseSession"
   | "expenseTransaction"
   | "expenseTransactionItem"
+  | "onlineOrder"
+  | "onlineOrderItem"
   | "operationalEvent"
   | "operationalWorkItem"
   | "oversizedOperationalWorkRepair"
@@ -2436,6 +2438,190 @@ describe("end-of-day review backend foundation", () => {
     );
     expect(snapshot.readyItems.map((item) => item.key)).not.toContain(
       "register_session:register-submitted:closed",
+    );
+  });
+
+  it("includes completed storefront revenue in the store-day sales total", async () => {
+    const { db } = createDb({
+      onlineOrder: [
+        {
+          _id: "online-order-1",
+          amount: 72_200,
+          completedAt: Date.UTC(2026, 4, 7, 19, 45),
+          deliveryFee: 0,
+          discount: null,
+          itemCount: 5,
+          orderNumber: "687185",
+          paymentDue: 72_200,
+          status: "picked-up",
+          storeId: "store-1",
+        },
+      ],
+      onlineOrderItem: [
+        {
+          _id: "online-order-item-1",
+          orderId: "online-order-1",
+          price: 14_000,
+          productSkuId: "sku-1",
+          quantity: 3,
+        },
+        {
+          _id: "online-order-item-2",
+          orderId: "online-order-1",
+          price: 20_000,
+          productSkuId: "sku-2",
+          quantity: 1,
+        },
+        {
+          _id: "online-order-item-3",
+          orderId: "online-order-1",
+          price: 10_200,
+          productSkuId: "sku-3",
+          quantity: 1,
+        },
+      ],
+      posTransaction: [
+        {
+          _id: "txn-1",
+          changeGiven: 0,
+          completedAt: Date.UTC(2026, 4, 7, 14),
+          payments: [{ amount: 12_000, method: "cash", timestamp: 1 }],
+          status: "completed",
+          storeId: "store-1",
+          subtotal: 12_000,
+          tax: 0,
+          total: 12_000,
+          totalPaid: 12_000,
+          transactionNumber: "TXN-1",
+        },
+      ],
+      store: [store],
+    });
+
+    const snapshot = await buildDailyCloseSnapshotWithCtx(
+      { db } as unknown as QueryCtx,
+      { operatingDate: "2026-05-07", storeId: "store-1" as Id<"store"> },
+    );
+
+    expect(snapshot.summary.salesTotal).toBe(84_200);
+    expect(snapshot.summary.transactionCount).toBe(2);
+    expect(snapshot.readyItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: "online_order:online-order-1:completed",
+          metadata: expect.objectContaining({
+            completedAt: Date.UTC(2026, 4, 7, 19, 45),
+            itemCount: 5,
+            order: "687185",
+            total: 72_200,
+          }),
+          subject: {
+            id: "online-order-1",
+            label: "687185",
+            type: "online_order",
+          },
+          title: "Completed online order",
+        }),
+      ]),
+    );
+    expect(snapshot.sourceCompleteness.entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          complete: true,
+          recordCount: 1,
+          source: "online_order",
+          statuses: ["delivered", "picked-up"],
+        }),
+      ]),
+    );
+  });
+
+  it("includes legacy inline storefront items in discounted sales totals", async () => {
+    const { db } = createDb({
+      onlineOrder: [
+        {
+          _id: "online-order-inline",
+          amount: 30_000,
+          completedAt: Date.UTC(2026, 4, 7, 19, 45),
+          deliveryFee: 0,
+          discount: { discountType: "percentage", discountValue: 10 },
+          items: [
+            { price: 10_000, productSkuId: "sku-1", quantity: 3 },
+          ],
+          orderNumber: "INLINE-1",
+          status: "delivered",
+          storeId: "store-1",
+        },
+      ],
+      store: [store],
+    });
+
+    const snapshot = await buildDailyCloseSnapshotWithCtx(
+      { db } as unknown as QueryCtx,
+      { operatingDate: "2026-05-07", storeId: "store-1" as Id<"store"> },
+    );
+
+    expect(snapshot.summary.salesTotal).toBe(27_000);
+    expect(snapshot.summary.transactionCount).toBe(1);
+    expect(snapshot.readyItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: "online_order:online-order-inline:completed",
+          metadata: expect.objectContaining({ itemCount: 3, total: 27_000 }),
+        }),
+      ]),
+    );
+  });
+
+  it("marks storefront order and item evidence incomplete at their source caps", async () => {
+    const orders = Array.from({ length: 201 }, (_, index) => ({
+      _id: `online-order-${index}`,
+      amount: 1_000,
+      completedAt: Date.UTC(2026, 4, 7, 12, index % 60),
+      deliveryFee: 0,
+      discount: null,
+      orderNumber: `ORDER-${index}`,
+      status: "delivered",
+      storeId: "store-1",
+    }));
+    const orderItems = Array.from({ length: 201 }, (_, index) => ({
+      _id: `online-order-item-${index}`,
+      orderId: "online-order-0",
+      price: 1_000,
+      productSkuId: `sku-${index}`,
+      quantity: 1,
+    }));
+
+    const orderCapSnapshot = await buildDailyCloseSnapshotWithCtx(
+      { db: createDb({ onlineOrder: orders, store: [store] }).db } as unknown as QueryCtx,
+      { operatingDate: "2026-05-07", storeId: "store-1" as Id<"store"> },
+    );
+    const itemCapSnapshot = await buildDailyCloseSnapshotWithCtx(
+      {
+        db: createDb({
+          onlineOrder: [orders[0]],
+          onlineOrderItem: orderItems,
+          store: [store],
+        }).db,
+      } as unknown as QueryCtx,
+      { operatingDate: "2026-05-07", storeId: "store-1" as Id<"store"> },
+    );
+
+    expect(orderCapSnapshot.sourceCompleteness.entries).toContainEqual(
+      expect.objectContaining({
+        complete: false,
+        reason: "online_order_source_cap_reached",
+        recordCount: 200,
+        source: "online_order",
+      }),
+    );
+    expect(itemCapSnapshot.sourceCompleteness.entries).toContainEqual(
+      expect.objectContaining({
+        complete: false,
+        reason: "online_order_item_source_cap_reached",
+        recordCount: 0,
+        source: "online_order_item",
+      }),
     );
   });
 

--- a/packages/athena-webapp/convex/operations/dailyClose.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.ts
@@ -69,6 +69,7 @@ import {
   normalizeCurrencyCode,
   type NewReportFact,
 } from "../../shared/reportsContract";
+import { getOrderAmount } from "../inventory/utils";
 
 export { buildAdjustmentReportTotals, listAppliedTransactionAdjustmentsForDay };
 
@@ -87,6 +88,7 @@ const ACTIVE_OVERSIZED_REPAIR_STATUSES = [
 const ACTIVE_REGISTER_STATUSES = ["open", "active", "closing"] as const;
 const REVIEW_ONLY_REGISTER_CLOSEOUT_STATUSES = ["closeout_rejected"] as const;
 const OPEN_POS_SESSION_STATUSES = ["active", "held"] as const;
+const COMPLETED_ONLINE_ORDER_STATUSES = ["delivered", "picked-up"] as const;
 const DAILY_CLOSE_BLOCKER_CATEGORY_PRECEDENCE: Record<string, number> = {
   approval: 0,
   register_session: 10,
@@ -1739,6 +1741,115 @@ async function listTransactionsForDay(
   });
 }
 
+async function listCompletedOnlineOrdersForDay(
+  ctx: Pick<QueryCtx, "db">,
+  args: {
+    endAt: number;
+    startAt: number;
+    storeId: Id<"store">;
+  },
+): Promise<DailyCloseSourceRead<Doc<"onlineOrder">>> {
+  const range = { startAt: args.startAt, endAt: args.endAt };
+  const pages = await Promise.all(
+    COMPLETED_ONLINE_ORDER_STATUSES.map((status) =>
+      ctx.db
+        .query("onlineOrder")
+        .withIndex("by_storeId_status_completedAt", (q) =>
+          q
+            .eq("storeId", args.storeId)
+            .eq("status", status)
+            .gte("completedAt", args.startAt)
+            .lt("completedAt", args.endAt),
+        )
+        .take(DAILY_CLOSE_QUERY_LIMIT + 1),
+    ),
+  );
+  const matchingRows = pages
+    .flat()
+    .sort((left, right) => (left.completedAt ?? 0) - (right.completedAt ?? 0));
+  const rows = matchingRows.slice(0, DAILY_CLOSE_QUERY_LIMIT);
+
+  return {
+    rows,
+    completeness: sourceCompletenessEntry({
+      source: "online_order",
+      complete: matchingRows.length <= DAILY_CLOSE_QUERY_LIMIT,
+      readMode: "by_storeId_status_completedAt",
+      recordCount: rows.length,
+      limit: DAILY_CLOSE_QUERY_LIMIT,
+      range,
+      reason: "online_order_source_cap_reached",
+      statuses: [...COMPLETED_ONLINE_ORDER_STATUSES],
+    }),
+  };
+}
+
+async function buildCompletedOnlineOrderTotals(
+  ctx: Pick<QueryCtx, "db">,
+  orders: Array<Doc<"onlineOrder">>,
+) {
+  const totalsByOrderId = new Map<
+    string,
+    { itemCount: number; total: number }
+  >();
+  let sourceItemCount = 0;
+  let sourceCapReached = false;
+
+  for (const order of orders) {
+    if (
+      typeof order.paymentDue === "number" &&
+      typeof order.itemCount === "number"
+    ) {
+      totalsByOrderId.set(String(order._id), {
+        itemCount: order.itemCount,
+        total: order.paymentDue,
+      });
+      continue;
+    }
+
+    const remainingBudget = Math.max(
+      0,
+      DAILY_CLOSE_QUERY_LIMIT - sourceItemCount,
+    );
+    const inlineItems = order.items ?? [];
+    const itemProbe =
+      inlineItems.length > 0
+        ? inlineItems
+        : await ctx.db
+            .query("onlineOrderItem")
+            .withIndex("by_orderId", (q) => q.eq("orderId", order._id))
+            .take(remainingBudget + 1);
+    if (itemProbe.length > remainingBudget) {
+      sourceCapReached = true;
+      break;
+    }
+
+    const items = itemProbe.slice(0, remainingBudget);
+    sourceItemCount += items.length;
+    totalsByOrderId.set(String(order._id), {
+      itemCount: items.reduce((sum, item) => sum + item.quantity, 0),
+      total: getOrderAmount({
+        items,
+        discount: order.discount,
+        deliveryFee: order.deliveryFee,
+        subtotal: order.amount,
+      }),
+    });
+  }
+
+  return {
+    totalsByOrderId,
+    completeness: sourceCompletenessEntry({
+      source: "online_order_item",
+      complete: !sourceCapReached,
+      readMode: "by_orderId",
+      recordCount: sourceItemCount,
+      limit: DAILY_CLOSE_QUERY_LIMIT,
+      reason: "online_order_item_source_cap_reached",
+    }),
+  };
+}
+
 async function listExpensesForDay(
   ctx: Pick<QueryCtx, "db">,
   args: {
@@ -2676,6 +2787,7 @@ export async function buildDailyCloseSnapshotWithCtx(
     openWorkItemRead,
     activeOversizedRepairRead,
     completedTransactionRead,
+    completedOnlineOrderRead,
     appliedTransactionAdjustmentRead,
     voidedTransactionRead,
     expenseTransactionRead,
@@ -2696,6 +2808,10 @@ export async function buildDailyCloseSnapshotWithCtx(
       status: "completed",
       storeId: args.storeId,
     }),
+    listCompletedOnlineOrdersForDay(ctx, {
+      ...range,
+      storeId: args.storeId,
+    }),
     readAppliedTransactionAdjustmentsForDay(ctx, {
       ...range,
       storeId: args.storeId,
@@ -2710,6 +2826,11 @@ export async function buildDailyCloseSnapshotWithCtx(
     getPriorCompletedDailyClose(ctx, args),
   ]);
   const completedTransactions = completedTransactionRead.rows;
+  const completedOnlineOrders = completedOnlineOrderRead.rows;
+  const completedOnlineOrderTotals = await buildCompletedOnlineOrderTotals(
+    ctx,
+    completedOnlineOrders,
+  );
   const appliedTransactionAdjustments = appliedTransactionAdjustmentRead.rows;
   const voidedTransactions = voidedTransactionRead.rows;
   const expenseTransactions = expenseTransactionRead.rows;
@@ -2751,6 +2872,8 @@ export async function buildDailyCloseSnapshotWithCtx(
     openWorkItemRead.completeness,
     activeOversizedRepairRead.completeness,
     completedTransactionRead.completeness,
+    completedOnlineOrderRead.completeness,
+    completedOnlineOrderTotals.completeness,
     appliedTransactionAdjustmentRead.completeness,
     voidedTransactionRead.completeness,
     expenseTransactionRead.completeness,
@@ -3298,6 +3421,37 @@ export async function buildDailyCloseSnapshotWithCtx(
     });
   });
 
+  completedOnlineOrders.forEach((order) => {
+    const totals = completedOnlineOrderTotals.totalsByOrderId.get(
+      String(order._id),
+    );
+    if (!totals) return;
+
+    readyItems.push({
+      key: `online_order:${order._id}:completed`,
+      severity: "ready",
+      category: "sale",
+      title: "Completed online order",
+      message: "Completed online order is included in the end of day review.",
+      subject: {
+        type: "online_order",
+        id: order._id,
+        label: order.orderNumber,
+      },
+      link: {
+        label: "View order",
+        params: { orderSlug: order._id },
+        to: "/$orgUrlSlug/store/$storeUrlSlug/orders/$orderSlug",
+      },
+      metadata: {
+        order: order.orderNumber,
+        total: totals.total,
+        completedAt: order.completedAt,
+        itemCount: totals.itemCount,
+      },
+    });
+  });
+
   appliedTransactionAdjustments.forEach((adjustment) => {
     const originalTotal =
       typeof adjustment.originalTotal === "number"
@@ -3467,10 +3621,15 @@ export async function buildDailyCloseSnapshotWithCtx(
     (sum, transaction) => sum + transactionCashDelta(transaction),
     0,
   );
-  const salesTotal = completedTransactions.reduce(
-    (sum, transaction) => sum + transaction.total,
-    0,
-  );
+  const salesTotal =
+    completedTransactions.reduce(
+      (sum, transaction) => sum + transaction.total,
+      0,
+    ) +
+    Array.from(completedOnlineOrderTotals.totalsByOrderId.values()).reduce(
+      (sum, order) => sum + order.total,
+      0,
+    );
   const adjustmentReportTotals = buildAdjustmentReportTotals({
     appliedAdjustments: appliedTransactionAdjustments,
     completedTransactions,
@@ -3530,7 +3689,8 @@ export async function buildDailyCloseSnapshotWithCtx(
       Boolean(session.variance),
     ).length,
     salesTotal,
-    transactionCount: completedTransactions.length,
+    transactionCount:
+      completedTransactions.length + completedOnlineOrders.length,
     voidedTransactionCount: voidedTransactions.length,
     paymentTotals: buildPaymentTotals(completedTransactions),
   };

--- a/packages/athena-webapp/convex/schemas/storeFront/onlineOrder/onlineOrder.ts
+++ b/packages/athena-webapp/convex/schemas/storeFront/onlineOrder/onlineOrder.ts
@@ -76,6 +76,7 @@ export const onlineOrderSchema = v.object({
   externalReference: v.optional(v.string()),
   externalTransactionId: v.optional(v.string()),
   hasVerifiedPayment: v.boolean(),
+  itemCount: v.optional(v.number()),
   items: v.optional(v.array(onlineOrderItemSchema)),
   orderNumber: v.string(),
   orderReceivedEmailSentAt: v.optional(v.number()),

--- a/packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts
+++ b/packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts
@@ -254,6 +254,10 @@ export async function createOrderFromCheckoutSession(
     externalTransactionId:
       args.externalTransactionId ?? session.externalTransactionId?.toString(),
     hasVerifiedPayment: session.hasVerifiedPayment,
+    itemCount: serverPricedItems.reduce(
+      (total, item) => total + item.quantity,
+      0,
+    ),
     orderNumber: generateOrderNumber(),
     paymentDue,
     paymentMethod: args.paymentMethod,

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -7,7 +7,7 @@ This key-folder index highlights the main directories agents are likely to need 
 ## Core app surfaces
 
 - [`src/routes`](../../src/routes) — TanStack route entrypoints and authenticated shells. Currently 145 file(s); key children: -app-entry-route.tsx, -authed-layout.tsx, -authenticated-layout.tsx, -demo-presentation.ts, -docs-back-link.tsx.
-- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 797 file(s); key children: GenericComboBox.tsx, Navbar.test.tsx, Navbar.tsx, OrganizationView.test.tsx, OrganizationView.tsx.
+- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 799 file(s); key children: GenericComboBox.tsx, Navbar.test.tsx, Navbar.tsx, OrganizationView.test.tsx, OrganizationView.tsx.
 - [`src/components/traces`](../../src/components/traces) — Shared workflow trace screens, ordered timelines, and trace detail primitives. Currently 3 file(s); key children: WorkflowTraceRouteLink.tsx, WorkflowTraceView.test.tsx, WorkflowTraceView.tsx.
 - [`src/components/operations`](../../src/components/operations) — Manager-queue and stock-adjustment workflows that share approval rails with other operational surfaces. Currently 37 file(s); key children: CommandApprovalDialog.test.tsx, CommandApprovalDialog.tsx, DailyCloseHistoryView.test.tsx, DailyCloseHistoryView.tsx, DailyCloseView.test.tsx.
 - [`src/components/procurement`](../../src/components/procurement) — Procurement planning and receiving views for replenishment pressure and purchase-order execution. Currently 4 file(s); key children: ProcurementView.test.tsx, ProcurementView.tsx, ReceivingView.test.tsx, ReceivingView.tsx.

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -503,6 +503,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`src/components/reports/ReportCustomRangePanel.test.tsx`](../../src/components/reports/ReportCustomRangePanel.test.tsx)
 - [`src/components/reports/ReportDateRangeField.test.tsx`](../../src/components/reports/ReportDateRangeField.test.tsx)
 - [`src/components/reports/ReportDaysPanel.test.tsx`](../../src/components/reports/ReportDaysPanel.test.tsx)
+- [`src/components/reports/ReportSegmentedTabs.test.tsx`](../../src/components/reports/ReportSegmentedTabs.test.tsx)
 - [`src/components/reports/ReportSkuMixChart.test.tsx`](../../src/components/reports/ReportSkuMixChart.test.tsx)
 - [`src/components/reports/ReportTrendChart.test.tsx`](../../src/components/reports/ReportTrendChart.test.tsx)
 - [`src/components/reports/ReportUnitsMovedChartSheet.test.tsx`](../../src/components/reports/ReportUnitsMovedChartSheet.test.tsx)

--- a/packages/athena-webapp/src/components/reports/ReportSegmentedTabs.test.tsx
+++ b/packages/athena-webapp/src/components/reports/ReportSegmentedTabs.test.tsx
@@ -1,0 +1,45 @@
+import { createRef } from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Tabs } from "@/components/ui/tabs";
+import {
+  ReportSegmentedTabsList,
+  ReportSegmentedTabsTrigger,
+} from "./ReportSegmentedTabs";
+
+describe("ReportSegmentedTabs", () => {
+  it("owns the report segmented-control styling and preserves consumer overrides", () => {
+    const triggerRef = createRef<HTMLButtonElement>();
+
+    render(
+      <Tabs defaultValue="first">
+        <ReportSegmentedTabsList aria-label="Test views">
+          <ReportSegmentedTabsTrigger value="first">
+            First
+          </ReportSegmentedTabsTrigger>
+          <ReportSegmentedTabsTrigger
+            className="h-11 sm:h-8"
+            ref={triggerRef}
+            value="second"
+          >
+            Second
+          </ReportSegmentedTabsTrigger>
+        </ReportSegmentedTabsList>
+      </Tabs>,
+    );
+
+    expect(screen.getByRole("tablist", { name: "Test views" })).toHaveClass(
+      "bg-surface-raised",
+      "shadow-surface",
+    );
+    expect(screen.getByRole("tab", { name: "First" })).toHaveClass(
+      "min-h-8",
+      "data-[state=active]:bg-primary-soft",
+    );
+    expect(screen.getByRole("tab", { name: "Second" })).toHaveClass(
+      "h-11",
+      "sm:h-8",
+    );
+    expect(triggerRef.current).toBe(screen.getByRole("tab", { name: "Second" }));
+  });
+});

--- a/packages/athena-webapp/src/components/reports/ReportSegmentedTabs.tsx
+++ b/packages/athena-webapp/src/components/reports/ReportSegmentedTabs.tsx
@@ -1,0 +1,37 @@
+import * as React from "react";
+import { TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { cn } from "@/lib/utils";
+
+const ReportSegmentedTabsList = React.forwardRef<
+  React.ElementRef<typeof TabsList>,
+  Omit<React.ComponentPropsWithoutRef<typeof TabsList>, "size">
+>(({ className, ...props }, ref) => (
+  <TabsList
+    className={cn(
+      "h-auto flex-wrap justify-start gap-1 border border-border bg-surface-raised p-1 text-muted-foreground shadow-surface",
+      className,
+    )}
+    ref={ref}
+    size="sm"
+    {...props}
+  />
+));
+ReportSegmentedTabsList.displayName = "ReportSegmentedTabsList";
+
+const ReportSegmentedTabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsTrigger>,
+  Omit<React.ComponentPropsWithoutRef<typeof TabsTrigger>, "size">
+>(({ className, ...props }, ref) => (
+  <TabsTrigger
+    className={cn(
+      "min-h-8 px-3 data-[state=active]:bg-primary-soft data-[state=active]:text-primary data-[state=active]:shadow-none",
+      className,
+    )}
+    ref={ref}
+    size="sm"
+    {...props}
+  />
+));
+ReportSegmentedTabsTrigger.displayName = "ReportSegmentedTabsTrigger";
+
+export { ReportSegmentedTabsList, ReportSegmentedTabsTrigger };

--- a/packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx
+++ b/packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx
@@ -30,12 +30,7 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@/components/ui/sheet";
-import {
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-} from "@/components/ui/tabs";
+import { Tabs, TabsContent } from "@/components/ui/tabs";
 import useGetActiveStore from "@/hooks/useGetActiveStore";
 import {
   findScrollableAncestor,
@@ -60,6 +55,10 @@ import {
   formatReportMoney,
   formatUnits,
 } from "./reportFormat";
+import {
+  ReportSegmentedTabsList,
+  ReportSegmentedTabsTrigger,
+} from "./ReportSegmentedTabs";
 import {
   useReportsSharedDemoMode,
   useSharedDemoLiveReportsDay,
@@ -795,27 +794,21 @@ export function ReportUnitsMovedChartSheet({
             }
             value={activeTab}
           >
-            <TabsList
-              aria-label="Item movement view"
-              className="h-auto flex-wrap justify-start gap-1 border border-border bg-surface-raised p-1 text-muted-foreground shadow-surface"
-              size="sm"
-            >
-              <TabsTrigger
-                className="h-11 min-h-8 px-3 data-[state=active]:bg-primary-soft data-[state=active]:text-primary data-[state=active]:shadow-none sm:h-8"
-                size="sm"
+            <ReportSegmentedTabsList aria-label="Item movement view">
+              <ReportSegmentedTabsTrigger
+                className="h-11 sm:h-8"
                 value="top"
               >
                 Top movers
-              </TabsTrigger>
-              <TabsTrigger
-                className="h-11 min-h-8 px-3 data-[state=active]:bg-primary-soft data-[state=active]:text-primary data-[state=active]:shadow-none sm:h-8"
+              </ReportSegmentedTabsTrigger>
+              <ReportSegmentedTabsTrigger
+                className="h-11 sm:h-8"
                 ref={granularTabRef}
-                size="sm"
                 value="granular"
               >
                 All items
-              </TabsTrigger>
-            </TabsList>
+              </ReportSegmentedTabsTrigger>
+            </ReportSegmentedTabsList>
 
             {/* Lifecycle / count message slot. */}
             {isPending ? (

--- a/packages/athena-webapp/src/components/reports/ReportsOverviewView.tsx
+++ b/packages/athena-webapp/src/components/reports/ReportsOverviewView.tsx
@@ -2,7 +2,7 @@ import { useNavigate, useParams } from "@tanstack/react-router";
 
 import { EmptyState } from "@/components/states/empty/empty-state";
 import { FadeIn } from "@/components/common/FadeIn";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tabs } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 import { getOrigin } from "@/lib/navigationUtils";
 import {
@@ -10,6 +10,10 @@ import {
   type ReportOverviewData,
 } from "~/shared/reportsContract";
 import { ReportPeriodMetrics } from "./ReportPeriodMetrics";
+import {
+  ReportSegmentedTabsList,
+  ReportSegmentedTabsTrigger,
+} from "./ReportSegmentedTabs";
 import { ReportFreshness } from "./ReportFreshness";
 import { ReportTrendChart } from "./ReportTrendChart";
 import { ReportTrustStrip } from "./ReportTrustStrip";
@@ -144,22 +148,16 @@ export function ReportsOverviewView({
               }
               value={selectedWindow}
             >
-              <TabsList
-                aria-label="Report period"
-                className="h-auto flex-wrap justify-start gap-1 border border-border bg-surface-raised p-1 text-muted-foreground shadow-surface"
-                size="sm"
-              >
+              <ReportSegmentedTabsList aria-label="Report period">
                 {REPORT_OVERVIEW_WINDOWS.map((window) => (
-                  <TabsTrigger
-                    className="min-h-8 px-3 data-[state=active]:bg-primary-soft data-[state=active]:text-primary data-[state=active]:shadow-none"
+                  <ReportSegmentedTabsTrigger
                     key={window}
-                    size="sm"
                     value={window}
                   >
                     {REPORT_OVERVIEW_WINDOW_LABELS[window]}
-                  </TabsTrigger>
+                  </ReportSegmentedTabsTrigger>
                 ))}
-              </TabsList>
+              </ReportSegmentedTabsList>
             </Tabs>
 
             <ReportFreshness

--- a/packages/athena-webapp/src/components/reports/ReportsWeeklyView.test.tsx
+++ b/packages/athena-webapp/src/components/reports/ReportsWeeklyView.test.tsx
@@ -469,7 +469,9 @@ describe("ReportsWeeklyView", () => {
     expect(screen.getByText(/Accepted Aug 8, 2026.*Corrected Aug 9, 2026/)).toBeInTheDocument();
   });
 
-  it("renders close-backed cash, payment, and expense evidence value-first", () => {
+  it("renders close-backed cash, payment, and tabbed expense evidence value-first", async () => {
+    const user = userEvent.setup();
+
     render(
       <ReportsWeeklyView
         report={{ ...report, closeEvidence } as WeeklyReportProjection}
@@ -513,15 +515,103 @@ describe("ReportsWeeklyView", () => {
     expect(
       screen.queryByText("Shares may not total 100% due to rounding."),
     ).not.toBeInTheDocument();
+    const expenseSort = screen.getByRole("tablist", {
+      name: "Expense product sort order",
+    });
+    expect(expenseSort).toBeInTheDocument();
+    expect(
+      screen.getByRole("tab", { name: "Expense spend" }),
+    ).toHaveAttribute("aria-selected", "true");
     expect(screen.getByText("Highest expense spend")).toBeInTheDocument();
-    expect(screen.getByText("Most consumed expense products")).toBeInTheDocument();
-    expect(screen.getAllByText("6 of 6 scheduled days")).toHaveLength(3);
+    expect(
+      screen.queryByText("Most consumed expense products"),
+    ).not.toBeInTheDocument();
+    const sharedCoverage = screen.getByTestId("weekly-close-evidence-coverage");
+    expect(sharedCoverage).toHaveTextContent("Daily Close evidence");
+    expect(sharedCoverage).toHaveTextContent("6 of 6 scheduled days");
+    expect(screen.getAllByText("6 of 6 scheduled days")).toHaveLength(1);
     expect(screen.getByText("2 other products")).toBeInTheDocument();
-    expect(screen.getByText("1 other product")).toBeInTheDocument();
-    // Frozen evidence keeps the source spelling; the view normalizes on read.
-    expect(screen.getByText("Styling Gel")).toBeInTheDocument();
-    expect(screen.getByText("Lace Remover")).toBeInTheDocument();
+    expect(screen.queryByText("1 other product")).not.toBeInTheDocument();
+    // Frozen evidence keeps the source spelling; the view normalizes on read
+    // and gives the product label hierarchy a compact reporting treatment.
+    const spendProduct = screen.getByText("Lace Remover");
+    expect(spendProduct).toHaveClass("text-sm");
+    expect(screen.getByText("LR-02")).toHaveClass("text-xs");
+    expect(screen.queryByText("Styling Gel")).not.toBeInTheDocument();
     expect(screen.queryByText("STYLING GEL")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "Units consumed" }));
+
+    expect(
+      screen.getByRole("tab", { name: "Units consumed" }),
+    ).toHaveAttribute("aria-selected", "true");
+    expect(
+      screen.queryByText("Highest expense spend"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Most consumed expense products")).toBeInTheDocument();
+    expect(screen.getByText("1 other product")).toBeInTheDocument();
+    expect(screen.queryByText("2 other products")).not.toBeInTheDocument();
+    expect(screen.getByText("Styling Gel")).toHaveClass("text-sm");
+    expect(screen.getByText("GEL-01")).toHaveClass("text-xs");
+    expect(screen.queryByText("Lace Remover")).not.toBeInTheDocument();
+  });
+
+  it("keeps lane-specific coverage when Daily Close evidence does not agree", () => {
+    render(
+      <ReportsWeeklyView
+        report={{
+          ...report,
+          closeEvidence: {
+            ...closeEvidence,
+            cash: {
+              ...closeEvidence.cash,
+              coverage: {
+                scheduledDayCount: 6,
+                status: "partial",
+                usableDayCount: 3,
+              },
+            },
+          },
+        } as WeeklyReportProjection}
+      />,
+    );
+
+    expect(
+      screen.queryByTestId("weekly-close-evidence-coverage"),
+    ).not.toBeInTheDocument();
+    expect(screen.getAllByText("6 of 6 scheduled days")).toHaveLength(2);
+    expect(screen.getByText(/Based on 3 of 6 scheduled days/)).toBeInTheDocument();
+  });
+
+  it("hides expense sort controls when there are no expense products", () => {
+    render(
+      <ReportsWeeklyView
+        report={{
+          ...report,
+          closeEvidence: {
+            ...closeEvidence,
+            expenses: {
+              ...closeEvidence.expenses,
+              byQuantity: [],
+              bySpend: [],
+              coveredQuantity: 0,
+              coveredSpendMinor: 0,
+              quantityRemainder: null,
+              spendRemainder: null,
+            },
+          },
+        } as WeeklyReportProjection}
+      />,
+    );
+
+    expect(screen.getByText(/Covered expense spend:/)).toBeInTheDocument();
+    expect(screen.queryByRole("tablist", {
+      name: "Expense product sort order",
+    })).not.toBeInTheDocument();
+    expect(screen.queryByText("Highest expense spend")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Most consumed expense products"),
+    ).not.toBeInTheDocument();
   });
 
   it("discloses rounding only when persisted shares do not total 100%", () => {
@@ -566,7 +656,7 @@ describe("ReportsWeeklyView", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders a certified-zero payment week as covered zero, not a sync promise", () => {
+  it("does not render payment mix when there are no payments", () => {
     render(
       <ReportsWeeklyView
         report={{
@@ -587,17 +677,9 @@ describe("ReportsWeeklyView", () => {
       />,
     );
 
-    const paymentMixHeading = screen.getByText("Payment mix");
-    const section = paymentMixHeading.closest("section")!;
-    expect(section).toHaveTextContent("$0 · Based on 3 of 6 scheduled days");
+    expect(screen.queryByText("Payment mix")).not.toBeInTheDocument();
     expect(
-      screen.queryByText(
-        "Payment method shares will appear after completed sales sync.",
-      ),
-    ).not.toBeInTheDocument();
-    expect(screen.queryByText("No payment mix yet")).not.toBeInTheDocument();
-    expect(
-      screen.queryByText(/Covered tender value:/),
+      screen.queryByRole("region", { name: "Payment methods" }),
     ).not.toBeInTheDocument();
   });
 

--- a/packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx
+++ b/packages/athena-webapp/src/components/reports/ReportsWeeklyView.tsx
@@ -1,7 +1,9 @@
+import { useState } from "react";
 import { Link, useParams } from "@tanstack/react-router";
 import { ArrowUpRight, CheckCircle2, Info } from "lucide-react";
 import { FlipNumber } from "@/components/common/FlipNumber";
 import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent } from "@/components/ui/tabs";
 import {
   Tooltip,
   TooltipContent,
@@ -46,6 +48,10 @@ import {
   type ReportUnitsMovedFocusSurface,
   type ReportUnitsMovedTab,
 } from "./ReportUnitsMovedChartSheet";
+import {
+  ReportSegmentedTabsList,
+  ReportSegmentedTabsTrigger,
+} from "./ReportSegmentedTabs";
 
 /**
  * The server-owned weekly projection shown by both active and history reads.
@@ -287,6 +293,29 @@ function closeEvidenceCoverageLabel(coverage: WeeklyEvidenceCoverage) {
   return `${coverage.usableDayCount.toLocaleString()} of ${coverage.scheduledDayCount.toLocaleString()} scheduled days`;
 }
 
+function sharedCloseEvidenceCoverage(
+  evidence: WeeklyCloseEvidence | undefined,
+): WeeklyEvidenceCoverage | null {
+  if (!evidence) return null;
+
+  const coverages = [
+    evidence.payments.coverage,
+    evidence.cash.coverage,
+    evidence.expenses.coverage,
+  ];
+  const [first, ...rest] = coverages;
+  if (first.status === "unavailable") return null;
+
+  return rest.every(
+    (coverage) =>
+      coverage.status === first.status &&
+      coverage.usableDayCount === first.usableDayCount &&
+      coverage.scheduledDayCount === first.scheduledDayCount,
+  )
+    ? first
+    : null;
+}
+
 function weeklyPaymentMix(
   rows: WeeklyCloseEvidence["payments"]["rows"],
 ): StorePulsePaymentMixEntry[] {
@@ -495,6 +524,9 @@ export function ReportsWeeklyView({
     report.inventoryAttention?.completeness === "complete" &&
     report.inventoryAttention.newCount === 0 &&
     report.inventoryAttention.carriedForwardCount === 0;
+  const sharedEvidenceCoverage = sharedCloseEvidenceCoverage(
+    report.closeEvidence,
+  );
   /**
    * Mixed currency and a breached fact cap both tell the operator that totals
    * are withheld. Sections keep their shape so the report stays navigable,
@@ -844,67 +876,61 @@ export function ReportsWeeklyView({
             Payment allocation is incomplete.
           </p>
         ) : null}
+        {sharedEvidenceCoverage ? (
+          <dl
+            className="mt-layout-md flex flex-wrap items-baseline gap-x-layout-sm gap-y-1 text-sm"
+            data-testid="weekly-close-evidence-coverage"
+          >
+            <dt className="font-medium text-foreground">
+              Daily Close evidence
+            </dt>
+            <dd className="text-muted-foreground">
+              {sharedEvidenceCoverage.usableDayCount.toLocaleString()} of{" "}
+              {sharedEvidenceCoverage.scheduledDayCount.toLocaleString()}
+              {" scheduled days"}
+            </dd>
+          </dl>
+        ) : null}
       </Section>
 
-      {report.closeEvidence ? (
+      {report.closeEvidence?.payments.rows.length ? (
         <Section title="Payment mix">
-          {report.closeEvidence.payments.coverage.status === "unavailable" ? (
+          {!sharedEvidenceCoverage ? (
             <p className="mt-layout-sm text-sm leading-6 text-muted-foreground">
               {closeEvidenceCoverageLabel(
                 report.closeEvidence.payments.coverage,
               )}
             </p>
-          ) : report.closeEvidence.payments.rows.length === 0 ? (
-            /*
-             * Certified zero: covered days exist but recorded no tender at
-             * all. Mirrors the cash lane's covered-zero pattern rather than
-             * the live-sync empty state, which promises data that will never
-             * arrive for a closed week.
-             */
-            <p className="mt-layout-sm text-sm leading-6 text-muted-foreground">
-              <span className="font-medium text-foreground">{money(0)}</span> ·{" "}
-              {closeEvidenceCoverageLabel(report.closeEvidence.payments.coverage)}
-            </p>
-          ) : (
-            <>
-              <p className="mt-layout-sm text-sm text-muted-foreground">
-                {closeEvidenceCoverageLabel(
-                  report.closeEvidence.payments.coverage,
-                )}
-              </p>
-              {/* The qualified subtotal: only the covered days' tender value. */}
-              <p className="mt-layout-xs text-sm text-muted-foreground">
-                Covered tender value:{" "}
-                <span className="font-medium text-foreground">
-                  {money(report.closeEvidence.payments.coveredTenderValueMinor)}
-                </span>
-              </p>
-              <div className="mt-layout-md lg:w-1/2">
-                <PaymentMethodsPanel
-                  countNoun="tender use"
-                  paymentMix={weeklyPaymentMix(
-                    report.closeEvidence.payments.rows,
-                  )}
-                  shareSource="provided"
-                  showHeader={false}
-                  totalTransactions={report.closeEvidence.payments.rows.reduce(
-                    (total, row) => total + row.tenderUseCount,
-                    0,
-                  )}
-                  valueFormatter={(payment) => money(payment.total)}
-                  variant="canvas"
-                />
-              </div>
-              {report.closeEvidence.payments.rows.reduce(
-                (total, row) => total + row.shareBasisPoints,
+          ) : null}
+          {/* The qualified subtotal: only the covered days' tender value. */}
+          <p className="mt-layout-xs text-sm text-muted-foreground">
+            Covered tender value:{" "}
+            <span className="font-medium text-foreground">
+              {money(report.closeEvidence.payments.coveredTenderValueMinor)}
+            </span>
+          </p>
+          <div className="mt-layout-md lg:w-1/2">
+            <PaymentMethodsPanel
+              countNoun="tender use"
+              paymentMix={weeklyPaymentMix(report.closeEvidence.payments.rows)}
+              shareSource="provided"
+              showHeader={false}
+              totalTransactions={report.closeEvidence.payments.rows.reduce(
+                (total, row) => total + row.tenderUseCount,
                 0,
-              ) !== 10_000 ? (
-                <p className="mt-layout-sm text-xs text-muted-foreground">
-                  Shares may not total 100% due to rounding.
-                </p>
-              ) : null}
-            </>
-          )}
+              )}
+              valueFormatter={(payment) => money(payment.total)}
+              variant="canvas"
+            />
+          </div>
+          {report.closeEvidence.payments.rows.reduce(
+            (total, row) => total + row.shareBasisPoints,
+            0,
+          ) !== 10_000 ? (
+            <p className="mt-layout-sm text-xs text-muted-foreground">
+              Shares may not total 100% due to rounding.
+            </p>
+          ) : null}
         </Section>
       ) : null}
 
@@ -975,7 +1001,8 @@ export function ReportsWeeklyView({
               </p>
             ) : (
               <p className="mt-layout-xs text-sm leading-6 text-muted-foreground">
-                {report.closeEvidence.cash.coverage.status === "partial" ? (
+                {report.closeEvidence.cash.coverage.status === "partial" &&
+                !sharedEvidenceCoverage ? (
                   `${formatCashVariance(report.closeEvidence.cash.cashVarianceMinor, money)} · ${closeEvidenceCoverageLabel(report.closeEvidence.cash.coverage)}`
                 ) : (
                   <span className="font-medium text-foreground">
@@ -985,7 +1012,8 @@ export function ReportsWeeklyView({
                     )}
                   </span>
                 )}
-                {report.closeEvidence.cash.coverage.status === "complete" ? (
+                {report.closeEvidence.cash.coverage.status === "complete" &&
+                !sharedEvidenceCoverage ? (
                   <span className="block">
                     {closeEvidenceCoverageLabel(
                       report.closeEvidence.cash.coverage,
@@ -1031,11 +1059,13 @@ export function ReportsWeeklyView({
             </p>
           ) : (
             <>
-              <p className="mt-layout-sm text-sm text-muted-foreground">
-                {closeEvidenceCoverageLabel(
-                  report.closeEvidence.expenses.coverage,
-                )}
-              </p>
+              {!sharedEvidenceCoverage ? (
+                <p className="mt-layout-sm text-sm text-muted-foreground">
+                  {closeEvidenceCoverageLabel(
+                    report.closeEvidence.expenses.coverage,
+                  )}
+                </p>
+              ) : null}
               {/* The qualified subtotal: only the covered days' expense spend. */}
               <p className="mt-layout-xs text-sm text-muted-foreground">
                 Covered expense spend:{" "}
@@ -1048,22 +1078,10 @@ export function ReportsWeeklyView({
                   ? "unit"
                   : "units"}
               </p>
-              <div className="mt-layout-md grid gap-layout-xl lg:grid-cols-2">
-                <ExpenseRanking
-                  currency={currency}
-                  emphasis="spend"
-                  remainder={report.closeEvidence.expenses.spendRemainder}
-                  rows={report.closeEvidence.expenses.bySpend}
-                  title="Highest expense spend"
-                />
-                <ExpenseRanking
-                  currency={currency}
-                  emphasis="quantity"
-                  remainder={report.closeEvidence.expenses.quantityRemainder}
-                  rows={report.closeEvidence.expenses.byQuantity}
-                  title="Most consumed expense products"
-                />
-              </div>
+              <ExpenseProductRankings
+                currency={currency}
+                expenses={report.closeEvidence.expenses}
+              />
             </>
           )}
         </Section>
@@ -1225,6 +1243,60 @@ function formatReportTimestamp(at: number): string {
   });
 }
 
+function ExpenseProductRankings({
+  currency,
+  expenses,
+}: {
+  currency: string;
+  expenses: WeeklyCloseEvidence["expenses"];
+}) {
+  const [sortOrder, setSortOrder] = useState<"spend" | "quantity">("spend");
+  const hasExpenseProducts =
+    expenses.bySpend.length > 0 ||
+    expenses.byQuantity.length > 0 ||
+    (expenses.spendRemainder?.productCount ?? 0) > 0 ||
+    (expenses.quantityRemainder?.productCount ?? 0) > 0;
+
+  if (!hasExpenseProducts) return null;
+
+  return (
+    <Tabs
+      className="mt-layout-md"
+      onValueChange={(value) =>
+        setSortOrder(value === "quantity" ? "quantity" : "spend")
+      }
+      value={sortOrder}
+    >
+      <ReportSegmentedTabsList aria-label="Expense product sort order">
+        <ReportSegmentedTabsTrigger value="spend">
+          Expense spend
+        </ReportSegmentedTabsTrigger>
+        <ReportSegmentedTabsTrigger value="quantity">
+          Units consumed
+        </ReportSegmentedTabsTrigger>
+      </ReportSegmentedTabsList>
+      <TabsContent className="mt-layout-md" value="spend">
+        <ExpenseRanking
+          currency={currency}
+          emphasis="spend"
+          remainder={expenses.spendRemainder}
+          rows={expenses.bySpend}
+          title="Highest expense spend"
+        />
+      </TabsContent>
+      <TabsContent className="mt-layout-md" value="quantity">
+        <ExpenseRanking
+          currency={currency}
+          emphasis="quantity"
+          remainder={expenses.quantityRemainder}
+          rows={expenses.byQuantity}
+          title="Most consumed expense products"
+        />
+      </TabsContent>
+    </Tabs>
+  );
+}
+
 function ExpenseRanking({
   currency,
   emphasis,
@@ -1264,10 +1336,10 @@ function ExpenseRanking({
               key={row.productSkuId}
             >
               <span>
-                <span className="block font-medium text-foreground">
+                <span className="block text-sm font-medium leading-5 text-foreground">
                   {formatProductDisplayName(row.productName)}
                 </span>
-                <span className="block text-sm text-muted-foreground">
+                <span className="block text-xs leading-5 text-muted-foreground">
                   {row.productSku}
                 </span>
               </span>

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports/weekly.lifecycle.test.tsx
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports/weekly.lifecycle.test.tsx
@@ -591,6 +591,41 @@ describe("ReportsWeeklyRoute query lifecycle", () => {
     expect(state.search.sheetReturn).toBeUndefined();
   });
 
+  it("returns from an accepted week to the current week and closes history", async () => {
+    const user = userEvent.setup();
+    state.search = {
+      history: true,
+      historyCursor: "older-page",
+      historyCursorTrail: [null],
+      overviewWindow: "last_7_days",
+      reportId: "week:2026-07-06",
+      sheetReturn: "sku-61~640",
+      unitsPage: 4,
+      unitsTab: "granular",
+    };
+    render(<ReportsWeeklyRoute />);
+
+    const returnButton = screen.getByRole("button", {
+      name: "Return to current week",
+    });
+    expect(returnButton).toHaveClass("h-control-standard");
+    expect(
+      returnButton.querySelector("svg.lucide-calendar-days"),
+    ).toBeInTheDocument();
+
+    await user.click(returnButton);
+
+    expect(state.search.reportId).toBeUndefined();
+    expect(state.search.history).toBeUndefined();
+    expect(state.search.historyCursor).toBeUndefined();
+    expect(state.search.historyCursorTrail).toBeUndefined();
+    expect(state.search.units).toBeUndefined();
+    expect(state.search.unitsTab).toBeUndefined();
+    expect(state.search.unitsPage).toBeUndefined();
+    expect(state.search.sheetReturn).toBeUndefined();
+    expect(state.search.overviewWindow).toBe("last_7_days");
+  });
+
   it("uses one active query, adds history only on demand, and replaces active with detail", async () => {
     const user = userEvent.setup();
     const { rerender } = render(<ReportsWeeklyRoute />);

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports/weekly.tsx
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports/weekly.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, useParams } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { CalendarDaysIcon } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 
 import { EmptyState } from "@/components/states/empty/empty-state";
@@ -334,6 +335,31 @@ export function ReportsWeeklyRoute() {
                   aria-label="Weekly report history"
                   className="border-y border-border py-layout-md"
                 >
+                  {selectedReportId ? (
+                    <Button
+                      className="-ml-2 mb-layout-sm h-control-standard gap-2 px-2 text-foreground"
+                      onClick={() =>
+                        void navigate({
+                          search: (current) => ({
+                            ...current,
+                            history: undefined,
+                            historyCursor: undefined,
+                            historyCursorTrail: undefined,
+                            reportId: undefined,
+                            ...closedUnitsSheetSearch,
+                          }),
+                        })
+                      }
+                      type="button"
+                      variant="clear"
+                    >
+                      <CalendarDaysIcon
+                        aria-hidden="true"
+                        className="h-4 w-4"
+                      />
+                      Return to current week
+                    </Button>
+                  ) : null}
                   {history === undefined ? (
                     <p className="text-sm text-muted-foreground">
                       Loading weekly history.


### PR DESCRIPTION
## Summary

End of Day Review now includes fulfilled storefront orders in the same store-day sales total used for POS activity, closing the net-sales gap with the Reports workspace. The weekly workspace also presents evidence and alternate orderings more clearly through shared segmented controls, conditional sections, consolidated Daily Close coverage, and an explicit return from historical weeks.

The backend keeps the live snapshot bounded: current orders expose their authoritative `paymentDue` and a compact `itemCount` on the parent row, while older documents use a capped reconstruction path that fails closed when source completeness cannot be proven.

## What changed

- Include `delivered` and `picked-up` online orders in Daily Close sales totals, transaction counts, source evidence, and operator-visible ready items.
- Preserve legacy inline and split-row order support with bounded source-cap handling.
- Reuse one report segmented-control component across Overview, Units Moved, and weekly expense rankings.
- Show spend and units-consumed expense rankings as alternate tabs with more compact product labels.
- Consolidate matching payment, cash, and expense coverage into one Daily Close evidence line.
- Omit Payment mix and expense sort controls when their datasets are empty.
- Let historical weekly reports return to the current week while clearing period-owned route and sheet state.

## Validation

- `bun run pr:athena`
- Final candidate reviews: correctness, testing, TypeScript, adversarial, agent-native, performance, project standards, and maintainability
- Delivery report: `docs/reports/2026-08-12-store-day-sales-parity-weekly-review-report.html`
- Reusable learning: `docs/solutions/logic-errors/daily-close-storefront-sales-parity-2026-08-12.md`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
