### PR TITLE
[V26-1201, V26-1221]: Make linked-worktree pushes safe and reusable

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 #!/bin/sh
 bun scripts/worktree-bootstrap-check.ts || exit $?
 cd "$(git rev-parse --show-toplevel)" || exit 1
+. "$(dirname "$0")/scrub-git-env.sh" || exit $?
 bun run pre-commit:generated-artifacts

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,6 +1,7 @@
 #!/bin/sh
 bun scripts/worktree-bootstrap-check.ts || exit $?
 cd "$(git rev-parse --show-toplevel)" || exit 1
+. "$(dirname "$0")/scrub-git-env.sh" || exit $?
 
 ATHENA_PRE_PUSH_TMP_DIR=${TMPDIR:-/tmp}
 ATHENA_PRE_PUSH_HEARTBEAT_SECONDS=${ATHENA_PRE_PUSH_HEARTBEAT_SECONDS:-10}

--- a/.husky/scrub-git-env.sh
+++ b/.husky/scrub-git-env.sh
@@ -1,0 +1,6 @@
+for ATHENA_GIT_ENV_NAME in $(
+  env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'
+); do
+  unset "$ATHENA_GIT_ENV_NAME"
+done
+unset ATHENA_GIT_ENV_NAME

--- a/docs/reports/2026-08-14-hook-safe-validation-proof-reuse-report.html
+++ b/docs/reports/2026-08-14-hook-safe-validation-proof-reuse-report.html
@@ -5,7 +5,7 @@
   <title>Hook-Safe Validation and Telemetry Proof Reuse</title>
 </head>
 <body>
-<article data-athena-landed-change-report="v2" data-athena-report-diff-fingerprint="4f5723b7c76a0ecd526c0471ff32f481be5a8ca2638809ae6fd01132e1398733">
+<article data-athena-landed-change-report="v2" data-athena-report-diff-fingerprint="dc7e06e5e32d6f2caa9c5a18ec2eba5bfc20aab09586e7d0f69208f467c9bf50">
   <header data-report-section="header">
     <h1>Hook-Safe Validation and Telemetry Proof Reuse</h1>
     <p>V26-1201 and V26-1221 delivery candidate</p>

--- a/docs/reports/2026-08-14-hook-safe-validation-proof-reuse-report.html
+++ b/docs/reports/2026-08-14-hook-safe-validation-proof-reuse-report.html
@@ -18,7 +18,7 @@
     <dl data-report-meta>
       <dt>Linear</dt><dd>V26-1201 and V26-1221</dd>
       <dt>Branch</dt><dd>codex/v26-1220-git-hook-isolation</dd>
-      <dt>Candidate head</dt><dd>4dcae61eb1f324f64b8ca42a06c85df35ae719c9</dd>
+      <dt>Reviewed code head</dt><dd>c5aaad05093b0d8dafa8627241a2fb1044c6baf9</dd>
       <dt>Base</dt><dd>origin/main at b271119c6b55b870d968404f18100f0bedb4e2e8</dd>
       <dt>PR</dt><dd>Pending</dd>
       <dt>Status</dt><dd>In review preparation</dd>
@@ -47,7 +47,7 @@
   <section data-report-section="mechanics">
     <h2>How the boundaries work</h2>
       <p>The shell helper discovers variable names from env and unsets every name beginning with GIT_. The TypeScript helper returns a copied environment without those keys, leaving the caller&#x27;s process environment unchanged. Hook tests inject GIT_COMMON_DIR, GIT_DIR, GIT_INDEX_FILE, GIT_OBJECT_DIRECTORY, GIT_PREFIX, and GIT_WORK_TREE and prove ordinary Athena variables still arrive.</p>
-      <p>For proof reuse, the evaluator compares the validated and current tree with NUL-delimited git diff --name-status --no-renames. Every entry must be an addition under telemetry/delivery-runs/ ending in .json. Any malformed comparison, unsafe status or path, or failed delivery telemetry check returns a named stale reason instead of reusing proof.</p>
+    <p>For proof reuse, the evaluator compares the validated and current tree with NUL-delimited git diff --name-status --no-renames. Every entry must be an addition under telemetry/delivery-runs/ ending in .json. The telemetry check runs in strict CI mode so a missing or mismatched private ledger cannot suppress current-record enforcement. Any malformed comparison, unsafe status or path, or failed delivery telemetry check returns a named stale reason instead of reusing proof.</p>
   </section>
   <section data-report-section="failure-boundaries">
     <h2>Failure boundaries</h2>
@@ -66,7 +66,7 @@
   </section>
   <section data-report-section="validation">
     <h2>Validation and finish-line status</h2>
-      <p>Completed locally: 133 focused tests passed across the combined hook, identity, proof, and integration surfaces. The complete bun run harness:test suite passed 945 tests across 59 files with zero failures. The compound solution gate passed after refreshing the combined delivery fingerprint.</p>
+    <p>Completed locally: 134 focused tests passed across the combined hook, identity, proof, and integration surfaces, including strict post-gate telemetry validation without a matching local ledger. The complete bun run harness:test suite passed 945 tests across 59 files with zero failures. The compound solution gate passed after refreshing the combined delivery fingerprint.</p>
       <p>The real merge-grade pr:athena run, independent exact-candidate review, normal pre-push execution, GitHub CI, merge, root alignment, and Linear completion are still pending for this delivery candidate. Runtime deployment is not claimed here; its applicability will be decided from the final committed surface at closeout.</p>
   </section>
   <section data-report-section="guidance">

--- a/docs/reports/2026-08-14-hook-safe-validation-proof-reuse-report.html
+++ b/docs/reports/2026-08-14-hook-safe-validation-proof-reuse-report.html
@@ -1,0 +1,217 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Hook-Safe Validation and Telemetry Proof Reuse</title>
+</head>
+<body>
+<article data-athena-landed-change-report="v2" data-athena-report-diff-fingerprint="4f5723b7c76a0ecd526c0471ff32f481be5a8ca2638809ae6fd01132e1398733">
+  <header data-report-section="header">
+    <h1>Hook-Safe Validation and Telemetry Proof Reuse</h1>
+    <p>V26-1201 and V26-1221 delivery candidate</p>
+    <ul data-report-pills>
+      <li>Delivery candidate</li>
+      <li>V26-1201 + V26-1221</li>
+      <li>Hook and harness workflow</li>
+      <li>945 harness tests green</li>
+    </ul>
+    <dl data-report-meta>
+      <dt>Linear</dt><dd>V26-1201 and V26-1221</dd>
+      <dt>Branch</dt><dd>codex/v26-1220-git-hook-isolation</dd>
+      <dt>Candidate head</dt><dd>4dcae61eb1f324f64b8ca42a06c85df35ae719c9</dd>
+      <dt>Base</dt><dd>origin/main at b271119c6b55b870d968404f18100f0bedb4e2e8</dd>
+      <dt>PR</dt><dd>Pending</dd>
+      <dt>Status</dt><dd>In review preparation</dd>
+    </dl>
+  </header>
+  <section data-report-section="summary">
+    <h2>Executive summary</h2>
+      <p>This delivery closes two finish-line gaps. V26-1201 prevents Git hook repository pointers from leaking into validators and their disposable Git fixtures. V26-1221 lets pre-push reuse a completed pr:athena proof after the required canonical delivery telemetry record is added, without treating documentation or arbitrary post-gate edits as safe.</p>
+      <p>The result is a safer real push path: nested tests cannot silently target the parent repository, and a valid merge-grade run is not repeated solely because its own validated telemetry record was committed afterward. Both boundaries remain fail-closed.</p>
+  </section>
+  <section data-report-section="problem">
+    <h2>Why this mattered</h2>
+      <p>The gap appeared while finishing V26-1219. Git exported hook-scoped GIT_* variables, and nested fixture commands inherited them. A fixture that believed it was changing a temporary repository could instead address the outer checkout, causing false failures and risking mutations to shared config, refs, or index state. The immediate V26-1220 harness fix proved the issue, but the failure recurred in another validator, showing that the production boundary belonged in both hook wrappers.</p>
+      <p>A second loop appeared after merge-grade validation. pr:athena proved one tree, then the required telemetry command wrote a JSON record describing that run. Committing the record changed the raw tree, so pre-push discarded otherwise-current proof and wanted to repeat the expensive gate.</p>
+  </section>
+  <section data-report-section="mental-model">
+    <h2>Mental model: an airlock and a sealed receipt</h2>
+      <p>Treat each hook as an airlock. It first uses Git&#x27;s ambient context to confirm the worktree and enter the repository. It then removes every inherited GIT_* pointer before opening the door to validation. Independently executable fixture helpers keep their own smaller airlocks because they may run outside the hook.</p>
+      <p>Treat the pr:athena proof as a seal on the validated tree. The only item allowed to accompany that seal afterward is a newly added canonical telemetry JSON receipt, and the receipt must validate. Source, generated files, documentation, telemetry edits, deletions, and lookalike paths break the seal and require validation again.</p>
+  </section>
+  <section data-report-section="before-after">
+    <h2>Before and after</h2>
+      <p>Before: worktree bootstrap ran, validators inherited hook-owned repository pointers, and nested Git fixtures could escape their temporary repositories. After a successful pr:athena run, committing its telemetry record also made the proof look stale.</p>
+      <p>After: bootstrap and root discovery still run first. Both tracked hooks then source one scrubber before validation. The harness test runner and independent fixture helpers also sanitize owned subprocesses. Proof evaluation separately permits only additive telemetry/delivery-runs/*.json deltas, validates the telemetry corpus, and retains every existing base, runtime, command, wiring, and clean-tree check.</p>
+  </section>
+  <section data-report-section="mechanics">
+    <h2>How the boundaries work</h2>
+      <p>The shell helper discovers variable names from env and unsets every name beginning with GIT_. The TypeScript helper returns a copied environment without those keys, leaving the caller&#x27;s process environment unchanged. Hook tests inject GIT_COMMON_DIR, GIT_DIR, GIT_INDEX_FILE, GIT_OBJECT_DIRECTORY, GIT_PREFIX, and GIT_WORK_TREE and prove ordinary Athena variables still arrive.</p>
+      <p>For proof reuse, the evaluator compares the validated and current tree with NUL-delimited git diff --name-status --no-renames. Every entry must be an addition under telemetry/delivery-runs/ ending in .json. Any malformed comparison, unsafe status or path, or failed delivery telemetry check returns a named stale reason instead of reusing proof.</p>
+  </section>
+  <section data-report-section="failure-boundaries">
+    <h2>Failure boundaries</h2>
+      <ul>
+        <li>The bootstrap check is intentionally before scrubbing; it needs the hook&#x27;s repository context to identify the worktree.</li>
+        <li>Modified or deleted telemetry, reports, solution notes, source, generated artifacts, and prefix lookalikes invalidate proof.</li>
+        <li>A canonical telemetry filename is not sufficient: delivery:telemetry-check must accept the current tracked record.</li>
+        <li>Changes to origin/main, Bun, the pr:athena command, or validation wiring still invalidate proof.</li>
+        <li>No hook validation command is removed, bypassed, or weakened; a non-reusable proof falls back to the normal validation path.</li>
+      </ul>
+  </section>
+  <section data-report-section="changes">
+    <h2>What changed and what did not</h2>
+      <p>V26-1220&#x27;s owned harness subprocess isolation was retained as a defense for direct harness execution and consolidated into V26-1201&#x27;s broader hook-wrapper boundary. V26-1221 adds a distinct, narrower proof-lifecycle rule rather than widening the existing review-neutral policy.</p>
+      <p>Intentionally unchanged: worktree bootstrap remains first; non-Git environment values remain available; reports and solution notes still require their validators; raw-tree identity still protects preparation and race checks; all noncanonical post-gate changes still force the merge-grade path. Graphify was regenerated only to keep repository navigation current.</p>
+  </section>
+  <section data-report-section="validation">
+    <h2>Validation and finish-line status</h2>
+      <p>Completed locally: 133 focused tests passed across the combined hook, identity, proof, and integration surfaces. The complete bun run harness:test suite passed 945 tests across 59 files with zero failures. The compound solution gate passed after refreshing the combined delivery fingerprint.</p>
+      <p>The real merge-grade pr:athena run, independent exact-candidate review, normal pre-push execution, GitHub CI, merge, root alignment, and Linear completion are still pending for this delivery candidate. Runtime deployment is not claimed here; its applicability will be decided from the final committed surface at closeout.</p>
+  </section>
+  <section data-report-section="guidance">
+    <h2>Next-time guidance</h2>
+      <ul>
+        <li>Consume any legitimately required Git hook pointer before the scrub boundary; never let ambient repository authority flow into general validators.</li>
+        <li>Sanitize at the highest child-process boundary that exclusively owns nested repository work, while retaining lower-level protection for independently callable helpers.</li>
+        <li>Test hook behavior with representative GIT_* values and compare parent config, refs, and index before and after real nested operations.</li>
+        <li>Keep post-gate exemptions narrower than review-neutral narration. Expanding the telemetry allowlist requires an equally narrow validator and fail-closed regression tests.</li>
+        <li>When pre-push rejects proof, use its named invalidation reason to decide whether the tree, base, runtime, wiring, or telemetry contract changed.</li>
+      </ul>
+  </section>
+  <section data-report-section="key-files">
+    <h2>Key files</h2>
+    <table>
+      <thead><tr><th>File</th><th>Why it matters</th></tr></thead>
+      <tbody>
+        <tr><td><code>.husky/pre-commit and .husky/pre-push</code></td><td>Preserve bootstrap/root discovery ordering and scrub Git context before validation.</td></tr>
+        <tr><td><code>.husky/scrub-git-env.sh</code></td><td>Shared production shell boundary that removes every inherited GIT_* variable.</td></tr>
+        <tr><td><code>scripts/git-environment.ts</code></td><td>Returns a copied environment without Git repository context for owned child processes.</td></tr>
+        <tr><td><code>scripts/harness-test.ts</code></td><td>Applies TypeScript isolation to the complete root bun test subprocess.</td></tr>
+        <tr><td><code>scripts/harness-test.test.ts</code></td><td>Proves nested fixture mutations stay local and parent config, refs, and index remain unchanged.</td></tr>
+        <tr><td><code>scripts/pre-push-hook.test.ts</code></td><td>Executes both shell hooks under representative Git context and checks downstream environments.</td></tr>
+        <tr><td><code>scripts/harness-review-identity.ts</code></td><td>Separates broad review neutrality from narrow post-gate validation neutrality.</td></tr>
+        <tr><td><code>scripts/pre-push-validation-proof.ts</code></td><td>Compares tree deltas and validates canonical telemetry before proof reuse.</td></tr>
+        <tr><td><code>scripts/pre-push-validation-proof.test.ts</code></td><td>Covers valid receipt addition and fail-closed edits, lookalikes, docs, and invalid telemetry.</td></tr>
+        <tr><td><code>docs/solutions/harness/daily-operations-hydration-and-hook-env-2026-06-30.md</code></td><td>Captures the reusable boundary and proof-lifecycle lessons.</td></tr>
+        <tr><td><code>telemetry/delivery-runs/2026-08-14T05-12-30-649Z-codex-v26-1220-git-hook-isolation.json</code></td><td>Existing tracked evidence from the earlier passing merge-grade run; final proof remains pending.</td></tr>
+      </tbody>
+    </table>
+  </section>
+  <section data-report-section="quiz" data-quiz-pass-threshold="8">
+    <h2>Comprehension quiz</h2>
+    <p>Pass required: 8 of 10.</p>
+    <ol data-quiz>
+      <li data-quiz-question>
+        <p data-quiz-prompt>Why does the hook scrub Git variables only after bootstrap and root discovery?</p>
+        <ol data-quiz-options>
+          <li data-quiz-correct>The bootstrap needs repository context to identify the worktree</li>
+          <li>The scrubber cannot run in POSIX shell</li>
+          <li>Telemetry must be written first</li>
+          <li>Graphify supplies the variables</li>
+        </ol>
+        <p data-quiz-explanation>The initial hook steps legitimately need Git&#x27;s ambient pointers; general validation does not.</p>
+      </li>
+      <li data-quiz-question>
+        <p data-quiz-prompt>What is the main risk of leaking hook-provided GIT_* variables into fixture commands?</p>
+        <ol data-quiz-options>
+          <li data-quiz-correct>Fixtures may target and mutate the parent repository</li>
+          <li>Bun automatically upgrades Convex</li>
+          <li>The hook loses network access</li>
+          <li>Reports gain embedded styling</li>
+        </ol>
+        <p data-quiz-explanation>Repository pointers can redirect nested Git commands away from their disposable fixture.</p>
+      </li>
+      <li data-quiz-question>
+        <p data-quiz-prompt>Why keep TypeScript subprocess sanitization after adding hook-wide scrubbing?</p>
+        <ol data-quiz-options>
+          <li data-quiz-correct>The harness and fixture helpers can run independently of hooks</li>
+          <li>It speeds up every Vitest assertion</li>
+          <li>It preserves GIT_INDEX_FILE for children</li>
+          <li>It replaces worktree bootstrap</li>
+        </ol>
+        <p data-quiz-explanation>Defense at owned child boundaries protects direct invocation and future callers outside the shell hooks.</p>
+      </li>
+      <li data-quiz-question>
+        <p data-quiz-prompt>Which post-gate delta may preserve a current pr:athena proof?</p>
+        <ol data-quiz-options>
+          <li data-quiz-correct>A newly added valid telemetry/delivery-runs/*.json record</li>
+          <li>An edited solution note</li>
+          <li>A regenerated graph file</li>
+          <li>A modified telemetry JSON record</li>
+        </ol>
+        <p data-quiz-explanation>The exception is additive, canonical telemetry only, followed by telemetry validation.</p>
+      </li>
+      <li data-quiz-question>
+        <p data-quiz-prompt>What happens if delivery:telemetry-check rejects the added record?</p>
+        <ol data-quiz-options>
+          <li data-quiz-correct>The proof becomes stale and normal validation is required</li>
+          <li>The hook silently ignores the record</li>
+          <li>The record becomes review-neutral</li>
+          <li>The base SHA check is skipped</li>
+        </ol>
+        <p data-quiz-explanation>Path eligibility never overrides the semantic telemetry contract; failure is closed.</p>
+      </li>
+      <li data-quiz-question>
+        <p data-quiz-prompt>Are reports and solution notes post-gate-validation-neutral?</p>
+        <ol data-quiz-options>
+          <li data-quiz-correct>No; they still require their own validation</li>
+          <li>Yes; all review-neutral paths qualify</li>
+          <li>Only reports qualify</li>
+          <li>Only solution notes qualify</li>
+        </ol>
+        <p data-quiz-explanation>Review neutrality is deliberately broader than permission to reuse merge-grade proof.</p>
+      </li>
+      <li data-quiz-question>
+        <p data-quiz-prompt>Which existing proof checks remain required?</p>
+        <ol data-quiz-options>
+          <li data-quiz-correct>Base SHA, Bun version, command, validation wiring, and clean tree</li>
+          <li>Only the branch name</li>
+          <li>Only the telemetry filename</li>
+          <li>Only the commit message ticket ID</li>
+        </ol>
+        <p data-quiz-explanation>Telemetry-only reuse is one additional tree-delta rule, not a replacement for existing freshness checks.</p>
+      </li>
+      <li data-quiz-question>
+        <p data-quiz-prompt>What does the real-repository integration sensor prove?</p>
+        <ol data-quiz-options>
+          <li data-quiz-correct>Nested fixture changes are local while parent config, refs, and index stay unchanged</li>
+          <li>Every Git command in the operating system is scrubbed</li>
+          <li>Pre-push never runs merge-grade validation</li>
+          <li>Convex DNS always resolves</li>
+        </ol>
+        <p data-quiz-explanation>The sensor exercises representative hook context and observes both fixture mutation and parent integrity.</p>
+      </li>
+      <li data-quiz-question>
+        <p data-quiz-prompt>What should a future legitimate consumer of a Git hook pointer do?</p>
+        <ol data-quiz-options>
+          <li data-quiz-correct>Consume it before scrubbing or reconstruct an explicit safe value</li>
+          <li>Widen the telemetry allowlist</li>
+          <li>Disable the hook</li>
+          <li>Put the pointer in a report</li>
+        </ol>
+        <p data-quiz-explanation>Ambient Git authority should not cross into general validation; explicit, scoped use belongs before or beyond that boundary.</p>
+      </li>
+      <li data-quiz-question>
+        <p data-quiz-prompt>What is the current finish-line state of this report?</p>
+        <ol data-quiz-options>
+          <li data-quiz-correct>It documents a delivery candidate with merge-grade validation and merge still pending</li>
+          <li>The changes are merged and deployed</li>
+          <li>Both Linear tickets are Done</li>
+          <li>The root checkout is already aligned to the merge</li>
+        </ol>
+        <p data-quiz-explanation>The report is committed before the shared PR and must not predict pending merge, deployment, or root-alignment events.</p>
+      </li>
+    </ol>
+  </section>
+  <section data-report-section="subagent-evidence">
+    <h2>Subagent evidence</h2>
+    <dl>
+      <dt>Ramanujan — session context</dt><dd>Reconstructed the V26-1219 hook failure, V26-1220 precursor, V26-1201 consolidation, and V26-1221 finish-line addition from commits and repository evidence.</dd>
+      <dt>Turing — delivered diff</dt><dd>Mapped the implementation, safety boundaries, key files, tests, intentionally unchanged behavior, and residual risks from origin/main...HEAD.</dd>
+      <dt>Helmholtz — report reviewer</dt><dd>Defined the report contract checklist and verified the precise hook ordering, isolation layers, telemetry-only eligibility, and candidate-status claims to audit in the final draft.</dd>
+    </dl>
+  </section>
+</article>
+</body>
+</html>

--- a/docs/solutions/harness/daily-operations-hydration-and-hook-env-2026-06-30.md
+++ b/docs/solutions/harness/daily-operations-hydration-and-hook-env-2026-06-30.md
@@ -13,7 +13,7 @@ symptoms:
 root_cause: boundary_mismatch
 resolution_type: architecture
 severity: medium
-delivery_diff_fingerprint: 4f5723b7c76a0ecd526c0471ff32f481be5a8ca2638809ae6fd01132e1398733
+delivery_diff_fingerprint: dc7e06e5e32d6f2caa9c5a18ec2eba5bfc20aab09586e7d0f69208f467c9bf50
 tags:
   - daily-operations
   - store-pulse

--- a/docs/solutions/harness/daily-operations-hydration-and-hook-env-2026-06-30.md
+++ b/docs/solutions/harness/daily-operations-hydration-and-hook-env-2026-06-30.md
@@ -1,6 +1,7 @@
 ---
 title: Daily Operations Hydration Should Be Split From Hook-Safe Delivery Checks
 date: 2026-06-30
+last_updated: 2026-08-14
 category: harness
 module: athena-webapp
 problem_type: performance_regression
@@ -12,6 +13,7 @@ symptoms:
 root_cause: boundary_mismatch
 resolution_type: architecture
 severity: medium
+delivery_diff_fingerprint: 8cbd008877cdbe118f1dac8b52f478905e33c3ce4ace7938ad506c3944fc9826
 tags:
   - daily-operations
   - store-pulse
@@ -55,6 +57,14 @@ Git hook should use a sanitized environment that removes inherited `GIT_*`
 variables. This is production harness behavior, not only test fixture behavior,
 because pre-push and pre-commit hooks routinely execute nested Git commands.
 
+When a parent command owns a complete test subprocess, sanitize once at that
+boundary. `scripts/harness-test.ts` now launches `bun test` with
+`withoutGitRepositoryContext(process.env)`, which removes every `GIT_*` entry
+while preserving ordinary environment variables such as `PATH`. This protects
+all real-repository fixtures selected by `harness:test`, including future ones,
+without mutating the hook process or relying on every test helper to remember
+the cleanup independently.
+
 ## Prevention
 
 - Do not add heavyweight analytics to `getDailyOperationsSnapshot` just because
@@ -65,6 +75,13 @@ because pre-push and pre-commit hooks routinely execute nested Git commands.
 - For nested fixture repos or provider-evidence writers, sanitize `GIT_*` before
   invoking Git. This includes `GIT_DIR`, `GIT_WORK_TREE`, and `GIT_INDEX_FILE`,
   plus any future hook-scoped Git variables.
+- Prefer the highest shared child-process boundary that exclusively owns nested
+  fixture work. Keep lower-level sanitization where commands can also run
+  independently of that boundary.
 - Validate hook-safe changes with both focused tests and the full root harness:
   `bun test scripts/harness-inferential-review.test.ts scripts/pr-athena-delivery-run.test.ts`
   and `bun run harness:test`.
+- Simulate the hook environment by setting representative `GIT_DIR`,
+  `GIT_WORK_TREE`, `GIT_INDEX_FILE`, and `GIT_PREFIX` values. Hash the parent
+  repository's local config, refs, and index before and after the run; all three
+  must remain byte-for-byte unchanged.

--- a/docs/solutions/harness/daily-operations-hydration-and-hook-env-2026-06-30.md
+++ b/docs/solutions/harness/daily-operations-hydration-and-hook-env-2026-06-30.md
@@ -13,7 +13,7 @@ symptoms:
 root_cause: boundary_mismatch
 resolution_type: architecture
 severity: medium
-delivery_diff_fingerprint: 8cbd008877cdbe118f1dac8b52f478905e33c3ce4ace7938ad506c3944fc9826
+delivery_diff_fingerprint: f728a5c3a53e46b3c4a3d94792cf84343eb14f6f3742f3a62f7e849feb8b4417
 tags:
   - daily-operations
   - store-pulse
@@ -65,6 +65,15 @@ all real-repository fixtures selected by `harness:test`, including future ones,
 without mutating the hook process or relying on every test helper to remember
 the cleanup independently.
 
+Validation freshness has a related but narrower boundary. Exact raw-tree
+identity remains authoritative while preparing a candidate and guarding against
+races. Review evidence uses the shared deliverable identity so narration written
+about already-reviewed code does not force another review. Pre-push proof reuse
+allows only the canonical `telemetry/delivery-runs/*.json` record to appear after
+the merge-grade gate, and it runs `delivery:telemetry-check` before accepting
+that delta. Reports and solution notes are review-neutral but are not
+post-gate-validation-neutral because their own validators still need to run.
+
 ## Prevention
 
 - Do not add heavyweight analytics to `getDailyOperationsSnapshot` just because
@@ -85,3 +94,6 @@ the cleanup independently.
   `GIT_WORK_TREE`, `GIT_INDEX_FILE`, and `GIT_PREFIX` values. Hash the parent
   repository's local config, refs, and index before and after the run; all three
   must remain byte-for-byte unchanged.
+- Keep identity exemptions tied to the sensor they protect. A path may be
+  review-neutral without being validation-neutral; do not reuse the broader
+  review-neutral allowlist to skip merge-grade validation.

--- a/docs/solutions/harness/daily-operations-hydration-and-hook-env-2026-06-30.md
+++ b/docs/solutions/harness/daily-operations-hydration-and-hook-env-2026-06-30.md
@@ -13,7 +13,7 @@ symptoms:
 root_cause: boundary_mismatch
 resolution_type: architecture
 severity: medium
-delivery_diff_fingerprint: f728a5c3a53e46b3c4a3d94792cf84343eb14f6f3742f3a62f7e849feb8b4417
+delivery_diff_fingerprint: 4f5723b7c76a0ecd526c0471ff32f481be5a8ca2638809ae6fd01132e1398733
 tags:
   - daily-operations
   - store-pulse

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 12263 nodes · 15099 edges · 2808 communities detected
+- 12265 nodes · 15103 edges · 2808 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -3286,48 +3286,48 @@ Cohesion: 0.17
 Nodes (13): buildSkuContinuityContextById(), deriveContinuityStatus(), getPlannedActionAt(), getStartOfCurrentDay(), hasLateInbound(), hasRelatedPurchaseOrderContext(), hasStalePlannedAction(), isInboundStatus() (+5 more)
 
 ### Community 110 - "Community 110"
+Cohesion: 0.22
+Nodes (18): assertPrAthenaProofReady(), classifySnapshotError(), collectFilesUnder(), collectProofSnapshot(), collectTreeChangedPaths(), collectUnstagedFiles(), collectUntrackedFiles(), collectValidationFingerprintPaths() (+10 more)
+
+### Community 111 - "Community 111"
 Cohesion: 0.13
 Nodes (5): buildRegisterCloseoutSubmittedTimelineMessage(), buildRegisterCloseoutVarianceTimelineMessage(), cancelPendingApprovalIfNeeded(), formatCloseoutVarianceAmount(), omitUndefined()
 
-### Community 111 - "Community 111"
+### Community 112 - "Community 112"
 Cohesion: 0.17
 Nodes (13): buildProviderRegistry(), createIntelligenceRun(), defaultFakeOutput(), failedGenerationResult(), getStoreInsightsSnapshotFallback(), isActivityTrend(), isDeviceDistribution(), isInsightGenerationInProgressError() (+5 more)
 
-### Community 112 - "Community 112"
+### Community 113 - "Community 113"
 Cohesion: 0.21
 Nodes (15): amountComparison(), buildAcceptedWeeklyManagerReportPayload(), buildAcceptedWeeklyTopItems(), buildWeeklyReportUrl(), buildWeeklyTopMoversUrl(), countedCashVarianceMessage(), coverageLabel(), expenseRankedSections() (+7 more)
 
-### Community 113 - "Community 113"
+### Community 114 - "Community 114"
 Cohesion: 0.27
 Nodes (16): assertCompleteScan(), buildPendingCheckoutReviewWorkItemMetadata(), buildPendingCheckoutReviewWorkItemPriority(), buildPendingCheckoutReviewWorkItemTitle(), cancelPendingCheckoutReviewWorkItem(), ensurePendingCheckoutReviewWorkForUnarchivedProduct(), getOpenReviewWorkItemFromPointer(), getOpenReviewWorkItemsForStore() (+8 more)
 
-### Community 114 - "Community 114"
+### Community 115 - "Community 115"
 Cohesion: 0.11
 Nodes (0):
 
-### Community 115 - "Community 115"
+### Community 116 - "Community 116"
 Cohesion: 0.22
 Nodes (15): cacheAssetRequest(), cacheFirstAsset(), cacheLinkedShellAssets(), cacheModuleDependencies(), isExcluded(), isHtmlResponse(), isJavaScriptLikeResponse(), isPosNavigation() (+7 more)
 
-### Community 116 - "Community 116"
+### Community 117 - "Community 117"
 Cohesion: 0.18
 Nodes (14): cleanValue(), drawColumnHeaders(), drawReportFooter(), drawReportHeader(), drawReportRow(), exportOpenWorkInventoryPdf(), formatOpenWorkInventoryReportEyebrow(), formatOpenWorkInventoryReportItemCount() (+6 more)
 
-### Community 117 - "Community 117"
+### Community 118 - "Community 118"
 Cohesion: 0.25
 Nodes (16): buildStorefrontContextEvent(), buildStorefrontIdempotencyKey(), compactScalarPayload(), createStorefrontContextTrackingEnvelope(), createStorefrontRouteViewedContextEvent(), getCartChange(), getCartContextEventInput(), getCheckoutBlocker() (+8 more)
 
-### Community 118 - "Community 118"
+### Community 119 - "Community 119"
 Cohesion: 0.21
 Nodes (15): assertDeliveryRunTelemetryCheck(), buildDeliveryRunTelemetryRecord(), collectChangedPathsForDiff(), collectDeliveryRunTelemetryFindings(), deliveryRunTelemetryPath(), evaluateDeliveryRunTelemetryCheck(), gitLines(), gitStdout() (+7 more)
 
-### Community 119 - "Community 119"
+### Community 120 - "Community 120"
 Cohesion: 0.22
 Nodes (16): buildDegreeIndex(), buildHotspotLines(), buildPackagePage(), buildRootIndexPage(), collectRepoCodeFiles(), compareHotspots(), countCommunities(), fileExists() (+8 more)
-
-### Community 120 - "Community 120"
-Cohesion: 0.23
-Nodes (17): assertPrAthenaProofReady(), classifySnapshotError(), collectFilesUnder(), collectProofSnapshot(), collectUnstagedFiles(), collectUntrackedFiles(), collectValidationFingerprintPaths(), evaluatePrePushValidationProof() (+9 more)
 
 ### Community 121 - "Community 121"
 Cohesion: 0.22
@@ -4594,76 +4594,76 @@ Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
 ### Community 437 - "Community 437"
+Cohesion: 0.48
+Nodes (6): computeDeliverableTreeIdentity(), digestDeliverableEntries(), isPostGateValidationNeutralPath(), isReviewNeutralPath(), normalizeRepoPath(), parseTreeEntries()
+
+### Community 438 - "Community 438"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 438 - "Community 438"
+### Community 439 - "Community 439"
 Cohesion: 0.43
 Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
 
-### Community 439 - "Community 439"
+### Community 440 - "Community 440"
 Cohesion: 0.53
 Nodes (4): bestEffortRecordScheduledRunEvidence(), buildScheduledRunKey(), recordScheduledRunEvidenceWithCtx(), resolveScheduledWindow()
 
-### Community 440 - "Community 440"
+### Community 441 - "Community 441"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 441 - "Community 441"
+### Community 442 - "Community 442"
 Cohesion: 0.6
 Nodes (5): appendContextEventWithCtx(), buildContextEventSemanticEnvelopeHash(), isAllowedGlobalContextEvent(), isContextEventWriteQuotaExceeded(), selectContextEventAppendQuotaDecision()
 
-### Community 442 - "Community 442"
+### Community 443 - "Community 443"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 443 - "Community 443"
+### Community 444 - "Community 444"
 Cohesion: 0.47
 Nodes (3): canonical(), isValidBody(), text()
 
-### Community 444 - "Community 444"
+### Community 445 - "Community 445"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 445 - "Community 445"
-Cohesion: 0.4
-Nodes (2): createMutationCtx(), seedTrustedConversionData()
 
 ### Community 446 - "Community 446"
 Cohesion: 0.4
-Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
+Nodes (2): createMutationCtx(), seedTrustedConversionData()
 
 ### Community 447 - "Community 447"
+Cohesion: 0.4
+Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
+
+### Community 448 - "Community 448"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 448 - "Community 448"
+### Community 449 - "Community 449"
 Cohesion: 0.6
 Nodes (5): backfillStoreCurrencyCaseWithCtx(), boundedLimit(), needsNormalization(), storePage(), verifyStoreCurrencyCaseWithCtx()
 
-### Community 449 - "Community 449"
+### Community 450 - "Community 450"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 450 - "Community 450"
+### Community 451 - "Community 451"
 Cohesion: 0.47
 Nodes (4): buildDailyCloseApprovalSubject(), buildDailyCloseCarryForwardApprovalRequirement(), buildDailyCloseCarryForwardApprovalSubject(), buildDailyCloseCompletionApprovalRequirement()
 
-### Community 451 - "Community 451"
+### Community 452 - "Community 452"
 Cohesion: 0.6
 Nodes (5): buildOnlineOrderOperationalEventMessage(), buildOperationalEventMessage(), buildStockAdjustmentOperationalEventMessage(), formatOnlineOrderLabel(), formatStockAdjustmentSubjectDetail()
 
-### Community 452 - "Community 452"
+### Community 453 - "Community 453"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 453 - "Community 453"
-Cohesion: 0.4
-Nodes (2): evidenceCoverage(), makeCloseEvidence()
 
 ### Community 454 - "Community 454"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): evidenceCoverage(), makeCloseEvidence()
 
 ### Community 455 - "Community 455"
 Cohesion: 0.33
@@ -4674,156 +4674,156 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 457 - "Community 457"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 458 - "Community 458"
 Cohesion: 0.4
 Nodes (2): scheduleRegisterCloseoutNotifications(), wasVarianceNotifiedBeforeRail()
 
-### Community 458 - "Community 458"
+### Community 459 - "Community 459"
 Cohesion: 0.6
 Nodes (4): cleanEventText(), cleanOptionalEventText(), sanitizeClientEventMetadata(), truncate()
 
-### Community 459 - "Community 459"
+### Community 460 - "Community 460"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 460 - "Community 460"
+### Community 461 - "Community 461"
 Cohesion: 0.47
 Nodes (3): foldDay(), revenueContribution(), zeroDayMetrics()
 
-### Community 461 - "Community 461"
+### Community 462 - "Community 462"
 Cohesion: 0.6
 Nodes (5): configuredTimezone(), isValidTimezone(), localDateLabel(), resolveOperatingDate(), resolveStoreTimezone()
 
-### Community 462 - "Community 462"
+### Community 463 - "Community 463"
 Cohesion: 0.4
 Nodes (2): at(), seedFullDay()
 
-### Community 463 - "Community 463"
+### Community 464 - "Community 464"
 Cohesion: 0.47
 Nodes (3): projectFrozenWeeklyInventoryAttention(), projectLiveWeeklyInventoryAttention(), summarizeWeeklyInventoryAttention()
 
-### Community 464 - "Community 464"
+### Community 465 - "Community 465"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 465 - "Community 465"
+### Community 466 - "Community 466"
 Cohesion: 0.6
 Nodes (5): getSharedDemoActorWithCtx(), requireReadySharedDemoStoreCapabilityIfApplicable(), requireSharedDemoActorWithCtx(), requireSharedDemoCapabilityIfApplicable(), requireSharedDemoStoreCapabilityIfApplicable()
 
-### Community 466 - "Community 466"
+### Community 467 - "Community 467"
 Cohesion: 0.53
 Nodes (4): provisionForScheduledWorkWithCtx(), runDailyRestoreWithCtx(), runHourlyProvisionHealWithCtx(), sharedDemoRestoreEnabled()
 
-### Community 467 - "Community 467"
+### Community 468 - "Community 468"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 468 - "Community 468"
+### Community 469 - "Community 469"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 469 - "Community 469"
+### Community 470 - "Community 470"
 Cohesion: 0.53
 Nodes (4): buildOnlineOrderReportedReturns(), buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 470 - "Community 470"
+### Community 471 - "Community 471"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 471 - "Community 471"
+### Community 472 - "Community 472"
 Cohesion: 0.4
 Nodes (2): localDate(), resolveStoreTimeAuthority()
 
-### Community 472 - "Community 472"
+### Community 473 - "Community 473"
 Cohesion: 0.53
 Nodes (4): buildPurchaseOrderTraceSeed(), compactDetails(), formatPurchaseOrderLabel(), normalizeLookup()
 
-### Community 473 - "Community 473"
+### Community 474 - "Community 474"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 474 - "Community 474"
+### Community 475 - "Community 475"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 475 - "Community 475"
+### Community 476 - "Community 476"
 Cohesion: 0.4
 Nodes (2): compareHomepageRankedItems(), getHomepageSortRank()
 
-### Community 476 - "Community 476"
+### Community 477 - "Community 477"
 Cohesion: 0.47
 Nodes (3): canUploadPosLocalSyncLocalEventType(), getPosLocalSyncEventContractForLocalEventType(), getPosLocalSyncEventTypeForLocalEventType()
 
-### Community 477 - "Community 477"
+### Community 478 - "Community 478"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 478 - "Community 478"
+### Community 479 - "Community 479"
 Cohesion: 0.47
 Nodes (4): assertObjectKeysAreMinimized(), assertWorkflowTraceDetailsAreMinimized(), createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 479 - "Community 479"
+### Community 480 - "Community 480"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 480 - "Community 480"
+### Community 481 - "Community 481"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 481 - "Community 481"
+### Community 482 - "Community 482"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
-
-### Community 482 - "Community 482"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 483 - "Community 483"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 484 - "Community 484"
-Cohesion: 0.4
-Nodes (2): moveBestSeller(), saveOrder()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 485 - "Community 485"
 Cohesion: 0.4
-Nodes (2): moveFeaturedItem(), saveOrder()
+Nodes (2): moveBestSeller(), saveOrder()
 
 ### Community 486 - "Community 486"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): moveFeaturedItem(), saveOrder()
 
 ### Community 487 - "Community 487"
-Cohesion: 0.47
-Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
-
-### Community 488 - "Community 488"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 488 - "Community 488"
+Cohesion: 0.47
+Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
 
 ### Community 489 - "Community 489"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 490 - "Community 490"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 491 - "Community 491"
 Cohesion: 0.4
 Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
-### Community 491 - "Community 491"
+### Community 492 - "Community 492"
 Cohesion: 0.47
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
 
-### Community 492 - "Community 492"
+### Community 493 - "Community 493"
 Cohesion: 0.47
 Nodes (3): formatNextOpeningLabel(), formatStoreHoursTimeLabel(), formatStoreLocalDateLabel()
 
-### Community 493 - "Community 493"
+### Community 494 - "Community 494"
 Cohesion: 0.4
 Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
-
-### Community 494 - "Community 494"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 495 - "Community 495"
 Cohesion: 0.33
@@ -4838,96 +4838,96 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 498 - "Community 498"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 499 - "Community 499"
 Cohesion: 0.4
 Nodes (2): parseServiceCatalogCreateForm(), parseServiceCatalogUpdateForm()
 
-### Community 499 - "Community 499"
+### Community 500 - "Community 500"
 Cohesion: 0.6
 Nodes (5): identity(), liveResult(), metrics(), quickAddIdentity(), skuMetrics()
 
-### Community 500 - "Community 500"
+### Community 501 - "Community 501"
 Cohesion: 0.6
 Nodes (5): addSkuMetrics(), sharedDemoFixtureSkuId(), toSharedDemoLiveReportsDay(), toSharedDemoLiveSkuStock(), zeroDayMetrics()
 
-### Community 501 - "Community 501"
+### Community 502 - "Community 502"
 Cohesion: 0.6
 Nodes (5): classifyAthenaViewSurface(), isSharedDemoSurfaceVisible(), normalizePathname(), resolveAthenaViewRoute(), routeTemplateMatches()
 
-### Community 502 - "Community 502"
+### Community 503 - "Community 503"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
-### Community 503 - "Community 503"
+### Community 504 - "Community 504"
 Cohesion: 0.4
 Nodes (2): isValidRecipientEmail(), normalizeRecipientEmailInput()
 
-### Community 504 - "Community 504"
+### Community 505 - "Community 505"
 Cohesion: 0.47
 Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
-### Community 505 - "Community 505"
+### Community 506 - "Community 506"
 Cohesion: 0.6
 Nodes (5): deriveStoreFrontFromAdminHost(), getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
-
-### Community 506 - "Community 506"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 507 - "Community 507"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 508 - "Community 508"
-Cohesion: 0.73
-Nodes (5): canAccessCashControlsSurface(), canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
-
-### Community 509 - "Community 509"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 509 - "Community 509"
+Cohesion: 0.73
+Nodes (5): canAccessCashControlsSurface(), canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
 ### Community 510 - "Community 510"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 511 - "Community 511"
-Cohesion: 0.4
-Nodes (2): deriveRegisterLifecycleAuthorityCandidates(), mappingCandidate()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 512 - "Community 512"
 Cohesion: 0.4
-Nodes (2): buildRecoveryCommandStore(), storeFactory()
+Nodes (2): deriveRegisterLifecycleAuthorityCandidates(), mappingCandidate()
 
 ### Community 513 - "Community 513"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): buildRecoveryCommandStore(), storeFactory()
 
 ### Community 514 - "Community 514"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 515 - "Community 515"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 516 - "Community 516"
 Cohesion: 0.4
 Nodes (2): encodeFocusKey(), encodeSheetReturn()
 
-### Community 516 - "Community 516"
+### Community 517 - "Community 517"
 Cohesion: 0.47
 Nodes (3): buildAdminSkuSearchOption(), compactJoin(), presentationText()
 
-### Community 517 - "Community 517"
+### Community 518 - "Community 518"
 Cohesion: 0.53
 Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
 
-### Community 518 - "Community 518"
+### Community 519 - "Community 519"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 519 - "Community 519"
-Cohesion: 0.33
-Nodes (1): MemoryCache
-
 ### Community 520 - "Community 520"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): MemoryCache
 
 ### Community 521 - "Community 521"
 Cohesion: 0.33
@@ -4942,80 +4942,80 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 524 - "Community 524"
-Cohesion: 0.47
-Nodes (3): completePendingAuthSync(), navigationTargetForRedirect(), sleep()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 525 - "Community 525"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.47
+Nodes (3): completePendingAuthSync(), navigationTargetForRedirect(), sleep()
 
 ### Community 526 - "Community 526"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 527 - "Community 527"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
+### Community 528 - "Community 528"
 Cohesion: 0.6
 Nodes (5): useDailyCloseFixture(), useDailyOpeningFixture(), useDailyOperationsFixture(), usePosHubFixture(), useWorkspaceFixture()
 
-### Community 528 - "Community 528"
+### Community 529 - "Community 529"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 529 - "Community 529"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 530 - "Community 530"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 531 - "Community 531"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
 ### Community 532 - "Community 532"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 533 - "Community 533"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
-
-### Community 534 - "Community 534"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 534 - "Community 534"
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
+
 ### Community 535 - "Community 535"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 536 - "Community 536"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 536 - "Community 536"
+### Community 537 - "Community 537"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 537 - "Community 537"
+### Community 538 - "Community 538"
 Cohesion: 0.53
 Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
 
-### Community 538 - "Community 538"
+### Community 539 - "Community 539"
 Cohesion: 0.67
 Nodes (5): assertDocsLinks(), classifyLink(), collectDocsLinkFindings(), collectSolutionSlugs(), solutionsRoot()
 
-### Community 539 - "Community 539"
+### Community 540 - "Community 540"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 540 - "Community 540"
+### Community 541 - "Community 541"
 Cohesion: 0.47
 Nodes (4): commitFixtureRepo(), createFixtureRepo(), runFixtureCommand(), write()
 
-### Community 541 - "Community 541"
+### Community 542 - "Community 542"
 Cohesion: 0.47
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
-
-### Community 542 - "Community 542"
-Cohesion: 0.53
-Nodes (5): computeDeliverableTreeIdentity(), digestDeliverableEntries(), isReviewNeutralPath(), normalizeRepoPath(), parseTreeEntries()
 
 ### Community 543 - "Community 543"
 Cohesion: 0.4
@@ -5070,168 +5070,168 @@ Cohesion: 0.5
 Nodes (2): historicalCostLane(), materializeDeferredAdjustmentWithCtx()
 
 ### Community 556 - "Community 556"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
 ### Community 557 - "Community 557"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 558 - "Community 558"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 559 - "Community 559"
 Cohesion: 0.7
 Nodes (4): backfillStoreTimezoneAuthorityWithCtx(), buildRow(), listSchedulesForStore(), normalizeLimit()
 
-### Community 559 - "Community 559"
+### Community 560 - "Community 560"
 Cohesion: 0.5
 Nodes (2): recordNotificationFailureEventWithCtx(), recordTerminalDeliveryFailureEvent()
 
-### Community 560 - "Community 560"
+### Community 561 - "Community 561"
 Cohesion: 0.6
 Nodes (4): dedupeKey(), keyFor(), prepare(), stubCtx()
 
-### Community 561 - "Community 561"
+### Community 562 - "Community 562"
 Cohesion: 0.7
 Nodes (4): createNormalUserOperationAdapter(), createPublicOperationAdapter(), isAdmitted(), resolveOperationAdmission()
 
-### Community 562 - "Community 562"
+### Community 563 - "Community 563"
 Cohesion: 0.6
 Nodes (4): consumeApprovalRequesterChallengeWithCtx(), createApprovalRequesterChallengeWithCtx(), invalidApprovalRequesterChallengeResult(), toRequesterBinding()
 
-### Community 563 - "Community 563"
+### Community 564 - "Community 564"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
-
-### Community 564 - "Community 564"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 565 - "Community 565"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 566 - "Community 566"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 567 - "Community 567"
 Cohesion: 0.6
 Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
 
-### Community 567 - "Community 567"
+### Community 568 - "Community 568"
 Cohesion: 0.5
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
 
-### Community 568 - "Community 568"
+### Community 569 - "Community 569"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 569 - "Community 569"
-Cohesion: 0.7
-Nodes (4): acknowledgeRegisterLifecycleAuthority(), equivalentAcknowledgement(), isRevision(), normalizeSafeMetadata()
 
 ### Community 570 - "Community 570"
 Cohesion: 0.7
-Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
+Nodes (4): acknowledgeRegisterLifecycleAuthority(), equivalentAcknowledgement(), isRevision(), normalizeSafeMetadata()
 
 ### Community 571 - "Community 571"
+Cohesion: 0.7
+Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
+
+### Community 572 - "Community 572"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 572 - "Community 572"
+### Community 573 - "Community 573"
 Cohesion: 0.5
 Nodes (2): baseInput(), buildRuntimeStatus()
 
-### Community 573 - "Community 573"
+### Community 574 - "Community 574"
 Cohesion: 0.6
 Nodes (4): buildCtx(), buildQueryCtx(), filterRows(), orderedRows()
 
-### Community 574 - "Community 574"
+### Community 575 - "Community 575"
 Cohesion: 0.6
 Nodes (4): requirePosCustomerAccessById(), requirePosCustomerReadAccessById(), requirePosCustomerStoreAccess(), requirePosCustomerStoreReadAccess()
-
-### Community 575 - "Community 575"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 576 - "Community 576"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 577 - "Community 577"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 578 - "Community 578"
 Cohesion: 0.5
 Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
-### Community 578 - "Community 578"
+### Community 579 - "Community 579"
 Cohesion: 0.6
 Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
 
-### Community 579 - "Community 579"
+### Community 580 - "Community 580"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 580 - "Community 580"
+### Community 581 - "Community 581"
 Cohesion: 0.7
 Nodes (4): factFingerprint(), fingerprintPayload(), matchesStoredFingerprint(), stableStringHash()
 
-### Community 581 - "Community 581"
+### Community 582 - "Community 582"
 Cohesion: 0.6
 Nodes (3): fact(), receipt(), sale()
 
-### Community 582 - "Community 582"
+### Community 583 - "Community 583"
 Cohesion: 0.5
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 583 - "Community 583"
+### Community 584 - "Community 584"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 584 - "Community 584"
+### Community 585 - "Community 585"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 585 - "Community 585"
+### Community 586 - "Community 586"
 Cohesion: 0.6
 Nodes (3): isSharedDemoEnabled(), readRuntimeSharedDemoConfig(), readSharedDemoConfig()
 
-### Community 586 - "Community 586"
+### Community 587 - "Community 587"
 Cohesion: 0.8
 Nodes (4): buildSharedDemoOpeningBaseline(), buildSharedDemoStoreDayEvent(), rollSharedDemoOpeningBaselineWithCtx(), sharedDemoOperatingDateRange()
 
-### Community 587 - "Community 587"
+### Community 588 - "Community 588"
 Cohesion: 0.5
 Nodes (2): sharedDemoDenialError(), sharedDemoDenied()
 
-### Community 588 - "Community 588"
+### Community 589 - "Community 589"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
-### Community 589 - "Community 589"
+### Community 590 - "Community 590"
 Cohesion: 0.7
 Nodes (4): buildLookup(), buildOnlineOrderTraceSeed(), buildSafeExternalReferenceRef(), stableFingerprint()
 
-### Community 590 - "Community 590"
+### Community 591 - "Community 591"
 Cohesion: 0.5
 Nodes (2): createAdminTraceReadCtx(), createTestCtx()
-
-### Community 591 - "Community 591"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 592 - "Community 592"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 593 - "Community 593"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 594 - "Community 594"
 Cohesion: 0.5
 Nodes (2): cancel(), handleClick()
 
-### Community 594 - "Community 594"
+### Community 595 - "Community 595"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 595 - "Community 595"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 596 - "Community 596"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 597 - "Community 597"
 Cohesion: 0.4
@@ -5242,12 +5242,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 599 - "Community 599"
-Cohesion: 0.5
-Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
-
-### Community 600 - "Community 600"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 600 - "Community 600"
+Cohesion: 0.5
+Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 601 - "Community 601"
 Cohesion: 0.4
@@ -5286,72 +5286,72 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 610 - "Community 610"
-Cohesion: 0.5
-Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 611 - "Community 611"
 Cohesion: 0.5
-Nodes (2): getSelectedAppMessage(), sortAppMessages()
+Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
 ### Community 612 - "Community 612"
 Cohesion: 0.5
-Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
+Nodes (2): getSelectedAppMessage(), sortAppMessages()
 
 ### Community 613 - "Community 613"
+Cohesion: 0.5
+Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
+
+### Community 614 - "Community 614"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 614 - "Community 614"
+### Community 615 - "Community 615"
 Cohesion: 0.6
 Nodes (3): extractTraceId(), getSharedDemoDenial(), runCommand()
 
-### Community 615 - "Community 615"
+### Community 616 - "Community 616"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 616 - "Community 616"
+### Community 617 - "Community 617"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 617 - "Community 617"
+### Community 618 - "Community 618"
 Cohesion: 0.5
 Nodes (2): mapRegisterStateDto(), useConvexRegisterState()
 
-### Community 618 - "Community 618"
+### Community 619 - "Community 619"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 619 - "Community 619"
+### Community 620 - "Community 620"
 Cohesion: 0.6
 Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
-### Community 620 - "Community 620"
+### Community 621 - "Community 621"
 Cohesion: 0.8
 Nodes (4): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPagesOrFallback(), readScopedPosLocalEvents()
 
-### Community 621 - "Community 621"
+### Community 622 - "Community 622"
 Cohesion: 0.6
 Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
-### Community 622 - "Community 622"
+### Community 623 - "Community 623"
 Cohesion: 0.6
 Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
 
-### Community 623 - "Community 623"
+### Community 624 - "Community 624"
 Cohesion: 0.6
 Nodes (3): applySnapshot(), isRegisterLifecycleRepairClassification(), toObservation()
 
-### Community 624 - "Community 624"
+### Community 625 - "Community 625"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 625 - "Community 625"
-Cohesion: 0.7
-Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
 
 ### Community 626 - "Community 626"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
 
 ### Community 627 - "Community 627"
 Cohesion: 0.4
@@ -5366,40 +5366,40 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 630 - "Community 630"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 631 - "Community 631"
 Cohesion: 0.5
 Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
 
-### Community 631 - "Community 631"
+### Community 632 - "Community 632"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 632 - "Community 632"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 633 - "Community 633"
 Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 634 - "Community 634"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 635 - "Community 635"
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+
+### Community 636 - "Community 636"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 636 - "Community 636"
+### Community 637 - "Community 637"
 Cohesion: 0.6
 Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
 
-### Community 637 - "Community 637"
+### Community 638 - "Community 638"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 638 - "Community 638"
-Cohesion: 0.6
-Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
 ### Community 639 - "Community 639"
 Cohesion: 0.7

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 12265 nodes · 15103 edges · 2808 communities detected
+- 12266 nodes · 15104 edges · 2808 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -3270,24 +3270,24 @@ Cohesion: 0.22
 Nodes (18): assertLandedChangeReportCheck(), collectChangedFiles(), collectExistingFiles(), collectLandedChangeReportFindings(), collectReportContents(), collectReportsExistingAtBase(), collectSourceLineChanges(), countFileLines() (+10 more)
 
 ### Community 106 - "Community 106"
+Cohesion: 0.2
+Nodes (18): assertPrAthenaProofReady(), classifySnapshotError(), collectFilesUnder(), collectProofSnapshot(), collectTreeChangedPaths(), collectUnstagedFiles(), collectUntrackedFiles(), collectValidationFingerprintPaths() (+10 more)
+
+### Community 107 - "Community 107"
 Cohesion: 0.21
 Nodes (16): commandForPort(), defaultCommand(), isProcessAlive(), isReachable(), listPreviews(), optionsFromEnv(), pruneState(), readState() (+8 more)
 
-### Community 107 - "Community 107"
+### Community 108 - "Community 108"
 Cohesion: 0.27
 Nodes (18): assertConformsToExportedReturns(), collectReturnValidatorIssues(), decodeSerializedFloat64(), decodeSerializedInt64(), decodeSerializedLiteralValue(), describeValue(), formatReturnValidatorIssues(), isConvexValue() (+10 more)
 
-### Community 108 - "Community 108"
+### Community 109 - "Community 109"
 Cohesion: 0.15
 Nodes (12): hasPendingWeeklyDirtyMarks(), isReverifyTick(), isVerificationAlertEmailEnabled(), logSwallowed(), maybeEmitVerificationAlert(), normalizeMissingDayResult(), recordErrorOutcome(), runVerificationSweepWithCtx() (+4 more)
 
-### Community 109 - "Community 109"
+### Community 110 - "Community 110"
 Cohesion: 0.17
 Nodes (13): buildSkuContinuityContextById(), deriveContinuityStatus(), getPlannedActionAt(), getStartOfCurrentDay(), hasLateInbound(), hasRelatedPurchaseOrderContext(), hasStalePlannedAction(), isInboundStatus() (+5 more)
-
-### Community 110 - "Community 110"
-Cohesion: 0.22
-Nodes (18): assertPrAthenaProofReady(), classifySnapshotError(), collectFilesUnder(), collectProofSnapshot(), collectTreeChangedPaths(), collectUnstagedFiles(), collectUntrackedFiles(), collectValidationFingerprintPaths() (+10 more)
 
 ### Community 111 - "Community 111"
 Cohesion: 0.13
@@ -3835,59 +3835,59 @@ Nodes (2): isValidEmail(), validateCustomerInfo()
 
 ### Community 247 - "Community 247"
 Cohesion: 0.33
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
-
-### Community 248 - "Community 248"
-Cohesion: 0.33
 Nodes (8): landingFunnelHourlyLimit(), parseBoundedPositiveInteger(), resolveWalkthroughAllowedOrigins(), walkthroughAllowedOrigins(), walkthroughDailyPerEmailLimit(), walkthroughHourlyGlobalLimit(), walkthroughHourlyNotificationLimit(), walkthroughMaxBodyBytes()
 
-### Community 249 - "Community 249"
+### Community 248 - "Community 248"
 Cohesion: 0.36
 Nodes (8): costOverlayStoreWriteOperation(), cycleCountDraftStoreWriteOperation(), defineOperation(), inventoryImportReviewPayloadWriteOperation(), notificationSubscriptionRowWriteOperation(), orderStoreWriteOperation(), storeWriteOperation(), transactionStoreWriteOperation()
 
-### Community 250 - "Community 250"
+### Community 249 - "Community 249"
 Cohesion: 0.29
 Nodes (7): adjustmentSalesDelta(), adjustmentSettlementAmount(), buildAdjustmentPaymentTotals(), buildAdjustmentReportTotals(), listAppliedTransactionAdjustmentsForDay(), readAppliedTransactionAdjustmentsForDay(), sourceCompletenessEntry()
 
-### Community 251 - "Community 251"
+### Community 250 - "Community 250"
 Cohesion: 0.38
 Nodes (7): assertNoBusinessEventConflict(), buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
-### Community 252 - "Community 252"
+### Community 251 - "Community 251"
 Cohesion: 0.33
 Nodes (8): buildOperationalEvent(), buildTraceMetadata(), isRecord(), matchesExistingEvent(), metadataDedupeKeysMatch(), normalizeOperationalEventTraceFields(), recordOperationalEventWithCtx(), shouldNormalizePosTrace()
 
-### Community 253 - "Community 253"
+### Community 252 - "Community 252"
 Cohesion: 0.58
 Nodes (9): amendRepairWithCtx(), createRepairWithCtx(), pauseRepair(), processRepairBatchWithCtx(), readCurrentGroup(), recordRepairAuditEvent(), requireEvidence(), resumeRepairWithCtx() (+1 more)
 
-### Community 254 - "Community 254"
+### Community 253 - "Community 253"
 Cohesion: 0.38
 Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
-### Community 255 - "Community 255"
+### Community 254 - "Community 254"
 Cohesion: 0.33
 Nodes (8): classifyFinalizedLineageRepairConflicts(), classifyRepairCandidate(), countRepairableFinalizedLineageLines(), getProvisionalImportSku(), isClosedRegisterRepairReplayConflict(), isFinalizedLineageRepairConflict(), isProvisionalRowChangedConflict(), skipped()
 
-### Community 256 - "Community 256"
+### Community 255 - "Community 255"
 Cohesion: 0.27
 Nodes (5): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository(), dedupeRecoveryConflictsById(), listTerminalRecoveryConflictsForRepair(), listTerminalRecoveryConflictSources()
 
-### Community 257 - "Community 257"
+### Community 256 - "Community 256"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 258 - "Community 258"
+### Community 257 - "Community 257"
 Cohesion: 0.36
 Nodes (9): aggregateSkuDays(), computeRange(), computeRequestKey(), inclusiveDaySpan(), isValidOperatingDate(), requestRangeCore(), sumDays(), utcMillisForLabel() (+1 more)
 
-### Community 259 - "Community 259"
+### Community 258 - "Community 258"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 260 - "Community 260"
+### Community 259 - "Community 259"
 Cohesion: 0.36
 Nodes (8): buildClassification(), classifyDayResult(), classifyWeekResult(), confirmsClean(), explainMetricDifference(), fingerprintDifferences(), nextStreakState(), partitionDifferences()
+
+### Community 260 - "Community 260"
+Cohesion: 0.33
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 261 - "Community 261"
 Cohesion: 0.31

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 2882 files · ~0 words
+- 2883 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 12260 nodes · 15097 edges · 2807 communities detected
+- 12263 nodes · 15099 edges · 2808 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2817,6 +2817,7 @@
 - [[_COMMUNITY_Community 2804|Community 2804]]
 - [[_COMMUNITY_Community 2805|Community 2805]]
 - [[_COMMUNITY_Community 2806|Community 2806]]
+- [[_COMMUNITY_Community 2807|Community 2807]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -3625,44 +3626,44 @@ Cohesion: 0.26
 Nodes (10): archivedProductNestedOrigin(), buildVariantSkuMoneyPayload(), createVariantSku(), decodeOriginValue(), deleteActiveProduct(), getArchivedProductRedirect(), modifyProduct(), onSubmit() (+2 more)
 
 ### Community 195 - "Community 195"
+Cohesion: 0.23
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
+
+### Community 196 - "Community 196"
 Cohesion: 0.17
 Nodes (2): formatRegisterLabel(), getRegisterLabel()
 
-### Community 196 - "Community 196"
+### Community 197 - "Community 197"
 Cohesion: 0.22
 Nodes (6): blocked(), evaluateLocalPosReadiness(), hasSettledLocalCloseout(), localReadinessMatchesInput(), localReadinessRecordFromSnapshots(), refreshLocalPosReadinessFromSnapshots()
 
-### Community 197 - "Community 197"
+### Community 198 - "Community 198"
 Cohesion: 0.31
 Nodes (12): captureRegisterCatalogRuntimePin(), chooseRegisterCatalogRuntimeOwnerId(), clearRegisterCatalogRuntimeActionGuard(), clearRegisterCatalogRuntimeSelection(), getRegisterCatalogRuntimeOwnerId(), hasRegisterCatalogRuntimeActionGuard(), keyForScope(), maintainOwnerClaim() (+4 more)
 
-### Community 198 - "Community 198"
+### Community 199 - "Community 199"
 Cohesion: 0.31
 Nodes (11): appendEvent(), beginPrintAttempt(), buildMetadata(), finalizePrintAttempt(), getPrintRejectionMetadata(), getReasonMessage(), isTargetTerminal(), mintAttemptId() (+3 more)
 
-### Community 199 - "Community 199"
+### Community 200 - "Community 200"
 Cohesion: 0.32
 Nodes (11): clearPosClientTelemetryBuffer(), enqueuePosClientEvent(), mintClientEventId(), normalizePosTelemetryError(), peekPosClientEventBatch(), posClientTelemetryBufferSize(), readBuffer(), removePosClientEvents() (+3 more)
 
-### Community 200 - "Community 200"
+### Community 201 - "Community 201"
 Cohesion: 0.19
 Nodes (5): buildCompletedSalePayload(), completedCustomerInfo(), hasCustomerDetails(), isPosPaymentMethod(), mapLocalPaymentToPayment()
 
-### Community 201 - "Community 201"
+### Community 202 - "Community 202"
 Cohesion: 0.22
 Nodes (9): findRegisterCloseoutReviewItem(), formatCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionId(), getLatestLocalRegisterLifecycleEvent(), getPendingLocalCashVoidApprovals(), getPendingLocalCloseoutRegisterSession(), readLocalSyncStatus() (+1 more)
 
-### Community 202 - "Community 202"
+### Community 203 - "Community 203"
 Cohesion: 0.38
 Nodes (12): base64ToBytes(), bytesToBase64(), createLocalPinVerifier(), cryptoRefDecrypt(), derivePinHash(), deriveWrappingKey(), getCrypto(), isLocalPinVerifierMetadata() (+4 more)
 
-### Community 203 - "Community 203"
+### Community 204 - "Community 204"
 Cohesion: 0.29
 Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
-
-### Community 204 - "Community 204"
-Cohesion: 0.23
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 205 - "Community 205"
 Cohesion: 0.28
@@ -4117,24 +4118,24 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 318 - "Community 318"
-Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
-
-### Community 319 - "Community 319"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 320 - "Community 320"
+### Community 319 - "Community 319"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 321 - "Community 321"
+### Community 320 - "Community 320"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 322 - "Community 322"
+### Community 321 - "Community 321"
 Cohesion: 0.31
 Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+
+### Community 322 - "Community 322"
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
 ### Community 323 - "Community 323"
 Cohesion: 0.39
@@ -5069,168 +5070,168 @@ Cohesion: 0.5
 Nodes (2): historicalCostLane(), materializeDeferredAdjustmentWithCtx()
 
 ### Community 556 - "Community 556"
-Cohesion: 0.6
-Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 557 - "Community 557"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 558 - "Community 558"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 559 - "Community 559"
 Cohesion: 0.7
 Nodes (4): backfillStoreTimezoneAuthorityWithCtx(), buildRow(), listSchedulesForStore(), normalizeLimit()
 
-### Community 560 - "Community 560"
+### Community 559 - "Community 559"
 Cohesion: 0.5
 Nodes (2): recordNotificationFailureEventWithCtx(), recordTerminalDeliveryFailureEvent()
 
-### Community 561 - "Community 561"
+### Community 560 - "Community 560"
 Cohesion: 0.6
 Nodes (4): dedupeKey(), keyFor(), prepare(), stubCtx()
 
-### Community 562 - "Community 562"
+### Community 561 - "Community 561"
 Cohesion: 0.7
 Nodes (4): createNormalUserOperationAdapter(), createPublicOperationAdapter(), isAdmitted(), resolveOperationAdmission()
 
-### Community 563 - "Community 563"
+### Community 562 - "Community 562"
 Cohesion: 0.6
 Nodes (4): consumeApprovalRequesterChallengeWithCtx(), createApprovalRequesterChallengeWithCtx(), invalidApprovalRequesterChallengeResult(), toRequesterBinding()
 
-### Community 564 - "Community 564"
+### Community 563 - "Community 563"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
+
+### Community 564 - "Community 564"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 565 - "Community 565"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 566 - "Community 566"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 567 - "Community 567"
 Cohesion: 0.6
 Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
 
-### Community 568 - "Community 568"
+### Community 567 - "Community 567"
 Cohesion: 0.5
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
 
-### Community 569 - "Community 569"
+### Community 568 - "Community 568"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 570 - "Community 570"
+### Community 569 - "Community 569"
 Cohesion: 0.7
 Nodes (4): acknowledgeRegisterLifecycleAuthority(), equivalentAcknowledgement(), isRevision(), normalizeSafeMetadata()
 
-### Community 571 - "Community 571"
+### Community 570 - "Community 570"
 Cohesion: 0.7
 Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
-### Community 572 - "Community 572"
+### Community 571 - "Community 571"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 573 - "Community 573"
+### Community 572 - "Community 572"
 Cohesion: 0.5
 Nodes (2): baseInput(), buildRuntimeStatus()
 
-### Community 574 - "Community 574"
+### Community 573 - "Community 573"
 Cohesion: 0.6
 Nodes (4): buildCtx(), buildQueryCtx(), filterRows(), orderedRows()
 
-### Community 575 - "Community 575"
+### Community 574 - "Community 574"
 Cohesion: 0.6
 Nodes (4): requirePosCustomerAccessById(), requirePosCustomerReadAccessById(), requirePosCustomerStoreAccess(), requirePosCustomerStoreReadAccess()
+
+### Community 575 - "Community 575"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 576 - "Community 576"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 577 - "Community 577"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 578 - "Community 578"
 Cohesion: 0.5
 Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
-### Community 579 - "Community 579"
+### Community 578 - "Community 578"
 Cohesion: 0.6
 Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
 
-### Community 580 - "Community 580"
+### Community 579 - "Community 579"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 581 - "Community 581"
+### Community 580 - "Community 580"
 Cohesion: 0.7
 Nodes (4): factFingerprint(), fingerprintPayload(), matchesStoredFingerprint(), stableStringHash()
 
-### Community 582 - "Community 582"
+### Community 581 - "Community 581"
 Cohesion: 0.6
 Nodes (3): fact(), receipt(), sale()
 
-### Community 583 - "Community 583"
+### Community 582 - "Community 582"
 Cohesion: 0.5
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 584 - "Community 584"
+### Community 583 - "Community 583"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 585 - "Community 585"
+### Community 584 - "Community 584"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 586 - "Community 586"
+### Community 585 - "Community 585"
 Cohesion: 0.6
 Nodes (3): isSharedDemoEnabled(), readRuntimeSharedDemoConfig(), readSharedDemoConfig()
 
-### Community 587 - "Community 587"
+### Community 586 - "Community 586"
 Cohesion: 0.8
 Nodes (4): buildSharedDemoOpeningBaseline(), buildSharedDemoStoreDayEvent(), rollSharedDemoOpeningBaselineWithCtx(), sharedDemoOperatingDateRange()
 
-### Community 588 - "Community 588"
+### Community 587 - "Community 587"
 Cohesion: 0.5
 Nodes (2): sharedDemoDenialError(), sharedDemoDenied()
 
-### Community 589 - "Community 589"
+### Community 588 - "Community 588"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
-### Community 590 - "Community 590"
+### Community 589 - "Community 589"
 Cohesion: 0.7
 Nodes (4): buildLookup(), buildOnlineOrderTraceSeed(), buildSafeExternalReferenceRef(), stableFingerprint()
 
-### Community 591 - "Community 591"
+### Community 590 - "Community 590"
 Cohesion: 0.5
 Nodes (2): createAdminTraceReadCtx(), createTestCtx()
+
+### Community 591 - "Community 591"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 592 - "Community 592"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 593 - "Community 593"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 594 - "Community 594"
 Cohesion: 0.5
 Nodes (2): cancel(), handleClick()
 
-### Community 595 - "Community 595"
+### Community 594 - "Community 594"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 596 - "Community 596"
+### Community 595 - "Community 595"
 Cohesion: 0.5
 Nodes (2): handleFileSelect(), validateFile()
+
+### Community 596 - "Community 596"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 597 - "Community 597"
 Cohesion: 0.4
@@ -5241,12 +5242,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 599 - "Community 599"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 600 - "Community 600"
 Cohesion: 0.5
 Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
+
+### Community 600 - "Community 600"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 601 - "Community 601"
 Cohesion: 0.4
@@ -5285,72 +5286,72 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 610 - "Community 610"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 611 - "Community 611"
 Cohesion: 0.5
 Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
-### Community 612 - "Community 612"
+### Community 611 - "Community 611"
 Cohesion: 0.5
 Nodes (2): getSelectedAppMessage(), sortAppMessages()
 
-### Community 613 - "Community 613"
+### Community 612 - "Community 612"
 Cohesion: 0.5
 Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
 
-### Community 614 - "Community 614"
+### Community 613 - "Community 613"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 615 - "Community 615"
+### Community 614 - "Community 614"
 Cohesion: 0.6
 Nodes (3): extractTraceId(), getSharedDemoDenial(), runCommand()
 
-### Community 616 - "Community 616"
+### Community 615 - "Community 615"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 617 - "Community 617"
+### Community 616 - "Community 616"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 618 - "Community 618"
+### Community 617 - "Community 617"
 Cohesion: 0.5
 Nodes (2): mapRegisterStateDto(), useConvexRegisterState()
 
-### Community 619 - "Community 619"
+### Community 618 - "Community 618"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 620 - "Community 620"
+### Community 619 - "Community 619"
 Cohesion: 0.6
 Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
-### Community 621 - "Community 621"
+### Community 620 - "Community 620"
 Cohesion: 0.8
 Nodes (4): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPagesOrFallback(), readScopedPosLocalEvents()
 
-### Community 622 - "Community 622"
+### Community 621 - "Community 621"
 Cohesion: 0.6
 Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
-### Community 623 - "Community 623"
+### Community 622 - "Community 622"
 Cohesion: 0.6
 Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
 
-### Community 624 - "Community 624"
+### Community 623 - "Community 623"
 Cohesion: 0.6
 Nodes (3): applySnapshot(), isRegisterLifecycleRepairClassification(), toObservation()
 
-### Community 625 - "Community 625"
+### Community 624 - "Community 624"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 626 - "Community 626"
+### Community 625 - "Community 625"
 Cohesion: 0.7
 Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
+
+### Community 626 - "Community 626"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 627 - "Community 627"
 Cohesion: 0.4
@@ -5365,40 +5366,40 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 630 - "Community 630"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 631 - "Community 631"
 Cohesion: 0.5
 Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
 
-### Community 632 - "Community 632"
+### Community 631 - "Community 631"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 633 - "Community 633"
+### Community 632 - "Community 632"
 Cohesion: 0.7
 Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
-### Community 634 - "Community 634"
+### Community 633 - "Community 633"
 Cohesion: 0.7
 Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
-### Community 635 - "Community 635"
+### Community 634 - "Community 634"
 Cohesion: 0.7
 Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
-### Community 636 - "Community 636"
+### Community 635 - "Community 635"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 637 - "Community 637"
+### Community 636 - "Community 636"
 Cohesion: 0.6
 Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
 
-### Community 638 - "Community 638"
+### Community 637 - "Community 637"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 638 - "Community 638"
+Cohesion: 0.6
+Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
 ### Community 639 - "Community 639"
 Cohesion: 0.7
@@ -6201,32 +6202,32 @@ Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
 ### Community 839 - "Community 839"
-Cohesion: 0.67
-Nodes (2): collectHarnessTestTargets(), runHarnessTest()
-
-### Community 840 - "Community 840"
 Cohesion: 0.5
 Nodes (0):
 
+### Community 840 - "Community 840"
+Cohesion: 0.67
+Nodes (2): collectHarnessTestTargets(), runHarnessTest()
+
 ### Community 841 - "Community 841"
-Cohesion: 0.83
-Nodes (3): resolveGitPath(), runGit(), validateWorktreeBootstrap()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 842 - "Community 842"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): resolveGitPath(), runGit(), validateWorktreeBootstrap()
 
 ### Community 843 - "Community 843"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 844 - "Community 844"
-Cohesion: 1.0
-Nodes (2): buildSharedDemoActionAppendArgs(), captureSharedDemoAdmittedActionWithCtx()
-
-### Community 845 - "Community 845"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 845 - "Community 845"
+Cohesion: 1.0
+Nodes (2): buildSharedDemoActionAppendArgs(), captureSharedDemoAdmittedActionWithCtx()
 
 ### Community 846 - "Community 846"
 Cohesion: 0.67
@@ -6237,16 +6238,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 848 - "Community 848"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 849 - "Community 849"
 Cohesion: 1.0
-Nodes (2): buildApprovalRequestPendingSubject(), getApprovalRequestDescriptor()
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 850 - "Community 850"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildApprovalRequestPendingSubject(), getApprovalRequestDescriptor()
 
 ### Community 851 - "Community 851"
 Cohesion: 0.67
@@ -6277,24 +6278,24 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 858 - "Community 858"
-Cohesion: 1.0
-Nodes (2): removeOrganizationBatchWithCtx(), removeOrganizationWithCtx()
-
-### Community 859 - "Community 859"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 859 - "Community 859"
+Cohesion: 1.0
+Nodes (2): removeOrganizationBatchWithCtx(), removeOrganizationWithCtx()
 
 ### Community 860 - "Community 860"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 861 - "Community 861"
-Cohesion: 1.0
-Nodes (2): cycleDate(), seedWeeklyRowsForDeletionTest()
-
-### Community 862 - "Community 862"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 862 - "Community 862"
+Cohesion: 1.0
+Nodes (2): cycleDate(), seedWeeklyRowsForDeletionTest()
 
 ### Community 863 - "Community 863"
 Cohesion: 0.67
@@ -6313,12 +6314,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 867 - "Community 867"
-Cohesion: 1.0
-Nodes (2): appendFunnelAggregateWithCtx(), appendFunnelEventWithCtx()
-
-### Community 868 - "Community 868"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 868 - "Community 868"
+Cohesion: 1.0
+Nodes (2): appendFunnelAggregateWithCtx(), appendFunnelEventWithCtx()
 
 ### Community 869 - "Community 869"
 Cohesion: 0.67
@@ -6329,24 +6330,24 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 871 - "Community 871"
-Cohesion: 1.0
-Nodes (2): admitActionOperationWithCtx(), findOperationDefinition()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 872 - "Community 872"
 Cohesion: 1.0
-Nodes (2): admitPublicQuery(), withOperationReadAdmission()
+Nodes (2): admitActionOperationWithCtx(), findOperationDefinition()
 
 ### Community 873 - "Community 873"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): admitPublicQuery(), withOperationReadAdmission()
 
 ### Community 874 - "Community 874"
-Cohesion: 1.0
-Nodes (2): buildApprovalRequest(), insertApprovalRequestWithCtx()
-
-### Community 875 - "Community 875"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 875 - "Community 875"
+Cohesion: 1.0
+Nodes (2): buildApprovalRequest(), insertApprovalRequestWithCtx()
 
 ### Community 876 - "Community 876"
 Cohesion: 0.67
@@ -6369,12 +6370,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 881 - "Community 881"
-Cohesion: 1.0
-Nodes (2): isAthenaAppLoginEmailApproved(), normalizeAthenaAppLoginEmail()
-
-### Community 882 - "Community 882"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 882 - "Community 882"
+Cohesion: 1.0
+Nodes (2): isAthenaAppLoginEmailApproved(), normalizeAthenaAppLoginEmail()
 
 ### Community 883 - "Community 883"
 Cohesion: 0.67
@@ -6385,52 +6386,52 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 885 - "Community 885"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 886 - "Community 886"
 Cohesion: 1.0
 Nodes (2): closedRegisterReplayConflict(), repairConflict()
 
-### Community 886 - "Community 886"
+### Community 887 - "Community 887"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 887 - "Community 887"
-Cohesion: 1.0
-Nodes (2): resolveLocalSyncReview(), resolveLocalSyncReviewWithCtx()
 
 ### Community 888 - "Community 888"
 Cohesion: 1.0
-Nodes (2): decide(), gap()
+Nodes (2): resolveLocalSyncReview(), resolveLocalSyncReviewWithCtx()
 
 ### Community 889 - "Community 889"
 Cohesion: 1.0
-Nodes (2): hashPosTerminalSyncSecret(), toHex()
+Nodes (2): decide(), gap()
 
 ### Community 890 - "Community 890"
 Cohesion: 1.0
-Nodes (2): collectTerminalOperationalFacts(), toRegisterSessionLink()
+Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
 ### Community 891 - "Community 891"
 Cohesion: 1.0
-Nodes (2): resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
+Nodes (2): collectTerminalOperationalFacts(), toRegisterSessionLink()
 
 ### Community 892 - "Community 892"
 Cohesion: 1.0
-Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
+Nodes (2): resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
 
 ### Community 893 - "Community 893"
 Cohesion: 1.0
-Nodes (2): classifyTerminalHealthAlertConditions(), resolveTerminalHealthAlertTransitions()
+Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
 
 ### Community 894 - "Community 894"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): classifyTerminalHealthAlertConditions(), resolveTerminalHealthAlertTransitions()
 
 ### Community 895 - "Community 895"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 896 - "Community 896"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 897 - "Community 897"
 Cohesion: 0.67
@@ -6445,16 +6446,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 900 - "Community 900"
-Cohesion: 1.0
-Nodes (2): createRegisterLifecycleAuthorityStatusReadRepository(), createRegisterLifecycleAuthorityStatusRepository()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 901 - "Community 901"
 Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
+Nodes (2): createRegisterLifecycleAuthorityStatusReadRepository(), createRegisterLifecycleAuthorityStatusRepository()
 
 ### Community 902 - "Community 902"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 903 - "Community 903"
 Cohesion: 0.67
@@ -6481,12 +6482,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 909 - "Community 909"
-Cohesion: 1.0
-Nodes (2): day(), dayFields()
-
-### Community 910 - "Community 910"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 910 - "Community 910"
+Cohesion: 1.0
+Nodes (2): day(), dayFields()
 
 ### Community 911 - "Community 911"
 Cohesion: 0.67
@@ -6529,16 +6530,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 921 - "Community 921"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 922 - "Community 922"
 Cohesion: 1.0
-Nodes (2): scheduleCatalogSummaryDirtyMarker(), updateOnlineOrderItem()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 923 - "Community 923"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): scheduleCatalogSummaryDirtyMarker(), updateOnlineOrderItem()
 
 ### Community 924 - "Community 924"
 Cohesion: 0.67
@@ -6549,28 +6550,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 926 - "Community 926"
-Cohesion: 1.0
-Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 927 - "Community 927"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
 
 ### Community 928 - "Community 928"
 Cohesion: 1.0
-Nodes (2): addLookup(), buildServiceCaseTraceSeed()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 929 - "Community 929"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): addLookup(), buildServiceCaseTraceSeed()
 
 ### Community 930 - "Community 930"
-Cohesion: 1.0
-Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
-
-### Community 931 - "Community 931"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 931 - "Community 931"
+Cohesion: 1.0
+Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
 
 ### Community 932 - "Community 932"
 Cohesion: 0.67
@@ -6578,11 +6579,11 @@ Nodes (0):
 
 ### Community 933 - "Community 933"
 Cohesion: 0.67
-Nodes (1): View()
+Nodes (0):
 
 ### Community 934 - "Community 934"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 935 - "Community 935"
 Cohesion: 0.67
@@ -6597,12 +6598,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 938 - "Community 938"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
-
-### Community 939 - "Community 939"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 939 - "Community 939"
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 940 - "Community 940"
 Cohesion: 0.67
@@ -6630,23 +6631,23 @@ Nodes (0):
 
 ### Community 946 - "Community 946"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 947 - "Community 947"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 948 - "Community 948"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 949 - "Community 949"
-Cohesion: 1.0
-Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
-
-### Community 950 - "Community 950"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 950 - "Community 950"
+Cohesion: 1.0
+Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
 
 ### Community 951 - "Community 951"
 Cohesion: 0.67
@@ -6654,11 +6655,11 @@ Nodes (0):
 
 ### Community 952 - "Community 952"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 953 - "Community 953"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 954 - "Community 954"
 Cohesion: 0.67
@@ -6689,16 +6690,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 961 - "Community 961"
-Cohesion: 1.0
-Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 962 - "Community 962"
 Cohesion: 1.0
-Nodes (2): buildTodaySummary(), renderStorePulse()
+Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
 
 ### Community 963 - "Community 963"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildTodaySummary(), renderStorePulse()
 
 ### Community 964 - "Community 964"
 Cohesion: 0.67
@@ -6733,12 +6734,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 972 - "Community 972"
-Cohesion: 1.0
-Nodes (2): getDateRangePresets(), ReportDateRangeField()
-
-### Community 973 - "Community 973"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 973 - "Community 973"
+Cohesion: 1.0
+Nodes (2): getDateRangePresets(), ReportDateRangeField()
 
 ### Community 974 - "Community 974"
 Cohesion: 0.67
@@ -6786,83 +6787,83 @@ Nodes (0):
 
 ### Community 985 - "Community 985"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 986 - "Community 986"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): SingleLineError()
 
 ### Community 987 - "Community 987"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 988 - "Community 988"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 989 - "Community 989"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 990 - "Community 990"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 991 - "Community 991"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 992 - "Community 992"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): NotFound()
 
 ### Community 993 - "Community 993"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 994 - "Community 994"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 994 - "Community 994"
+### Community 995 - "Community 995"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 995 - "Community 995"
+### Community 996 - "Community 996"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 996 - "Community 996"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 997 - "Community 997"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (0):
 
 ### Community 998 - "Community 998"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): LoadingButton()
 
 ### Community 999 - "Community 999"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): onChange()
 
 ### Community 1000 - "Community 1000"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): AlertModal()
 
 ### Community 1001 - "Community 1001"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): OverlayModal()
 
 ### Community 1002 - "Community 1002"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): Skeleton()
 
 ### Community 1003 - "Community 1003"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Toaster()
 
 ### Community 1004 - "Community 1004"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 1005 - "Community 1005"
 Cohesion: 0.67
@@ -6894,11 +6895,11 @@ Nodes (0):
 
 ### Community 1012 - "Community 1012"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 1013 - "Community 1013"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 1014 - "Community 1014"
 Cohesion: 0.67
@@ -6913,12 +6914,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 1017 - "Community 1017"
-Cohesion: 1.0
-Nodes (2): sharedDemoQueryArgs(), useSharedDemoContext()
-
-### Community 1018 - "Community 1018"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 1018 - "Community 1018"
+Cohesion: 1.0
+Nodes (2): sharedDemoQueryArgs(), useSharedDemoContext()
 
 ### Community 1019 - "Community 1019"
 Cohesion: 0.67
@@ -6957,28 +6958,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 1028 - "Community 1028"
-Cohesion: 1.0
-Nodes (2): loadSolutionDocPageData(), stripSolutionDocHeading()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 1029 - "Community 1029"
 Cohesion: 1.0
-Nodes (2): getApprovalGuidance(), presentCommandToast()
+Nodes (2): loadSolutionDocPageData(), stripSolutionDocHeading()
 
 ### Community 1030 - "Community 1030"
+Cohesion: 1.0
+Nodes (2): getApprovalGuidance(), presentCommandToast()
+
+### Community 1031 - "Community 1031"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 1031 - "Community 1031"
+### Community 1032 - "Community 1032"
 Cohesion: 1.0
 Nodes (2): buildInventoryImportReviewUploadKey(), hashFingerprint()
 
-### Community 1032 - "Community 1032"
-Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
-
 ### Community 1033 - "Community 1033"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 1034 - "Community 1034"
 Cohesion: 0.67
@@ -6989,12 +6990,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 1036 - "Community 1036"
-Cohesion: 1.0
-Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
-
-### Community 1037 - "Community 1037"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 1037 - "Community 1037"
+Cohesion: 1.0
+Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
 ### Community 1038 - "Community 1038"
 Cohesion: 0.67
@@ -7013,28 +7014,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 1042 - "Community 1042"
-Cohesion: 1.0
-Nodes (2): deriveLocalSaleBlocker(), hasSaleUsableActiveRegisterSession()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 1043 - "Community 1043"
 Cohesion: 1.0
-Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
+Nodes (2): deriveLocalSaleBlocker(), hasSaleUsableActiveRegisterSession()
 
 ### Community 1044 - "Community 1044"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 1045 - "Community 1045"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 1046 - "Community 1046"
-Cohesion: 1.0
-Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
-
-### Community 1047 - "Community 1047"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 1047 - "Community 1047"
+Cohesion: 1.0
+Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
 
 ### Community 1048 - "Community 1048"
 Cohesion: 0.67
@@ -7061,32 +7062,32 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 1054 - "Community 1054"
-Cohesion: 1.0
-Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 1055 - "Community 1055"
 Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
 
 ### Community 1056 - "Community 1056"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 1057 - "Community 1057"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 1058 - "Community 1058"
-Cohesion: 1.0
-Nodes (2): isoDateOffset(), ReportsOverviewRoute()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 1059 - "Community 1059"
 Cohesion: 1.0
-Nodes (2): isoDateOffset(), resolveSkuDetailDateRange()
+Nodes (2): isoDateOffset(), ReportsOverviewRoute()
 
 ### Community 1060 - "Community 1060"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): isoDateOffset(), resolveSkuDetailDateRange()
 
 ### Community 1061 - "Community 1061"
 Cohesion: 0.67
@@ -7105,60 +7106,60 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 1065 - "Community 1065"
-Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 1066 - "Community 1066"
 Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 1067 - "Community 1067"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 1068 - "Community 1068"
 Cohesion: 0.67
-Nodes (1): hashPassword()
+Nodes (0):
 
 ### Community 1069 - "Community 1069"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): hashPassword()
 
 ### Community 1070 - "Community 1070"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (0):
 
 ### Community 1071 - "Community 1071"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 1072 - "Community 1072"
-Cohesion: 1.0
-Nodes (2): getAllColors(), getBaseUrl()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 1073 - "Community 1073"
 Cohesion: 1.0
-Nodes (2): getHomepageSnapshot(), getStoredMarker()
+Nodes (2): getAllColors(), getBaseUrl()
 
 ### Community 1074 - "Community 1074"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getHomepageSnapshot(), getStoredMarker()
 
 ### Community 1075 - "Community 1075"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 1076 - "Community 1076"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 1077 - "Community 1077"
 Cohesion: 1.0
-Nodes (2): getPreferredCardSku(), hasSellableAvailability()
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 1078 - "Community 1078"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPreferredCardSku(), hasSellableAvailability()
 
 ### Community 1079 - "Community 1079"
 Cohesion: 0.67
@@ -7173,12 +7174,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 1082 - "Community 1082"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 1083 - "Community 1083"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 1083 - "Community 1083"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 1084 - "Community 1084"
 Cohesion: 0.67
@@ -7189,12 +7190,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 1086 - "Community 1086"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 1087 - "Community 1087"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 1087 - "Community 1087"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 1088 - "Community 1088"
 Cohesion: 0.67
@@ -7261,64 +7262,64 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 1104 - "Community 1104"
-Cohesion: 1.0
-Nodes (2): pinnedBunVersion(), runBunVersionCheck()
-
-### Community 1105 - "Community 1105"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 1105 - "Community 1105"
+Cohesion: 1.0
+Nodes (2): pinnedBunVersion(), runBunVersionCheck()
 
 ### Community 1106 - "Community 1106"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 1107 - "Community 1107"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 1108 - "Community 1108"
 Cohesion: 1.0
 Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
 
-### Community 1108 - "Community 1108"
+### Community 1109 - "Community 1109"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 1109 - "Community 1109"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
 
 ### Community 1110 - "Community 1110"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 1111 - "Community 1111"
 Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
-### Community 1112 - "Community 1112"
+### Community 1111 - "Community 1111"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 1113 - "Community 1113"
+### Community 1112 - "Community 1112"
 Cohesion: 1.0
-Nodes (2): duplicateIdFindings(), validateHarnessGateRegistry()
+Nodes (2): createFixtureRepo(), write()
+
+### Community 1113 - "Community 1113"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 1114 - "Community 1114"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): duplicateIdFindings(), validateHarnessGateRegistry()
 
 ### Community 1115 - "Community 1115"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 1116 - "Community 1116"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 1117 - "Community 1117"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
-
-### Community 1118 - "Community 1118"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 1118 - "Community 1118"
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 1119 - "Community 1119"
 Cohesion: 0.67
@@ -14072,6 +14073,10 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 2807 - "Community 2807"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **3 isolated node(s):** `StaleConstructionError`, `FakeMessageChannel`, `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
@@ -15359,2123 +15364,2125 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1747`** (2 nodes): `fixture()`, `docs-solution-link-check.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1748`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 1748`** (2 nodes): `withoutGitRepositoryContext()`, `git-environment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1749`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 1749`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1750`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 1750`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1751`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 1751`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1752`** (2 nodes): `readRepoFile()`, `pr-athena-guidance-contract.test.ts`
+- **Thin community `Community 1752`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1753`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 1753`** (2 nodes): `readRepoFile()`, `pr-athena-guidance-contract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1754`** (1 nodes): `api.d.ts`
+- **Thin community `Community 1754`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1755`** (1 nodes): `api.js`
+- **Thin community `Community 1755`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1756`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 1756`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1757`** (1 nodes): `server.d.ts`
+- **Thin community `Community 1757`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1758`** (1 nodes): `server.js`
+- **Thin community `Community 1758`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1759`** (1 nodes): `app.ts`
+- **Thin community `Community 1759`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1760`** (1 nodes): `PosRecoveryCode.test.ts`
+- **Thin community `Community 1760`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1761`** (1 nodes): `PosRecoveryCode.ts`
+- **Thin community `Community 1761`** (1 nodes): `PosRecoveryCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1762`** (1 nodes): `SharedDemoTicket.test.ts`
+- **Thin community `Community 1762`** (1 nodes): `PosRecoveryCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1763`** (1 nodes): `auth.config.js`
+- **Thin community `Community 1763`** (1 nodes): `SharedDemoTicket.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1764`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1764`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1765`** (1 nodes): `auth.ts`
+- **Thin community `Community 1765`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1766`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 1766`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1767`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 1767`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1768`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 1768`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1769`** (1 nodes): `countries.ts`
+- **Thin community `Community 1769`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1770`** (1 nodes): `email.ts`
+- **Thin community `Community 1770`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1771`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1771`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1772`** (1 nodes): `payment.ts`
+- **Thin community `Community 1772`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1773`** (1 nodes): `athenaWebappEvents.test.ts`
+- **Thin community `Community 1773`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1774`** (1 nodes): `sharedDemoActionCapture.test.ts`
+- **Thin community `Community 1774`** (1 nodes): `athenaWebappEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1775`** (1 nodes): `types.ts`
+- **Thin community `Community 1775`** (1 nodes): `sharedDemoActionCapture.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1776`** (1 nodes): `convex.config.ts`
+- **Thin community `Community 1776`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1777`** (1 nodes): `crons.test.ts`
+- **Thin community `Community 1777`** (1 nodes): `convex.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1778`** (1 nodes): `crons.ts`
+- **Thin community `Community 1778`** (1 nodes): `crons.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1779`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 1779`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1780`** (1 nodes): `internal.ts`
+- **Thin community `Community 1780`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1781`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1781`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1782`** (1 nodes): `token.test.ts`
+- **Thin community `Community 1782`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1783`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 1783`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1784`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 1784`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1785`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 1785`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1786`** (1 nodes): `ApprovalRequestPending.test.tsx`
+- **Thin community `Community 1786`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1787`** (1 nodes): `DailyManagerReport.test.tsx`
+- **Thin community `Community 1787`** (1 nodes): `ApprovalRequestPending.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1788`** (1 nodes): `DailyManagerReportComparisonPreview.tsx`
+- **Thin community `Community 1788`** (1 nodes): `DailyManagerReport.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1789`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 1789`** (1 nodes): `DailyManagerReportComparisonPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1790`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 1790`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1791`** (1 nodes): `NewOrderAdmin.test.tsx`
+- **Thin community `Community 1791`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1792`** (1 nodes): `OrderEmail.test.tsx`
+- **Thin community `Community 1792`** (1 nodes): `NewOrderAdmin.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1793`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 1793`** (1 nodes): `OrderEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1794`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 1794`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1795`** (1 nodes): `PosTerminalHealthAlert.test.tsx`
+- **Thin community `Community 1795`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1796`** (1 nodes): `RegisterCloseoutVarianceAlert.test.tsx`
+- **Thin community `Community 1796`** (1 nodes): `PosTerminalHealthAlert.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1797`** (1 nodes): `ReportVerificationAlert.test.tsx`
+- **Thin community `Community 1797`** (1 nodes): `RegisterCloseoutVarianceAlert.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1798`** (1 nodes): `ReportVerificationAlert.tsx`
+- **Thin community `Community 1798`** (1 nodes): `ReportVerificationAlert.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1799`** (1 nodes): `WalkthroughRequestNotification.test.tsx`
+- **Thin community `Community 1799`** (1 nodes): `ReportVerificationAlert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1800`** (1 nodes): `WeeklyManagerReport.test.tsx`
+- **Thin community `Community 1800`** (1 nodes): `WalkthroughRequestNotification.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1801`** (1 nodes): `emailOperationalCtaStyles.ts`
+- **Thin community `Community 1801`** (1 nodes): `WeeklyManagerReport.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1802`** (1 nodes): `env.ts`
+- **Thin community `Community 1802`** (1 nodes): `emailOperationalCtaStyles.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1803`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1803`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1804`** (1 nodes): `auth.ts`
+- **Thin community `Community 1804`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1805`** (1 nodes): `bannerMessage.test.ts`
+- **Thin community `Community 1805`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1806`** (1 nodes): `colors.ts`
+- **Thin community `Community 1806`** (1 nodes): `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1807`** (1 nodes): `index.ts`
+- **Thin community `Community 1807`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1808`** (1 nodes): `landingFunnelEvents.test.ts`
+- **Thin community `Community 1808`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1809`** (1 nodes): `landingFunnelEvents.ts`
+- **Thin community `Community 1809`** (1 nodes): `landingFunnelEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1810`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1810`** (1 nodes): `landingFunnelEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1811`** (1 nodes): `products.ts`
+- **Thin community `Community 1811`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1812`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 1812`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1813`** (1 nodes): `stores.ts`
+- **Thin community `Community 1813`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1814`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 1814`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1815`** (1 nodes): `walkthroughRequests.test.ts`
+- **Thin community `Community 1815`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1816`** (1 nodes): `bag.ts`
+- **Thin community `Community 1816`** (1 nodes): `walkthroughRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1817`** (1 nodes): `guest.ts`
+- **Thin community `Community 1817`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1818`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 1818`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1819`** (1 nodes): `index.ts`
+- **Thin community `Community 1819`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1820`** (1 nodes): `me.ts`
+- **Thin community `Community 1820`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1821`** (1 nodes): `offers.ts`
+- **Thin community `Community 1821`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1822`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1822`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1823`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1823`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1824`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1824`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1825`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1825`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1826`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1826`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1827`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1827`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1828`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1828`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1829`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1829`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1830`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1830`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1831`** (1 nodes): `user.ts`
+- **Thin community `Community 1831`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1832`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1832`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1833`** (1 nodes): `index.ts`
+- **Thin community `Community 1833`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1834`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1834`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1835`** (1 nodes): `http.ts`
+- **Thin community `Community 1835`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1836`** (1 nodes): `access.ts`
+- **Thin community `Community 1836`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1837`** (1 nodes): `actions.test.ts`
+- **Thin community `Community 1837`** (1 nodes): `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1838`** (1 nodes): `insights.test.ts`
+- **Thin community `Community 1838`** (1 nodes): `actions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1839`** (1 nodes): `lifecycle.test.ts`
+- **Thin community `Community 1839`** (1 nodes): `insights.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1840`** (1 nodes): `index.ts`
+- **Thin community `Community 1840`** (1 nodes): `lifecycle.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1841`** (1 nodes): `providerFoundation.test.ts`
+- **Thin community `Community 1841`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1842`** (1 nodes): `types.ts`
+- **Thin community `Community 1842`** (1 nodes): `providerFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1843`** (1 nodes): `athenaUser.test.ts`
+- **Thin community `Community 1843`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1844`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1844`** (1 nodes): `athenaUser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1845`** (1 nodes): `categories.ts`
+- **Thin community `Community 1845`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1846`** (1 nodes): `colors.ts`
+- **Thin community `Community 1846`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1847`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1847`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1848`** (1 nodes): `inviteCode.test.ts`
+- **Thin community `Community 1848`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1849`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1849`** (1 nodes): `inviteCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1850`** (1 nodes): `organizationMembers.test.ts`
+- **Thin community `Community 1850`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1851`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1851`** (1 nodes): `organizationMembers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1852`** (1 nodes): `pos.ts`
+- **Thin community `Community 1852`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1853`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1853`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1854`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1854`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1855`** (1 nodes): `productSku.test.ts`
+- **Thin community `Community 1855`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1856`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1856`** (1 nodes): `productSku.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1857`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1857`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1858`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1858`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1859`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1859`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1860`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1860`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1861`** (1 nodes): `corrections.ts`
+- **Thin community `Community 1861`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1862`** (1 nodes): `deficitResolutionWork.test.ts`
+- **Thin community `Community 1862`** (1 nodes): `corrections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1863`** (1 nodes): `types.ts`
+- **Thin community `Community 1863`** (1 nodes): `deficitResolutionWork.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1864`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1864`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1865`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1865`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1866`** (1 nodes): `storeMemberAccess.test.ts`
+- **Thin community `Community 1866`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1867`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1867`** (1 nodes): `storeMemberAccess.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1868`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1868`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1869`** (1 nodes): `landingFunnelEvents.test.ts`
+- **Thin community `Community 1869`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1870`** (1 nodes): `landingFunnelRetention.test.ts`
+- **Thin community `Community 1870`** (1 nodes): `landingFunnelEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1871`** (1 nodes): `walkthroughConfig.test.ts`
+- **Thin community `Community 1871`** (1 nodes): `landingFunnelRetention.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1872`** (1 nodes): `walkthroughRequestRetention.test.ts`
+- **Thin community `Community 1872`** (1 nodes): `walkthroughConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1873`** (1 nodes): `walkthroughRequests.test.ts`
+- **Thin community `Community 1873`** (1 nodes): `walkthroughRequestRetention.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1874`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1874`** (1 nodes): `walkthroughRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1875`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1875`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1876`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1876`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1877`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1877`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1878`** (1 nodes): `types.ts`
+- **Thin community `Community 1878`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1879`** (1 nodes): `deliveryPolicy.test.ts`
+- **Thin community `Community 1879`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1880`** (1 nodes): `seed.ts`
+- **Thin community `Community 1880`** (1 nodes): `deliveryPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1881`** (1 nodes): `actionAdmission.test.ts`
+- **Thin community `Community 1881`** (1 nodes): `seed.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1882`** (1 nodes): `adapters.test.ts`
+- **Thin community `Community 1882`** (1 nodes): `actionAdmission.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1883`** (1 nodes): `capabilities.ts`
+- **Thin community `Community 1883`** (1 nodes): `adapters.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1884`** (1 nodes): `definitions.test.ts`
+- **Thin community `Community 1884`** (1 nodes): `capabilities.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1885`** (1 nodes): `migrationInventory.test.ts`
+- **Thin community `Community 1885`** (1 nodes): `definitions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1886`** (1 nodes): `migrationInventory.ts`
+- **Thin community `Community 1886`** (1 nodes): `migrationInventory.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1887`** (1 nodes): `publicMutation.test.ts`
+- **Thin community `Community 1887`** (1 nodes): `migrationInventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1888`** (1 nodes): `publicQuery.test.ts`
+- **Thin community `Community 1888`** (1 nodes): `publicMutation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1889`** (1 nodes): `readDefinitions.test.ts`
+- **Thin community `Community 1889`** (1 nodes): `publicQuery.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1890`** (1 nodes): `types.ts`
+- **Thin community `Community 1890`** (1 nodes): `readDefinitions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1891`** (1 nodes): `approvalRequests.sharedDemo.test.ts`
+- **Thin community `Community 1891`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1892`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1892`** (1 nodes): `approvalRequests.sharedDemo.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1893`** (1 nodes): `adjustmentReports.test.ts`
+- **Thin community `Community 1893`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1894`** (1 nodes): `approval.test.ts`
+- **Thin community `Community 1894`** (1 nodes): `adjustmentReports.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1895`** (1 nodes): `automationPolicy.test.ts`
+- **Thin community `Community 1895`** (1 nodes): `approval.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1896`** (1 nodes): `eventBuilders.test.ts`
+- **Thin community `Community 1896`** (1 nodes): `automationPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1897`** (1 nodes): `posTerminalHealthAlertEmail.ts`
+- **Thin community `Community 1897`** (1 nodes): `eventBuilders.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1898`** (1 nodes): `registerSessionAuthorityRevision.test.ts`
+- **Thin community `Community 1898`** (1 nodes): `posTerminalHealthAlertEmail.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1899`** (1 nodes): `registerSessionCloseoutGate.test.ts`
+- **Thin community `Community 1899`** (1 nodes): `registerSessionAuthorityRevision.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1900`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1900`** (1 nodes): `registerSessionCloseoutGate.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1901`** (1 nodes): `appLoginEmailAllowlist.test.ts`
+- **Thin community `Community 1901`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1902`** (1 nodes): `capabilityCatalog.test.ts`
+- **Thin community `Community 1902`** (1 nodes): `appLoginEmailAllowlist.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1903`** (1 nodes): `registerLifecycleAuthority.test.ts`
+- **Thin community `Community 1903`** (1 nodes): `capabilityCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1904`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1904`** (1 nodes): `registerLifecycleAuthority.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1905`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1905`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1906`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1906`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1907`** (1 nodes): `dto.ts`
+- **Thin community `Community 1907`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1908`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1908`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1909`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1909`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1910`** (1 nodes): `searchCatalog.test.ts`
+- **Thin community `Community 1910`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1911`** (1 nodes): `localSyncReportingTypes.ts`
+- **Thin community `Community 1911`** (1 nodes): `searchCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1912`** (1 nodes): `registerMappingAuthorityRevision.test.ts`
+- **Thin community `Community 1912`** (1 nodes): `localSyncReportingTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1913`** (1 nodes): `registerSessionCloseoutHolds.test.ts`
+- **Thin community `Community 1913`** (1 nodes): `registerMappingAuthorityRevision.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1914`** (1 nodes): `registerSessionSyncReview.classify.test.ts`
+- **Thin community `Community 1914`** (1 nodes): `registerSessionCloseoutHolds.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1915`** (1 nodes): `types.ts`
+- **Thin community `Community 1915`** (1 nodes): `registerSessionSyncReview.classify.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1916`** (1 nodes): `facts.ts`
+- **Thin community `Community 1916`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1917`** (1 nodes): `types.ts`
+- **Thin community `Community 1917`** (1 nodes): `facts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1918`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1919`** (1 nodes): `terminalHealthAlerts.test.ts`
+- **Thin community `Community 1919`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1920`** (1 nodes): `terminalSyncEvidence.ts`
+- **Thin community `Community 1920`** (1 nodes): `terminalHealthAlerts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1921`** (1 nodes): `types.ts`
+- **Thin community `Community 1921`** (1 nodes): `terminalSyncEvidence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1922`** (1 nodes): `registerLifecycleAuthorityRepository.test.ts`
+- **Thin community `Community 1922`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1923`** (1 nodes): `registerLifecycleAuthorityStatusRepository.test.ts`
+- **Thin community `Community 1923`** (1 nodes): `registerLifecycleAuthorityRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1924`** (1 nodes): `transactionRepository.test.ts`
+- **Thin community `Community 1924`** (1 nodes): `registerLifecycleAuthorityStatusRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1925`** (1 nodes): `register.ts`
+- **Thin community `Community 1925`** (1 nodes): `transactionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1926`** (1 nodes): `posRuntimeAdapter.test.ts`
+- **Thin community `Community 1926`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1927`** (1 nodes): `types.test.ts`
+- **Thin community `Community 1927`** (1 nodes): `posRuntimeAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1928`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 1928`** (1 nodes): `types.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1929`** (1 nodes): `schema.ts`
+- **Thin community `Community 1929`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1930`** (1 nodes): `automation.ts`
+- **Thin community `Community 1930`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1931`** (1 nodes): `contextTracking.ts`
+- **Thin community `Community 1931`** (1 nodes): `automation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1932`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1932`** (1 nodes): `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1933`** (1 nodes): `index.ts`
+- **Thin community `Community 1933`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1934`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1934`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1935`** (1 nodes): `intelligence.ts`
+- **Thin community `Community 1935`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1936`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1936`** (1 nodes): `intelligence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1937`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1937`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1938`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1938`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1939`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1939`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1940`** (1 nodes): `catalogSummary.ts`
+- **Thin community `Community 1940`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1941`** (1 nodes): `category.ts`
+- **Thin community `Community 1941`** (1 nodes): `catalogSummary.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1942`** (1 nodes): `color.ts`
+- **Thin community `Community 1942`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1943`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1943`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1944`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1944`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1945`** (1 nodes): `index.ts`
+- **Thin community `Community 1945`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1946`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1946`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1947`** (1 nodes): `inventoryImportCostOverlayBulkDecisionRequest.ts`
+- **Thin community `Community 1947`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1948`** (1 nodes): `inventoryImportCostOverlayRow.ts`
+- **Thin community `Community 1948`** (1 nodes): `inventoryImportCostOverlayBulkDecisionRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1949`** (1 nodes): `inventoryImportCostOverlayRun.ts`
+- **Thin community `Community 1949`** (1 nodes): `inventoryImportCostOverlayRow.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1950`** (1 nodes): `inventoryImportProvisionalSku.ts`
+- **Thin community `Community 1950`** (1 nodes): `inventoryImportCostOverlayRun.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1951`** (1 nodes): `inventoryImportReviewVersion.ts`
+- **Thin community `Community 1951`** (1 nodes): `inventoryImportProvisionalSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1952`** (1 nodes): `inventoryImportReviewVersionPayloadChunk.ts`
+- **Thin community `Community 1952`** (1 nodes): `inventoryImportReviewVersion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1953`** (1 nodes): `inventoryImportReviewVersionPayloadUpload.ts`
+- **Thin community `Community 1953`** (1 nodes): `inventoryImportReviewVersionPayloadChunk.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1954`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1954`** (1 nodes): `inventoryImportReviewVersionPayloadUpload.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1955`** (1 nodes): `organization.ts`
+- **Thin community `Community 1955`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1956`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1956`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1957`** (1 nodes): `posRegisterCatalogRevision.ts`
+- **Thin community `Community 1957`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1958`** (1 nodes): `product.ts`
+- **Thin community `Community 1958`** (1 nodes): `posRegisterCatalogRevision.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1959`** (1 nodes): `productSkuSearch.ts`
+- **Thin community `Community 1959`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1960`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1960`** (1 nodes): `productSkuSearch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1961`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1961`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1962`** (1 nodes): `store.ts`
+- **Thin community `Community 1962`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1963`** (1 nodes): `storeSchedule.ts`
+- **Thin community `Community 1963`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1964`** (1 nodes): `storeTimezone.ts`
+- **Thin community `Community 1964`** (1 nodes): `storeSchedule.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1965`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1965`** (1 nodes): `storeTimezone.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1966`** (1 nodes): `index.ts`
+- **Thin community `Community 1966`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1967`** (1 nodes): `landingFunnelEvent.ts`
+- **Thin community `Community 1967`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1968`** (1 nodes): `walkthroughRequest.ts`
+- **Thin community `Community 1968`** (1 nodes): `landingFunnelEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1969`** (1 nodes): `index.ts`
+- **Thin community `Community 1969`** (1 nodes): `walkthroughRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1970`** (1 nodes): `notifications.ts`
+- **Thin community `Community 1970`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1971`** (1 nodes): `index.ts`
+- **Thin community `Community 1971`** (1 nodes): `notifications.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1972`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1972`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1973`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1973`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1974`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1974`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1975`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1975`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1976`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1976`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1977`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1977`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1978`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1978`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1979`** (1 nodes): `index.ts`
+- **Thin community `Community 1979`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1980`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1980`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1981`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1981`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1982`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1982`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1983`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1983`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1984`** (1 nodes): `oversizedOperationalWorkRepair.ts`
+- **Thin community `Community 1984`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1985`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1985`** (1 nodes): `oversizedOperationalWorkRepair.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1986`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1986`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1987`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1987`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1988`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1988`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1989`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1989`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1990`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1990`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1991`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1991`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1992`** (1 nodes): `customer.ts`
+- **Thin community `Community 1992`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1993`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1993`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1994`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1994`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1995`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1995`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1996`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1996`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1997`** (1 nodes): `index.ts`
+- **Thin community `Community 1997`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1998`** (1 nodes): `posAmountMigrationRun.ts`
+- **Thin community `Community 1998`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1999`** (1 nodes): `posClientEvent.ts`
+- **Thin community `Community 1999`** (1 nodes): `posAmountMigrationRun.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2000`** (1 nodes): `posLifecycleJournal.ts`
+- **Thin community `Community 2000`** (1 nodes): `posClientEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2001`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 2001`** (1 nodes): `posLifecycleJournal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2002`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 2002`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2003`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 2003`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2004`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 2004`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2005`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 2005`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2006`** (1 nodes): `posPendingCheckoutItem.ts`
+- **Thin community `Community 2006`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2007`** (1 nodes): `posPendingCheckoutLookupAlias.ts`
+- **Thin community `Community 2007`** (1 nodes): `posPendingCheckoutItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2008`** (1 nodes): `posRecoveryCredential.ts`
+- **Thin community `Community 2008`** (1 nodes): `posPendingCheckoutLookupAlias.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2009`** (1 nodes): `posRegisterAuthorityReplicationStatus.ts`
+- **Thin community `Community 2009`** (1 nodes): `posRecoveryCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2010`** (1 nodes): `posRegisterMappingAuthority.ts`
+- **Thin community `Community 2010`** (1 nodes): `posRegisterAuthorityReplicationStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2011`** (1 nodes): `posRegisterSessionActivity.ts`
+- **Thin community `Community 2011`** (1 nodes): `posRegisterMappingAuthority.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2012`** (1 nodes): `posRegisterSessionActivityCheckpoint.ts`
+- **Thin community `Community 2012`** (1 nodes): `posRegisterSessionActivity.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2013`** (1 nodes): `posSession.ts`
+- **Thin community `Community 2013`** (1 nodes): `posRegisterSessionActivityCheckpoint.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2014`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 2014`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2015`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 2015`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2016`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 2016`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2017`** (1 nodes): `posTerminalRecovery.ts`
+- **Thin community `Community 2017`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2018`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 2018`** (1 nodes): `posTerminalRecovery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2019`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 2019`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2020`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 2020`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2021`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 2021`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2022`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 2022`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2023`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 2023`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2024`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 2024`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2025`** (1 nodes): `index.ts`
+- **Thin community `Community 2025`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2026`** (1 nodes): `remoteAssistClient.ts`
+- **Thin community `Community 2026`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2027`** (1 nodes): `remoteAssistSession.ts`
+- **Thin community `Community 2027`** (1 nodes): `remoteAssistClient.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2028`** (1 nodes): `derived.ts`
+- **Thin community `Community 2028`** (1 nodes): `remoteAssistSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2029`** (1 nodes): `facts.ts`
+- **Thin community `Community 2029`** (1 nodes): `derived.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2030`** (1 nodes): `index.ts`
+- **Thin community `Community 2030`** (1 nodes): `facts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2031`** (1 nodes): `verificationRuns.ts`
+- **Thin community `Community 2031`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2032`** (1 nodes): `index.ts`
+- **Thin community `Community 2032`** (1 nodes): `verificationRuns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2033`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 2033`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2034`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 2034`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2035`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 2035`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2036`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 2036`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2037`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 2037`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2038`** (1 nodes): `sharedDemo.ts`
+- **Thin community `Community 2038`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2039`** (1 nodes): `staffMessages.ts`
+- **Thin community `Community 2039`** (1 nodes): `sharedDemo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2040`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 2040`** (1 nodes): `staffMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2041`** (1 nodes): `index.ts`
+- **Thin community `Community 2041`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2042`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 2042`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2043`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 2043`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2044`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 2044`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2045`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 2045`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2046`** (1 nodes): `vendor.ts`
+- **Thin community `Community 2046`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2047`** (1 nodes): `analytics.ts`
+- **Thin community `Community 2047`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2048`** (1 nodes): `bag.ts`
+- **Thin community `Community 2048`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2049`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 2049`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2050`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 2050`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2051`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 2051`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2052`** (1 nodes): `guest.ts`
+- **Thin community `Community 2052`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2053`** (1 nodes): `index.ts`
+- **Thin community `Community 2053`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2054`** (1 nodes): `offer.ts`
+- **Thin community `Community 2054`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2055`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 2055`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2056`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 2056`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2057`** (1 nodes): `review.ts`
+- **Thin community `Community 2057`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2058`** (1 nodes): `rewards.ts`
+- **Thin community `Community 2058`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2059`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 2059`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2060`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 2060`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2061`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 2061`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2062`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 2062`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2063`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 2063`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2064`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 2064`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2065`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 2065`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2066`** (1 nodes): `authBoundary.test.ts`
+- **Thin community `Community 2066`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2067`** (1 nodes): `config.test.ts`
+- **Thin community `Community 2067`** (1 nodes): `authBoundary.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2068`** (1 nodes): `domainRestore.test.ts`
+- **Thin community `Community 2068`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2069`** (1 nodes): `foundation.test.ts`
+- **Thin community `Community 2069`** (1 nodes): `domainRestore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2070`** (1 nodes): `openingBaseline.test.ts`
+- **Thin community `Community 2070`** (1 nodes): `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2071`** (1 nodes): `policy.test.ts`
+- **Thin community `Community 2071`** (1 nodes): `openingBaseline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2072`** (1 nodes): `public.test.ts`
+- **Thin community `Community 2072`** (1 nodes): `policy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2073`** (1 nodes): `serviceEffectBoundaryCoverage.test.ts`
+- **Thin community `Community 2073`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2074`** (1 nodes): `bag.ts`
+- **Thin community `Community 2074`** (1 nodes): `serviceEffectBoundaryCoverage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2075`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 2075`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2076`** (1 nodes): `customer.ts`
+- **Thin community `Community 2076`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2077`** (1 nodes): `guest.ts`
+- **Thin community `Community 2077`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2078`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 2078`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2079`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 2079`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2080`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 2080`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2081`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 2081`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2082`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 2082`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2083`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 2083`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2084`** (1 nodes): `userStoreActivity.test.ts`
+- **Thin community `Community 2084`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2085`** (1 nodes): `users.ts`
+- **Thin community `Community 2085`** (1 nodes): `userStoreActivity.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2086`** (1 nodes): `storeTimeAuthority.test.ts`
+- **Thin community `Community 2086`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2087`** (1 nodes): `payment.ts`
+- **Thin community `Community 2087`** (1 nodes): `storeTimeAuthority.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2088`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2088`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2089`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 2089`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2090`** (1 nodes): `purchaseOrder.test.ts`
+- **Thin community `Community 2090`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2091`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 2091`** (1 nodes): `purchaseOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2092`** (1 nodes): `serviceCase.test.ts`
+- **Thin community `Community 2092`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2093`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 2093`** (1 nodes): `serviceCase.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2094`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 2094`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2095`** (1 nodes): `index.ts`
+- **Thin community `Community 2095`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2096`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 2096`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2097`** (1 nodes): `playwright.prod.config.ts`
+- **Thin community `Community 2097`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2098`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 2098`** (1 nodes): `playwright.prod.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2099`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 2099`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2100`** (1 nodes): `auth.ts`
+- **Thin community `Community 2100`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2101`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 2101`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2102`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 2102`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2103`** (1 nodes): `homepageRanking.test.ts`
+- **Thin community `Community 2103`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2104`** (1 nodes): `contextBundleTypes.ts`
+- **Thin community `Community 2104`** (1 nodes): `homepageRanking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2105`** (1 nodes): `contextEventTypes.ts`
+- **Thin community `Community 2105`** (1 nodes): `contextBundleTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2106`** (1 nodes): `contextTracking.test.ts`
+- **Thin community `Community 2106`** (1 nodes): `contextEventTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2107`** (1 nodes): `contextTypes.ts`
+- **Thin community `Community 2107`** (1 nodes): `contextTracking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2108`** (1 nodes): `index.ts`
+- **Thin community `Community 2108`** (1 nodes): `contextTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2109`** (1 nodes): `providerTypes.ts`
+- **Thin community `Community 2109`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2110`** (1 nodes): `inventoryImportReviewPayload.test.ts`
+- **Thin community `Community 2110`** (1 nodes): `providerTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2111`** (1 nodes): `inventoryImportSource.test.ts`
+- **Thin community `Community 2111`** (1 nodes): `inventoryImportReviewPayload.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2112`** (1 nodes): `terminalRuntimeMaterial.test.ts`
+- **Thin community `Community 2112`** (1 nodes): `inventoryImportSource.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2113`** (1 nodes): `posRegisterSessionActivityContract.test.ts`
+- **Thin community `Community 2113`** (1 nodes): `terminalRuntimeMaterial.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2114`** (1 nodes): `productDisplayName.test.ts`
+- **Thin community `Community 2114`** (1 nodes): `posRegisterSessionActivityContract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2115`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
+- **Thin community `Community 2115`** (1 nodes): `productDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2116`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 2116`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2117`** (1 nodes): `sharedDemoRegisterError.test.ts`
+- **Thin community `Community 2117`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2118`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 2118`** (1 nodes): `sharedDemoRegisterError.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2119`** (1 nodes): `storefrontVisibility.test.ts`
+- **Thin community `Community 2119`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2120`** (1 nodes): `appRouter.ts`
+- **Thin community `Community 2120`** (1 nodes): `storefrontVisibility.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2121`** (1 nodes): `convexAuthUrl.test.ts`
+- **Thin community `Community 2121`** (1 nodes): `appRouter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2122`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 2122`** (1 nodes): `convexAuthUrl.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2123`** (1 nodes): `Navbar.test.tsx`
+- **Thin community `Community 2123`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2124`** (1 nodes): `Navbar.tsx`
+- **Thin community `Community 2124`** (1 nodes): `Navbar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2125`** (1 nodes): `OrganizationView.test.tsx`
+- **Thin community `Community 2125`** (1 nodes): `Navbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2126`** (1 nodes): `ProtectedRoute.test.tsx`
+- **Thin community `Community 2126`** (1 nodes): `OrganizationView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2127`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 2127`** (1 nodes): `ProtectedRoute.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2128`** (1 nodes): `StoreView.test.tsx`
+- **Thin community `Community 2128`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2129`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 2129`** (1 nodes): `StoreView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2130`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 2130`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2131`** (1 nodes): `View.test.tsx`
+- **Thin community `Community 2131`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2132`** (1 nodes): `AttributesTable.test.ts`
+- **Thin community `Community 2132`** (1 nodes): `View.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2133`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 2133`** (1 nodes): `AttributesTable.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2134`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 2134`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2135`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 2135`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2136`** (1 nodes): `ProductCategorization.test.ts`
+- **Thin community `Community 2136`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2137`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 2137`** (1 nodes): `ProductCategorization.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2138`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 2138`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2139`** (1 nodes): `CopyImagesView.test.tsx`
+- **Thin community `Community 2139`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2140`** (1 nodes): `constants.ts`
+- **Thin community `Community 2140`** (1 nodes): `CopyImagesView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2141`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2141`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2142`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2142`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2143`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2143`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2144`** (1 nodes): `types.ts`
+- **Thin community `Community 2144`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2145`** (1 nodes): `AnalyticsView.test.tsx`
+- **Thin community `Community 2145`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2146`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 2146`** (1 nodes): `AnalyticsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2147`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 2147`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2148`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 2148`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2149`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2149`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2150`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2150`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2151`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2151`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2152`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2152`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2153`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2153`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2154`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2154`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2155`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2155`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2156`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2156`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2157`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2157`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2158`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2158`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2159`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2159`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2160`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2160`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2161`** (1 nodes): `chart.tsx`
+- **Thin community `Community 2161`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2162`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2162`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2163`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2163`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2164`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2164`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2165`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2165`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2166`** (1 nodes): `constants.ts`
+- **Thin community `Community 2166`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2167`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2167`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2168`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2168`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2169`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2169`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2170`** (1 nodes): `data.ts`
+- **Thin community `Community 2170`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2171`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2171`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2172`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2172`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2173`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2173`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2174`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2174`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2175`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2175`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2176`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2176`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2177`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2177`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2178`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2178`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2179`** (1 nodes): `AppSettingsView.test.tsx`
+- **Thin community `Community 2179`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2180`** (1 nodes): `app-sidebar.test.tsx`
+- **Thin community `Community 2180`** (1 nodes): `AppSettingsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2181`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 2181`** (1 nodes): `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2182`** (1 nodes): `constants.ts`
+- **Thin community `Community 2182`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2183`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2183`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2184`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2184`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2185`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2185`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2186`** (1 nodes): `data.ts`
+- **Thin community `Community 2186`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2187`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 2187`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2188`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 2188`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2189`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 2189`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2190`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
+- **Thin community `Community 2190`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2191`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2191`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2192`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2192`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2193`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2193`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2194`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2194`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2195`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2195`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2196`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2196`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2197`** (1 nodes): `constants.ts`
+- **Thin community `Community 2197`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2198`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2198`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2199`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2199`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2200`** (1 nodes): `data-table.test.tsx`
+- **Thin community `Community 2200`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2201`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2201`** (1 nodes): `data-table.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2202`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 2202`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2203`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 2203`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2204`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 2204`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2205`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 2205`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2206`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 2206`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2207`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 2207`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2208`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 2208`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2209`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 2209`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2210`** (1 nodes): `registerSessionTimestamps.test.ts`
+- **Thin community `Community 2210`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2211`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2211`** (1 nodes): `registerSessionTimestamps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2212`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2212`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2213`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2213`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2214`** (1 nodes): `AnimatedDataState.test.tsx`
+- **Thin community `Community 2214`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2215`** (1 nodes): `ListPagination.test.tsx`
+- **Thin community `Community 2215`** (1 nodes): `AnimatedDataState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2216`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 2216`** (1 nodes): `ListPagination.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2217`** (1 nodes): `PageHeader.test.tsx`
+- **Thin community `Community 2217`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2218`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 2218`** (1 nodes): `PageHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2219`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 2219`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2220`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 2220`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2221`** (1 nodes): `DocsReportView.tsx`
+- **Thin community `Community 2221`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2222`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 2222`** (1 nodes): `DocsReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2223`** (1 nodes): `Home.test.tsx`
+- **Thin community `Community 2223`** (1 nodes): `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2224`** (1 nodes): `HomepagePlacementProductImage.test.ts`
+- **Thin community `Community 2224`** (1 nodes): `Home.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2225`** (1 nodes): `ShopLookImageUploader.test.tsx`
+- **Thin community `Community 2225`** (1 nodes): `HomepagePlacementProductImage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2226`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 2226`** (1 nodes): `ShopLookImageUploader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2227`** (1 nodes): `demoDay.test.ts`
+- **Thin community `Community 2227`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2228`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 2228`** (1 nodes): `demoDay.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2229`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 2229`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2230`** (1 nodes): `OperationsSummaryMetric.test.tsx`
+- **Thin community `Community 2230`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2231`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 2231`** (1 nodes): `OperationsSummaryMetric.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2232`** (1 nodes): `openWorkInventoryReport.test.ts`
+- **Thin community `Community 2232`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2233`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 2233`** (1 nodes): `openWorkInventoryReport.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2234`** (1 nodes): `skuActivityUntrustedSalesAdapter.test.ts`
+- **Thin community `Community 2234`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2235`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 2235`** (1 nodes): `skuActivityUntrustedSalesAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2236`** (1 nodes): `CustomerDetailsView.test.tsx`
+- **Thin community `Community 2236`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2237`** (1 nodes): `CustomerDetailsView.tsx`
+- **Thin community `Community 2237`** (1 nodes): `CustomerDetailsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2238`** (1 nodes): `OrderDetailsView.test.tsx`
+- **Thin community `Community 2238`** (1 nodes): `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2239`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 2239`** (1 nodes): `OrderDetailsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2240`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 2240`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2241`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 2241`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2242`** (1 nodes): `OrderView.test.tsx`
+- **Thin community `Community 2242`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2243`** (1 nodes): `OrdersView.test.tsx`
+- **Thin community `Community 2243`** (1 nodes): `OrderView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2244`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 2244`** (1 nodes): `OrdersView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2245`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 2245`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2246`** (1 nodes): `constants.ts`
+- **Thin community `Community 2246`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2247`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2247`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2248`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2248`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2249`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2249`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2250`** (1 nodes): `data.ts`
+- **Thin community `Community 2250`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2251`** (1 nodes): `orderColumns.test.tsx`
+- **Thin community `Community 2251`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2252`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 2252`** (1 nodes): `orderColumns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2253`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2253`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2254`** (1 nodes): `constants.ts`
+- **Thin community `Community 2254`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2255`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2255`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2256`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2256`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2257`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2257`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2258`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2258`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2259`** (1 nodes): `data.ts`
+- **Thin community `Community 2259`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2260`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 2260`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2261`** (1 nodes): `constants.ts`
+- **Thin community `Community 2261`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2262`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2262`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2263`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2263`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2264`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2264`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2265`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2265`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2266`** (1 nodes): `data.ts`
+- **Thin community `Community 2266`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2267`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 2267`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2268`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 2268`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2269`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 2269`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2270`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 2270`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2271`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 2271`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2272`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 2272`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2273`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 2273`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2274`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 2274`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2275`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 2275`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2276`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 2276`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2277`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 2277`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2278`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 2278`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2279`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 2279`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2280`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 2280`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2281`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 2281`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2282`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 2282`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2283`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 2283`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2284`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 2284`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2285`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 2285`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2286`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 2286`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2287`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 2287`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2288`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 2288`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2289`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 2289`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2290`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 2290`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2291`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 2291`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2292`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 2292`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2293`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 2293`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2294`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 2294`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2295`** (1 nodes): `types.ts`
+- **Thin community `Community 2295`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2296`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 2296`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2297`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 2297`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2298`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 2298`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2299`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 2299`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2300`** (1 nodes): `ImagesView.test.tsx`
+- **Thin community `Community 2300`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2301`** (1 nodes): `ProductDetailView.test.tsx`
+- **Thin community `Community 2301`** (1 nodes): `ImagesView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2302`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 2302`** (1 nodes): `ProductDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2303`** (1 nodes): `productStockPresentation.test.ts`
+- **Thin community `Community 2303`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2304`** (1 nodes): `ArchivedProducts.test.tsx`
+- **Thin community `Community 2304`** (1 nodes): `productStockPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2305`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 2305`** (1 nodes): `ArchivedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2306`** (1 nodes): `ProductsListView.test.ts`
+- **Thin community `Community 2306`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2307`** (1 nodes): `ProductsListView.test.tsx`
+- **Thin community `Community 2307`** (1 nodes): `ProductsListView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2308`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 2308`** (1 nodes): `ProductsListView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2309`** (1 nodes): `UnresolvedProducts.test.tsx`
+- **Thin community `Community 2309`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2310`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 2310`** (1 nodes): `UnresolvedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2311`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 2311`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2312`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 2312`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2313`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2313`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2314`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2314`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2315`** (1 nodes): `data-table-toolbar.test.tsx`
+- **Thin community `Community 2315`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2316`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2316`** (1 nodes): `data-table-toolbar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2317`** (1 nodes): `data-table.test.tsx`
+- **Thin community `Community 2317`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2318`** (1 nodes): `data.ts`
+- **Thin community `Community 2318`** (1 nodes): `data-table.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2319`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 2319`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2320`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 2320`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2321`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 2321`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2322`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 2322`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2323`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 2323`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2324`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 2324`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2325`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2325`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2326`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2326`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2327`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2327`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2328`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2328`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2329`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2329`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2330`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2330`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2331`** (1 nodes): `constants.ts`
+- **Thin community `Community 2331`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2332`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2332`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2333`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2333`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2334`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2334`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2335`** (1 nodes): `data.ts`
+- **Thin community `Community 2335`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2336`** (1 nodes): `types.ts`
+- **Thin community `Community 2336`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2337`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 2337`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2338`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
+- **Thin community `Community 2338`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2339`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
+- **Thin community `Community 2339`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2340`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
+- **Thin community `Community 2340`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2341`** (1 nodes): `RemoteAssistSupportConsole.tsx`
+- **Thin community `Community 2341`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2342`** (1 nodes): `index.ts`
+- **Thin community `Community 2342`** (1 nodes): `RemoteAssistSupportConsole.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2343`** (1 nodes): `ReportCalendar.test.tsx`
+- **Thin community `Community 2343`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2344`** (1 nodes): `ReportCustomRangePanel.test.tsx`
+- **Thin community `Community 2344`** (1 nodes): `ReportCalendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2345`** (1 nodes): `ReportDateRangeField.test.tsx`
+- **Thin community `Community 2345`** (1 nodes): `ReportCustomRangePanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2346`** (1 nodes): `ReportSegmentedTabs.test.tsx`
+- **Thin community `Community 2346`** (1 nodes): `ReportDateRangeField.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2347`** (1 nodes): `ReportSegmentedTabs.tsx`
+- **Thin community `Community 2347`** (1 nodes): `ReportSegmentedTabs.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2348`** (1 nodes): `ReportSkuMixChart.test.tsx`
+- **Thin community `Community 2348`** (1 nodes): `ReportSegmentedTabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2349`** (1 nodes): `reportFormat.test.ts`
+- **Thin community `Community 2349`** (1 nodes): `ReportSkuMixChart.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2350`** (1 nodes): `reportPeriodKeys.test.ts`
+- **Thin community `Community 2350`** (1 nodes): `reportFormat.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2351`** (1 nodes): `reportRouteSearch.test.ts`
+- **Thin community `Community 2351`** (1 nodes): `reportPeriodKeys.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2352`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 2352`** (1 nodes): `reportRouteSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2353`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 2353`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2354`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 2354`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2355`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 2355`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2356`** (1 nodes): `SharedDemoExperience.test.tsx`
+- **Thin community `Community 2356`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2357`** (1 nodes): `SharedDemoRestoreOverlay.test.tsx`
+- **Thin community `Community 2357`** (1 nodes): `SharedDemoExperience.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2358`** (1 nodes): `sharedDemoLocalBootstrap.test.ts`
+- **Thin community `Community 2358`** (1 nodes): `SharedDemoRestoreOverlay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2359`** (1 nodes): `sharedDemoRestoreOverlay.test.ts`
+- **Thin community `Community 2359`** (1 nodes): `sharedDemoLocalBootstrap.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2360`** (1 nodes): `sharedDemoRestoreOverlay.tsx`
+- **Thin community `Community 2360`** (1 nodes): `sharedDemoRestoreOverlay.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2361`** (1 nodes): `index.tsx`
+- **Thin community `Community 2361`** (1 nodes): `sharedDemoRestoreOverlay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2362`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 2362`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2363`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 2363`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2364`** (1 nodes): `NotFound.test.tsx`
+- **Thin community `Community 2364`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2365`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 2365`** (1 nodes): `NotFound.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2366`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 2366`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2367`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 2367`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2368`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 2368`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2369`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 2369`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2370`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 2370`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2371`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
+- **Thin community `Community 2371`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2372`** (1 nodes): `index.tsx`
+- **Thin community `Community 2372`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2373`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 2373`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2374`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 2374`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2375`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 2375`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2376`** (1 nodes): `button.tsx`
+- **Thin community `Community 2376`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2377`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 2377`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2378`** (1 nodes): `card.tsx`
+- **Thin community `Community 2378`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2379`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 2379`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2380`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 2380`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2381`** (1 nodes): `command.tsx`
+- **Thin community `Community 2381`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2382`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 2382`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2383`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 2383`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2384`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 2384`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2385`** (1 nodes): `form.tsx`
+- **Thin community `Community 2385`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2386`** (1 nodes): `icons.tsx`
+- **Thin community `Community 2386`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2387`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 2387`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2388`** (1 nodes): `input.test.tsx`
+- **Thin community `Community 2388`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2389`** (1 nodes): `input.tsx`
+- **Thin community `Community 2389`** (1 nodes): `input.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2390`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 2390`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2391`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 2391`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2392`** (1 nodes): `popover.tsx`
+- **Thin community `Community 2392`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2393`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 2393`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2394`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 2394`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2395`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 2395`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2396`** (1 nodes): `select.tsx`
+- **Thin community `Community 2396`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2397`** (1 nodes): `separator.tsx`
+- **Thin community `Community 2397`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2398`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 2398`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2399`** (1 nodes): `switch.tsx`
+- **Thin community `Community 2399`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2400`** (1 nodes): `table.test.tsx`
+- **Thin community `Community 2400`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2401`** (1 nodes): `table.tsx`
+- **Thin community `Community 2401`** (1 nodes): `table.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2402`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 2402`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2403`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 2403`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2404`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 2404`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2405`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 2405`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2406`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 2406`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2407`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 2407`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2408`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 2408`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2409`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2409`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2410`** (1 nodes): `constants.ts`
+- **Thin community `Community 2410`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2411`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2411`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2412`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2412`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2413`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2413`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2414`** (1 nodes): `data.ts`
+- **Thin community `Community 2414`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2415`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 2415`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2416`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 2416`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2417`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2417`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2418`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2418`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2419`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2419`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2420`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2420`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2421`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2421`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2422`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 2422`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2423`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 2423`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2424`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 2424`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2425`** (1 nodes): `index.ts`
+- **Thin community `Community 2425`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2426`** (1 nodes): `config.test.ts`
+- **Thin community `Community 2426`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2427`** (1 nodes): `docsWorkspaceTracking.test.ts`
+- **Thin community `Community 2427`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2428`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 2428`** (1 nodes): `docsWorkspaceTracking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2429`** (1 nodes): `onlineOrderSessionOverlay.test.ts`
+- **Thin community `Community 2429`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2430`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 2430`** (1 nodes): `onlineOrderSessionOverlay.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2431`** (1 nodes): `use-pagination-persistence.test.ts`
+- **Thin community `Community 2431`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2432`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 2432`** (1 nodes): `use-pagination-persistence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2433`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 2433`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2434`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 2434`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2435`** (1 nodes): `useGetActiveStore.test.ts`
+- **Thin community `Community 2435`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2436`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 2436`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2437`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 2437`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2438`** (1 nodes): `usePOSProducts.test.ts`
+- **Thin community `Community 2438`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2439`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 2439`** (1 nodes): `usePOSProducts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2440`** (1 nodes): `useSharedDemoContext.test.ts`
+- **Thin community `Community 2440`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2441`** (1 nodes): `useStoreOperatingClock.test.tsx`
+- **Thin community `Community 2441`** (1 nodes): `useSharedDemoContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2442`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 2442`** (1 nodes): `useStoreOperatingClock.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2443`** (1 nodes): `AppMessagesContext.ts`
+- **Thin community `Community 2443`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2444`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
+- **Thin community `Community 2444`** (1 nodes): `AppMessagesContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2445`** (1 nodes): `index.ts`
+- **Thin community `Community 2445`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2446`** (1 nodes): `appUpdateActions.ts`
+- **Thin community `Community 2446`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2447`** (1 nodes): `index.ts`
+- **Thin community `Community 2447`** (1 nodes): `appUpdateActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2448`** (1 nodes): `updateCommunicationPreferenceContext.ts`
+- **Thin community `Community 2448`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2449`** (1 nodes): `updateCoordinator.test.ts`
+- **Thin community `Community 2449`** (1 nodes): `updateCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2450`** (1 nodes): `aws.ts`
+- **Thin community `Community 2450`** (1 nodes): `updateCoordinator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2451`** (1 nodes): `constants.ts`
+- **Thin community `Community 2451`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2452`** (1 nodes): `countries.ts`
+- **Thin community `Community 2452`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2453`** (1 nodes): `access.test.ts`
+- **Thin community `Community 2453`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2454`** (1 nodes): `content.test.ts`
+- **Thin community `Community 2454`** (1 nodes): `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2455`** (1 nodes): `navigation.test.ts`
+- **Thin community `Community 2455`** (1 nodes): `content.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2456`** (1 nodes): `parsing.test.ts`
+- **Thin community `Community 2456`** (1 nodes): `navigation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2457`** (1 nodes): `reportContract.test.ts`
+- **Thin community `Community 2457`** (1 nodes): `parsing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2458`** (1 nodes): `scrollProgress.test.ts`
+- **Thin community `Community 2458`** (1 nodes): `reportContract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2459`** (1 nodes): `virtual-docs-index.d.ts`
+- **Thin community `Community 2459`** (1 nodes): `scrollProgress.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2460`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 2460`** (1 nodes): `virtual-docs-index.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2461`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 2461`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2462`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 2462`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2463`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 2463`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2464`** (1 nodes): `ghana.ts`
+- **Thin community `Community 2464`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2465`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 2465`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2466`** (1 nodes): `inventoryImportParser.test.ts`
+- **Thin community `Community 2466`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2467`** (1 nodes): `landingFunnelClient.test.ts`
+- **Thin community `Community 2467`** (1 nodes): `inventoryImportParser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2468`** (1 nodes): `walkthroughPrivacy.ts`
+- **Thin community `Community 2468`** (1 nodes): `landingFunnelClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2469`** (1 nodes): `walkthroughRequestClient.test.ts`
+- **Thin community `Community 2469`** (1 nodes): `walkthroughPrivacy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2470`** (1 nodes): `appEntryRoutes.test.ts`
+- **Thin community `Community 2470`** (1 nodes): `walkthroughRequestClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2471`** (1 nodes): `storeEntryRoute.test.ts`
+- **Thin community `Community 2471`** (1 nodes): `appEntryRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2472`** (1 nodes): `operatingDate.test.ts`
+- **Thin community `Community 2472`** (1 nodes): `storeEntryRoute.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2473`** (1 nodes): `dto.ts`
+- **Thin community `Community 2473`** (1 nodes): `operatingDate.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2474`** (1 nodes): `ports.ts`
+- **Thin community `Community 2474`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2475`** (1 nodes): `posLocalStorePort.ts`
+- **Thin community `Community 2475`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2476`** (1 nodes): `results.test.ts`
+- **Thin community `Community 2476`** (1 nodes): `posLocalStorePort.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2477`** (1 nodes): `constants.ts`
+- **Thin community `Community 2477`** (1 nodes): `results.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2478`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 2478`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2479`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 2479`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2480`** (1 nodes): `index.ts`
+- **Thin community `Community 2480`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2481`** (1 nodes): `session.test.ts`
+- **Thin community `Community 2481`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2482`** (1 nodes): `types.ts`
+- **Thin community `Community 2482`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2483`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 2483`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2484`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 2484`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2485`** (1 nodes): `registerLifecycleAuthorityGateway.test.ts`
+- **Thin community `Community 2485`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2486`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 2486`** (1 nodes): `registerLifecycleAuthorityGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2487`** (1 nodes): `drawerAuthorityReconciliation.test.ts`
+- **Thin community `Community 2487`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2488`** (1 nodes): `indexedDbPosLocalStorageEngine.test.ts`
+- **Thin community `Community 2488`** (1 nodes): `drawerAuthorityReconciliation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2489`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 2489`** (1 nodes): `indexedDbPosLocalStorageEngine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2490`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 2490`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2491`** (1 nodes): `posLocalLedgerPolicy.test.ts`
+- **Thin community `Community 2491`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2492`** (1 nodes): `posLocalStorageHealth.test.ts`
+- **Thin community `Community 2492`** (1 nodes): `posLocalLedgerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2493`** (1 nodes): `posLocalStorageRuntime.test.ts`
+- **Thin community `Community 2493`** (1 nodes): `posLocalStorageHealth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2494`** (1 nodes): `posLocalStoreInitialization.test.ts`
+- **Thin community `Community 2494`** (1 nodes): `posLocalStorageRuntime.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2495`** (1 nodes): `posLocalStoreMaintenance.test.ts`
+- **Thin community `Community 2495`** (1 nodes): `posLocalStoreInitialization.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2496`** (1 nodes): `posLocalStoreMigrations.test.ts`
+- **Thin community `Community 2496`** (1 nodes): `posLocalStoreMaintenance.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2497`** (1 nodes): `posLocalStoreSnapshot.test.ts`
+- **Thin community `Community 2497`** (1 nodes): `posLocalStoreMigrations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2498`** (1 nodes): `registerCatalogPinRuntime.test.ts`
+- **Thin community `Community 2498`** (1 nodes): `posLocalStoreSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2499`** (1 nodes): `registerLifecycleAuthorityRollout.test.ts`
+- **Thin community `Community 2499`** (1 nodes): `registerCatalogPinRuntime.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2500`** (1 nodes): `registerSessionAuthorityBootstrap.test.ts`
+- **Thin community `Community 2500`** (1 nodes): `registerLifecycleAuthorityRollout.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2501`** (1 nodes): `saleBlockerPolicy.test.ts`
+- **Thin community `Community 2501`** (1 nodes): `registerSessionAuthorityBootstrap.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2502`** (1 nodes): `syncGapDiagnosis.test.ts`
+- **Thin community `Community 2502`** (1 nodes): `saleBlockerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2503`** (1 nodes): `printAttemptTelemetry.test.ts`
+- **Thin community `Community 2503`** (1 nodes): `syncGapDiagnosis.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2504`** (1 nodes): `runtimeCounters.test.ts`
+- **Thin community `Community 2504`** (1 nodes): `printAttemptTelemetry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2505`** (1 nodes): `telemetryBuffer.test.ts`
+- **Thin community `Community 2505`** (1 nodes): `runtimeCounters.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2506`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 2506`** (1 nodes): `telemetryBuffer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2507`** (1 nodes): `catalogSearchPresentation.test.ts`
+- **Thin community `Community 2507`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2508`** (1 nodes): `registerCashierPresence.test.ts`
+- **Thin community `Community 2508`** (1 nodes): `catalogSearchPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2509`** (1 nodes): `registerCheckoutProjection.test.ts`
+- **Thin community `Community 2509`** (1 nodes): `registerCashierPresence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2510`** (1 nodes): `registerUiState.test.ts`
+- **Thin community `Community 2510`** (1 nodes): `registerCheckoutProjection.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2511`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
+- **Thin community `Community 2511`** (1 nodes): `registerUiState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2512`** (1 nodes): `registerSessionCode.test.ts`
+- **Thin community `Community 2512`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2513`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 2513`** (1 nodes): `registerSessionCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2514`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 2514`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2515`** (1 nodes): `contract.test.ts`
+- **Thin community `Community 2515`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2516`** (1 nodes): `guardrails.test.ts`
+- **Thin community `Community 2516`** (1 nodes): `contract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2517`** (1 nodes): `index.ts`
+- **Thin community `Community 2517`** (1 nodes): `guardrails.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2518`** (1 nodes): `runtimeBuildMetadata.test.ts`
+- **Thin community `Community 2518`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2519`** (1 nodes): `category.ts`
+- **Thin community `Community 2519`** (1 nodes): `runtimeBuildMetadata.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2520`** (1 nodes): `product.ts`
+- **Thin community `Community 2520`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2521`** (1 nodes): `store.ts`
+- **Thin community `Community 2521`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2522`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 2522`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2523`** (1 nodes): `user.ts`
+- **Thin community `Community 2523`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2524`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 2524`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2525`** (1 nodes): `sheetReturn.test.ts`
+- **Thin community `Community 2525`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2526`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 2526`** (1 nodes): `sheetReturn.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2527`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 2527`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2528`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 2528`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2529`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2529`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2530`** (1 nodes): `main.tsx`
+- **Thin community `Community 2530`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2531`** (1 nodes): `posAppShellReadiness.test.ts`
+- **Thin community `Community 2531`** (1 nodes): `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2532`** (1 nodes): `posAppShellRoutes.test.ts`
+- **Thin community `Community 2532`** (1 nodes): `posAppShellReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2533`** (1 nodes): `posOfflineReadiness.test.ts`
+- **Thin community `Community 2533`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2534`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
+- **Thin community `Community 2534`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2535`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 2535`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2536`** (1 nodes): `-app-entry-route.tsx`
+- **Thin community `Community 2536`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2537`** (1 nodes): `-privacy-page.tsx`
+- **Thin community `Community 2537`** (1 nodes): `-app-entry-route.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2538`** (1 nodes): `-root-page-search.ts`
+- **Thin community `Community 2538`** (1 nodes): `-privacy-page.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2539`** (1 nodes): `-shared-demo-entry.tsx`
+- **Thin community `Community 2539`** (1 nodes): `-root-page-search.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2540`** (1 nodes): `-walkthrough-page.tsx`
+- **Thin community `Community 2540`** (1 nodes): `-shared-demo-entry.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2541`** (1 nodes): `__root.test.ts`
+- **Thin community `Community 2541`** (1 nodes): `-walkthrough-page.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2542`** (1 nodes): `index.tsx`
+- **Thin community `Community 2542`** (1 nodes): `__root.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 2543`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 2544`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2545`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 2545`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2546`** (1 nodes): `app-settings.tsx`
+- **Thin community `Community 2546`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2547`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 2547`** (1 nodes): `app-settings.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2548`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 2548`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2549`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 2549`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2550`** (1 nodes): `index.tsx`
+- **Thin community `Community 2550`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2551`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 2551`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2552`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 2552`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2553`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 2553`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2554`** (1 nodes): `home.tsx`
+- **Thin community `Community 2554`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2555`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 2555`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2556`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 2556`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2557`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 2557`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2558`** (1 nodes): `index.test.ts`
+- **Thin community `Community 2558`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2559`** (1 nodes): `-cost-overlay-search.ts`
+- **Thin community `Community 2559`** (1 nodes): `index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2560`** (1 nodes): `cost-overlay.test.ts`
+- **Thin community `Community 2560`** (1 nodes): `-cost-overlay-search.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2561`** (1 nodes): `cost-overlay.tsx`
+- **Thin community `Community 2561`** (1 nodes): `cost-overlay.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2562`** (1 nodes): `review.tsx`
+- **Thin community `Community 2562`** (1 nodes): `cost-overlay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2563`** (1 nodes): `inventory-import.test.tsx`
+- **Thin community `Community 2563`** (1 nodes): `review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2564`** (1 nodes): `inventory-import.tsx`
+- **Thin community `Community 2564`** (1 nodes): `inventory-import.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2565`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 2565`** (1 nodes): `inventory-import.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2566`** (1 nodes): `index.tsx`
+- **Thin community `Community 2566`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2567`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 2567`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2568`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 2568`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2569`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 2569`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2570`** (1 nodes): `index.tsx`
+- **Thin community `Community 2570`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2571`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 2571`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2572`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 2572`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2573`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 2573`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2574`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 2574`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2575`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 2575`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2576`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 2576`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2577`** (1 nodes): `expense.index.test.tsx`
+- **Thin community `Community 2577`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2578`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 2578`** (1 nodes): `expense.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2579`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 2579`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2580`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 2580`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2581`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 2581`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2582`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 2582`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2583`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 2583`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2584`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 2584`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2585`** (1 nodes): `edit.tsx`
+- **Thin community `Community 2585`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2586`** (1 nodes): `index.tsx`
+- **Thin community `Community 2586`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2587`** (1 nodes): `archived.tsx`
+- **Thin community `Community 2587`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2588`** (1 nodes): `new.tsx`
+- **Thin community `Community 2588`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 2589`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2590`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 2590`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2591`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 2591`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2592`** (1 nodes): `index.tsx`
+- **Thin community `Community 2592`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2593`** (1 nodes): `new.tsx`
+- **Thin community `Community 2593`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2594`** (1 nodes): `$productSkuId.test.ts`
+- **Thin community `Community 2594`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2595`** (1 nodes): `index.test.ts`
+- **Thin community `Community 2595`** (1 nodes): `$productSkuId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2596`** (1 nodes): `items.tsx`
+- **Thin community `Community 2596`** (1 nodes): `index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2597`** (1 nodes): `weekly.test.ts`
+- **Thin community `Community 2597`** (1 nodes): `items.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2598`** (1 nodes): `reports.tsx`
+- **Thin community `Community 2598`** (1 nodes): `weekly.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2599`** (1 nodes): `index.tsx`
+- **Thin community `Community 2599`** (1 nodes): `reports.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2600`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 2600`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2601`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 2601`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2602`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 2602`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2603`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 2603`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2604`** (1 nodes): `index.tsx`
+- **Thin community `Community 2604`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2605`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 2605`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2606`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 2606`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2607`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 2607`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2608`** (1 nodes): `index.tsx`
+- **Thin community `Community 2608`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2609`** (1 nodes): `_authed-shell.test.tsx`
+- **Thin community `Community 2609`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2610`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 2610`** (1 nodes): `_authed-shell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2611`** (1 nodes): `app.route.test.tsx`
+- **Thin community `Community 2611`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2612`** (1 nodes): `app.test.tsx`
+- **Thin community `Community 2612`** (1 nodes): `app.route.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2613`** (1 nodes): `app.tsx`
+- **Thin community `Community 2613`** (1 nodes): `app.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2614`** (1 nodes): `demo.test.tsx`
+- **Thin community `Community 2614`** (1 nodes): `app.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2615`** (1 nodes): `demo.tsx`
+- **Thin community `Community 2615`** (1 nodes): `demo.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2616`** (1 nodes): `docs.index.tsx`
+- **Thin community `Community 2616`** (1 nodes): `demo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2617`** (1 nodes): `docs.reports.$slug.tsx`
+- **Thin community `Community 2617`** (1 nodes): `docs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2618`** (1 nodes): `docs.solutions.$category.$slug.test.tsx`
+- **Thin community `Community 2618`** (1 nodes): `docs.reports.$slug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2619`** (1 nodes): `docs.tsx`
+- **Thin community `Community 2619`** (1 nodes): `docs.solutions.$category.$slug.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2620`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 2620`** (1 nodes): `docs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2621`** (1 nodes): `index.tsx`
+- **Thin community `Community 2621`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2622`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 2622`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2623`** (1 nodes): `landing.tsx`
+- **Thin community `Community 2623`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2624`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 2624`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2625`** (1 nodes): `_layout.index.tsx`
+- **Thin community `Community 2625`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2626`** (1 nodes): `_layout.tsx`
+- **Thin community `Community 2626`** (1 nodes): `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2627`** (1 nodes): `privacy.test.tsx`
+- **Thin community `Community 2627`** (1 nodes): `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2628`** (1 nodes): `privacy.tsx`
+- **Thin community `Community 2628`** (1 nodes): `privacy.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2629`** (1 nodes): `register-interest.tsx`
+- **Thin community `Community 2629`** (1 nodes): `privacy.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2630`** (1 nodes): `walkthrough.test.tsx`
+- **Thin community `Community 2630`** (1 nodes): `register-interest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2631`** (1 nodes): `walkthrough.tsx`
+- **Thin community `Community 2631`** (1 nodes): `walkthrough.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2632`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 2632`** (1 nodes): `walkthrough.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2633`** (1 nodes): `expenseStore.test.ts`
+- **Thin community `Community 2633`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2634`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 2634`** (1 nodes): `expenseStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2635`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 2635`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2636`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 2636`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2637`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 2637`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2638`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 2638`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2639`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 2639`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2640`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 2640`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2641`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 2641`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2642`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 2642`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2643`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 2643`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2644`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 2644`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2645`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 2645`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2646`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 2646`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2647`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 2647`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2648`** (1 nodes): `eodReviewFixtures.ts`
+- **Thin community `Community 2648`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2649`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 2649`** (1 nodes): `eodReviewFixtures.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2650`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 2650`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2651`** (1 nodes): `setup.ts`
+- **Thin community `Community 2651`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2652`** (1 nodes): `vite-env.d.ts`
+- **Thin community `Community 2652`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2653`** (1 nodes): `viteConfig.test.ts`
+- **Thin community `Community 2653`** (1 nodes): `vite-env.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2654`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 2654`** (1 nodes): `viteConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2655`** (1 nodes): `types.ts`
+- **Thin community `Community 2655`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2656`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 2656`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2657`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 2657`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2658`** (1 nodes): `global.d.ts`
+- **Thin community `Community 2658`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2659`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 2659`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2660`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 2660`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2661`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 2661`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2662`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 2662`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2663`** (1 nodes): `types.ts`
+- **Thin community `Community 2663`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2664`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 2664`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2665`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 2665`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2666`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 2666`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2667`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 2667`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2668`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 2668`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2669`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 2669`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2670`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 2670`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2671`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 2671`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2672`** (1 nodes): `schema.ts`
+- **Thin community `Community 2672`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2673`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 2673`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2674`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 2674`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2675`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 2675`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2676`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 2676`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2677`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 2677`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2678`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 2678`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2679`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 2679`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2680`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 2680`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2681`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 2681`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2682`** (1 nodes): `types.ts`
+- **Thin community `Community 2682`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2683`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2683`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2684`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 2684`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2685`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 2685`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2686`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 2686`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2687`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 2687`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2688`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 2688`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2689`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 2689`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2690`** (1 nodes): `constants.ts`
+- **Thin community `Community 2690`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2691`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 2691`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2692`** (1 nodes): `About.tsx`
+- **Thin community `Community 2692`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2693`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 2693`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2694`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 2694`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2695`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 2695`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2696`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 2696`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2697`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 2697`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2698`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 2698`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2699`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 2699`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2700`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 2700`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2701`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 2701`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2702`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 2702`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2703`** (1 nodes): `types.ts`
+- **Thin community `Community 2703`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2704`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 2704`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2705`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 2705`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2706`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 2706`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2707`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 2707`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2708`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 2708`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2709`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 2709`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2710`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 2710`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2711`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 2711`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2712`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 2712`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2713`** (1 nodes): `alert.tsx`
+- **Thin community `Community 2713`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2714`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 2714`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2715`** (1 nodes): `button.tsx`
+- **Thin community `Community 2715`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2716`** (1 nodes): `card.tsx`
+- **Thin community `Community 2716`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2717`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 2717`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2718`** (1 nodes): `command.tsx`
+- **Thin community `Community 2718`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2719`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 2719`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2720`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 2720`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2721`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 2721`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2722`** (1 nodes): `form.tsx`
+- **Thin community `Community 2722`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2723`** (1 nodes): `icons.tsx`
+- **Thin community `Community 2723`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2724`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 2724`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2725`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 2725`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2726`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 2726`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2727`** (1 nodes): `input.tsx`
+- **Thin community `Community 2727`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2728`** (1 nodes): `label.tsx`
+- **Thin community `Community 2728`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2729`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 2729`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2730`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 2730`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2731`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 2731`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2732`** (1 nodes): `index.ts`
+- **Thin community `Community 2732`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2733`** (1 nodes): `types.ts`
+- **Thin community `Community 2733`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2734`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 2734`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2735`** (1 nodes): `popover.tsx`
+- **Thin community `Community 2735`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2736`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 2736`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2737`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 2737`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2738`** (1 nodes): `select.tsx`
+- **Thin community `Community 2738`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2739`** (1 nodes): `separator.tsx`
+- **Thin community `Community 2739`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2740`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 2740`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2741`** (1 nodes): `table.tsx`
+- **Thin community `Community 2741`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2742`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 2742`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2743`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 2743`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2744`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 2744`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2745`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 2745`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2746`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 2746`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2747`** (1 nodes): `config.ts`
+- **Thin community `Community 2747`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2748`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
+- **Thin community `Community 2748`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2749`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 2749`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2750`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 2750`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2751`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 2751`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2752`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 2752`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2753`** (1 nodes): `constants.ts`
+- **Thin community `Community 2753`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2754`** (1 nodes): `countries.ts`
+- **Thin community `Community 2754`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2755`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 2755`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2756`** (1 nodes): `ghana.ts`
+- **Thin community `Community 2756`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2757`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 2757`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2758`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 2758`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2759`** (1 nodes): `index.ts`
+- **Thin community `Community 2759`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2760`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 2760`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2761`** (1 nodes): `store.ts`
+- **Thin community `Community 2761`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2762`** (1 nodes): `bag.ts`
+- **Thin community `Community 2762`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2763`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 2763`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2764`** (1 nodes): `category.ts`
+- **Thin community `Community 2764`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2765`** (1 nodes): `organization.ts`
+- **Thin community `Community 2765`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2766`** (1 nodes): `product.ts`
+- **Thin community `Community 2766`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2767`** (1 nodes): `store.ts`
+- **Thin community `Community 2767`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2768`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 2768`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2769`** (1 nodes): `user.ts`
+- **Thin community `Community 2769`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2770`** (1 nodes): `states.ts`
+- **Thin community `Community 2770`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2771`** (1 nodes): `storefrontContextEvents.test.ts`
+- **Thin community `Community 2771`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2772`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 2772`** (1 nodes): `storefrontContextEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2773`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 2773`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2774`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2774`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2775`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 2775`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2776`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 2776`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2777`** (1 nodes): `__root.tsx`
+- **Thin community `Community 2777`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2778`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 2778`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2779`** (1 nodes): `index.tsx`
+- **Thin community `Community 2779`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2780`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 2780`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2781`** (1 nodes): `index.tsx`
+- **Thin community `Community 2781`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2782`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 2782`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2783`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 2783`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2784`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 2784`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2785`** (1 nodes): `complete.tsx`
+- **Thin community `Community 2785`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2786`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 2786`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2787`** (1 nodes): `index.tsx`
+- **Thin community `Community 2787`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2788`** (1 nodes): `pending.tsx`
+- **Thin community `Community 2788`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2789`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 2789`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2790`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 2790`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2791`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 2791`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2792`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 2792`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2793`** (1 nodes): `index.js`
+- **Thin community `Community 2793`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2794`** (1 nodes): `check-register-session-authority-writers.test.ts`
+- **Thin community `Community 2794`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2795`** (1 nodes): `delivery-documentation-check.test.ts`
+- **Thin community `Community 2795`** (1 nodes): `check-register-session-authority-writers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2796`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 2796`** (1 nodes): `delivery-documentation-check.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2797`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 2797`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2798`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 2798`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2799`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 2799`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2800`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 2800`** (1 nodes): `valkey-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2801`** (1 nodes): `harness-execution-context.test.ts`
+- **Thin community `Community 2801`** (1 nodes): `harness-behavior-scenarios.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2802`** (1 nodes): `harness-gate-registry.test.ts`
+- **Thin community `Community 2802`** (1 nodes): `harness-execution-context.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2803`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 2803`** (1 nodes): `harness-gate-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2804`** (1 nodes): `operational-work-repair.test.ts`
+- **Thin community `Community 2804`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2805`** (1 nodes): `background.js`
+- **Thin community `Community 2805`** (1 nodes): `operational-work-repair.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2806`** (1 nodes): `popup.js`
+- **Thin community `Community 2806`** (1 nodes): `background.js`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2807`** (1 nodes): `popup.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -25079,7 +25079,7 @@
       "relation": "calls",
       "source": "harness_test_collectharnesstesttargets",
       "source_file": "scripts/harness-test.ts",
-      "source_location": "L44",
+      "source_location": "L51",
       "target": "harness_test_runharnesstest",
       "weight": 1
     },
@@ -152644,6 +152644,18 @@
       "weight": 1
     },
     {
+      "_src": "scripts_git_environment_ts",
+      "_tgt": "git_environment_withoutgitrepositorycontext",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_git_environment_ts",
+      "source_file": "scripts/git-environment.ts",
+      "source_location": "L1",
+      "target": "git_environment_withoutgitrepositorycontext",
+      "weight": 1
+    },
+    {
       "_src": "scripts_github_pr_merge_test_ts",
       "_tgt": "github_pr_merge_test_runcommand",
       "confidence": "EXTRACTED",
@@ -159737,6 +159749,18 @@
     },
     {
       "_src": "scripts_harness_test_test_ts",
+      "_tgt": "harness_test_test_rungit",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_harness_test_test_ts",
+      "source_file": "scripts/harness-test.test.ts",
+      "source_location": "L27",
+      "target": "harness_test_test_rungit",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_harness_test_test_ts",
       "_tgt": "harness_test_test_write",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
@@ -159755,7 +159779,7 @@
       "relation": "contains",
       "source": "scripts_harness_test_ts",
       "source_file": "scripts/harness-test.ts",
-      "source_location": "L26",
+      "source_location": "L33",
       "target": "harness_test_collectharnesstesttargets",
       "weight": 1
     },
@@ -159767,7 +159791,7 @@
       "relation": "contains",
       "source": "scripts_harness_test_ts",
       "source_file": "scripts/harness-test.ts",
-      "source_location": "L72",
+      "source_location": "L80",
       "target": "harness_test_parseharnesstestcliargs",
       "weight": 1
     },
@@ -159779,7 +159803,7 @@
       "relation": "contains",
       "source": "scripts_harness_test_ts",
       "source_file": "scripts/harness-test.ts",
-      "source_location": "L36",
+      "source_location": "L43",
       "target": "harness_test_runharnesstest",
       "weight": 1
     },
@@ -183531,6 +183555,33 @@
     {
       "community": 1000,
       "file_type": "code",
+      "id": "alert_modal_alertmodal",
+      "label": "AlertModal()",
+      "norm_label": "alertmodal()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/alert-modal.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 1000,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modals_alert_modal_tsx",
+      "label": "alert-modal.tsx",
+      "norm_label": "alert-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/alert-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1000,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_alert_modal_tsx",
+      "label": "alert-modal.tsx",
+      "norm_label": "alert-modal.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/alert-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1001,
+      "file_type": "code",
       "id": "overlay_modal_overlaymodal",
       "label": "OverlayModal()",
       "norm_label": "overlaymodal()",
@@ -183538,7 +183589,7 @@
       "source_location": "L12"
     },
     {
-      "community": 1000,
+      "community": 1001,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -183547,7 +183598,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1000,
+      "community": 1001,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_overlay_modal_tsx",
       "label": "overlay-modal.tsx",
@@ -183556,7 +183607,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1001,
+      "community": 1002,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -183565,7 +183616,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1001,
+      "community": 1002,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_skeleton_tsx",
       "label": "skeleton.tsx",
@@ -183574,7 +183625,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1001,
+      "community": 1002,
       "file_type": "code",
       "id": "skeleton_skeleton",
       "label": "Skeleton()",
@@ -183583,7 +183634,7 @@
       "source_location": "L3"
     },
     {
-      "community": 1002,
+      "community": 1003,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -183592,7 +183643,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1002,
+      "community": 1003,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sonner_tsx",
       "label": "sonner.tsx",
@@ -183601,7 +183652,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1002,
+      "community": 1003,
       "file_type": "code",
       "id": "sonner_toaster",
       "label": "Toaster()",
@@ -183610,7 +183661,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1003,
+      "community": 1004,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -183619,7 +183670,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1003,
+      "community": 1004,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_spinner_tsx",
       "label": "spinner.tsx",
@@ -183628,7 +183679,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1003,
+      "community": 1004,
       "file_type": "code",
       "id": "spinner_spinner",
       "label": "Spinner()",
@@ -183637,7 +183688,7 @@
       "source_location": "L3"
     },
     {
-      "community": 1004,
+      "community": 1005,
       "file_type": "code",
       "id": "activitysummarycards_activitysummarycards",
       "label": "ActivitySummaryCards()",
@@ -183646,7 +183697,7 @@
       "source_location": "L44"
     },
     {
-      "community": 1004,
+      "community": 1005,
       "file_type": "code",
       "id": "activitysummarycards_summarycard",
       "label": "SummaryCard()",
@@ -183655,7 +183706,7 @@
       "source_location": "L19"
     },
     {
-      "community": 1004,
+      "community": 1005,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_activitysummarycards_tsx",
       "label": "ActivitySummaryCards.tsx",
@@ -183664,7 +183715,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1005,
+      "community": 1006,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_tsx",
       "label": "TimelineEventCard.tsx",
@@ -183673,7 +183724,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1005,
+      "community": 1006,
       "file_type": "code",
       "id": "timelineeventcard_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -183682,7 +183733,7 @@
       "source_location": "L163"
     },
     {
-      "community": 1005,
+      "community": 1006,
       "file_type": "code",
       "id": "timelineeventcard_loadmore",
       "label": "loadMore()",
@@ -183691,7 +183742,7 @@
       "source_location": "L199"
     },
     {
-      "community": 1006,
+      "community": 1007,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useractivity_tsx",
       "label": "UserActivity.tsx",
@@ -183700,7 +183751,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1006,
+      "community": 1007,
       "file_type": "code",
       "id": "useractivity_activityheader",
       "label": "ActivityHeader()",
@@ -183709,7 +183760,7 @@
       "source_location": "L22"
     },
     {
-      "community": 1006,
+      "community": 1007,
       "file_type": "code",
       "id": "useractivity_useractivity",
       "label": "UserActivity()",
@@ -183718,7 +183769,7 @@
       "source_location": "L45"
     },
     {
-      "community": 1007,
+      "community": 1008,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
       "label": "UserInsightsSection.tsx",
@@ -183727,7 +183778,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1007,
+      "community": 1008,
       "file_type": "code",
       "id": "userinsightssection_handledismiss",
       "label": "handleDismiss()",
@@ -183736,7 +183787,7 @@
       "source_location": "L104"
     },
     {
-      "community": 1007,
+      "community": 1008,
       "file_type": "code",
       "id": "userinsightssection_handlegenerate",
       "label": "handleGenerate()",
@@ -183745,7 +183796,7 @@
       "source_location": "L83"
     },
     {
-      "community": 1008,
+      "community": 1009,
       "file_type": "code",
       "id": "appshellfullscreencontext_iseditablekeyboardtarget",
       "label": "isEditableKeyboardTarget()",
@@ -183754,7 +183805,7 @@
       "source_location": "L18"
     },
     {
-      "community": 1008,
+      "community": 1009,
       "file_type": "code",
       "id": "appshellfullscreencontext_useappshellfullscreenmode",
       "label": "useAppShellFullscreenMode()",
@@ -183763,39 +183814,12 @@
       "source_location": "L27"
     },
     {
-      "community": 1008,
+      "community": 1009,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_appshellfullscreencontext_tsx",
       "label": "AppShellFullscreenContext.tsx",
       "norm_label": "appshellfullscreencontext.tsx",
       "source_file": "packages/athena-webapp/src/contexts/AppShellFullscreenContext.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1009,
-      "file_type": "code",
-      "id": "onlineordercontext_onlineorderprovider",
-      "label": "OnlineOrderProvider()",
-      "norm_label": "onlineorderprovider()",
-      "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
-      "source_location": "L37"
-    },
-    {
-      "community": 1009,
-      "file_type": "code",
-      "id": "onlineordercontext_useonlineorder",
-      "label": "useOnlineOrder()",
-      "norm_label": "useonlineorder()",
-      "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
-      "source_location": "L114"
-    },
-    {
-      "community": 1009,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_contexts_onlineordercontext_tsx",
-      "label": "OnlineOrderContext.tsx",
-      "norm_label": "onlineordercontext.tsx",
-      "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
       "source_location": "L1"
     },
     {
@@ -183981,6 +184005,33 @@
     {
       "community": 1010,
       "file_type": "code",
+      "id": "onlineordercontext_onlineorderprovider",
+      "label": "OnlineOrderProvider()",
+      "norm_label": "onlineorderprovider()",
+      "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
+      "source_location": "L37"
+    },
+    {
+      "community": 1010,
+      "file_type": "code",
+      "id": "onlineordercontext_useonlineorder",
+      "label": "useOnlineOrder()",
+      "norm_label": "useonlineorder()",
+      "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
+      "source_location": "L114"
+    },
+    {
+      "community": 1010,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_contexts_onlineordercontext_tsx",
+      "label": "OnlineOrderContext.tsx",
+      "norm_label": "onlineordercontext.tsx",
+      "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1011,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_permissionscontext_tsx",
       "label": "PermissionsContext.tsx",
       "norm_label": "permissionscontext.tsx",
@@ -183988,7 +184039,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1010,
+      "community": 1011,
       "file_type": "code",
       "id": "permissionscontext_permissionsprovider",
       "label": "PermissionsProvider()",
@@ -183997,7 +184048,7 @@
       "source_location": "L23"
     },
     {
-      "community": 1010,
+      "community": 1011,
       "file_type": "code",
       "id": "permissionscontext_usepermissionscontext",
       "label": "usePermissionsContext()",
@@ -184006,7 +184057,7 @@
       "source_location": "L51"
     },
     {
-      "community": 1011,
+      "community": 1012,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_usercontext_tsx",
       "label": "UserContext.tsx",
@@ -184015,7 +184066,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1011,
+      "community": 1012,
       "file_type": "code",
       "id": "usercontext_userprovider",
       "label": "UserProvider()",
@@ -184024,7 +184075,7 @@
       "source_location": "L12"
     },
     {
-      "community": 1011,
+      "community": 1012,
       "file_type": "code",
       "id": "usercontext_useusercontext",
       "label": "useUserContext()",
@@ -184033,7 +184084,7 @@
       "source_location": "L37"
     },
     {
-      "community": 1012,
+      "community": 1013,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -184042,7 +184093,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1012,
+      "community": 1013,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useauth_ts",
       "label": "useAuth.ts",
@@ -184051,7 +184102,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1012,
+      "community": 1013,
       "file_type": "code",
       "id": "useauth_useauth",
       "label": "useAuth()",
@@ -184060,7 +184111,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1013,
+      "community": 1014,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpenselocalruntime_test_ts",
       "label": "useExpenseLocalRuntime.test.ts",
@@ -184069,7 +184120,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1013,
+      "community": 1014,
       "file_type": "code",
       "id": "useexpenselocalruntime_test_importruntime",
       "label": "importRuntime()",
@@ -184078,7 +184129,7 @@
       "source_location": "L54"
     },
     {
-      "community": 1013,
+      "community": 1014,
       "file_type": "code",
       "id": "useexpenselocalruntime_test_renderruntime",
       "label": "renderRuntime()",
@@ -184087,7 +184138,7 @@
       "source_location": "L59"
     },
     {
-      "community": 1014,
+      "community": 1015,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactivestore_ts",
       "label": "useGetActiveStore.ts",
@@ -184096,7 +184147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1014,
+      "community": 1015,
       "file_type": "code",
       "id": "usegetactivestore_usegetactivestore",
       "label": "useGetActiveStore()",
@@ -184105,7 +184156,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1014,
+      "community": 1015,
       "file_type": "code",
       "id": "usegetactivestore_usegetstores",
       "label": "useGetStores()",
@@ -184114,7 +184165,7 @@
       "source_location": "L32"
     },
     {
-      "community": 1015,
+      "community": 1016,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetorganizations_ts",
       "label": "useGetOrganizations.ts",
@@ -184123,7 +184174,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1015,
+      "community": 1016,
       "file_type": "code",
       "id": "usegetorganizations_usegetactiveorganization",
       "label": "useGetActiveOrganization()",
@@ -184132,7 +184183,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1015,
+      "community": 1016,
       "file_type": "code",
       "id": "usegetorganizations_usegetorganizations",
       "label": "useGetOrganizations()",
@@ -184141,7 +184192,7 @@
       "source_location": "L31"
     },
     {
-      "community": 1016,
+      "community": 1017,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesessionmanagementexpense_ts",
       "label": "useSessionManagementExpense.ts",
@@ -184150,7 +184201,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1016,
+      "community": 1017,
       "file_type": "code",
       "id": "usesessionmanagementexpense_getcommanderrormessage",
       "label": "getCommandErrorMessage()",
@@ -184159,7 +184210,7 @@
       "source_location": "L12"
     },
     {
-      "community": 1016,
+      "community": 1017,
       "file_type": "code",
       "id": "usesessionmanagementexpense_usesessionmanagementexpense",
       "label": "useSessionManagementExpense()",
@@ -184168,7 +184219,7 @@
       "source_location": "L26"
     },
     {
-      "community": 1017,
+      "community": 1018,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useshareddemocontext_ts",
       "label": "useSharedDemoContext.ts",
@@ -184177,7 +184228,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1017,
+      "community": 1018,
       "file_type": "code",
       "id": "useshareddemocontext_shareddemoqueryargs",
       "label": "sharedDemoQueryArgs()",
@@ -184186,7 +184237,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1017,
+      "community": 1018,
       "file_type": "code",
       "id": "useshareddemocontext_useshareddemocontext",
       "label": "useSharedDemoContext()",
@@ -184195,7 +184246,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1018,
+      "community": 1019,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesheetreturnposition_test_tsx",
       "label": "useSheetReturnPosition.test.tsx",
@@ -184204,7 +184255,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1018,
+      "community": 1019,
       "file_type": "code",
       "id": "usesheetreturnposition_test_harness",
       "label": "Harness()",
@@ -184213,40 +184264,13 @@
       "source_location": "L33"
     },
     {
-      "community": 1018,
+      "community": 1019,
       "file_type": "code",
       "id": "usesheetreturnposition_test_mockscrollable",
       "label": "mockScrollable()",
       "norm_label": "mockscrollable()",
       "source_file": "packages/athena-webapp/src/hooks/useSheetReturnPosition.test.tsx",
       "source_location": "L8"
-    },
-    {
-      "community": 1019,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usesheetscrollpreservation_test_tsx",
-      "label": "useSheetScrollPreservation.test.tsx",
-      "norm_label": "usesheetscrollpreservation.test.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/useSheetScrollPreservation.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1019,
-      "file_type": "code",
-      "id": "usesheetscrollpreservation_test_harness",
-      "label": "Harness()",
-      "norm_label": "harness()",
-      "source_file": "packages/athena-webapp/src/hooks/useSheetScrollPreservation.test.tsx",
-      "source_location": "L35"
-    },
-    {
-      "community": 1019,
-      "file_type": "code",
-      "id": "usesheetscrollpreservation_test_mockscrollable",
-      "label": "mockScrollable()",
-      "norm_label": "mockscrollable()",
-      "source_file": "packages/athena-webapp/src/hooks/useSheetScrollPreservation.test.tsx",
-      "source_location": "L16"
     },
     {
       "community": 102,
@@ -184431,6 +184455,33 @@
     {
       "community": 1020,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usesheetscrollpreservation_test_tsx",
+      "label": "useSheetScrollPreservation.test.tsx",
+      "norm_label": "usesheetscrollpreservation.test.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/useSheetScrollPreservation.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1020,
+      "file_type": "code",
+      "id": "usesheetscrollpreservation_test_harness",
+      "label": "Harness()",
+      "norm_label": "harness()",
+      "source_file": "packages/athena-webapp/src/hooks/useSheetScrollPreservation.test.tsx",
+      "source_location": "L35"
+    },
+    {
+      "community": 1020,
+      "file_type": "code",
+      "id": "usesheetscrollpreservation_test_mockscrollable",
+      "label": "mockScrollable()",
+      "norm_label": "mockscrollable()",
+      "source_file": "packages/athena-webapp/src/hooks/useSheetScrollPreservation.test.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 1021,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesheetscrollpreservation_ts",
       "label": "useSheetScrollPreservation.ts",
       "norm_label": "usesheetscrollpreservation.ts",
@@ -184438,7 +184489,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1020,
+      "community": 1021,
       "file_type": "code",
       "id": "usesheetscrollpreservation_findscrollableancestor",
       "label": "findScrollableAncestor()",
@@ -184447,7 +184498,7 @@
       "source_location": "L51"
     },
     {
-      "community": 1020,
+      "community": 1021,
       "file_type": "code",
       "id": "usesheetscrollpreservation_usesheetscrollpreservation",
       "label": "useSheetScrollPreservation()",
@@ -184456,7 +184507,7 @@
       "source_location": "L84"
     },
     {
-      "community": 1021,
+      "community": 1022,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_messages_useappmessage_ts",
       "label": "useAppMessage.ts",
@@ -184465,7 +184516,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1021,
+      "community": 1022,
       "file_type": "code",
       "id": "useappmessage_useappmessage",
       "label": "useAppMessage()",
@@ -184474,7 +184525,7 @@
       "source_location": "L10"
     },
     {
-      "community": 1021,
+      "community": 1022,
       "file_type": "code",
       "id": "useappmessage_useappmessages",
       "label": "useAppMessages()",
@@ -184483,7 +184534,7 @@
       "source_location": "L55"
     },
     {
-      "community": 1022,
+      "community": 1023,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_messages_useappmessagecommunicationpreference_ts",
       "label": "useAppMessageCommunicationPreference.ts",
@@ -184492,7 +184543,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1022,
+      "community": 1023,
       "file_type": "code",
       "id": "useappmessagecommunicationpreference_useappmessagecommunicationpreference",
       "label": "useAppMessageCommunicationPreference()",
@@ -184501,7 +184552,7 @@
       "source_location": "L16"
     },
     {
-      "community": 1022,
+      "community": 1023,
       "file_type": "code",
       "id": "useappmessagecommunicationpreference_usepreferredappmessagecommunicationvariant",
       "label": "usePreferredAppMessageCommunicationVariant()",
@@ -184510,7 +184561,7 @@
       "source_location": "L9"
     },
     {
-      "community": 1023,
+      "community": 1024,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_update_useupdatecommunicationpreference_ts",
       "label": "useUpdateCommunicationPreference.ts",
@@ -184519,7 +184570,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1023,
+      "community": 1024,
       "file_type": "code",
       "id": "useupdatecommunicationpreference_usepreferredupdatecommunicationvariant",
       "label": "usePreferredUpdateCommunicationVariant()",
@@ -184528,7 +184579,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1023,
+      "community": 1024,
       "file_type": "code",
       "id": "useupdatecommunicationpreference_useupdatecommunicationpreference",
       "label": "useUpdateCommunicationPreference()",
@@ -184537,7 +184588,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1024,
+      "community": 1025,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_cashcontrols_pendingcashvoidpresentation_ts",
       "label": "pendingCashVoidPresentation.ts",
@@ -184546,7 +184597,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1024,
+      "community": 1025,
       "file_type": "code",
       "id": "pendingcashvoidpresentation_formatpendingcashvoidnotice",
       "label": "formatPendingCashVoidNotice()",
@@ -184555,7 +184606,7 @@
       "source_location": "L59"
     },
     {
-      "community": 1024,
+      "community": 1025,
       "file_type": "code",
       "id": "pendingcashvoidpresentation_getpendingcashvoidcontext",
       "label": "getPendingCashVoidContext()",
@@ -184564,7 +184615,7 @@
       "source_location": "L20"
     },
     {
-      "community": 1025,
+      "community": 1026,
       "file_type": "code",
       "id": "access_canaccesssolutioncategory",
       "label": "canAccessSolutionCategory()",
@@ -184573,7 +184624,7 @@
       "source_location": "L3"
     },
     {
-      "community": 1025,
+      "community": 1026,
       "file_type": "code",
       "id": "access_filteraccessiblesolutiondocs",
       "label": "filterAccessibleSolutionDocs()",
@@ -184582,7 +184633,7 @@
       "source_location": "L10"
     },
     {
-      "community": 1025,
+      "community": 1026,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_docs_access_ts",
       "label": "access.ts",
@@ -184591,7 +184642,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1026,
+      "community": 1027,
       "file_type": "code",
       "id": "delivery_test_report",
       "label": "report()",
@@ -184600,7 +184651,7 @@
       "source_location": "L30"
     },
     {
-      "community": 1026,
+      "community": 1027,
       "file_type": "code",
       "id": "delivery_test_solutiondoc",
       "label": "solutionDoc()",
@@ -184609,7 +184660,7 @@
       "source_location": "L12"
     },
     {
-      "community": 1026,
+      "community": 1027,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_docs_delivery_test_ts",
       "label": "delivery.test.ts",
@@ -184618,7 +184669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1027,
+      "community": 1028,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_docs_scrollprogress_ts",
       "label": "scrollProgress.ts",
@@ -184627,7 +184678,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1027,
+      "community": 1028,
       "file_type": "code",
       "id": "scrollprogress_computescrollprogress",
       "label": "computeScrollProgress()",
@@ -184636,7 +184687,7 @@
       "source_location": "L15"
     },
     {
-      "community": 1027,
+      "community": 1028,
       "file_type": "code",
       "id": "scrollprogress_scrolltotopdurationms",
       "label": "scrollToTopDurationMs()",
@@ -184645,7 +184696,7 @@
       "source_location": "L32"
     },
     {
-      "community": 1028,
+      "community": 1029,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_docs_solutionpage_ts",
       "label": "solutionPage.ts",
@@ -184654,7 +184705,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1028,
+      "community": 1029,
       "file_type": "code",
       "id": "solutionpage_loadsolutiondocpagedata",
       "label": "loadSolutionDocPageData()",
@@ -184663,40 +184714,13 @@
       "source_location": "L15"
     },
     {
-      "community": 1028,
+      "community": 1029,
       "file_type": "code",
       "id": "solutionpage_stripsolutiondocheading",
       "label": "stripSolutionDocHeading()",
       "norm_label": "stripsolutiondocheading()",
       "source_file": "packages/athena-webapp/src/lib/docs/solutionPage.ts",
       "source_location": "L41"
-    },
-    {
-      "community": 1029,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_ts",
-      "label": "presentCommandToast.ts",
-      "norm_label": "presentcommandtoast.ts",
-      "source_file": "packages/athena-webapp/src/lib/errors/presentCommandToast.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1029,
-      "file_type": "code",
-      "id": "presentcommandtoast_getapprovalguidance",
-      "label": "getApprovalGuidance()",
-      "norm_label": "getapprovalguidance()",
-      "source_file": "packages/athena-webapp/src/lib/errors/presentCommandToast.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 1029,
-      "file_type": "code",
-      "id": "presentcommandtoast_presentcommandtoast",
-      "label": "presentCommandToast()",
-      "norm_label": "presentcommandtoast()",
-      "source_file": "packages/athena-webapp/src/lib/errors/presentCommandToast.ts",
-      "source_location": "L16"
     },
     {
       "community": 103,
@@ -184881,6 +184905,33 @@
     {
       "community": 1030,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_ts",
+      "label": "presentCommandToast.ts",
+      "norm_label": "presentcommandtoast.ts",
+      "source_file": "packages/athena-webapp/src/lib/errors/presentCommandToast.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1030,
+      "file_type": "code",
+      "id": "presentcommandtoast_getapprovalguidance",
+      "label": "getApprovalGuidance()",
+      "norm_label": "getapprovalguidance()",
+      "source_file": "packages/athena-webapp/src/lib/errors/presentCommandToast.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 1030,
+      "file_type": "code",
+      "id": "presentcommandtoast_presentcommandtoast",
+      "label": "presentCommandToast()",
+      "norm_label": "presentcommandtoast()",
+      "source_file": "packages/athena-webapp/src/lib/errors/presentCommandToast.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 1031,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_shareddemodenialobserver_ts",
       "label": "sharedDemoDenialObserver.ts",
       "norm_label": "shareddemodenialobserver.ts",
@@ -184888,7 +184939,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1030,
+      "community": 1031,
       "file_type": "code",
       "id": "shareddemodenialobserver_notifyshareddemodenial",
       "label": "notifySharedDemoDenial()",
@@ -184897,7 +184948,7 @@
       "source_location": "L24"
     },
     {
-      "community": 1030,
+      "community": 1031,
       "file_type": "code",
       "id": "shareddemodenialobserver_setshareddemodenialobserver",
       "label": "setSharedDemoDenialObserver()",
@@ -184906,7 +184957,7 @@
       "source_location": "L15"
     },
     {
-      "community": 1031,
+      "community": 1032,
       "file_type": "code",
       "id": "inventoryimportreviewuploadkey_buildinventoryimportreviewuploadkey",
       "label": "buildInventoryImportReviewUploadKey()",
@@ -184915,7 +184966,7 @@
       "source_location": "L21"
     },
     {
-      "community": 1031,
+      "community": 1032,
       "file_type": "code",
       "id": "inventoryimportreviewuploadkey_hashfingerprint",
       "label": "hashFingerprint()",
@@ -184924,7 +184975,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1031,
+      "community": 1032,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_inventory_import_inventoryimportreviewuploadkey_ts",
       "label": "inventoryImportReviewUploadKey.ts",
@@ -184933,7 +184984,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1032,
+      "community": 1033,
       "file_type": "code",
       "id": "maintenanceutils_isinmaintenancemode",
       "label": "isInMaintenanceMode()",
@@ -184942,7 +184993,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1032,
+      "community": 1033,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_maintenanceutils_ts",
       "label": "maintenanceUtils.ts",
@@ -184951,7 +185002,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1032,
+      "community": 1033,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_ts",
       "label": "maintenanceUtils.ts",
@@ -184960,7 +185011,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1033,
+      "community": 1034,
       "file_type": "code",
       "id": "navigationutils_getorigin",
       "label": "getOrigin()",
@@ -184969,7 +185020,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1033,
+      "community": 1034,
       "file_type": "code",
       "id": "navigationutils_reloadwindow",
       "label": "reloadWindow()",
@@ -184978,7 +185029,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1033,
+      "community": 1034,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_navigationutils_ts",
       "label": "navigationUtils.ts",
@@ -184987,7 +185038,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1034,
+      "community": 1035,
       "file_type": "code",
       "id": "bootstrapregister_test_drawer",
       "label": "drawer()",
@@ -184996,7 +185047,7 @@
       "source_location": "L9"
     },
     {
-      "community": 1034,
+      "community": 1035,
       "file_type": "code",
       "id": "bootstrapregister_test_state",
       "label": "state()",
@@ -185005,7 +185056,7 @@
       "source_location": "L23"
     },
     {
-      "community": 1034,
+      "community": 1035,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_bootstrapregister_test_ts",
       "label": "bootstrapRegister.test.ts",
@@ -185014,7 +185065,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1035,
+      "community": 1036,
       "file_type": "code",
       "id": "errortelemetry_reportposunexpectederror",
       "label": "reportPosUnexpectedError()",
@@ -185023,7 +185074,7 @@
       "source_location": "L26"
     },
     {
-      "community": 1035,
+      "community": 1036,
       "file_type": "code",
       "id": "errortelemetry_setposerrortelemetrysink",
       "label": "setPosErrorTelemetrySink()",
@@ -185032,7 +185083,7 @@
       "source_location": "L20"
     },
     {
-      "community": 1035,
+      "community": 1036,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_errortelemetry_ts",
       "label": "errorTelemetry.ts",
@@ -185041,7 +185092,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1036,
+      "community": 1037,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_registerandprovisionposterminal_ts",
       "label": "registerAndProvisionPosTerminal.ts",
@@ -185050,7 +185101,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1036,
+      "community": 1037,
       "file_type": "code",
       "id": "registerandprovisionposterminal_createterminalsyncsecrettoken",
       "label": "createTerminalSyncSecretToken()",
@@ -185059,7 +185110,7 @@
       "source_location": "L40"
     },
     {
-      "community": 1036,
+      "community": 1037,
       "file_type": "code",
       "id": "registerandprovisionposterminal_registerandprovisionposterminal",
       "label": "registerAndProvisionPosTerminal()",
@@ -185068,7 +185119,7 @@
       "source_location": "L50"
     },
     {
-      "community": 1037,
+      "community": 1038,
       "file_type": "code",
       "id": "commandgateway_useconvexcommandgateway",
       "label": "useConvexCommandGateway()",
@@ -185077,7 +185128,7 @@
       "source_location": "L18"
     },
     {
-      "community": 1037,
+      "community": 1038,
       "file_type": "code",
       "id": "commandgateway_useconvexdirecttransactionmutation",
       "label": "useConvexDirectTransactionMutation()",
@@ -185086,7 +185137,7 @@
       "source_location": "L80"
     },
     {
-      "community": 1037,
+      "community": 1038,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_commandgateway_ts",
       "label": "commandGateway.ts",
@@ -185095,7 +185146,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1038,
+      "community": 1039,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registerlifecycleauthoritygateway_ts",
       "label": "registerLifecycleAuthorityGateway.ts",
@@ -185104,7 +185155,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1038,
+      "community": 1039,
       "file_type": "code",
       "id": "registerlifecycleauthoritygateway_useregisterlifecycleauthorityacknowledgement",
       "label": "useRegisterLifecycleAuthorityAcknowledgement()",
@@ -185113,40 +185164,13 @@
       "source_location": "L30"
     },
     {
-      "community": 1038,
+      "community": 1039,
       "file_type": "code",
       "id": "registerlifecycleauthoritygateway_useregisterlifecycleauthoritysnapshot",
       "label": "useRegisterLifecycleAuthoritySnapshot()",
       "norm_label": "useregisterlifecycleauthoritysnapshot()",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerLifecycleAuthorityGateway.ts",
       "source_location": "L24"
-    },
-    {
-      "community": 1039,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstorageruntimecontext_tsx",
-      "label": "posLocalStorageRuntimeContext.tsx",
-      "norm_label": "poslocalstorageruntimecontext.tsx",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageRuntimeContext.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1039,
-      "file_type": "code",
-      "id": "poslocalstorageruntimecontext_poslocalstorageruntimeprovider",
-      "label": "PosLocalStorageRuntimeProvider()",
-      "norm_label": "poslocalstorageruntimeprovider()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageRuntimeContext.tsx",
-      "source_location": "L24"
-    },
-    {
-      "community": 1039,
-      "file_type": "code",
-      "id": "poslocalstorageruntimecontext_useposlocalstorageruntime",
-      "label": "usePosLocalStorageRuntime()",
-      "norm_label": "useposlocalstorageruntime()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageRuntimeContext.tsx",
-      "source_location": "L53"
     },
     {
       "community": 104,
@@ -185331,6 +185355,33 @@
     {
       "community": 1040,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstorageruntimecontext_tsx",
+      "label": "posLocalStorageRuntimeContext.tsx",
+      "norm_label": "poslocalstorageruntimecontext.tsx",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageRuntimeContext.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1040,
+      "file_type": "code",
+      "id": "poslocalstorageruntimecontext_poslocalstorageruntimeprovider",
+      "label": "PosLocalStorageRuntimeProvider()",
+      "norm_label": "poslocalstorageruntimeprovider()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageRuntimeContext.tsx",
+      "source_location": "L24"
+    },
+    {
+      "community": 1040,
+      "file_type": "code",
+      "id": "poslocalstorageruntimecontext_useposlocalstorageruntime",
+      "label": "usePosLocalStorageRuntime()",
+      "norm_label": "useposlocalstorageruntime()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageRuntimeContext.tsx",
+      "source_location": "L53"
+    },
+    {
+      "community": 1041,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoreindexeddbupgrade_test_ts",
       "label": "posLocalStoreIndexedDbUpgrade.test.ts",
       "norm_label": "poslocalstoreindexeddbupgrade.test.ts",
@@ -185338,7 +185389,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1040,
+      "community": 1041,
       "file_type": "code",
       "id": "poslocalstoreindexeddbupgrade_test_opendatabase",
       "label": "openDatabase()",
@@ -185347,7 +185398,7 @@
       "source_location": "L176"
     },
     {
-      "community": 1040,
+      "community": 1041,
       "file_type": "code",
       "id": "poslocalstoreindexeddbupgrade_test_transactioncomplete",
       "label": "transactionComplete()",
@@ -185356,7 +185407,7 @@
       "source_location": "L190"
     },
     {
-      "community": 1041,
+      "community": 1042,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registerlifecycleauthoritycandidates_test_ts",
       "label": "registerLifecycleAuthorityCandidates.test.ts",
@@ -185365,7 +185416,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1041,
+      "community": 1042,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_test_mapping",
       "label": "mapping()",
@@ -185374,7 +185425,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1041,
+      "community": 1042,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_test_openedevent",
       "label": "openedEvent()",
@@ -185383,7 +185434,7 @@
       "source_location": "L23"
     },
     {
-      "community": 1042,
+      "community": 1043,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_saleblockerpolicy_ts",
       "label": "saleBlockerPolicy.ts",
@@ -185392,7 +185443,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1042,
+      "community": 1043,
       "file_type": "code",
       "id": "saleblockerpolicy_derivelocalsaleblocker",
       "label": "deriveLocalSaleBlocker()",
@@ -185401,7 +185452,7 @@
       "source_location": "L17"
     },
     {
-      "community": 1042,
+      "community": 1043,
       "file_type": "code",
       "id": "saleblockerpolicy_hassaleusableactiveregistersession",
       "label": "hasSaleUsableActiveRegisterSession()",
@@ -185410,7 +185461,7 @@
       "source_location": "L59"
     },
     {
-      "community": 1043,
+      "community": 1044,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_synccontract_test_ts",
       "label": "syncContract.test.ts",
@@ -185419,7 +185470,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1043,
+      "community": 1044,
       "file_type": "code",
       "id": "synccontract_test_buildlocalevent",
       "label": "buildLocalEvent()",
@@ -185428,7 +185479,7 @@
       "source_location": "L1268"
     },
     {
-      "community": 1043,
+      "community": 1044,
       "file_type": "code",
       "id": "synccontract_test_isuploadsequenceeventtype",
       "label": "isUploadSequenceEventType()",
@@ -185437,7 +185488,7 @@
       "source_location": "L1301"
     },
     {
-      "community": 1044,
+      "community": 1045,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_terminalrecoverycommands_test_ts",
       "label": "terminalRecoveryCommands.test.ts",
@@ -185446,7 +185497,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1044,
+      "community": 1045,
       "file_type": "code",
       "id": "terminalrecoverycommands_test_buildcommand",
       "label": "buildCommand()",
@@ -185455,7 +185506,7 @@
       "source_location": "L25"
     },
     {
-      "community": 1044,
+      "community": 1045,
       "file_type": "code",
       "id": "terminalrecoverycommands_test_buildlocalevent",
       "label": "buildLocalEvent()",
@@ -185464,7 +185515,7 @@
       "source_location": "L38"
     },
     {
-      "community": 1045,
+      "community": 1046,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_terminalscope_ts",
       "label": "terminalScope.ts",
@@ -185473,7 +185524,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1045,
+      "community": 1046,
       "file_type": "code",
       "id": "terminalscope_isposlocaleventinterminalscope",
       "label": "isPosLocalEventInTerminalScope()",
@@ -185482,7 +185533,7 @@
       "source_location": "L50"
     },
     {
-      "community": 1045,
+      "community": 1046,
       "file_type": "code",
       "id": "terminalscope_resolveposlocalterminalscope",
       "label": "resolvePosLocalTerminalScope()",
@@ -185491,7 +185542,7 @@
       "source_location": "L15"
     },
     {
-      "community": 1046,
+      "community": 1047,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_terminalstaffauthorityrefresh_ts",
       "label": "terminalStaffAuthorityRefresh.ts",
@@ -185500,7 +185551,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1046,
+      "community": 1047,
       "file_type": "code",
       "id": "terminalstaffauthorityrefresh_classifyterminalstaffauthorityrefreshresult",
       "label": "classifyTerminalStaffAuthorityRefreshResult()",
@@ -185509,7 +185560,7 @@
       "source_location": "L49"
     },
     {
-      "community": 1046,
+      "community": 1047,
       "file_type": "code",
       "id": "terminalstaffauthorityrefresh_refreshandstoreterminalstaffauthority",
       "label": "refreshAndStoreTerminalStaffAuthority()",
@@ -185518,7 +185569,7 @@
       "source_location": "L77"
     },
     {
-      "community": 1047,
+      "community": 1048,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_terminal_posterminalappsessionrecoverycontext_tsx",
       "label": "posTerminalAppSessionRecoveryContext.tsx",
@@ -185527,7 +185578,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1047,
+      "community": 1048,
       "file_type": "code",
       "id": "posterminalappsessionrecoverycontext_toposterminalappsessionrecoveryruntimeinput",
       "label": "toPosTerminalAppSessionRecoveryRuntimeInput()",
@@ -185536,7 +185587,7 @@
       "source_location": "L16"
     },
     {
-      "community": 1047,
+      "community": 1048,
       "file_type": "code",
       "id": "posterminalappsessionrecoverycontext_useposterminalappsessionrecoveryruntimeinput",
       "label": "usePosTerminalAppSessionRecoveryRuntimeInput()",
@@ -185545,7 +185596,7 @@
       "source_location": "L12"
     },
     {
-      "community": 1048,
+      "community": 1049,
       "file_type": "code",
       "id": "catalogsearchpresentation_mapcatalogrowtoproduct",
       "label": "mapCatalogRowToProduct()",
@@ -185554,7 +185605,7 @@
       "source_location": "L19"
     },
     {
-      "community": 1048,
+      "community": 1049,
       "file_type": "code",
       "id": "catalogsearchpresentation_normalizeexactinput",
       "label": "normalizeExactInput()",
@@ -185563,40 +185614,13 @@
       "source_location": "L84"
     },
     {
-      "community": 1048,
+      "community": 1049,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearchpresentation_ts",
       "label": "catalogSearchPresentation.ts",
       "norm_label": "catalogsearchpresentation.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/catalogSearchPresentation.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 1049,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registercartprojection_test_ts",
-      "label": "registerCartProjection.test.ts",
-      "norm_label": "registercartprojection.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1049,
-      "file_type": "code",
-      "id": "registercartprojection_test_localevent",
-      "label": "localEvent()",
-      "norm_label": "localevent()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.test.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 1049,
-      "file_type": "code",
-      "id": "registercartprojection_test_readmodel",
-      "label": "readModel()",
-      "norm_label": "readmodel()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.test.ts",
-      "source_location": "L35"
     },
     {
       "community": 105,
@@ -185781,6 +185805,33 @@
     {
       "community": 1050,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registercartprojection_test_ts",
+      "label": "registerCartProjection.test.ts",
+      "norm_label": "registercartprojection.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1050,
+      "file_type": "code",
+      "id": "registercartprojection_test_localevent",
+      "label": "localEvent()",
+      "norm_label": "localevent()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.test.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 1050,
+      "file_type": "code",
+      "id": "registercartprojection_test_readmodel",
+      "label": "readModel()",
+      "norm_label": "readmodel()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCartProjection.test.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 1051,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_registerdrawerpresentation_test_ts",
       "label": "registerDrawerPresentation.test.ts",
       "norm_label": "registerdrawerpresentation.test.ts",
@@ -185788,7 +185839,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1050,
+      "community": 1051,
       "file_type": "code",
       "id": "registerdrawerpresentation_test_localevent",
       "label": "localEvent()",
@@ -185797,7 +185848,7 @@
       "source_location": "L19"
     },
     {
-      "community": 1050,
+      "community": 1051,
       "file_type": "code",
       "id": "registerdrawerpresentation_test_readmodel",
       "label": "readModel()",
@@ -185806,7 +185857,7 @@
       "source_location": "L37"
     },
     {
-      "community": 1051,
+      "community": 1052,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterlocalruntime_ts",
       "label": "useRegisterLocalRuntime.ts",
@@ -185815,7 +185866,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1051,
+      "community": 1052,
       "file_type": "code",
       "id": "useregisterlocalruntime_buildlocalsalevalidationmetadata",
       "label": "buildLocalSaleValidationMetadata()",
@@ -185824,7 +185875,7 @@
       "source_location": "L25"
     },
     {
-      "community": 1051,
+      "community": 1052,
       "file_type": "code",
       "id": "useregisterlocalruntime_useregisterlocalruntime",
       "label": "useRegisterLocalRuntime()",
@@ -185833,7 +185884,7 @@
       "source_location": "L43"
     },
     {
-      "community": 1052,
+      "community": 1053,
       "file_type": "code",
       "id": "contract_buildremoteassistcobrowseframe",
       "label": "buildRemoteAssistCoBrowseFrame()",
@@ -185842,7 +185893,7 @@
       "source_location": "L77"
     },
     {
-      "community": 1052,
+      "community": 1053,
       "file_type": "code",
       "id": "contract_validateremoteassistcontrolintent",
       "label": "validateRemoteAssistControlIntent()",
@@ -185851,7 +185902,7 @@
       "source_location": "L107"
     },
     {
-      "community": 1052,
+      "community": 1053,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_remote_assist_contract_ts",
       "label": "contract.ts",
@@ -185860,7 +185911,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1053,
+      "community": 1054,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_remote_assist_runtime_useremoteassistruntimetransport_test_ts",
       "label": "useRemoteAssistRuntimeTransport.test.ts",
@@ -185869,7 +185920,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1053,
+      "community": 1054,
       "file_type": "code",
       "id": "useremoteassistruntimetransport_test_activesession",
       "label": "activeSession()",
@@ -185878,7 +185929,7 @@
       "source_location": "L344"
     },
     {
-      "community": 1053,
+      "community": 1054,
       "file_type": "code",
       "id": "useremoteassistruntimetransport_test_createfakeclient",
       "label": "createFakeClient()",
@@ -185887,7 +185938,7 @@
       "source_location": "L359"
     },
     {
-      "community": 1054,
+      "community": 1055,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_remote_assist_transport_remoteassistlivetransportclient_ts",
       "label": "RemoteAssistLiveTransportClient.ts",
@@ -185896,7 +185947,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1054,
+      "community": 1055,
       "file_type": "code",
       "id": "remoteassistlivetransportclient_isrecord",
       "label": "isRecord()",
@@ -185905,7 +185956,7 @@
       "source_location": "L97"
     },
     {
-      "community": 1054,
+      "community": 1055,
       "file_type": "code",
       "id": "remoteassistlivetransportclient_parseremoteassisttransportmessage",
       "label": "parseRemoteAssistTransportMessage()",
@@ -185914,7 +185965,7 @@
       "source_location": "L75"
     },
     {
-      "community": 1055,
+      "community": 1056,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_browser_boundary_test_ts",
       "label": "routeTree.browser-boundary.test.ts",
@@ -185923,7 +185974,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1055,
+      "community": 1056,
       "file_type": "code",
       "id": "routetree_browser_boundary_test_collectsourcefiles",
       "label": "collectSourceFiles()",
@@ -185932,7 +185983,7 @@
       "source_location": "L36"
     },
     {
-      "community": 1055,
+      "community": 1056,
       "file_type": "code",
       "id": "routetree_browser_boundary_test_findillegalconveximports",
       "label": "findIllegalConvexImports()",
@@ -185941,7 +185992,7 @@
       "source_location": "L54"
     },
     {
-      "community": 1056,
+      "community": 1057,
       "file_type": "code",
       "id": "docs_back_link_handleclick",
       "label": "handleClick()",
@@ -185950,7 +186001,7 @@
       "source_location": "L85"
     },
     {
-      "community": 1056,
+      "community": 1057,
       "file_type": "code",
       "id": "docs_back_link_targetlink",
       "label": "TargetLink()",
@@ -185959,7 +186010,7 @@
       "source_location": "L19"
     },
     {
-      "community": 1056,
+      "community": 1057,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_docs_back_link_tsx",
       "label": "-docs-back-link.tsx",
@@ -185968,7 +186019,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1057,
+      "community": 1058,
       "file_type": "code",
       "id": "index_test_isodateoffset",
       "label": "isoDateOffset()",
@@ -185977,7 +186028,7 @@
       "source_location": "L274"
     },
     {
-      "community": 1057,
+      "community": 1058,
       "file_type": "code",
       "id": "index_test_stubensuremutation",
       "label": "stubEnsureMutation()",
@@ -185986,7 +186037,7 @@
       "source_location": "L78"
     },
     {
-      "community": 1057,
+      "community": 1058,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_index_test_ts",
       "label": "index.test.ts",
@@ -185995,7 +186046,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1058,
+      "community": 1059,
       "file_type": "code",
       "id": "index_isodateoffset",
       "label": "isoDateOffset()",
@@ -186004,7 +186055,7 @@
       "source_location": "L35"
     },
     {
-      "community": 1058,
+      "community": 1059,
       "file_type": "code",
       "id": "index_reportsoverviewroute",
       "label": "ReportsOverviewRoute()",
@@ -186013,40 +186064,13 @@
       "source_location": "L48"
     },
     {
-      "community": 1058,
+      "community": 1059,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports/index.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 1059,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_items_productskuid_tsx",
-      "label": "$productSkuId.tsx",
-      "norm_label": "$productskuid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports/items/$productSkuId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1059,
-      "file_type": "code",
-      "id": "productskuid_isodateoffset",
-      "label": "isoDateOffset()",
-      "norm_label": "isodateoffset()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports/items/$productSkuId.tsx",
-      "source_location": "L26"
-    },
-    {
-      "community": 1059,
-      "file_type": "code",
-      "id": "productskuid_resolveskudetaildaterange",
-      "label": "resolveSkuDetailDateRange()",
-      "norm_label": "resolveskudetaildaterange()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports/items/$productSkuId.tsx",
-      "source_location": "L32"
     },
     {
       "community": 106,
@@ -186231,6 +186255,33 @@
     {
       "community": 1060,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_items_productskuid_tsx",
+      "label": "$productSkuId.tsx",
+      "norm_label": "$productskuid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports/items/$productSkuId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1060,
+      "file_type": "code",
+      "id": "productskuid_isodateoffset",
+      "label": "isoDateOffset()",
+      "norm_label": "isodateoffset()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports/items/$productSkuId.tsx",
+      "source_location": "L26"
+    },
+    {
+      "community": 1060,
+      "file_type": "code",
+      "id": "productskuid_resolveskudetaildaterange",
+      "label": "resolveSkuDetailDateRange()",
+      "norm_label": "resolveskudetaildaterange()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports/items/$productSkuId.tsx",
+      "source_location": "L32"
+    },
+    {
+      "community": 1061,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_weekly_tsx",
       "label": "weekly.tsx",
       "norm_label": "weekly.tsx",
@@ -186238,7 +186289,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1060,
+      "community": 1061,
       "file_type": "code",
       "id": "weekly_unavailableweeklycopy",
       "label": "unavailableWeeklyCopy()",
@@ -186247,7 +186298,7 @@
       "source_location": "L94"
     },
     {
-      "community": 1060,
+      "community": 1061,
       "file_type": "code",
       "id": "weekly_weeklystatusrow",
       "label": "WeeklyStatusRow()",
@@ -186256,7 +186307,7 @@
       "source_location": "L40"
     },
     {
-      "community": 1061,
+      "community": 1062,
       "file_type": "code",
       "id": "landing_test_pause",
       "label": "pause()",
@@ -186265,7 +186316,7 @@
       "source_location": "L29"
     },
     {
-      "community": 1061,
+      "community": 1062,
       "file_type": "code",
       "id": "landing_test_revert",
       "label": "revert()",
@@ -186274,7 +186325,7 @@
       "source_location": "L29"
     },
     {
-      "community": 1061,
+      "community": 1062,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_landing_test_tsx",
       "label": "landing.test.tsx",
@@ -186283,7 +186334,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1062,
+      "community": 1063,
       "file_type": "code",
       "id": "packages_athena_webapp_src_static_product_metadata_test_ts",
       "label": "static-product-metadata.test.ts",
@@ -186292,7 +186343,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1062,
+      "community": 1063,
       "file_type": "code",
       "id": "static_product_metadata_test_content",
       "label": "content()",
@@ -186301,7 +186352,7 @@
       "source_location": "L34"
     },
     {
-      "community": 1062,
+      "community": 1063,
       "file_type": "code",
       "id": "static_product_metadata_test_parseindexhtml",
       "label": "parseIndexHtml()",
@@ -186310,7 +186361,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1063,
+      "community": 1064,
       "file_type": "code",
       "id": "actioncolorreview_stories_swatch",
       "label": "Swatch()",
@@ -186319,7 +186370,7 @@
       "source_location": "L177"
     },
     {
-      "community": 1063,
+      "community": 1064,
       "file_type": "code",
       "id": "actioncolorreview_stories_tokenscope",
       "label": "TokenScope()",
@@ -186328,7 +186379,7 @@
       "source_location": "L166"
     },
     {
-      "community": 1063,
+      "community": 1064,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_actioncolorreview_stories_tsx",
       "label": "ActionColorReview.stories.tsx",
@@ -186337,7 +186388,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1064,
+      "community": 1065,
       "file_type": "code",
       "id": "admin_shell_patterns_patterncard",
       "label": "PatternCard()",
@@ -186346,7 +186397,7 @@
       "source_location": "L127"
     },
     {
-      "community": 1064,
+      "community": 1065,
       "file_type": "code",
       "id": "admin_shell_patterns_patternshell",
       "label": "PatternShell()",
@@ -186355,7 +186406,7 @@
       "source_location": "L106"
     },
     {
-      "community": 1064,
+      "community": 1065,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_tsx",
       "label": "admin-shell-patterns.tsx",
@@ -186364,7 +186415,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1065,
+      "community": 1066,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_tsx",
       "label": "storybook-theme-decorator.tsx",
@@ -186373,7 +186424,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1065,
+      "community": 1066,
       "file_type": "code",
       "id": "storybook_theme_decorator_getathenadesigntokenstyle",
       "label": "getAthenaDesignTokenStyle()",
@@ -186382,7 +186433,7 @@
       "source_location": "L49"
     },
     {
-      "community": 1065,
+      "community": 1066,
       "file_type": "code",
       "id": "storybook_theme_decorator_withathenatheme",
       "label": "withAthenaTheme()",
@@ -186391,7 +186442,7 @@
       "source_location": "L62"
     },
     {
-      "community": 1066,
+      "community": 1067,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_mockgetsku",
       "label": "mockGetSku()",
@@ -186400,7 +186451,7 @@
       "source_location": "L66"
     },
     {
-      "community": 1066,
+      "community": 1067,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_validateinventoryfortransaction",
       "label": "validateInventoryForTransaction()",
@@ -186409,7 +186460,7 @@
       "source_location": "L20"
     },
     {
-      "community": 1066,
+      "community": 1067,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_inventoryvalidationlogic_test_ts",
       "label": "inventoryValidationLogic.test.ts",
@@ -186418,7 +186469,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1067,
+      "community": 1068,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
       "label": "usePrint.test.ts",
@@ -186427,7 +186478,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1067,
+      "community": 1068,
       "file_type": "code",
       "id": "useprint_test_emitprintwindowevent",
       "label": "emitPrintWindowEvent()",
@@ -186436,7 +186487,7 @@
       "source_location": "L43"
     },
     {
-      "community": 1067,
+      "community": 1068,
       "file_type": "code",
       "id": "useprint_test_setwindowopenmock",
       "label": "setWindowOpenMock()",
@@ -186445,7 +186496,7 @@
       "source_location": "L50"
     },
     {
-      "community": 1068,
+      "community": 1069,
       "file_type": "code",
       "id": "index_hashpassword",
       "label": "hashPassword()",
@@ -186454,7 +186505,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1068,
+      "community": 1069,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -186463,40 +186514,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1068,
+      "community": 1069,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/storefront-webapp/src/utils/index.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 1069,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_utils_versionchecker_test_ts",
-      "label": "versionChecker.test.ts",
-      "norm_label": "versionchecker.test.ts",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1069,
-      "file_type": "code",
-      "id": "versionchecker_test_importversionchecker",
-      "label": "importVersionChecker()",
-      "norm_label": "importversionchecker()",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.test.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 1069,
-      "file_type": "code",
-      "id": "versionchecker_test_installinitialscript",
-      "label": "installInitialScript()",
-      "norm_label": "installinitialscript()",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.test.ts",
-      "source_location": "L3"
     },
     {
       "community": 107,
@@ -186672,6 +186696,33 @@
     {
       "community": 1070,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_utils_versionchecker_test_ts",
+      "label": "versionChecker.test.ts",
+      "norm_label": "versionchecker.test.ts",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1070,
+      "file_type": "code",
+      "id": "versionchecker_test_importversionchecker",
+      "label": "importVersionChecker()",
+      "norm_label": "importversionchecker()",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.test.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 1070,
+      "file_type": "code",
+      "id": "versionchecker_test_installinitialscript",
+      "label": "installInitialScript()",
+      "norm_label": "installinitialscript()",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.test.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 1071,
+      "file_type": "code",
       "id": "packages_athena_webapp_vite_config_ts",
       "label": "vite.config.ts",
       "norm_label": "vite.config.ts",
@@ -186679,7 +186730,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1070,
+      "community": 1071,
       "file_type": "code",
       "id": "packages_storefront_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -186688,7 +186739,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1070,
+      "community": 1071,
       "file_type": "code",
       "id": "vite_config_manualchunks",
       "label": "manualChunks()",
@@ -186697,7 +186748,7 @@
       "source_location": "L26"
     },
     {
-      "community": 1071,
+      "community": 1072,
       "file_type": "code",
       "id": "auth_logout",
       "label": "logout()",
@@ -186706,7 +186757,7 @@
       "source_location": "L32"
     },
     {
-      "community": 1071,
+      "community": 1072,
       "file_type": "code",
       "id": "auth_verifyuseraccount",
       "label": "verifyUserAccount()",
@@ -186715,7 +186766,7 @@
       "source_location": "L3"
     },
     {
-      "community": 1071,
+      "community": 1072,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_auth_ts",
       "label": "auth.ts",
@@ -186724,7 +186775,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1072,
+      "community": 1073,
       "file_type": "code",
       "id": "color_getallcolors",
       "label": "getAllColors()",
@@ -186733,7 +186784,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1072,
+      "community": 1073,
       "file_type": "code",
       "id": "color_getbaseurl",
       "label": "getBaseUrl()",
@@ -186742,7 +186793,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1072,
+      "community": 1073,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_color_ts",
       "label": "color.ts",
@@ -186751,7 +186802,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1073,
+      "community": 1074,
       "file_type": "code",
       "id": "homepagesnapshot_gethomepagesnapshot",
       "label": "getHomepageSnapshot()",
@@ -186760,7 +186811,7 @@
       "source_location": "L96"
     },
     {
-      "community": 1073,
+      "community": 1074,
       "file_type": "code",
       "id": "homepagesnapshot_getstoredmarker",
       "label": "getStoredMarker()",
@@ -186769,7 +186820,7 @@
       "source_location": "L85"
     },
     {
-      "community": 1073,
+      "community": 1074,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_homepagesnapshot_ts",
       "label": "homepageSnapshot.ts",
@@ -186778,7 +186829,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1074,
+      "community": 1075,
       "file_type": "code",
       "id": "organization_getallorganizations",
       "label": "getAllOrganizations()",
@@ -186787,7 +186838,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1074,
+      "community": 1075,
       "file_type": "code",
       "id": "organization_getorganization",
       "label": "getOrganization()",
@@ -186796,7 +186847,7 @@
       "source_location": "L18"
     },
     {
-      "community": 1074,
+      "community": 1075,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_organization_ts",
       "label": "organization.ts",
@@ -186805,7 +186856,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1075,
+      "community": 1076,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_upsells_ts",
       "label": "upsells.ts",
@@ -186814,7 +186865,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1075,
+      "community": 1076,
       "file_type": "code",
       "id": "upsells_getbaseurl",
       "label": "getBaseUrl()",
@@ -186823,7 +186874,7 @@
       "source_location": "L3"
     },
     {
-      "community": 1075,
+      "community": 1076,
       "file_type": "code",
       "id": "upsells_getlastviewedproduct",
       "label": "getLastViewedProduct()",
@@ -186832,7 +186883,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1076,
+      "community": 1077,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_useroffers_ts",
       "label": "userOffers.ts",
@@ -186841,7 +186892,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1076,
+      "community": 1077,
       "file_type": "code",
       "id": "useroffers_getbaseurl",
       "label": "getBaseUrl()",
@@ -186850,7 +186901,7 @@
       "source_location": "L18"
     },
     {
-      "community": 1076,
+      "community": 1077,
       "file_type": "code",
       "id": "useroffers_getuserofferseligibility",
       "label": "getUserOffersEligibility()",
@@ -186859,7 +186910,7 @@
       "source_location": "L23"
     },
     {
-      "community": 1077,
+      "community": 1078,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_tsx",
       "label": "ProductCard.tsx",
@@ -186868,7 +186919,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1077,
+      "community": 1078,
       "file_type": "code",
       "id": "productcard_getpreferredcardsku",
       "label": "getPreferredCardSku()",
@@ -186877,7 +186928,7 @@
       "source_location": "L26"
     },
     {
-      "community": 1077,
+      "community": 1078,
       "file_type": "code",
       "id": "productcard_hassellableavailability",
       "label": "hasSellableAvailability()",
@@ -186886,7 +186937,7 @@
       "source_location": "L23"
     },
     {
-      "community": 1078,
+      "community": 1079,
       "file_type": "code",
       "id": "customerdetails_enteredcustomerdetails",
       "label": "EnteredCustomerDetails()",
@@ -186895,7 +186946,7 @@
       "source_location": "L22"
     },
     {
-      "community": 1078,
+      "community": 1079,
       "file_type": "code",
       "id": "customerdetails_onsubmit",
       "label": "onSubmit()",
@@ -186904,39 +186955,12 @@
       "source_location": "L55"
     },
     {
-      "community": 1078,
+      "community": 1079,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerdetails_tsx",
       "label": "CustomerDetails.tsx",
       "norm_label": "customerdetails.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/CustomerDetails.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1079,
-      "file_type": "code",
-      "id": "deliveryoptionsselector_handlechange",
-      "label": "handleChange()",
-      "norm_label": "handlechange()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
-      "source_location": "L77"
-    },
-    {
-      "community": 1079,
-      "file_type": "code",
-      "id": "deliveryoptionsselector_storeselector",
-      "label": "StoreSelector()",
-      "norm_label": "storeselector()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 1079,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliveryoptionsselector_tsx",
-      "label": "DeliveryOptionsSelector.tsx",
-      "norm_label": "deliveryoptionsselector.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
       "source_location": "L1"
     },
     {
@@ -187113,6 +187137,33 @@
     {
       "community": 1080,
       "file_type": "code",
+      "id": "deliveryoptionsselector_handlechange",
+      "label": "handleChange()",
+      "norm_label": "handlechange()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
+      "source_location": "L77"
+    },
+    {
+      "community": 1080,
+      "file_type": "code",
+      "id": "deliveryoptionsselector_storeselector",
+      "label": "StoreSelector()",
+      "norm_label": "storeselector()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 1080,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliveryoptionsselector_tsx",
+      "label": "DeliveryOptionsSelector.tsx",
+      "norm_label": "deliveryoptionsselector.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1081,
+      "file_type": "code",
       "id": "deliverysection_deliverydetails",
       "label": "DeliveryDetails()",
       "norm_label": "deliverydetails()",
@@ -187120,7 +187171,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1080,
+      "community": 1081,
       "file_type": "code",
       "id": "deliverysection_deliveryoptions",
       "label": "DeliveryOptions()",
@@ -187129,7 +187180,7 @@
       "source_location": "L22"
     },
     {
-      "community": 1080,
+      "community": 1081,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliverysection_tsx",
       "label": "DeliverySection.tsx",
@@ -187138,7 +187189,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1081,
+      "community": 1082,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_pickupoptions_tsx",
       "label": "PickupOptions.tsx",
@@ -187147,7 +187198,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1081,
+      "community": 1082,
       "file_type": "code",
       "id": "pickupoptions_formatstoredamount",
       "label": "formatStoredAmount()",
@@ -187156,7 +187207,7 @@
       "source_location": "L165"
     },
     {
-      "community": 1081,
+      "community": 1082,
       "file_type": "code",
       "id": "pickupoptions_iswithinrestrictiontime",
       "label": "isWithinRestrictionTime()",
@@ -187165,7 +187216,7 @@
       "source_location": "L12"
     },
     {
-      "community": 1082,
+      "community": 1083,
       "file_type": "code",
       "id": "mobilebagsummary_handlekeydown",
       "label": "handleKeyDown()",
@@ -187174,7 +187225,7 @@
       "source_location": "L110"
     },
     {
-      "community": 1082,
+      "community": 1083,
       "file_type": "code",
       "id": "mobilebagsummary_handleredeempromocode",
       "label": "handleRedeemPromoCode()",
@@ -187183,7 +187234,7 @@
       "source_location": "L89"
     },
     {
-      "community": 1082,
+      "community": 1083,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
       "label": "MobileBagSummary.tsx",
@@ -187192,7 +187243,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1083,
+      "community": 1084,
       "file_type": "code",
       "id": "checkoutstorage_loadcheckoutstate",
       "label": "loadCheckoutState()",
@@ -187201,7 +187252,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1083,
+      "community": 1084,
       "file_type": "code",
       "id": "checkoutstorage_savecheckoutstate",
       "label": "saveCheckoutState()",
@@ -187210,7 +187261,7 @@
       "source_location": "L24"
     },
     {
-      "community": 1083,
+      "community": 1084,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_ts",
       "label": "checkoutStorage.ts",
@@ -187219,7 +187270,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1084,
+      "community": 1085,
       "file_type": "code",
       "id": "footer_enablecategories",
       "label": "enableCategories()",
@@ -187228,7 +187279,7 @@
       "source_location": "L131"
     },
     {
-      "community": 1084,
+      "community": 1085,
       "file_type": "code",
       "id": "footer_linkgroup",
       "label": "LinkGroup()",
@@ -187237,7 +187288,7 @@
       "source_location": "L12"
     },
     {
-      "community": 1084,
+      "community": 1085,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_footer_tsx",
       "label": "Footer.tsx",
@@ -187246,7 +187297,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1085,
+      "community": 1086,
       "file_type": "code",
       "id": "featuredproductssection_featuredproductssection",
       "label": "FeaturedProductsSection()",
@@ -187255,7 +187306,7 @@
       "source_location": "L35"
     },
     {
-      "community": 1085,
+      "community": 1086,
       "file_type": "code",
       "id": "featuredproductssection_featuredsection",
       "label": "FeaturedSection()",
@@ -187264,7 +187315,7 @@
       "source_location": "L61"
     },
     {
-      "community": 1085,
+      "community": 1086,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_featuredproductssection_tsx",
       "label": "FeaturedProductsSection.tsx",
@@ -187273,7 +187324,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1086,
+      "community": 1087,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_promoalert_tsx",
       "label": "PromoAlert.tsx",
@@ -187282,7 +187333,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1086,
+      "community": 1087,
       "file_type": "code",
       "id": "promoalert_getpromoalertcopy",
       "label": "getPromoAlertCopy()",
@@ -187291,7 +187342,7 @@
       "source_location": "L20"
     },
     {
-      "community": 1086,
+      "community": 1087,
       "file_type": "code",
       "id": "promoalert_promoalert",
       "label": "PromoAlert()",
@@ -187300,7 +187351,7 @@
       "source_location": "L59"
     },
     {
-      "community": 1087,
+      "community": 1088,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_rewardsalert_tsx",
       "label": "RewardsAlert.tsx",
@@ -187309,7 +187360,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1087,
+      "community": 1088,
       "file_type": "code",
       "id": "rewardsalert_handleshopnow",
       "label": "handleShopNow()",
@@ -187318,7 +187369,7 @@
       "source_location": "L25"
     },
     {
-      "community": 1087,
+      "community": 1088,
       "file_type": "code",
       "id": "rewardsalert_onrewardsalertclose",
       "label": "onRewardsAlertClose()",
@@ -187327,7 +187378,7 @@
       "source_location": "L20"
     },
     {
-      "community": 1088,
+      "community": 1089,
       "file_type": "code",
       "id": "navigationbar_navigationbar",
       "label": "NavigationBar()",
@@ -187336,7 +187387,7 @@
       "source_location": "L30"
     },
     {
-      "community": 1088,
+      "community": 1089,
       "file_type": "code",
       "id": "navigationbar_storecategoriessubmenu",
       "label": "StoreCategoriesSubmenu()",
@@ -187345,40 +187396,13 @@
       "source_location": "L95"
     },
     {
-      "community": 1088,
+      "community": 1089,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navigationbar_tsx",
       "label": "NavigationBar.tsx",
       "norm_label": "navigationbar.tsx",
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 1089,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_revieweditor_tsx",
-      "label": "ReviewEditor.tsx",
-      "norm_label": "revieweditor.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1089,
-      "file_type": "code",
-      "id": "revieweditor_handleformdatachange",
-      "label": "handleFormDataChange()",
-      "norm_label": "handleformdatachange()",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
-      "source_location": "L150"
-    },
-    {
-      "community": 1089,
-      "file_type": "code",
-      "id": "revieweditor_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
-      "source_location": "L157"
     },
     {
       "community": 109,
@@ -187554,6 +187578,33 @@
     {
       "community": 1090,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_reviews_revieweditor_tsx",
+      "label": "ReviewEditor.tsx",
+      "norm_label": "revieweditor.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1090,
+      "file_type": "code",
+      "id": "revieweditor_handleformdatachange",
+      "label": "handleFormDataChange()",
+      "norm_label": "handleformdatachange()",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
+      "source_location": "L150"
+    },
+    {
+      "community": 1090,
+      "file_type": "code",
+      "id": "revieweditor_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
+      "source_location": "L157"
+    },
+    {
+      "community": 1091,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
       "label": "WelcomeBackModal.tsx",
       "norm_label": "welcomebackmodal.tsx",
@@ -187561,7 +187612,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1090,
+      "community": 1091,
       "file_type": "code",
       "id": "welcomebackmodal_handleclose",
       "label": "handleClose()",
@@ -187570,7 +187621,7 @@
       "source_location": "L63"
     },
     {
-      "community": 1090,
+      "community": 1091,
       "file_type": "code",
       "id": "welcomebackmodal_handlesuccess",
       "label": "handleSuccess()",
@@ -187579,7 +187630,7 @@
       "source_location": "L76"
     },
     {
-      "community": 1091,
+      "community": 1092,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
       "label": "WelcomeBackModalForm.tsx",
@@ -187588,7 +187639,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1091,
+      "community": 1092,
       "file_type": "code",
       "id": "welcomebackmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -187597,7 +187648,7 @@
       "source_location": "L51"
     },
     {
-      "community": 1091,
+      "community": 1092,
       "file_type": "code",
       "id": "welcomebackmodalform_handlesubmit",
       "label": "handleSubmit()",
@@ -187606,7 +187657,7 @@
       "source_location": "L36"
     },
     {
-      "community": 1092,
+      "community": 1093,
       "file_type": "code",
       "id": "navigationbarprovider_navigationbarprovider",
       "label": "NavigationBarProvider()",
@@ -187615,7 +187666,7 @@
       "source_location": "L16"
     },
     {
-      "community": 1092,
+      "community": 1093,
       "file_type": "code",
       "id": "navigationbarprovider_usenavigationbarcontext",
       "label": "useNavigationBarContext()",
@@ -187624,7 +187675,7 @@
       "source_location": "L39"
     },
     {
-      "community": 1092,
+      "community": 1093,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_navigationbarprovider_tsx",
       "label": "NavigationBarProvider.tsx",
@@ -187633,7 +187684,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1093,
+      "community": 1094,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
       "label": "StorefrontObservabilityProvider.tsx",
@@ -187642,7 +187693,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1093,
+      "community": 1094,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
       "label": "StorefrontObservabilityProvider()",
@@ -187651,7 +187702,7 @@
       "source_location": "L24"
     },
     {
-      "community": 1093,
+      "community": 1094,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_usestorefrontobservability",
       "label": "useStorefrontObservability()",
@@ -187660,7 +187711,7 @@
       "source_location": "L74"
     },
     {
-      "community": 1094,
+      "community": 1095,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
       "label": "useProductDiscount.ts",
@@ -187669,7 +187720,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1094,
+      "community": 1095,
       "file_type": "code",
       "id": "useproductdiscount_useproductdiscount",
       "label": "useProductDiscount()",
@@ -187678,7 +187729,7 @@
       "source_location": "L107"
     },
     {
-      "community": 1094,
+      "community": 1095,
       "file_type": "code",
       "id": "useproductdiscount_useproductdiscounts",
       "label": "useProductDiscounts()",
@@ -187687,7 +187738,7 @@
       "source_location": "L25"
     },
     {
-      "community": 1095,
+      "community": 1096,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useshoppingbag_ts",
       "label": "useShoppingBag.ts",
@@ -187696,7 +187747,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1095,
+      "community": 1096,
       "file_type": "code",
       "id": "useshoppingbag_isunavailableproductlist",
       "label": "isUnavailableProductList()",
@@ -187705,7 +187756,7 @@
       "source_location": "L556"
     },
     {
-      "community": 1095,
+      "community": 1096,
       "file_type": "code",
       "id": "useshoppingbag_useshoppingbag",
       "label": "useShoppingBag()",
@@ -187714,7 +187765,7 @@
       "source_location": "L52"
     },
     {
-      "community": 1096,
+      "community": 1097,
       "file_type": "code",
       "id": "index_getordermessage",
       "label": "getOrderMessage()",
@@ -187723,7 +187774,7 @@
       "source_location": "L431"
     },
     {
-      "community": 1096,
+      "community": 1097,
       "file_type": "code",
       "id": "index_getpaymenttext",
       "label": "getPaymentText()",
@@ -187732,7 +187783,7 @@
       "source_location": "L102"
     },
     {
-      "community": 1096,
+      "community": 1097,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_index_tsx",
       "label": "index.tsx",
@@ -187741,7 +187792,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1097,
+      "community": 1098,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_review_tsx",
       "label": "review.tsx",
@@ -187750,7 +187801,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1097,
+      "community": 1098,
       "file_type": "code",
       "id": "review_getordermessage",
       "label": "getOrderMessage()",
@@ -187759,7 +187810,7 @@
       "source_location": "L257"
     },
     {
-      "community": 1097,
+      "community": 1098,
       "file_type": "code",
       "id": "review_ordernavigation",
       "label": "OrderNavigation()",
@@ -187768,7 +187819,7 @@
       "source_location": "L47"
     },
     {
-      "community": 1098,
+      "community": 1099,
       "file_type": "code",
       "id": "account_accountbeforeload",
       "label": "accountBeforeLoad()",
@@ -187777,7 +187828,7 @@
       "source_location": "L17"
     },
     {
-      "community": 1098,
+      "community": 1099,
       "file_type": "code",
       "id": "account_handleonsubmitform",
       "label": "handleOnSubmitForm()",
@@ -187786,39 +187837,12 @@
       "source_location": "L63"
     },
     {
-      "community": 1098,
+      "community": 1099,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_account_tsx",
       "label": "account.tsx",
       "norm_label": "account.tsx",
       "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1099,
-      "file_type": "code",
-      "id": "login_loginbeforeload",
-      "label": "loginBeforeLoad()",
-      "norm_label": "loginbeforeload()",
-      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
-      "source_location": "L47"
-    },
-    {
-      "community": 1099,
-      "file_type": "code",
-      "id": "login_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
-      "source_location": "L141"
-    },
-    {
-      "community": 1099,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_login_tsx",
-      "label": "login.tsx",
-      "norm_label": "login.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
       "source_location": "L1"
     },
     {
@@ -188427,6 +188451,33 @@
     {
       "community": 1100,
       "file_type": "code",
+      "id": "login_loginbeforeload",
+      "label": "loginBeforeLoad()",
+      "norm_label": "loginbeforeload()",
+      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 1100,
+      "file_type": "code",
+      "id": "login_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
+      "source_location": "L141"
+    },
+    {
+      "community": 1100,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_login_tsx",
+      "label": "login.tsx",
+      "norm_label": "login.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1101,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
       "label": "verify.index.tsx",
       "norm_label": "verify.index.tsx",
@@ -188434,7 +188485,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1100,
+      "community": 1101,
       "file_type": "code",
       "id": "verify_index_verify",
       "label": "Verify()",
@@ -188443,7 +188494,7 @@
       "source_location": "L21"
     },
     {
-      "community": 1100,
+      "community": 1101,
       "file_type": "code",
       "id": "verify_index_verifycheckoutsessionpayment",
       "label": "VerifyCheckoutSessionPayment()",
@@ -188452,7 +188503,7 @@
       "source_location": "L107"
     },
     {
-      "community": 1101,
+      "community": 1102,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_signup_tsx",
       "label": "signup.tsx",
@@ -188461,7 +188512,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1101,
+      "community": 1102,
       "file_type": "code",
       "id": "signup_onsubmit",
       "label": "onSubmit()",
@@ -188470,7 +188521,7 @@
       "source_location": "L161"
     },
     {
-      "community": 1101,
+      "community": 1102,
       "file_type": "code",
       "id": "signup_signupbeforeload",
       "label": "signupBeforeLoad()",
@@ -188479,7 +188530,7 @@
       "source_location": "L66"
     },
     {
-      "community": 1102,
+      "community": 1103,
       "file_type": "code",
       "id": "env_optionalnumberenv",
       "label": "optionalNumberEnv()",
@@ -188488,7 +188539,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1102,
+      "community": 1103,
       "file_type": "code",
       "id": "env_requireenv",
       "label": "requireEnv()",
@@ -188497,7 +188548,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1102,
+      "community": 1103,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_env_ts",
       "label": "env.ts",
@@ -188506,7 +188557,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1103,
+      "community": 1104,
       "file_type": "code",
       "id": "bun_version_check_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -188515,7 +188566,7 @@
       "source_location": "L10"
     },
     {
-      "community": 1103,
+      "community": 1104,
       "file_type": "code",
       "id": "bun_version_check_test_write",
       "label": "write()",
@@ -188524,7 +188575,7 @@
       "source_location": "L16"
     },
     {
-      "community": 1103,
+      "community": 1104,
       "file_type": "code",
       "id": "scripts_bun_version_check_test_ts",
       "label": "bun-version-check.test.ts",
@@ -188533,7 +188584,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1104,
+      "community": 1105,
       "file_type": "code",
       "id": "bun_version_check_pinnedbunversion",
       "label": "pinnedBunVersion()",
@@ -188542,7 +188593,7 @@
       "source_location": "L15"
     },
     {
-      "community": 1104,
+      "community": 1105,
       "file_type": "code",
       "id": "bun_version_check_runbunversioncheck",
       "label": "runBunVersionCheck()",
@@ -188551,7 +188602,7 @@
       "source_location": "L30"
     },
     {
-      "community": 1104,
+      "community": 1105,
       "file_type": "code",
       "id": "scripts_bun_version_check_ts",
       "label": "bun-version-check.ts",
@@ -188560,7 +188611,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1105,
+      "community": 1106,
       "file_type": "code",
       "id": "convex_operation_admission_check_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -188569,7 +188620,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1105,
+      "community": 1106,
       "file_type": "code",
       "id": "convex_operation_admission_check_test_writefixture",
       "label": "writeFixture()",
@@ -188578,7 +188629,7 @@
       "source_location": "L22"
     },
     {
-      "community": 1105,
+      "community": 1106,
       "file_type": "code",
       "id": "scripts_convex_operation_admission_check_test_ts",
       "label": "convex-operation-admission-check.test.ts",
@@ -188587,7 +188638,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1106,
+      "community": 1107,
       "file_type": "code",
       "id": "github_workflows_check_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -188596,7 +188647,7 @@
       "source_location": "L10"
     },
     {
-      "community": 1106,
+      "community": 1107,
       "file_type": "code",
       "id": "github_workflows_check_test_write",
       "label": "write()",
@@ -188605,7 +188656,7 @@
       "source_location": "L16"
     },
     {
-      "community": 1106,
+      "community": 1107,
       "file_type": "code",
       "id": "scripts_github_workflows_check_test_ts",
       "label": "github-workflows-check.test.ts",
@@ -188614,7 +188665,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1107,
+      "community": 1108,
       "file_type": "code",
       "id": "github_workflows_check_collectworkflowfiles",
       "label": "collectWorkflowFiles()",
@@ -188623,7 +188674,7 @@
       "source_location": "L19"
     },
     {
-      "community": 1107,
+      "community": 1108,
       "file_type": "code",
       "id": "github_workflows_check_runworkflowcheck",
       "label": "runWorkflowCheck()",
@@ -188632,7 +188683,7 @@
       "source_location": "L29"
     },
     {
-      "community": 1107,
+      "community": 1108,
       "file_type": "code",
       "id": "scripts_github_workflows_check_ts",
       "label": "github-workflows-check.ts",
@@ -188641,7 +188692,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1108,
+      "community": 1109,
       "file_type": "code",
       "id": "graphify_wiki_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -188650,7 +188701,7 @@
       "source_location": "L16"
     },
     {
-      "community": 1108,
+      "community": 1109,
       "file_type": "code",
       "id": "graphify_wiki_test_write",
       "label": "write()",
@@ -188659,39 +188710,12 @@
       "source_location": "L10"
     },
     {
-      "community": 1108,
+      "community": 1109,
       "file_type": "code",
       "id": "scripts_graphify_wiki_test_ts",
       "label": "graphify-wiki.test.ts",
       "norm_label": "graphify-wiki.test.ts",
       "source_file": "scripts/graphify-wiki.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1109,
-      "file_type": "code",
-      "id": "harness_audit_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/harness-audit.test.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 1109,
-      "file_type": "code",
-      "id": "harness_audit_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-audit.test.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 1109,
-      "file_type": "code",
-      "id": "scripts_harness_audit_test_ts",
-      "label": "harness-audit.test.ts",
-      "norm_label": "harness-audit.test.ts",
-      "source_file": "scripts/harness-audit.test.ts",
       "source_location": "L1"
     },
     {
@@ -188859,6 +188883,33 @@
     {
       "community": 1110,
       "file_type": "code",
+      "id": "harness_audit_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/harness-audit.test.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 1110,
+      "file_type": "code",
+      "id": "harness_audit_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-audit.test.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 1110,
+      "file_type": "code",
+      "id": "scripts_harness_audit_test_ts",
+      "label": "harness-audit.test.ts",
+      "norm_label": "harness-audit.test.ts",
+      "source_file": "scripts/harness-audit.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1111,
+      "file_type": "code",
       "id": "harness_candidate_test_createcandidatespawn",
       "label": "createCandidateSpawn()",
       "norm_label": "createcandidatespawn()",
@@ -188866,7 +188917,7 @@
       "source_location": "L22"
     },
     {
-      "community": 1110,
+      "community": 1111,
       "file_type": "code",
       "id": "harness_candidate_test_spawn",
       "label": "spawn()",
@@ -188875,7 +188926,7 @@
       "source_location": "L168"
     },
     {
-      "community": 1110,
+      "community": 1111,
       "file_type": "code",
       "id": "scripts_harness_candidate_test_ts",
       "label": "harness-candidate.test.ts",
@@ -188884,7 +188935,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1111,
+      "community": 1112,
       "file_type": "code",
       "id": "harness_check_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -188893,7 +188944,7 @@
       "source_location": "L48"
     },
     {
-      "community": 1111,
+      "community": 1112,
       "file_type": "code",
       "id": "harness_check_test_write",
       "label": "write()",
@@ -188902,7 +188953,7 @@
       "source_location": "L42"
     },
     {
-      "community": 1111,
+      "community": 1112,
       "file_type": "code",
       "id": "scripts_harness_check_test_ts",
       "label": "harness-check.test.ts",
@@ -188911,7 +188962,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1112,
+      "community": 1113,
       "file_type": "code",
       "id": "harness_delivery_run_ledger_test_costledger",
       "label": "costLedger()",
@@ -188920,7 +188971,7 @@
       "source_location": "L339"
     },
     {
-      "community": 1112,
+      "community": 1113,
       "file_type": "code",
       "id": "harness_delivery_run_ledger_test_createtemproot",
       "label": "createTempRoot()",
@@ -188929,7 +188980,7 @@
       "source_location": "L19"
     },
     {
-      "community": 1112,
+      "community": 1113,
       "file_type": "code",
       "id": "scripts_harness_delivery_run_ledger_test_ts",
       "label": "harness-delivery-run-ledger.test.ts",
@@ -188938,7 +188989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1113,
+      "community": 1114,
       "file_type": "code",
       "id": "harness_gate_registry_duplicateidfindings",
       "label": "duplicateIdFindings()",
@@ -188947,7 +188998,7 @@
       "source_location": "L245"
     },
     {
-      "community": 1113,
+      "community": 1114,
       "file_type": "code",
       "id": "harness_gate_registry_validateharnessgateregistry",
       "label": "validateHarnessGateRegistry()",
@@ -188956,7 +189007,7 @@
       "source_location": "L260"
     },
     {
-      "community": 1113,
+      "community": 1114,
       "file_type": "code",
       "id": "scripts_harness_gate_registry_ts",
       "label": "harness-gate-registry.ts",
@@ -188965,7 +189016,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1114,
+      "community": 1115,
       "file_type": "code",
       "id": "harness_generate_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -188974,7 +189025,7 @@
       "source_location": "L19"
     },
     {
-      "community": 1114,
+      "community": 1115,
       "file_type": "code",
       "id": "harness_generate_test_write",
       "label": "write()",
@@ -188983,7 +189034,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1114,
+      "community": 1115,
       "file_type": "code",
       "id": "scripts_harness_generate_test_ts",
       "label": "harness-generate.test.ts",
@@ -188992,7 +189043,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1115,
+      "community": 1116,
       "file_type": "code",
       "id": "harness_mechanical_check_test_options",
       "label": "options()",
@@ -189001,7 +189052,7 @@
       "source_location": "L26"
     },
     {
-      "community": 1115,
+      "community": 1116,
       "file_type": "code",
       "id": "harness_mechanical_check_test_packagescripts",
       "label": "packageScripts()",
@@ -189010,7 +189061,7 @@
       "source_location": "L15"
     },
     {
-      "community": 1115,
+      "community": 1116,
       "file_type": "code",
       "id": "scripts_harness_mechanical_check_test_ts",
       "label": "harness-mechanical-check.test.ts",
@@ -189019,7 +189070,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1116,
+      "community": 1117,
       "file_type": "code",
       "id": "harness_review_evidence_test_fixture",
       "label": "fixture()",
@@ -189028,7 +189079,7 @@
       "source_location": "L14"
     },
     {
-      "community": 1116,
+      "community": 1117,
       "file_type": "code",
       "id": "harness_review_evidence_test_recordoptions",
       "label": "recordOptions()",
@@ -189037,7 +189088,7 @@
       "source_location": "L565"
     },
     {
-      "community": 1116,
+      "community": 1117,
       "file_type": "code",
       "id": "scripts_harness_review_evidence_test_ts",
       "label": "harness-review-evidence.test.ts",
@@ -189046,7 +189097,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1117,
+      "community": 1118,
       "file_type": "code",
       "id": "harness_self_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -189055,7 +189106,7 @@
       "source_location": "L16"
     },
     {
-      "community": 1117,
+      "community": 1118,
       "file_type": "code",
       "id": "harness_self_review_test_write",
       "label": "write()",
@@ -189064,39 +189115,12 @@
       "source_location": "L10"
     },
     {
-      "community": 1117,
+      "community": 1118,
       "file_type": "code",
       "id": "scripts_harness_self_review_test_ts",
       "label": "harness-self-review.test.ts",
       "norm_label": "harness-self-review.test.ts",
       "source_file": "scripts/harness-self-review.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1118,
-      "file_type": "code",
-      "id": "harness_test_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/harness-test.test.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 1118,
-      "file_type": "code",
-      "id": "harness_test_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-test.test.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 1118,
-      "file_type": "code",
-      "id": "scripts_harness_test_test_ts",
-      "label": "harness-test.test.ts",
-      "norm_label": "harness-test.test.ts",
-      "source_file": "scripts/harness-test.test.ts",
       "source_location": "L1"
     },
     {
@@ -212034,6 +212058,24 @@
     {
       "community": 1748,
       "file_type": "code",
+      "id": "git_environment_withoutgitrepositorycontext",
+      "label": "withoutGitRepositoryContext()",
+      "norm_label": "withoutgitrepositorycontext()",
+      "source_file": "scripts/git-environment.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1748,
+      "file_type": "code",
+      "id": "scripts_git_environment_ts",
+      "label": "git-environment.ts",
+      "norm_label": "git-environment.ts",
+      "source_file": "scripts/git-environment.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1749,
+      "file_type": "code",
       "id": "github_pr_merge_test_runcommand",
       "label": "runCommand()",
       "norm_label": "runcommand()",
@@ -212041,30 +212083,12 @@
       "source_location": "L16"
     },
     {
-      "community": 1748,
+      "community": 1749,
       "file_type": "code",
       "id": "scripts_github_pr_merge_test_ts",
       "label": "github-pr-merge.test.ts",
       "norm_label": "github-pr-merge.test.ts",
       "source_file": "scripts/github-pr-merge.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1749,
-      "file_type": "code",
-      "id": "athena_runtime_app_shutdown",
-      "label": "shutdown()",
-      "norm_label": "shutdown()",
-      "source_file": "scripts/harness-behavior-fixtures/athena-runtime-app.ts",
-      "source_location": "L211"
-    },
-    {
-      "community": 1749,
-      "file_type": "code",
-      "id": "scripts_harness_behavior_fixtures_athena_runtime_app_ts",
-      "label": "athena-runtime-app.ts",
-      "norm_label": "athena-runtime-app.ts",
-      "source_file": "scripts/harness-behavior-fixtures/athena-runtime-app.ts",
       "source_location": "L1"
     },
     {
@@ -212196,6 +212220,24 @@
     {
       "community": 1750,
       "file_type": "code",
+      "id": "athena_runtime_app_shutdown",
+      "label": "shutdown()",
+      "norm_label": "shutdown()",
+      "source_file": "scripts/harness-behavior-fixtures/athena-runtime-app.ts",
+      "source_location": "L211"
+    },
+    {
+      "community": 1750,
+      "file_type": "code",
+      "id": "scripts_harness_behavior_fixtures_athena_runtime_app_ts",
+      "label": "athena-runtime-app.ts",
+      "norm_label": "athena-runtime-app.ts",
+      "source_file": "scripts/harness-behavior-fixtures/athena-runtime-app.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1751,
+      "file_type": "code",
       "id": "sample_app_shutdown",
       "label": "shutdown()",
       "norm_label": "shutdown()",
@@ -212203,7 +212245,7 @@
       "source_location": "L85"
     },
     {
-      "community": 1750,
+      "community": 1751,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_sample_app_ts",
       "label": "sample-app.ts",
@@ -212212,7 +212254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1751,
+      "community": 1752,
       "file_type": "code",
       "id": "harness_runtime_trends_test_buildreportline",
       "label": "buildReportLine()",
@@ -212221,7 +212263,7 @@
       "source_location": "L15"
     },
     {
-      "community": 1751,
+      "community": 1752,
       "file_type": "code",
       "id": "scripts_harness_runtime_trends_test_ts",
       "label": "harness-runtime-trends.test.ts",
@@ -212230,7 +212272,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1752,
+      "community": 1753,
       "file_type": "code",
       "id": "pr_athena_guidance_contract_test_readrepofile",
       "label": "readRepoFile()",
@@ -212239,7 +212281,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1752,
+      "community": 1753,
       "file_type": "code",
       "id": "scripts_pr_athena_guidance_contract_test_ts",
       "label": "pr-athena-guidance-contract.test.ts",
@@ -212248,7 +212290,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1753,
+      "community": 1754,
       "file_type": "code",
       "id": "scripts_validate_plan_html_test_ts",
       "label": "validate-plan-html.test.ts",
@@ -212257,7 +212299,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1753,
+      "community": 1754,
       "file_type": "code",
       "id": "validate_plan_html_test_createtemprepo",
       "label": "createTempRepo()",
@@ -212266,7 +212308,7 @@
       "source_location": "L9"
     },
     {
-      "community": 1754,
+      "community": 1755,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_d_ts",
       "label": "api.d.ts",
@@ -212275,7 +212317,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1755,
+      "community": 1756,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_js",
       "label": "api.js",
@@ -212284,7 +212326,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1756,
+      "community": 1757,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_datamodel_d_ts",
       "label": "dataModel.d.ts",
@@ -212293,7 +212335,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1757,
+      "community": 1758,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_d_ts",
       "label": "server.d.ts",
@@ -212302,21 +212344,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1758,
+      "community": 1759,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_js",
       "label": "server.js",
       "norm_label": "server.js",
       "source_file": "packages/athena-webapp/convex/_generated/server.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 1759,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_app_ts",
-      "label": "app.ts",
-      "norm_label": "app.ts",
-      "source_file": "packages/athena-webapp/convex/app.ts",
       "source_location": "L1"
     },
     {
@@ -212448,6 +212481,15 @@
     {
       "community": 1760,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_app_ts",
+      "label": "app.ts",
+      "norm_label": "app.ts",
+      "source_file": "packages/athena-webapp/convex/app.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1761,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_posrecoverycode_test_ts",
       "label": "PosRecoveryCode.test.ts",
       "norm_label": "posrecoverycode.test.ts",
@@ -212455,7 +212497,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1761,
+      "community": 1762,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_posrecoverycode_ts",
       "label": "PosRecoveryCode.ts",
@@ -212464,7 +212506,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1762,
+      "community": 1763,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_shareddemoticket_test_ts",
       "label": "SharedDemoTicket.test.ts",
@@ -212473,7 +212515,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1763,
+      "community": 1764,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_config_js",
       "label": "auth.config.js",
@@ -212482,7 +212524,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1764,
+      "community": 1765,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_test_ts",
       "label": "auth.test.ts",
@@ -212491,7 +212533,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1765,
+      "community": 1766,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_ts",
       "label": "auth.ts",
@@ -212500,7 +212542,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1766,
+      "community": 1767,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_authconfig_test_ts",
       "label": "authConfig.test.ts",
@@ -212509,7 +212551,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1767,
+      "community": 1768,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_authconfig_ts",
       "label": "authConfig.ts",
@@ -212518,21 +212560,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1768,
+      "community": 1769,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cloudflare_r2_test_ts",
       "label": "r2.test.ts",
       "norm_label": "r2.test.ts",
       "source_file": "packages/athena-webapp/convex/cloudflare/r2.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1769,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_constants_countries_ts",
-      "label": "countries.ts",
-      "norm_label": "countries.ts",
-      "source_file": "packages/athena-webapp/convex/constants/countries.ts",
       "source_location": "L1"
     },
     {
@@ -212664,6 +212697,15 @@
     {
       "community": 1770,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_constants_countries_ts",
+      "label": "countries.ts",
+      "norm_label": "countries.ts",
+      "source_file": "packages/athena-webapp/convex/constants/countries.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1771,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_email_ts",
       "label": "email.ts",
       "norm_label": "email.ts",
@@ -212671,7 +212713,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1771,
+      "community": 1772,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_ghana_ts",
       "label": "ghana.ts",
@@ -212680,7 +212722,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1772,
+      "community": 1773,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_payment_ts",
       "label": "payment.ts",
@@ -212689,7 +212731,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1773,
+      "community": 1774,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_contexttracking_athenawebappevents_test_ts",
       "label": "athenaWebappEvents.test.ts",
@@ -212698,7 +212740,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1774,
+      "community": 1775,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_contexttracking_shareddemoactioncapture_test_ts",
       "label": "sharedDemoActionCapture.test.ts",
@@ -212707,7 +212749,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1775,
+      "community": 1776,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_contexttracking_types_ts",
       "label": "types.ts",
@@ -212716,7 +212758,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1776,
+      "community": 1777,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convex_config_ts",
       "label": "convex.config.ts",
@@ -212725,7 +212767,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1777,
+      "community": 1778,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_crons_test_ts",
       "label": "crons.test.ts",
@@ -212734,21 +212776,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1778,
+      "community": 1779,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_crons_ts",
       "label": "crons.ts",
       "norm_label": "crons.ts",
       "source_file": "packages/athena-webapp/convex/crons.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1779,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_customermessaging_domain_test_ts",
-      "label": "domain.test.ts",
-      "norm_label": "domain.test.ts",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/domain.test.ts",
       "source_location": "L1"
     },
     {
@@ -212880,6 +212913,15 @@
     {
       "community": 1780,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_customermessaging_domain_test_ts",
+      "label": "domain.test.ts",
+      "norm_label": "domain.test.ts",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/domain.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1781,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_internal_ts",
       "label": "internal.ts",
       "norm_label": "internal.ts",
@@ -212887,7 +212929,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1781,
+      "community": 1782,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_public_test_ts",
       "label": "public.test.ts",
@@ -212896,7 +212938,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1782,
+      "community": 1783,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_token_test_ts",
       "label": "token.test.ts",
@@ -212905,7 +212947,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1783,
+      "community": 1784,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_whatsappclient_test_ts",
       "label": "whatsappClient.test.ts",
@@ -212914,7 +212956,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1784,
+      "community": 1785,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_whatsappconfig_test_ts",
       "label": "whatsappConfig.test.ts",
@@ -212923,7 +212965,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1785,
+      "community": 1786,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_devpatchbadtransaction_ts",
       "label": "devPatchBadTransaction.ts",
@@ -212932,7 +212974,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1786,
+      "community": 1787,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_approvalrequestpending_test_tsx",
       "label": "ApprovalRequestPending.test.tsx",
@@ -212941,7 +212983,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1787,
+      "community": 1788,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_dailymanagerreport_test_tsx",
       "label": "DailyManagerReport.test.tsx",
@@ -212950,21 +212992,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1788,
+      "community": 1789,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_dailymanagerreportcomparisonpreview_tsx",
       "label": "DailyManagerReportComparisonPreview.tsx",
       "norm_label": "dailymanagerreportcomparisonpreview.tsx",
       "source_file": "packages/athena-webapp/convex/emails/DailyManagerReportComparisonPreview.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1789,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_expensereceiptemail_tsx",
-      "label": "ExpenseReceiptEmail.tsx",
-      "norm_label": "expensereceiptemail.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/ExpenseReceiptEmail.tsx",
       "source_location": "L1"
     },
     {
@@ -213096,6 +213129,15 @@
     {
       "community": 1790,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_expensereceiptemail_tsx",
+      "label": "ExpenseReceiptEmail.tsx",
+      "norm_label": "expensereceiptemail.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/ExpenseReceiptEmail.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1791,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_feedbackrequest_tsx",
       "label": "FeedbackRequest.tsx",
       "norm_label": "feedbackrequest.tsx",
@@ -213103,7 +213145,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1791,
+      "community": 1792,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_neworderadmin_test_tsx",
       "label": "NewOrderAdmin.test.tsx",
@@ -213112,7 +213154,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1792,
+      "community": 1793,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_orderemail_test_tsx",
       "label": "OrderEmail.test.tsx",
@@ -213121,7 +213163,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1793,
+      "community": 1794,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_posreceiptemail_test_tsx",
       "label": "PosReceiptEmail.test.tsx",
@@ -213130,7 +213172,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1794,
+      "community": 1795,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_posreceiptemail_tsx",
       "label": "PosReceiptEmail.tsx",
@@ -213139,7 +213181,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1795,
+      "community": 1796,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_posterminalhealthalert_test_tsx",
       "label": "PosTerminalHealthAlert.test.tsx",
@@ -213148,7 +213190,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1796,
+      "community": 1797,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_registercloseoutvariancealert_test_tsx",
       "label": "RegisterCloseoutVarianceAlert.test.tsx",
@@ -213157,7 +213199,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1797,
+      "community": 1798,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_reportverificationalert_test_tsx",
       "label": "ReportVerificationAlert.test.tsx",
@@ -213166,21 +213208,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1798,
+      "community": 1799,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_reportverificationalert_tsx",
       "label": "ReportVerificationAlert.tsx",
       "norm_label": "reportverificationalert.tsx",
       "source_file": "packages/athena-webapp/convex/emails/ReportVerificationAlert.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1799,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_walkthroughrequestnotification_test_tsx",
-      "label": "WalkthroughRequestNotification.test.tsx",
-      "norm_label": "walkthroughrequestnotification.test.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/WalkthroughRequestNotification.test.tsx",
       "source_location": "L1"
     },
     {
@@ -213699,6 +213732,15 @@
     {
       "community": 1800,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_walkthroughrequestnotification_test_tsx",
+      "label": "WalkthroughRequestNotification.test.tsx",
+      "norm_label": "walkthroughrequestnotification.test.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/WalkthroughRequestNotification.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1801,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_weeklymanagerreport_test_tsx",
       "label": "WeeklyManagerReport.test.tsx",
       "norm_label": "weeklymanagerreport.test.tsx",
@@ -213706,7 +213748,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1801,
+      "community": 1802,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_emailoperationalctastyles_ts",
       "label": "emailOperationalCtaStyles.ts",
@@ -213715,7 +213757,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1802,
+      "community": 1803,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_env_ts",
       "label": "env.ts",
@@ -213724,7 +213766,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1803,
+      "community": 1804,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_analytics_ts",
       "label": "analytics.ts",
@@ -213733,7 +213775,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1804,
+      "community": 1805,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_auth_ts",
       "label": "auth.ts",
@@ -213742,7 +213784,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1805,
+      "community": 1806,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_bannermessage_test_ts",
       "label": "bannerMessage.test.ts",
@@ -213751,7 +213793,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1806,
+      "community": 1807,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_colors_ts",
       "label": "colors.ts",
@@ -213760,7 +213802,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1807,
+      "community": 1808,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_index_ts",
       "label": "index.ts",
@@ -213769,21 +213811,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1808,
+      "community": 1809,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_landingfunnelevents_test_ts",
       "label": "landingFunnelEvents.test.ts",
       "norm_label": "landingfunnelevents.test.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/core/routes/landingFunnelEvents.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1809,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_core_routes_landingfunnelevents_ts",
-      "label": "landingFunnelEvents.ts",
-      "norm_label": "landingfunnelevents.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/landingFunnelEvents.ts",
       "source_location": "L1"
     },
     {
@@ -213915,6 +213948,15 @@
     {
       "community": 1810,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_core_routes_landingfunnelevents_ts",
+      "label": "landingFunnelEvents.ts",
+      "norm_label": "landingfunnelevents.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/landingFunnelEvents.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1811,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_organizations_ts",
       "label": "organizations.ts",
       "norm_label": "organizations.ts",
@@ -213922,7 +213964,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1811,
+      "community": 1812,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_products_ts",
       "label": "products.ts",
@@ -213931,7 +213973,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1812,
+      "community": 1813,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_storefronthidden_test_ts",
       "label": "storefrontHidden.test.ts",
@@ -213940,7 +213982,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1813,
+      "community": 1814,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_stores_ts",
       "label": "stores.ts",
@@ -213949,7 +213991,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1814,
+      "community": 1815,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_trackingevents_test_ts",
       "label": "trackingEvents.test.ts",
@@ -213958,7 +214000,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1815,
+      "community": 1816,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_walkthroughrequests_test_ts",
       "label": "walkthroughRequests.test.ts",
@@ -213967,7 +214009,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1816,
+      "community": 1817,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_bag_ts",
       "label": "bag.ts",
@@ -213976,7 +214018,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1817,
+      "community": 1818,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_guest_ts",
       "label": "guest.ts",
@@ -213985,21 +214027,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1818,
+      "community": 1819,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_homepagesnapshot_test_ts",
       "label": "homepageSnapshot.test.ts",
       "norm_label": "homepagesnapshot.test.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/homepageSnapshot.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1819,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/index.ts",
       "source_location": "L1"
     },
     {
@@ -214131,6 +214164,15 @@
     {
       "community": 1820,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1821,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_me_ts",
       "label": "me.ts",
       "norm_label": "me.ts",
@@ -214138,7 +214180,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1821,
+      "community": 1822,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_offers_ts",
       "label": "offers.ts",
@@ -214147,7 +214189,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1822,
+      "community": 1823,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -214156,7 +214198,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1823,
+      "community": 1824,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_paystack_ts",
       "label": "paystack.ts",
@@ -214165,7 +214207,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1824,
+      "community": 1825,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_postransaction_ts",
       "label": "posTransaction.ts",
@@ -214174,7 +214216,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1825,
+      "community": 1826,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_reviews_ts",
       "label": "reviews.ts",
@@ -214183,7 +214225,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1826,
+      "community": 1827,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_rewards_ts",
       "label": "rewards.ts",
@@ -214192,7 +214234,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1827,
+      "community": 1828,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_savedbag_ts",
       "label": "savedBag.ts",
@@ -214201,21 +214243,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1828,
+      "community": 1829,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_security_test_ts",
       "label": "security.test.ts",
       "norm_label": "security.test.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1829,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_storefront_ts",
-      "label": "storefront.ts",
-      "norm_label": "storefront.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/storefront.ts",
       "source_location": "L1"
     },
     {
@@ -214347,6 +214380,15 @@
     {
       "community": 1830,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_storefront_ts",
+      "label": "storefront.ts",
+      "norm_label": "storefront.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/storefront.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1831,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_upsells_ts",
       "label": "upsells.ts",
       "norm_label": "upsells.ts",
@@ -214354,7 +214396,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1831,
+      "community": 1832,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_user_ts",
       "label": "user.ts",
@@ -214363,7 +214405,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1832,
+      "community": 1833,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_useroffers_ts",
       "label": "userOffers.ts",
@@ -214372,7 +214414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1833,
+      "community": 1834,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_moneymovement_routes_index_ts",
       "label": "index.ts",
@@ -214381,7 +214423,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1834,
+      "community": 1835,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_health_test_ts",
       "label": "health.test.ts",
@@ -214390,7 +214432,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1835,
+      "community": 1836,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_ts",
       "label": "http.ts",
@@ -214399,7 +214441,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1836,
+      "community": 1837,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_intelligence_access_ts",
       "label": "access.ts",
@@ -214408,7 +214450,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1837,
+      "community": 1838,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_intelligence_capabilities_actions_test_ts",
       "label": "actions.test.ts",
@@ -214417,21 +214459,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1838,
+      "community": 1839,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_intelligence_capabilities_insights_test_ts",
       "label": "insights.test.ts",
       "norm_label": "insights.test.ts",
       "source_file": "packages/athena-webapp/convex/intelligence/capabilities/insights.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1839,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_intelligence_lifecycle_test_ts",
-      "label": "lifecycle.test.ts",
-      "norm_label": "lifecycle.test.ts",
-      "source_file": "packages/athena-webapp/convex/intelligence/lifecycle.test.ts",
       "source_location": "L1"
     },
     {
@@ -214563,6 +214596,15 @@
     {
       "community": 1840,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_intelligence_lifecycle_test_ts",
+      "label": "lifecycle.test.ts",
+      "norm_label": "lifecycle.test.ts",
+      "source_file": "packages/athena-webapp/convex/intelligence/lifecycle.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1841,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_intelligence_providers_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
@@ -214570,7 +214612,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1841,
+      "community": 1842,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_intelligence_providers_providerfoundation_test_ts",
       "label": "providerFoundation.test.ts",
@@ -214579,7 +214621,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1842,
+      "community": 1843,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_intelligence_types_ts",
       "label": "types.ts",
@@ -214588,7 +214630,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1843,
+      "community": 1844,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_athenauser_test_ts",
       "label": "athenaUser.test.ts",
@@ -214597,7 +214639,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1844,
+      "community": 1845,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_auth_test_ts",
       "label": "auth.test.ts",
@@ -214606,7 +214648,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1845,
+      "community": 1846,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_categories_ts",
       "label": "categories.ts",
@@ -214615,7 +214657,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1846,
+      "community": 1847,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_colors_ts",
       "label": "colors.ts",
@@ -214624,7 +214666,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1847,
+      "community": 1848,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
@@ -214633,21 +214675,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1848,
+      "community": 1849,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_invitecode_test_ts",
       "label": "inviteCode.test.ts",
       "norm_label": "invitecode.test.ts",
       "source_file": "packages/athena-webapp/convex/inventory/inviteCode.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1849,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_invitecode_ts",
-      "label": "inviteCode.ts",
-      "norm_label": "invitecode.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/inviteCode.ts",
       "source_location": "L1"
     },
     {
@@ -214779,6 +214812,15 @@
     {
       "community": 1850,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_invitecode_ts",
+      "label": "inviteCode.ts",
+      "norm_label": "invitecode.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/inviteCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1851,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizationmembers_test_ts",
       "label": "organizationMembers.test.ts",
       "norm_label": "organizationmembers.test.ts",
@@ -214786,7 +214828,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1851,
+      "community": 1852,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizationmembers_ts",
       "label": "organizationMembers.ts",
@@ -214795,7 +214837,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1852,
+      "community": 1853,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_pos_ts",
       "label": "pos.ts",
@@ -214804,7 +214846,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1853,
+      "community": 1854,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_poscustomers_ts",
       "label": "posCustomers.ts",
@@ -214813,7 +214855,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1854,
+      "community": 1855,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posterminal_ts",
       "label": "posTerminal.ts",
@@ -214822,7 +214864,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1855,
+      "community": 1856,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productsku_test_ts",
       "label": "productSku.test.ts",
@@ -214831,7 +214873,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1856,
+      "community": 1857,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productutil_test_ts",
       "label": "productUtil.test.ts",
@@ -214840,7 +214882,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1857,
+      "community": 1858,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_promocode_test_ts",
       "label": "promoCode.test.ts",
@@ -214849,21 +214891,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1858,
+      "community": 1859,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
       "label": "stockValidation.ts",
       "norm_label": "stockvalidation.ts",
       "source_file": "packages/athena-webapp/convex/inventory/stockValidation.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1859,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_storeconfigv2_test_ts",
-      "label": "storeConfigV2.test.ts",
-      "norm_label": "storeconfigv2.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.test.ts",
       "source_location": "L1"
     },
     {
@@ -214995,6 +215028,15 @@
     {
       "community": 1860,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_storeconfigv2_test_ts",
+      "label": "storeConfigV2.test.ts",
+      "norm_label": "storeconfigv2.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1861,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_subcategories_ts",
       "label": "subcategories.ts",
       "norm_label": "subcategories.ts",
@@ -215002,7 +215044,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1861,
+      "community": 1862,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventoryledger_corrections_ts",
       "label": "corrections.ts",
@@ -215011,7 +215053,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1862,
+      "community": 1863,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventoryledger_deficitresolutionwork_test_ts",
       "label": "deficitResolutionWork.test.ts",
@@ -215020,7 +215062,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1863,
+      "community": 1864,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventoryledger_types_ts",
       "label": "types.ts",
@@ -215029,7 +215071,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1864,
+      "community": 1865,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_commandresultvalidators_test_ts",
       "label": "commandResultValidators.test.ts",
@@ -215038,7 +215080,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1865,
+      "community": 1866,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_test_ts",
       "label": "currency.test.ts",
@@ -215047,7 +215089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1866,
+      "community": 1867,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_storememberaccess_test_ts",
       "label": "storeMemberAccess.test.ts",
@@ -215056,7 +215098,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1867,
+      "community": 1868,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_storeinsights_ts",
       "label": "storeInsights.ts",
@@ -215065,21 +215107,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1868,
+      "community": 1869,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_userinsights_ts",
       "label": "userInsights.ts",
       "norm_label": "userinsights.ts",
       "source_file": "packages/athena-webapp/convex/llm/userInsights.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1869,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_marketing_landingfunnelevents_test_ts",
-      "label": "landingFunnelEvents.test.ts",
-      "norm_label": "landingfunnelevents.test.ts",
-      "source_file": "packages/athena-webapp/convex/marketing/landingFunnelEvents.test.ts",
       "source_location": "L1"
     },
     {
@@ -215202,6 +215235,15 @@
     {
       "community": 1870,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_marketing_landingfunnelevents_test_ts",
+      "label": "landingFunnelEvents.test.ts",
+      "norm_label": "landingfunnelevents.test.ts",
+      "source_file": "packages/athena-webapp/convex/marketing/landingFunnelEvents.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1871,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_marketing_landingfunnelretention_test_ts",
       "label": "landingFunnelRetention.test.ts",
       "norm_label": "landingfunnelretention.test.ts",
@@ -215209,7 +215251,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1871,
+      "community": 1872,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_marketing_walkthroughconfig_test_ts",
       "label": "walkthroughConfig.test.ts",
@@ -215218,7 +215260,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1872,
+      "community": 1873,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_marketing_walkthroughrequestretention_test_ts",
       "label": "walkthroughRequestRetention.test.ts",
@@ -215227,7 +215269,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1873,
+      "community": 1874,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_marketing_walkthroughrequests_test_ts",
       "label": "walkthroughRequests.test.ts",
@@ -215236,7 +215278,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1874,
+      "community": 1875,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_migrateamountstopesewas_ts",
       "label": "migrateAmountsToPesewas.ts",
@@ -215245,7 +215287,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1875,
+      "community": 1876,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_client_test_ts",
       "label": "client.test.ts",
@@ -215254,7 +215296,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1876,
+      "community": 1877,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_config_test_ts",
       "label": "config.test.ts",
@@ -215263,7 +215305,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1877,
+      "community": 1878,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_test_ts",
       "label": "normalize.test.ts",
@@ -215272,21 +215314,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1878,
+      "community": 1879,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
       "source_file": "packages/athena-webapp/convex/mtn/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1879,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_notifications_deliverypolicy_test_ts",
-      "label": "deliveryPolicy.test.ts",
-      "norm_label": "deliverypolicy.test.ts",
-      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.test.ts",
       "source_location": "L1"
     },
     {
@@ -215409,6 +215442,15 @@
     {
       "community": 1880,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_notifications_deliverypolicy_test_ts",
+      "label": "deliveryPolicy.test.ts",
+      "norm_label": "deliverypolicy.test.ts",
+      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1881,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_notifications_seed_ts",
       "label": "seed.ts",
       "norm_label": "seed.ts",
@@ -215416,7 +215458,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1881,
+      "community": 1882,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_actionadmission_test_ts",
       "label": "actionAdmission.test.ts",
@@ -215425,7 +215467,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1882,
+      "community": 1883,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_adapters_test_ts",
       "label": "adapters.test.ts",
@@ -215434,7 +215476,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1883,
+      "community": 1884,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_capabilities_ts",
       "label": "capabilities.ts",
@@ -215443,7 +215485,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1884,
+      "community": 1885,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_definitions_test_ts",
       "label": "definitions.test.ts",
@@ -215452,7 +215494,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1885,
+      "community": 1886,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_migrationinventory_test_ts",
       "label": "migrationInventory.test.ts",
@@ -215461,7 +215503,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1886,
+      "community": 1887,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_migrationinventory_ts",
       "label": "migrationInventory.ts",
@@ -215470,7 +215512,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1887,
+      "community": 1888,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_publicmutation_test_ts",
       "label": "publicMutation.test.ts",
@@ -215479,21 +215521,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1888,
+      "community": 1889,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_publicquery_test_ts",
       "label": "publicQuery.test.ts",
       "norm_label": "publicquery.test.ts",
       "source_file": "packages/athena-webapp/convex/operationAdmission/publicQuery.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1889,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operationadmission_readdefinitions_test_ts",
-      "label": "readDefinitions.test.ts",
-      "norm_label": "readdefinitions.test.ts",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.test.ts",
       "source_location": "L1"
     },
     {
@@ -215616,6 +215649,15 @@
     {
       "community": 1890,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_operationadmission_readdefinitions_test_ts",
+      "label": "readDefinitions.test.ts",
+      "norm_label": "readdefinitions.test.ts",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1891,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
@@ -215623,7 +215665,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1891,
+      "community": 1892,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequests_shareddemo_test_ts",
       "label": "approvalRequests.sharedDemo.test.ts",
@@ -215632,7 +215674,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1892,
+      "community": 1893,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_customerprofiles_test_ts",
       "label": "customerProfiles.test.ts",
@@ -215641,7 +215683,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1893,
+      "community": 1894,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_dailyclose_adjustmentreports_test_ts",
       "label": "adjustmentReports.test.ts",
@@ -215650,7 +215692,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1894,
+      "community": 1895,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_dailyclose_approval_test_ts",
       "label": "approval.test.ts",
@@ -215659,7 +215701,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1895,
+      "community": 1896,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_dailyclose_automationpolicy_test_ts",
       "label": "automationPolicy.test.ts",
@@ -215668,7 +215710,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1896,
+      "community": 1897,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_helpers_eventbuilders_test_ts",
       "label": "eventBuilders.test.ts",
@@ -215677,7 +215719,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1897,
+      "community": 1898,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_posterminalhealthalertemail_ts",
       "label": "posTerminalHealthAlertEmail.ts",
@@ -215686,21 +215728,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1898,
+      "community": 1899,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessionauthorityrevision_test_ts",
       "label": "registerSessionAuthorityRevision.test.ts",
       "norm_label": "registersessionauthorityrevision.test.ts",
       "source_file": "packages/athena-webapp/convex/operations/registerSessionAuthorityRevision.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1899,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_registersessioncloseoutgate_test_ts",
-      "label": "registerSessionCloseoutGate.test.ts",
-      "norm_label": "registersessioncloseoutgate.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionCloseoutGate.test.ts",
       "source_location": "L1"
     },
     {
@@ -216192,6 +216225,15 @@
     {
       "community": 1900,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_registersessioncloseoutgate_test_ts",
+      "label": "registerSessionCloseoutGate.test.ts",
+      "norm_label": "registersessioncloseoutgate.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionCloseoutGate.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1901,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_emailotp_test_ts",
       "label": "EmailOTP.test.ts",
       "norm_label": "emailotp.test.ts",
@@ -216199,7 +216241,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1901,
+      "community": 1902,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_apploginemailallowlist_test_ts",
       "label": "appLoginEmailAllowlist.test.ts",
@@ -216208,7 +216250,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1902,
+      "community": 1903,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_platform_capabilitycatalog_test_ts",
       "label": "capabilityCatalog.test.ts",
@@ -216217,7 +216259,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1903,
+      "community": 1904,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_registerlifecycleauthority_test_ts",
       "label": "registerLifecycleAuthority.test.ts",
@@ -216226,7 +216268,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1904,
+      "community": 1905,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_correcttransactioncustomer_test_ts",
       "label": "correctTransactionCustomer.test.ts",
@@ -216235,7 +216277,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1905,
+      "community": 1906,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_corrections_correctionevents_test_ts",
       "label": "correctionEvents.test.ts",
@@ -216244,7 +216286,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1906,
+      "community": 1907,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_corrections_correctionpolicy_test_ts",
       "label": "correctionPolicy.test.ts",
@@ -216253,7 +216295,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1907,
+      "community": 1908,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_dto_ts",
       "label": "dto.ts",
@@ -216262,21 +216304,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1908,
+      "community": 1909,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_getregisterstate_test_ts",
       "label": "getRegisterState.test.ts",
       "norm_label": "getregisterstate.test.ts",
       "source_file": "packages/athena-webapp/convex/pos/application/getRegisterState.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1909,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_possessiontracing_test_ts",
-      "label": "posSessionTracing.test.ts",
-      "norm_label": "possessiontracing.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/posSessionTracing.test.ts",
       "source_location": "L1"
     },
     {
@@ -216399,6 +216432,15 @@
     {
       "community": 1910,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_possessiontracing_test_ts",
+      "label": "posSessionTracing.test.ts",
+      "norm_label": "possessiontracing.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/posSessionTracing.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1911,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_searchcatalog_test_ts",
       "label": "searchCatalog.test.ts",
       "norm_label": "searchcatalog.test.ts",
@@ -216406,7 +216448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1911,
+      "community": 1912,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_localsyncreportingtypes_ts",
       "label": "localSyncReportingTypes.ts",
@@ -216415,7 +216457,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1912,
+      "community": 1913,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_registermappingauthorityrevision_test_ts",
       "label": "registerMappingAuthorityRevision.test.ts",
@@ -216424,7 +216466,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1913,
+      "community": 1914,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_registersessioncloseoutholds_test_ts",
       "label": "registerSessionCloseoutHolds.test.ts",
@@ -216433,7 +216475,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1914,
+      "community": 1915,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_registersessionsyncreview_classify_test_ts",
       "label": "registerSessionSyncReview.classify.test.ts",
@@ -216442,7 +216484,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1915,
+      "community": 1916,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_types_ts",
       "label": "types.ts",
@@ -216451,7 +216493,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1916,
+      "community": 1917,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminaloperationalstate_facts_ts",
       "label": "facts.ts",
@@ -216460,7 +216502,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1917,
+      "community": 1918,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminaloperationalstate_types_ts",
       "label": "types.ts",
@@ -216469,21 +216511,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1918,
+      "community": 1919,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
       "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1919,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_terminalruntime_terminalhealthalerts_test_ts",
-      "label": "terminalHealthAlerts.test.ts",
-      "norm_label": "terminalhealthalerts.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRuntime/terminalHealthAlerts.test.ts",
       "source_location": "L1"
     },
     {
@@ -216606,6 +216639,15 @@
     {
       "community": 1920,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_terminalruntime_terminalhealthalerts_test_ts",
+      "label": "terminalHealthAlerts.test.ts",
+      "norm_label": "terminalhealthalerts.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRuntime/terminalHealthAlerts.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1921,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_terminalsyncevidence_ts",
       "label": "terminalSyncEvidence.ts",
       "norm_label": "terminalsyncevidence.ts",
@@ -216613,7 +216655,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1921,
+      "community": 1922,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_types_ts",
       "label": "types.ts",
@@ -216622,7 +216664,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1922,
+      "community": 1923,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registerlifecycleauthorityrepository_test_ts",
       "label": "registerLifecycleAuthorityRepository.test.ts",
@@ -216631,7 +216673,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1923,
+      "community": 1924,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registerlifecycleauthoritystatusrepository_test_ts",
       "label": "registerLifecycleAuthorityStatusRepository.test.ts",
@@ -216640,7 +216682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1924,
+      "community": 1925,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_transactionrepository_test_ts",
       "label": "transactionRepository.test.ts",
@@ -216649,7 +216691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1925,
+      "community": 1926,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_register_ts",
       "label": "register.ts",
@@ -216658,7 +216700,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1926,
+      "community": 1927,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_application_posruntimeadapter_test_ts",
       "label": "posRuntimeAdapter.test.ts",
@@ -216667,7 +216709,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1927,
+      "community": 1928,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_application_types_test_ts",
       "label": "types.test.ts",
@@ -216676,21 +216718,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1928,
+      "community": 1929,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_infrastructure_transport_remoteassisttransportprovider_test_ts",
       "label": "RemoteAssistTransportProvider.test.ts",
       "norm_label": "remoteassisttransportprovider.test.ts",
       "source_file": "packages/athena-webapp/convex/remoteAssist/infrastructure/transport/RemoteAssistTransportProvider.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1929,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schema_ts",
-      "label": "schema.ts",
-      "norm_label": "schema.ts",
-      "source_file": "packages/athena-webapp/convex/schema.ts",
       "source_location": "L1"
     },
     {
@@ -216813,6 +216846,15 @@
     {
       "community": 1930,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schema_ts",
+      "label": "schema.ts",
+      "norm_label": "schema.ts",
+      "source_file": "packages/athena-webapp/convex/schema.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1931,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_automation_ts",
       "label": "automation.ts",
       "norm_label": "automation.ts",
@@ -216820,7 +216862,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1931,
+      "community": 1932,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_contexttracking_ts",
       "label": "contextTracking.ts",
@@ -216829,7 +216871,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1932,
+      "community": 1933,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_customermessaging_customermessagedelivery_ts",
       "label": "customerMessageDelivery.ts",
@@ -216838,7 +216880,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1933,
+      "community": 1934,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_customermessaging_index_ts",
       "label": "index.ts",
@@ -216847,7 +216889,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1934,
+      "community": 1935,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_customermessaging_receiptsharetoken_ts",
       "label": "receiptShareToken.ts",
@@ -216856,7 +216898,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1935,
+      "community": 1936,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_intelligence_ts",
       "label": "intelligence.ts",
@@ -216865,7 +216907,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1936,
+      "community": 1937,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_appverificationcode_ts",
       "label": "appVerificationCode.ts",
@@ -216874,7 +216916,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1937,
+      "community": 1938,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -216883,21 +216925,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1938,
+      "community": 1939,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
       "norm_label": "bannermessage.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/bannerMessage.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1939,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_bestseller_ts",
-      "label": "bestSeller.ts",
-      "norm_label": "bestseller.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/bestSeller.ts",
       "source_location": "L1"
     },
     {
@@ -217020,6 +217053,15 @@
     {
       "community": 1940,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_bestseller_ts",
+      "label": "bestSeller.ts",
+      "norm_label": "bestseller.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/bestSeller.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1941,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_catalogsummary_ts",
       "label": "catalogSummary.ts",
       "norm_label": "catalogsummary.ts",
@@ -217027,7 +217069,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1941,
+      "community": 1942,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_category_ts",
       "label": "category.ts",
@@ -217036,7 +217078,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1942,
+      "community": 1943,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_color_ts",
       "label": "color.ts",
@@ -217045,7 +217087,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1943,
+      "community": 1944,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
@@ -217054,7 +217096,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1944,
+      "community": 1945,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -217063,7 +217105,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1945,
+      "community": 1946,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_index_ts",
       "label": "index.ts",
@@ -217072,7 +217114,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1946,
+      "community": 1947,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_inventoryhold_ts",
       "label": "inventoryHold.ts",
@@ -217081,7 +217123,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1947,
+      "community": 1948,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_inventoryimportcostoverlaybulkdecisionrequest_ts",
       "label": "inventoryImportCostOverlayBulkDecisionRequest.ts",
@@ -217090,7 +217132,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1948,
+      "community": 1949,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_inventoryimportcostoverlayrow_ts",
       "label": "inventoryImportCostOverlayRow.ts",
@@ -217099,7 +217141,124 @@
       "source_location": "L1"
     },
     {
-      "community": 1949,
+      "community": 195,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 195,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 195,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 195,
+      "file_type": "code",
+      "id": "utils_formatdeliveryaddress",
+      "label": "formatDeliveryAddress()",
+      "norm_label": "formatdeliveryaddress()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 195,
+      "file_type": "code",
+      "id": "utils_getamountpaidfororder",
+      "label": "getAmountPaidForOrder()",
+      "norm_label": "getamountpaidfororder()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L191"
+    },
+    {
+      "community": 195,
+      "file_type": "code",
+      "id": "utils_getdiscountvalue",
+      "label": "getDiscountValue()",
+      "norm_label": "getdiscountvalue()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 195,
+      "file_type": "code",
+      "id": "utils_getonlineorderplacedat",
+      "label": "getOnlineOrderPlacedAt()",
+      "norm_label": "getonlineorderplacedat()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 195,
+      "file_type": "code",
+      "id": "utils_getorderamount",
+      "label": "getOrderAmount()",
+      "norm_label": "getorderamount()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 195,
+      "file_type": "code",
+      "id": "utils_getorderstate",
+      "label": "getOrderState()",
+      "norm_label": "getorderstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 195,
+      "file_type": "code",
+      "id": "utils_getpickupactionstate",
+      "label": "getPickupActionState()",
+      "norm_label": "getpickupactionstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L102"
+    },
+    {
+      "community": 195,
+      "file_type": "code",
+      "id": "utils_getpotentialpoints",
+      "label": "getPotentialPoints()",
+      "norm_label": "getpotentialpoints()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 195,
+      "file_type": "code",
+      "id": "utils_getproductdiscountvalue",
+      "label": "getProductDiscountValue()",
+      "norm_label": "getproductdiscountvalue()",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 195,
+      "file_type": "code",
+      "id": "utils_shouldshowpickupexceptionaction",
+      "label": "shouldShowPickupExceptionAction()",
+      "norm_label": "shouldshowpickupexceptionaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L116"
+    },
+    {
+      "community": 1950,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_inventoryimportcostoverlayrun_ts",
       "label": "inventoryImportCostOverlayRun.ts",
@@ -217108,124 +217267,7 @@
       "source_location": "L1"
     },
     {
-      "community": 195,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_sessions_possessionsview_tsx",
-      "label": "POSSessionsView.tsx",
-      "norm_label": "possessionsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 195,
-      "file_type": "code",
-      "id": "possessionsview_formatexpiry",
-      "label": "formatExpiry()",
-      "norm_label": "formatexpiry()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L190"
-    },
-    {
-      "community": 195,
-      "file_type": "code",
-      "id": "possessionsview_formatholddetails",
-      "label": "formatHoldDetails()",
-      "norm_label": "formatholddetails()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L216"
-    },
-    {
-      "community": 195,
-      "file_type": "code",
-      "id": "possessionsview_formatregisterlabel",
-      "label": "formatRegisterLabel()",
-      "norm_label": "formatregisterlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L147"
-    },
-    {
-      "community": 195,
-      "file_type": "code",
-      "id": "possessionsview_formatstatuslabel",
-      "label": "formatStatusLabel()",
-      "norm_label": "formatstatuslabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L122"
-    },
-    {
-      "community": 195,
-      "file_type": "code",
-      "id": "possessionsview_getcartcount",
-      "label": "getCartCount()",
-      "norm_label": "getcartcount()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L180"
-    },
-    {
-      "community": 195,
-      "file_type": "code",
-      "id": "possessionsview_getcustomerlabel",
-      "label": "getCustomerLabel()",
-      "norm_label": "getcustomerlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L176"
-    },
-    {
-      "community": 195,
-      "file_type": "code",
-      "id": "possessionsview_getoperatorlabel",
-      "label": "getOperatorLabel()",
-      "norm_label": "getoperatorlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L138"
-    },
-    {
-      "community": 195,
-      "file_type": "code",
-      "id": "possessionsview_getregisterlabel",
-      "label": "getRegisterLabel()",
-      "norm_label": "getregisterlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L157"
-    },
-    {
-      "community": 195,
-      "file_type": "code",
-      "id": "possessionsview_getsessioncode",
-      "label": "getSessionCode()",
-      "norm_label": "getsessioncode()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L131"
-    },
-    {
-      "community": 195,
-      "file_type": "code",
-      "id": "possessionsview_getsessions",
-      "label": "getSessions()",
-      "norm_label": "getsessions()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L114"
-    },
-    {
-      "community": 195,
-      "file_type": "code",
-      "id": "possessionsview_getstatusbadgeclass",
-      "label": "getStatusBadgeClass()",
-      "norm_label": "getstatusbadgeclass()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L250"
-    },
-    {
-      "community": 195,
-      "file_type": "code",
-      "id": "possessionsview_possessionsheader",
-      "label": "POSSessionsHeader()",
-      "norm_label": "possessionsheader()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L261"
-    },
-    {
-      "community": 1950,
+      "community": 1951,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_inventoryimportprovisionalsku_ts",
       "label": "inventoryImportProvisionalSku.ts",
@@ -217234,7 +217276,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1951,
+      "community": 1952,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_inventoryimportreviewversion_ts",
       "label": "inventoryImportReviewVersion.ts",
@@ -217243,7 +217285,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1952,
+      "community": 1953,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_inventoryimportreviewversionpayloadchunk_ts",
       "label": "inventoryImportReviewVersionPayloadChunk.ts",
@@ -217252,7 +217294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1953,
+      "community": 1954,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_inventoryimportreviewversionpayloadupload_ts",
       "label": "inventoryImportReviewVersionPayloadUpload.ts",
@@ -217261,7 +217303,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1954,
+      "community": 1955,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_invitecode_ts",
       "label": "inviteCode.ts",
@@ -217270,7 +217312,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1955,
+      "community": 1956,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organization_ts",
       "label": "organization.ts",
@@ -217279,7 +217321,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1956,
+      "community": 1957,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organizationmember_ts",
       "label": "organizationMember.ts",
@@ -217288,7 +217330,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1957,
+      "community": 1958,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_posregistercatalogrevision_ts",
       "label": "posRegisterCatalogRevision.ts",
@@ -217297,7 +217339,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1958,
+      "community": 1959,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_product_ts",
       "label": "product.ts",
@@ -217306,7 +217348,124 @@
       "source_location": "L1"
     },
     {
-      "community": 1959,
+      "community": 196,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_sessions_possessionsview_tsx",
+      "label": "POSSessionsView.tsx",
+      "norm_label": "possessionsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "possessionsview_formatexpiry",
+      "label": "formatExpiry()",
+      "norm_label": "formatexpiry()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L190"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "possessionsview_formatholddetails",
+      "label": "formatHoldDetails()",
+      "norm_label": "formatholddetails()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L216"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "possessionsview_formatregisterlabel",
+      "label": "formatRegisterLabel()",
+      "norm_label": "formatregisterlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L147"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "possessionsview_formatstatuslabel",
+      "label": "formatStatusLabel()",
+      "norm_label": "formatstatuslabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L122"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "possessionsview_getcartcount",
+      "label": "getCartCount()",
+      "norm_label": "getcartcount()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L180"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "possessionsview_getcustomerlabel",
+      "label": "getCustomerLabel()",
+      "norm_label": "getcustomerlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L176"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "possessionsview_getoperatorlabel",
+      "label": "getOperatorLabel()",
+      "norm_label": "getoperatorlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L138"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "possessionsview_getregisterlabel",
+      "label": "getRegisterLabel()",
+      "norm_label": "getregisterlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L157"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "possessionsview_getsessioncode",
+      "label": "getSessionCode()",
+      "norm_label": "getsessioncode()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L131"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "possessionsview_getsessions",
+      "label": "getSessions()",
+      "norm_label": "getsessions()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L114"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "possessionsview_getstatusbadgeclass",
+      "label": "getStatusBadgeClass()",
+      "norm_label": "getstatusbadgeclass()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L250"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "possessionsview_possessionsheader",
+      "label": "POSSessionsHeader()",
+      "norm_label": "possessionsheader()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L261"
+    },
+    {
+      "community": 1960,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_productskusearch_ts",
       "label": "productSkuSearch.ts",
@@ -217315,124 +217474,7 @@
       "source_location": "L1"
     },
     {
-      "community": 196,
-      "file_type": "code",
-      "id": "localposreadiness_blocked",
-      "label": "blocked()",
-      "norm_label": "blocked()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L638"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "localposreadiness_evaluatelocalposreadiness",
-      "label": "evaluateLocalPosReadiness()",
-      "norm_label": "evaluatelocalposreadiness()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L124"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "localposreadiness_evaluatelocalposservicecatalogreadiness",
-      "label": "evaluateLocalPosServiceCatalogReadiness()",
-      "norm_label": "evaluatelocalposservicecatalogreadiness()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L258"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "localposreadiness_formatreadinessstatekey",
-      "label": "formatReadinessStateKey()",
-      "norm_label": "formatreadinessstatekey()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L591"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "localposreadiness_hassettledlocalcloseout",
-      "label": "hasSettledLocalCloseout()",
-      "norm_label": "hassettledlocalcloseout()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L248"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "localposreadiness_localreadinessmatchesinput",
-      "label": "localReadinessMatchesInput()",
-      "norm_label": "localreadinessmatchesinput()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L287"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "localposreadiness_localreadinessrecordfromsnapshots",
-      "label": "localReadinessRecordFromSnapshots()",
-      "norm_label": "localreadinessrecordfromsnapshots()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L83"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "localposreadiness_readinessstatekey",
-      "label": "readinessStateKey()",
-      "norm_label": "readinessstatekey()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L610"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "localposreadiness_readinessstatekeysequal",
-      "label": "readinessStateKeysEqual()",
-      "norm_label": "readinessstatekeysequal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L624"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "localposreadiness_readlocalposreadiness",
-      "label": "readLocalPosReadiness()",
-      "norm_label": "readlocalposreadiness()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L299"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "localposreadiness_refreshlocalposreadinessfromsnapshots",
-      "label": "refreshLocalPosReadinessFromSnapshots()",
-      "norm_label": "refreshlocalposreadinessfromsnapshots()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L343"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "localposreadiness_uselocalposreadiness",
-      "label": "useLocalPosReadiness()",
-      "norm_label": "uselocalposreadiness()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L391"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localposreadiness_ts",
-      "label": "localPosReadiness.ts",
-      "norm_label": "localposreadiness.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1960,
+      "community": 1961,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_promocode_ts",
       "label": "promoCode.ts",
@@ -217441,7 +217483,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1961,
+      "community": 1962,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_redeemedpromocode_ts",
       "label": "redeemedPromoCode.ts",
@@ -217450,7 +217492,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1962,
+      "community": 1963,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_store_ts",
       "label": "store.ts",
@@ -217459,7 +217501,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1963,
+      "community": 1964,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_storeschedule_ts",
       "label": "storeSchedule.ts",
@@ -217468,7 +217510,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1964,
+      "community": 1965,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_storetimezone_ts",
       "label": "storeTimezone.ts",
@@ -217477,7 +217519,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1965,
+      "community": 1966,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_subcategory_ts",
       "label": "subcategory.ts",
@@ -217486,7 +217528,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1966,
+      "community": 1967,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventoryledger_index_ts",
       "label": "index.ts",
@@ -217495,7 +217537,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1967,
+      "community": 1968,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_marketing_landingfunnelevent_ts",
       "label": "landingFunnelEvent.ts",
@@ -217504,7 +217546,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1968,
+      "community": 1969,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_marketing_walkthroughrequest_ts",
       "label": "walkthroughRequest.ts",
@@ -217513,7 +217555,124 @@
       "source_location": "L1"
     },
     {
-      "community": 1969,
+      "community": 197,
+      "file_type": "code",
+      "id": "localposreadiness_blocked",
+      "label": "blocked()",
+      "norm_label": "blocked()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L638"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "localposreadiness_evaluatelocalposreadiness",
+      "label": "evaluateLocalPosReadiness()",
+      "norm_label": "evaluatelocalposreadiness()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L124"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "localposreadiness_evaluatelocalposservicecatalogreadiness",
+      "label": "evaluateLocalPosServiceCatalogReadiness()",
+      "norm_label": "evaluatelocalposservicecatalogreadiness()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L258"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "localposreadiness_formatreadinessstatekey",
+      "label": "formatReadinessStateKey()",
+      "norm_label": "formatreadinessstatekey()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L591"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "localposreadiness_hassettledlocalcloseout",
+      "label": "hasSettledLocalCloseout()",
+      "norm_label": "hassettledlocalcloseout()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L248"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "localposreadiness_localreadinessmatchesinput",
+      "label": "localReadinessMatchesInput()",
+      "norm_label": "localreadinessmatchesinput()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L287"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "localposreadiness_localreadinessrecordfromsnapshots",
+      "label": "localReadinessRecordFromSnapshots()",
+      "norm_label": "localreadinessrecordfromsnapshots()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "localposreadiness_readinessstatekey",
+      "label": "readinessStateKey()",
+      "norm_label": "readinessstatekey()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L610"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "localposreadiness_readinessstatekeysequal",
+      "label": "readinessStateKeysEqual()",
+      "norm_label": "readinessstatekeysequal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L624"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "localposreadiness_readlocalposreadiness",
+      "label": "readLocalPosReadiness()",
+      "norm_label": "readlocalposreadiness()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L299"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "localposreadiness_refreshlocalposreadinessfromsnapshots",
+      "label": "refreshLocalPosReadinessFromSnapshots()",
+      "norm_label": "refreshlocalposreadinessfromsnapshots()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L343"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "localposreadiness_uselocalposreadiness",
+      "label": "useLocalPosReadiness()",
+      "norm_label": "uselocalposreadiness()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L391"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localposreadiness_ts",
+      "label": "localPosReadiness.ts",
+      "norm_label": "localposreadiness.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1970,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_migrations_index_ts",
       "label": "index.ts",
@@ -217522,124 +217681,7 @@
       "source_location": "L1"
     },
     {
-      "community": 197,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registercatalogpinruntime_ts",
-      "label": "registerCatalogPinRuntime.ts",
-      "norm_label": "registercatalogpinruntime.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "registercatalogpinruntime_captureregistercatalogruntimepin",
-      "label": "captureRegisterCatalogRuntimePin()",
-      "norm_label": "captureregistercatalogruntimepin()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L138"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "registercatalogpinruntime_chooseregistercatalogruntimeownerid",
-      "label": "chooseRegisterCatalogRuntimeOwnerId()",
-      "norm_label": "chooseregistercatalogruntimeownerid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "registercatalogpinruntime_clearregistercatalogruntimeactionguard",
-      "label": "clearRegisterCatalogRuntimeActionGuard()",
-      "norm_label": "clearregistercatalogruntimeactionguard()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L171"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "registercatalogpinruntime_clearregistercatalogruntimeselection",
-      "label": "clearRegisterCatalogRuntimeSelection()",
-      "norm_label": "clearregistercatalogruntimeselection()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L132"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "registercatalogpinruntime_getregistercatalogruntimeownerid",
-      "label": "getRegisterCatalogRuntimeOwnerId()",
-      "norm_label": "getregistercatalogruntimeownerid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L177"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "registercatalogpinruntime_hasregistercatalogruntimeactionguard",
-      "label": "hasRegisterCatalogRuntimeActionGuard()",
-      "norm_label": "hasregistercatalogruntimeactionguard()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L165"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "registercatalogpinruntime_keyforscope",
-      "label": "keyForScope()",
-      "norm_label": "keyforscope()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L122"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "registercatalogpinruntime_maintainownerclaim",
-      "label": "maintainOwnerClaim()",
-      "norm_label": "maintainownerclaim()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L87"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "registercatalogpinruntime_ownerclaimkey",
-      "label": "ownerClaimKey()",
-      "norm_label": "ownerclaimkey()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L47"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "registercatalogpinruntime_readownerclaim",
-      "label": "readOwnerClaim()",
-      "norm_label": "readownerclaim()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "registercatalogpinruntime_setregistercatalogruntimeselection",
-      "label": "setRegisterCatalogRuntimeSelection()",
-      "norm_label": "setregistercatalogruntimeselection()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L126"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "registercatalogpinruntime_writeownerclaim",
-      "label": "writeOwnerClaim()",
-      "norm_label": "writeownerclaim()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 1970,
+      "community": 1971,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_notifications_ts",
       "label": "notifications.ts",
@@ -217648,7 +217690,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1971,
+      "community": 1972,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_index_ts",
       "label": "index.ts",
@@ -217657,7 +217699,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1972,
+      "community": 1973,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtrace_ts",
       "label": "workflowTrace.ts",
@@ -217666,7 +217708,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1973,
+      "community": 1974,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtraceevent_ts",
       "label": "workflowTraceEvent.ts",
@@ -217675,7 +217717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1974,
+      "community": 1975,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtracelookup_ts",
       "label": "workflowTraceLookup.ts",
@@ -217684,7 +217726,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1975,
+      "community": 1976,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_approvalrequest_ts",
       "label": "approvalRequest.ts",
@@ -217693,7 +217735,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1976,
+      "community": 1977,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_customerprofile_ts",
       "label": "customerProfile.ts",
@@ -217702,7 +217744,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1977,
+      "community": 1978,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_dailyclose_ts",
       "label": "dailyClose.ts",
@@ -217711,7 +217753,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1978,
+      "community": 1979,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_dailyopening_ts",
       "label": "dailyOpening.ts",
@@ -217720,7 +217762,124 @@
       "source_location": "L1"
     },
     {
-      "community": 1979,
+      "community": 198,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registercatalogpinruntime_ts",
+      "label": "registerCatalogPinRuntime.ts",
+      "norm_label": "registercatalogpinruntime.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 198,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_captureregistercatalogruntimepin",
+      "label": "captureRegisterCatalogRuntimePin()",
+      "norm_label": "captureregistercatalogruntimepin()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L138"
+    },
+    {
+      "community": 198,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_chooseregistercatalogruntimeownerid",
+      "label": "chooseRegisterCatalogRuntimeOwnerId()",
+      "norm_label": "chooseregistercatalogruntimeownerid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 198,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_clearregistercatalogruntimeactionguard",
+      "label": "clearRegisterCatalogRuntimeActionGuard()",
+      "norm_label": "clearregistercatalogruntimeactionguard()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L171"
+    },
+    {
+      "community": 198,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_clearregistercatalogruntimeselection",
+      "label": "clearRegisterCatalogRuntimeSelection()",
+      "norm_label": "clearregistercatalogruntimeselection()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L132"
+    },
+    {
+      "community": 198,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_getregistercatalogruntimeownerid",
+      "label": "getRegisterCatalogRuntimeOwnerId()",
+      "norm_label": "getregistercatalogruntimeownerid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L177"
+    },
+    {
+      "community": 198,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_hasregistercatalogruntimeactionguard",
+      "label": "hasRegisterCatalogRuntimeActionGuard()",
+      "norm_label": "hasregistercatalogruntimeactionguard()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L165"
+    },
+    {
+      "community": 198,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_keyforscope",
+      "label": "keyForScope()",
+      "norm_label": "keyforscope()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L122"
+    },
+    {
+      "community": 198,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_maintainownerclaim",
+      "label": "maintainOwnerClaim()",
+      "norm_label": "maintainownerclaim()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 198,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_ownerclaimkey",
+      "label": "ownerClaimKey()",
+      "norm_label": "ownerclaimkey()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L47"
+    },
+    {
+      "community": 198,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_readownerclaim",
+      "label": "readOwnerClaim()",
+      "norm_label": "readownerclaim()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 198,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_setregistercatalogruntimeselection",
+      "label": "setRegisterCatalogRuntimeSelection()",
+      "norm_label": "setregistercatalogruntimeselection()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L126"
+    },
+    {
+      "community": 198,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_writeownerclaim",
+      "label": "writeOwnerClaim()",
+      "norm_label": "writeownerclaim()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 1980,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_index_ts",
       "label": "index.ts",
@@ -217729,124 +217888,7 @@
       "source_location": "L1"
     },
     {
-      "community": 198,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_printattempttelemetry_ts",
-      "label": "printAttemptTelemetry.ts",
-      "norm_label": "printattempttelemetry.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "printattempttelemetry_appendevent",
-      "label": "appendEvent()",
-      "norm_label": "appendevent()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L81"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "printattempttelemetry_beginprintattempt",
-      "label": "beginPrintAttempt()",
-      "norm_label": "beginprintattempt()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "printattempttelemetry_buildmetadata",
-      "label": "buildMetadata()",
-      "norm_label": "buildmetadata()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L88"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "printattempttelemetry_finalizeprintattempt",
-      "label": "finalizePrintAttempt()",
-      "norm_label": "finalizeprintattempt()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L211"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "printattempttelemetry_getprintrejectionmetadata",
-      "label": "getPrintRejectionMetadata()",
-      "norm_label": "getprintrejectionmetadata()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L250"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "printattempttelemetry_getreasonmessage",
-      "label": "getReasonMessage()",
-      "norm_label": "getreasonmessage()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L108"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "printattempttelemetry_istargetterminal",
-      "label": "isTargetTerminal()",
-      "norm_label": "istargetterminal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "printattempttelemetry_mintattemptid",
-      "label": "mintAttemptId()",
-      "norm_label": "mintattemptid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "printattempttelemetry_recordprintattemptevent",
-      "label": "recordPrintAttemptEvent()",
-      "norm_label": "recordprintattemptevent()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L195"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "printattempttelemetry_recordprintinvocation",
-      "label": "recordPrintInvocation()",
-      "norm_label": "recordprintinvocation()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L151"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "printattempttelemetry_recordprintreturn",
-      "label": "recordPrintReturn()",
-      "norm_label": "recordprintreturn()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L174"
-    },
-    {
-      "community": 198,
-      "file_type": "code",
-      "id": "printattempttelemetry_resetprintattempttelemetryfortests",
-      "label": "resetPrintAttemptTelemetryForTests()",
-      "norm_label": "resetprintattempttelemetryfortests()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L294"
-    },
-    {
-      "community": 1980,
+      "community": 1981,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_inventorymovement_ts",
       "label": "inventoryMovement.ts",
@@ -217855,7 +217897,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1981,
+      "community": 1982,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_managerelevation_ts",
       "label": "managerElevation.ts",
@@ -217864,7 +217906,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1982,
+      "community": 1983,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalevent_ts",
       "label": "operationalEvent.ts",
@@ -217873,7 +217915,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1983,
+      "community": 1984,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalworkitem_ts",
       "label": "operationalWorkItem.ts",
@@ -217882,7 +217924,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1984,
+      "community": 1985,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_oversizedoperationalworkrepair_ts",
       "label": "oversizedOperationalWorkRepair.ts",
@@ -217891,7 +217933,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1985,
+      "community": 1986,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_paymentallocation_ts",
       "label": "paymentAllocation.ts",
@@ -217900,7 +217942,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1986,
+      "community": 1987,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_registersession_ts",
       "label": "registerSession.ts",
@@ -217909,7 +217951,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1987,
+      "community": 1988,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_skuactivityevent_ts",
       "label": "skuActivityEvent.ts",
@@ -217918,7 +217960,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1988,
+      "community": 1989,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffcredential_ts",
       "label": "staffCredential.ts",
@@ -217927,7 +217969,124 @@
       "source_location": "L1"
     },
     {
-      "community": 1989,
+      "community": 199,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_printattempttelemetry_ts",
+      "label": "printAttemptTelemetry.ts",
+      "norm_label": "printattempttelemetry.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 199,
+      "file_type": "code",
+      "id": "printattempttelemetry_appendevent",
+      "label": "appendEvent()",
+      "norm_label": "appendevent()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L81"
+    },
+    {
+      "community": 199,
+      "file_type": "code",
+      "id": "printattempttelemetry_beginprintattempt",
+      "label": "beginPrintAttempt()",
+      "norm_label": "beginprintattempt()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 199,
+      "file_type": "code",
+      "id": "printattempttelemetry_buildmetadata",
+      "label": "buildMetadata()",
+      "norm_label": "buildmetadata()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L88"
+    },
+    {
+      "community": 199,
+      "file_type": "code",
+      "id": "printattempttelemetry_finalizeprintattempt",
+      "label": "finalizePrintAttempt()",
+      "norm_label": "finalizeprintattempt()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L211"
+    },
+    {
+      "community": 199,
+      "file_type": "code",
+      "id": "printattempttelemetry_getprintrejectionmetadata",
+      "label": "getPrintRejectionMetadata()",
+      "norm_label": "getprintrejectionmetadata()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L250"
+    },
+    {
+      "community": 199,
+      "file_type": "code",
+      "id": "printattempttelemetry_getreasonmessage",
+      "label": "getReasonMessage()",
+      "norm_label": "getreasonmessage()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L108"
+    },
+    {
+      "community": 199,
+      "file_type": "code",
+      "id": "printattempttelemetry_istargetterminal",
+      "label": "isTargetTerminal()",
+      "norm_label": "istargetterminal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 199,
+      "file_type": "code",
+      "id": "printattempttelemetry_mintattemptid",
+      "label": "mintAttemptId()",
+      "norm_label": "mintattemptid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 199,
+      "file_type": "code",
+      "id": "printattempttelemetry_recordprintattemptevent",
+      "label": "recordPrintAttemptEvent()",
+      "norm_label": "recordprintattemptevent()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L195"
+    },
+    {
+      "community": 199,
+      "file_type": "code",
+      "id": "printattempttelemetry_recordprintinvocation",
+      "label": "recordPrintInvocation()",
+      "norm_label": "recordprintinvocation()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L151"
+    },
+    {
+      "community": 199,
+      "file_type": "code",
+      "id": "printattempttelemetry_recordprintreturn",
+      "label": "recordPrintReturn()",
+      "norm_label": "recordprintreturn()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L174"
+    },
+    {
+      "community": 199,
+      "file_type": "code",
+      "id": "printattempttelemetry_resetprintattempttelemetryfortests",
+      "label": "resetPrintAttemptTelemetryForTests()",
+      "norm_label": "resetprintattempttelemetryfortests()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L294"
+    },
+    {
+      "community": 1990,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffprofile_ts",
       "label": "staffProfile.ts",
@@ -217936,124 +218095,7 @@
       "source_location": "L1"
     },
     {
-      "community": 199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_telemetrybuffer_ts",
-      "label": "telemetryBuffer.ts",
-      "norm_label": "telemetrybuffer.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "telemetrybuffer_clearposclienttelemetrybuffer",
-      "label": "clearPosClientTelemetryBuffer()",
-      "norm_label": "clearposclienttelemetrybuffer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L212"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "telemetrybuffer_enqueueposclientevent",
-      "label": "enqueuePosClientEvent()",
-      "norm_label": "enqueueposclientevent()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L167"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "telemetrybuffer_isbufferedevent",
-      "label": "isBufferedEvent()",
-      "norm_label": "isbufferedevent()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L100"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "telemetrybuffer_mintclienteventid",
-      "label": "mintClientEventId()",
-      "norm_label": "mintclienteventid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "telemetrybuffer_normalizepostelemetryerror",
-      "label": "normalizePosTelemetryError()",
-      "norm_label": "normalizepostelemetryerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "telemetrybuffer_peekposclienteventbatch",
-      "label": "peekPosClientEventBatch()",
-      "norm_label": "peekposclienteventbatch()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L194"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "telemetrybuffer_posclienttelemetrybuffersize",
-      "label": "posClientTelemetryBufferSize()",
-      "norm_label": "posclienttelemetrybuffersize()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L208"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "telemetrybuffer_readbuffer",
-      "label": "readBuffer()",
-      "norm_label": "readbuffer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "telemetrybuffer_removeposclientevents",
-      "label": "removePosClientEvents()",
-      "norm_label": "removeposclientevents()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L200"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "telemetrybuffer_sanitizemetadata",
-      "label": "sanitizeMetadata()",
-      "norm_label": "sanitizemetadata()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L145"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "telemetrybuffer_truncate",
-      "label": "truncate()",
-      "norm_label": "truncate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 199,
-      "file_type": "code",
-      "id": "telemetrybuffer_writebuffer",
-      "label": "writeBuffer()",
-      "norm_label": "writebuffer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 1990,
+      "community": 1991,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffroleassignment_ts",
       "label": "staffRoleAssignment.ts",
@@ -218062,7 +218104,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1991,
+      "community": 1992,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_payments_mtncollections_ts",
       "label": "mtnCollections.ts",
@@ -218071,7 +218113,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1992,
+      "community": 1993,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_customer_ts",
       "label": "customer.ts",
@@ -218080,7 +218122,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1993,
+      "community": 1994,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesession_ts",
       "label": "expenseSession.ts",
@@ -218089,7 +218131,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1994,
+      "community": 1995,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesessionitem_ts",
       "label": "expenseSessionItem.ts",
@@ -218098,7 +218140,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1995,
+      "community": 1996,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransaction_ts",
       "label": "expenseTransaction.ts",
@@ -218107,7 +218149,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1996,
+      "community": 1997,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransactionitem_ts",
       "label": "expenseTransactionItem.ts",
@@ -218116,7 +218158,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1997,
+      "community": 1998,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_index_ts",
       "label": "index.ts",
@@ -218125,21 +218167,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1998,
+      "community": 1999,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posamountmigrationrun_ts",
       "label": "posAmountMigrationRun.ts",
       "norm_label": "posamountmigrationrun.ts",
       "source_file": "packages/athena-webapp/convex/schemas/pos/posAmountMigrationRun.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1999,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_posclientevent_ts",
-      "label": "posClientEvent.ts",
-      "norm_label": "posclientevent.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/posClientEvent.ts",
       "source_location": "L1"
     },
     {
@@ -219315,122 +219348,131 @@
     {
       "community": 200,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registercheckoutprojection_ts",
-      "label": "registerCheckoutProjection.ts",
-      "norm_label": "registercheckoutprojection.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_telemetrybuffer_ts",
+      "label": "telemetryBuffer.ts",
+      "norm_label": "telemetrybuffer.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
       "source_location": "L1"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "registercheckoutprojection_buildcompletedsalepayload",
-      "label": "buildCompletedSalePayload()",
-      "norm_label": "buildcompletedsalepayload()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L121"
+      "id": "telemetrybuffer_clearposclienttelemetrybuffer",
+      "label": "clearPosClientTelemetryBuffer()",
+      "norm_label": "clearposclienttelemetrybuffer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L212"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "registercheckoutprojection_buildservicecheckoutblockmessage",
-      "label": "buildServiceCheckoutBlockMessage()",
-      "norm_label": "buildservicecheckoutblockmessage()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L16"
+      "id": "telemetrybuffer_enqueueposclientevent",
+      "label": "enqueuePosClientEvent()",
+      "norm_label": "enqueueposclientevent()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L167"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "registercheckoutprojection_combinepaymentsbymethod",
-      "label": "combinePaymentsByMethod()",
-      "norm_label": "combinepaymentsbymethod()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L78"
+      "id": "telemetrybuffer_isbufferedevent",
+      "label": "isBufferedEvent()",
+      "norm_label": "isbufferedevent()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L100"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "registercheckoutprojection_completedcustomerinfo",
-      "label": "completedCustomerInfo()",
-      "norm_label": "completedcustomerinfo()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L290"
+      "id": "telemetrybuffer_mintclienteventid",
+      "label": "mintClientEventId()",
+      "norm_label": "mintclienteventid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L63"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "registercheckoutprojection_hascustomerdetails",
-      "label": "hasCustomerDetails()",
-      "norm_label": "hascustomerdetails()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L50"
+      "id": "telemetrybuffer_normalizepostelemetryerror",
+      "label": "normalizePosTelemetryError()",
+      "norm_label": "normalizepostelemetryerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L116"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "registercheckoutprojection_ispospaymentmethod",
-      "label": "isPosPaymentMethod()",
-      "norm_label": "ispospaymentmethod()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L98"
+      "id": "telemetrybuffer_peekposclienteventbatch",
+      "label": "peekPosClientEventBatch()",
+      "norm_label": "peekposclienteventbatch()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L194"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "registercheckoutprojection_maplocalpaymenttopayment",
-      "label": "mapLocalPaymentToPayment()",
-      "norm_label": "maplocalpaymenttopayment()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L102"
+      "id": "telemetrybuffer_posclienttelemetrybuffersize",
+      "label": "posClientTelemetryBufferSize()",
+      "norm_label": "posclienttelemetrybuffersize()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L208"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "registercheckoutprojection_maplocalservicelinetostate",
-      "label": "mapLocalServiceLineToState()",
-      "norm_label": "maplocalservicelinetostate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L197"
+      "id": "telemetrybuffer_readbuffer",
+      "label": "readBuffer()",
+      "norm_label": "readbuffer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L74"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "registercheckoutprojection_mapsessioncustomer",
-      "label": "mapSessionCustomer()",
-      "norm_label": "mapsessioncustomer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L65"
+      "id": "telemetrybuffer_removeposclientevents",
+      "label": "removePosClientEvents()",
+      "norm_label": "removeposclientevents()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L200"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "registercheckoutprojection_matchingservicelinedraft",
-      "label": "matchingServiceLineDraft()",
-      "norm_label": "matchingservicelinedraft()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L223"
+      "id": "telemetrybuffer_sanitizemetadata",
+      "label": "sanitizeMetadata()",
+      "norm_label": "sanitizemetadata()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L145"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "registercheckoutprojection_servicelinestatetocartline",
-      "label": "serviceLineStateToCartLine()",
-      "norm_label": "servicelinestatetocartline()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L272"
+      "id": "telemetrybuffer_truncate",
+      "label": "truncate()",
+      "norm_label": "truncate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L59"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "registercheckoutprojection_servicelinestatetolocalpayload",
-      "label": "serviceLineStateToLocalPayload()",
-      "norm_label": "servicelinestatetolocalpayload()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L254"
+      "id": "telemetrybuffer_writebuffer",
+      "label": "writeBuffer()",
+      "norm_label": "writebuffer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L90"
     },
     {
       "community": 2000,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_posclientevent_ts",
+      "label": "posClientEvent.ts",
+      "norm_label": "posclientevent.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/posClientEvent.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2001,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_poslifecyclejournal_ts",
       "label": "posLifecycleJournal.ts",
@@ -219439,7 +219481,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2001,
+      "community": 2002,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_poslocalstaffproof_ts",
       "label": "posLocalStaffProof.ts",
@@ -219448,7 +219490,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2002,
+      "community": 2003,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_poslocalsyncconflict_ts",
       "label": "posLocalSyncConflict.ts",
@@ -219457,7 +219499,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2003,
+      "community": 2004,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_poslocalsynccursor_ts",
       "label": "posLocalSyncCursor.ts",
@@ -219466,7 +219508,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2004,
+      "community": 2005,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_poslocalsyncevent_ts",
       "label": "posLocalSyncEvent.ts",
@@ -219475,7 +219517,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2005,
+      "community": 2006,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_poslocalsyncmapping_ts",
       "label": "posLocalSyncMapping.ts",
@@ -219484,7 +219526,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2006,
+      "community": 2007,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_pospendingcheckoutitem_ts",
       "label": "posPendingCheckoutItem.ts",
@@ -219493,7 +219535,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2007,
+      "community": 2008,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_pospendingcheckoutlookupalias_ts",
       "label": "posPendingCheckoutLookupAlias.ts",
@@ -219502,7 +219544,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2008,
+      "community": 2009,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posrecoverycredential_ts",
       "label": "posRecoveryCredential.ts",
@@ -219511,7 +219553,124 @@
       "source_location": "L1"
     },
     {
-      "community": 2009,
+      "community": 201,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registercheckoutprojection_ts",
+      "label": "registerCheckoutProjection.ts",
+      "norm_label": "registercheckoutprojection.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "registercheckoutprojection_buildcompletedsalepayload",
+      "label": "buildCompletedSalePayload()",
+      "norm_label": "buildcompletedsalepayload()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L121"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "registercheckoutprojection_buildservicecheckoutblockmessage",
+      "label": "buildServiceCheckoutBlockMessage()",
+      "norm_label": "buildservicecheckoutblockmessage()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "registercheckoutprojection_combinepaymentsbymethod",
+      "label": "combinePaymentsByMethod()",
+      "norm_label": "combinepaymentsbymethod()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "registercheckoutprojection_completedcustomerinfo",
+      "label": "completedCustomerInfo()",
+      "norm_label": "completedcustomerinfo()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L290"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "registercheckoutprojection_hascustomerdetails",
+      "label": "hasCustomerDetails()",
+      "norm_label": "hascustomerdetails()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "registercheckoutprojection_ispospaymentmethod",
+      "label": "isPosPaymentMethod()",
+      "norm_label": "ispospaymentmethod()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L98"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "registercheckoutprojection_maplocalpaymenttopayment",
+      "label": "mapLocalPaymentToPayment()",
+      "norm_label": "maplocalpaymenttopayment()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L102"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "registercheckoutprojection_maplocalservicelinetostate",
+      "label": "mapLocalServiceLineToState()",
+      "norm_label": "maplocalservicelinetostate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L197"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "registercheckoutprojection_mapsessioncustomer",
+      "label": "mapSessionCustomer()",
+      "norm_label": "mapsessioncustomer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "registercheckoutprojection_matchingservicelinedraft",
+      "label": "matchingServiceLineDraft()",
+      "norm_label": "matchingservicelinedraft()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L223"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "registercheckoutprojection_servicelinestatetocartline",
+      "label": "serviceLineStateToCartLine()",
+      "norm_label": "servicelinestatetocartline()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L272"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "registercheckoutprojection_servicelinestatetolocalpayload",
+      "label": "serviceLineStateToLocalPayload()",
+      "norm_label": "servicelinestatetolocalpayload()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L254"
+    },
+    {
+      "community": 2010,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posregisterauthorityreplicationstatus_ts",
       "label": "posRegisterAuthorityReplicationStatus.ts",
@@ -219520,124 +219679,7 @@
       "source_location": "L1"
     },
     {
-      "community": 201,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registerdrawerpresentation_ts",
-      "label": "registerDrawerPresentation.ts",
-      "norm_label": "registerdrawerpresentation.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 201,
-      "file_type": "code",
-      "id": "registerdrawerpresentation_buildopendrawerfailuremessage",
-      "label": "buildOpenDrawerFailureMessage()",
-      "norm_label": "buildopendrawerfailuremessage()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L189"
-    },
-    {
-      "community": 201,
-      "file_type": "code",
-      "id": "registerdrawerpresentation_findregistercloseoutreviewitem",
-      "label": "findRegisterCloseoutReviewItem()",
-      "norm_label": "findregistercloseoutreviewitem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L171"
-    },
-    {
-      "community": 201,
-      "file_type": "code",
-      "id": "registerdrawerpresentation_formatcloseoutcloudregistersessioncode",
-      "label": "formatCloseoutCloudRegisterSessionCode()",
-      "norm_label": "formatcloseoutcloudregistersessioncode()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L98"
-    },
-    {
-      "community": 201,
-      "file_type": "code",
-      "id": "registerdrawerpresentation_getcloseoutcloudregistersessioncode",
-      "label": "getCloseoutCloudRegisterSessionCode()",
-      "norm_label": "getcloseoutcloudregistersessioncode()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L68"
-    },
-    {
-      "community": 201,
-      "file_type": "code",
-      "id": "registerdrawerpresentation_getcloseoutcloudregistersessionid",
-      "label": "getCloseoutCloudRegisterSessionId()",
-      "norm_label": "getcloseoutcloudregistersessionid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L50"
-    },
-    {
-      "community": 201,
-      "file_type": "code",
-      "id": "registerdrawerpresentation_getcloseoutlocalregistersessionid",
-      "label": "getCloseoutLocalRegisterSessionId()",
-      "norm_label": "getcloseoutlocalregistersessionid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 201,
-      "file_type": "code",
-      "id": "registerdrawerpresentation_getlatestlocalregisterlifecycleevent",
-      "label": "getLatestLocalRegisterLifecycleEvent()",
-      "norm_label": "getlatestlocalregisterlifecycleevent()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L207"
-    },
-    {
-      "community": 201,
-      "file_type": "code",
-      "id": "registerdrawerpresentation_getpendinglocalcashvoidapprovals",
-      "label": "getPendingLocalCashVoidApprovals()",
-      "norm_label": "getpendinglocalcashvoidapprovals()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L270"
-    },
-    {
-      "community": 201,
-      "file_type": "code",
-      "id": "registerdrawerpresentation_getpendinglocalcloseoutregistersession",
-      "label": "getPendingLocalCloseoutRegisterSession()",
-      "norm_label": "getpendinglocalcloseoutregistersession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L234"
-    },
-    {
-      "community": 201,
-      "file_type": "code",
-      "id": "registerdrawerpresentation_isknowncloudregistersessionblockinglocalprojection",
-      "label": "isKnownCloudRegisterSessionBlockingLocalProjection()",
-      "norm_label": "isknowncloudregistersessionblockinglocalprojection()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L114"
-    },
-    {
-      "community": 201,
-      "file_type": "code",
-      "id": "registerdrawerpresentation_readlocalsyncstatus",
-      "label": "readLocalSyncStatus()",
-      "norm_label": "readlocalsyncstatus()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L146"
-    },
-    {
-      "community": 201,
-      "file_type": "code",
-      "id": "registerdrawerpresentation_stringfield",
-      "label": "stringField()",
-      "norm_label": "stringfield()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L334"
-    },
-    {
-      "community": 2010,
+      "community": 2011,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posregistermappingauthority_ts",
       "label": "posRegisterMappingAuthority.ts",
@@ -219646,7 +219688,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2011,
+      "community": 2012,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posregistersessionactivity_ts",
       "label": "posRegisterSessionActivity.ts",
@@ -219655,7 +219697,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2012,
+      "community": 2013,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posregistersessionactivitycheckpoint_ts",
       "label": "posRegisterSessionActivityCheckpoint.ts",
@@ -219664,7 +219706,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2013,
+      "community": 2014,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possession_ts",
       "label": "posSession.ts",
@@ -219673,7 +219715,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2014,
+      "community": 2015,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possessionitem_ts",
       "label": "posSessionItem.ts",
@@ -219682,7 +219724,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2015,
+      "community": 2016,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posterminal_test_ts",
       "label": "posTerminal.test.ts",
@@ -219691,7 +219733,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2016,
+      "community": 2017,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posterminal_ts",
       "label": "posTerminal.ts",
@@ -219700,7 +219742,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2017,
+      "community": 2018,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posterminalrecovery_ts",
       "label": "posTerminalRecovery.ts",
@@ -219709,7 +219751,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2018,
+      "community": 2019,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posterminalruntimestatus_ts",
       "label": "posTerminalRuntimeStatus.ts",
@@ -219718,7 +219760,124 @@
       "source_location": "L1"
     },
     {
-      "community": 2019,
+      "community": 202,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registerdrawerpresentation_ts",
+      "label": "registerDrawerPresentation.ts",
+      "norm_label": "registerdrawerpresentation.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "registerdrawerpresentation_buildopendrawerfailuremessage",
+      "label": "buildOpenDrawerFailureMessage()",
+      "norm_label": "buildopendrawerfailuremessage()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L189"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "registerdrawerpresentation_findregistercloseoutreviewitem",
+      "label": "findRegisterCloseoutReviewItem()",
+      "norm_label": "findregistercloseoutreviewitem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L171"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "registerdrawerpresentation_formatcloseoutcloudregistersessioncode",
+      "label": "formatCloseoutCloudRegisterSessionCode()",
+      "norm_label": "formatcloseoutcloudregistersessioncode()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L98"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "registerdrawerpresentation_getcloseoutcloudregistersessioncode",
+      "label": "getCloseoutCloudRegisterSessionCode()",
+      "norm_label": "getcloseoutcloudregistersessioncode()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L68"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "registerdrawerpresentation_getcloseoutcloudregistersessionid",
+      "label": "getCloseoutCloudRegisterSessionId()",
+      "norm_label": "getcloseoutcloudregistersessionid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "registerdrawerpresentation_getcloseoutlocalregistersessionid",
+      "label": "getCloseoutLocalRegisterSessionId()",
+      "norm_label": "getcloseoutlocalregistersessionid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "registerdrawerpresentation_getlatestlocalregisterlifecycleevent",
+      "label": "getLatestLocalRegisterLifecycleEvent()",
+      "norm_label": "getlatestlocalregisterlifecycleevent()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L207"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "registerdrawerpresentation_getpendinglocalcashvoidapprovals",
+      "label": "getPendingLocalCashVoidApprovals()",
+      "norm_label": "getpendinglocalcashvoidapprovals()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L270"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "registerdrawerpresentation_getpendinglocalcloseoutregistersession",
+      "label": "getPendingLocalCloseoutRegisterSession()",
+      "norm_label": "getpendinglocalcloseoutregistersession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L234"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "registerdrawerpresentation_isknowncloudregistersessionblockinglocalprojection",
+      "label": "isKnownCloudRegisterSessionBlockingLocalProjection()",
+      "norm_label": "isknowncloudregistersessionblockinglocalprojection()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L114"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "registerdrawerpresentation_readlocalsyncstatus",
+      "label": "readLocalSyncStatus()",
+      "norm_label": "readlocalsyncstatus()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L146"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "registerdrawerpresentation_stringfield",
+      "label": "stringField()",
+      "norm_label": "stringfield()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L334"
+    },
+    {
+      "community": 2020,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransaction_ts",
       "label": "posTransaction.ts",
@@ -219727,124 +219886,7 @@
       "source_location": "L1"
     },
     {
-      "community": 202,
-      "file_type": "code",
-      "id": "localpinverifier_base64tobytes",
-      "label": "base64ToBytes()",
-      "norm_label": "base64tobytes()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L50"
-    },
-    {
-      "community": 202,
-      "file_type": "code",
-      "id": "localpinverifier_bytestobase64",
-      "label": "bytesToBase64()",
-      "norm_label": "bytestobase64()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 202,
-      "file_type": "code",
-      "id": "localpinverifier_createlocalpinverifier",
-      "label": "createLocalPinVerifier()",
-      "norm_label": "createlocalpinverifier()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L131"
-    },
-    {
-      "community": 202,
-      "file_type": "code",
-      "id": "localpinverifier_cryptorefdecrypt",
-      "label": "cryptoRefDecrypt()",
-      "norm_label": "cryptorefdecrypt()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L268"
-    },
-    {
-      "community": 202,
-      "file_type": "code",
-      "id": "localpinverifier_derivepinhash",
-      "label": "derivePinHash()",
-      "norm_label": "derivepinhash()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L76"
-    },
-    {
-      "community": 202,
-      "file_type": "code",
-      "id": "localpinverifier_derivewrappingkey",
-      "label": "deriveWrappingKey()",
-      "norm_label": "derivewrappingkey()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L103"
-    },
-    {
-      "community": 202,
-      "file_type": "code",
-      "id": "localpinverifier_getcrypto",
-      "label": "getCrypto()",
-      "norm_label": "getcrypto()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 202,
-      "file_type": "code",
-      "id": "localpinverifier_islocalpinverifiermetadata",
-      "label": "isLocalPinVerifierMetadata()",
-      "norm_label": "islocalpinverifiermetadata()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L281"
-    },
-    {
-      "community": 202,
-      "file_type": "code",
-      "id": "localpinverifier_timingsafeequal",
-      "label": "timingSafeEqual()",
-      "norm_label": "timingsafeequal()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 202,
-      "file_type": "code",
-      "id": "localpinverifier_unwraplocalstaffprooftoken",
-      "label": "unwrapLocalStaffProofToken()",
-      "norm_label": "unwraplocalstaffprooftoken()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L221"
-    },
-    {
-      "community": 202,
-      "file_type": "code",
-      "id": "localpinverifier_verifylocalpin",
-      "label": "verifyLocalPin()",
-      "norm_label": "verifylocalpin()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L152"
-    },
-    {
-      "community": 202,
-      "file_type": "code",
-      "id": "localpinverifier_wraplocalstaffprooftoken",
-      "label": "wrapLocalStaffProofToken()",
-      "norm_label": "wraplocalstaffprooftoken()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L183"
-    },
-    {
-      "community": 202,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_security_localpinverifier_ts",
-      "label": "localPinVerifier.ts",
-      "norm_label": "localpinverifier.ts",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2020,
+      "community": 2021,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransactionadjustment_ts",
       "label": "posTransactionAdjustment.ts",
@@ -219853,7 +219895,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2021,
+      "community": 2022,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransactionadjustmentline_ts",
       "label": "posTransactionAdjustmentLine.ts",
@@ -219862,7 +219904,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2022,
+      "community": 2023,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransactionitem_ts",
       "label": "posTransactionItem.ts",
@@ -219871,7 +219913,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2023,
+      "community": 2024,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransactionserviceline_test_ts",
       "label": "posTransactionServiceLine.test.ts",
@@ -219880,7 +219922,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2024,
+      "community": 2025,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransactionserviceline_ts",
       "label": "posTransactionServiceLine.ts",
@@ -219889,7 +219931,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2025,
+      "community": 2026,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_remoteassist_index_ts",
       "label": "index.ts",
@@ -219898,7 +219940,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2026,
+      "community": 2027,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_remoteassist_remoteassistclient_ts",
       "label": "remoteAssistClient.ts",
@@ -219907,7 +219949,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2027,
+      "community": 2028,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_remoteassist_remoteassistsession_ts",
       "label": "remoteAssistSession.ts",
@@ -219916,7 +219958,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2028,
+      "community": 2029,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_reports_derived_ts",
       "label": "derived.ts",
@@ -219925,7 +219967,124 @@
       "source_location": "L1"
     },
     {
-      "community": 2029,
+      "community": 203,
+      "file_type": "code",
+      "id": "localpinverifier_base64tobytes",
+      "label": "base64ToBytes()",
+      "norm_label": "base64tobytes()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 203,
+      "file_type": "code",
+      "id": "localpinverifier_bytestobase64",
+      "label": "bytesToBase64()",
+      "norm_label": "bytestobase64()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 203,
+      "file_type": "code",
+      "id": "localpinverifier_createlocalpinverifier",
+      "label": "createLocalPinVerifier()",
+      "norm_label": "createlocalpinverifier()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L131"
+    },
+    {
+      "community": 203,
+      "file_type": "code",
+      "id": "localpinverifier_cryptorefdecrypt",
+      "label": "cryptoRefDecrypt()",
+      "norm_label": "cryptorefdecrypt()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L268"
+    },
+    {
+      "community": 203,
+      "file_type": "code",
+      "id": "localpinverifier_derivepinhash",
+      "label": "derivePinHash()",
+      "norm_label": "derivepinhash()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 203,
+      "file_type": "code",
+      "id": "localpinverifier_derivewrappingkey",
+      "label": "deriveWrappingKey()",
+      "norm_label": "derivewrappingkey()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L103"
+    },
+    {
+      "community": 203,
+      "file_type": "code",
+      "id": "localpinverifier_getcrypto",
+      "label": "getCrypto()",
+      "norm_label": "getcrypto()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 203,
+      "file_type": "code",
+      "id": "localpinverifier_islocalpinverifiermetadata",
+      "label": "isLocalPinVerifierMetadata()",
+      "norm_label": "islocalpinverifiermetadata()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L281"
+    },
+    {
+      "community": 203,
+      "file_type": "code",
+      "id": "localpinverifier_timingsafeequal",
+      "label": "timingSafeEqual()",
+      "norm_label": "timingsafeequal()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 203,
+      "file_type": "code",
+      "id": "localpinverifier_unwraplocalstaffprooftoken",
+      "label": "unwrapLocalStaffProofToken()",
+      "norm_label": "unwraplocalstaffprooftoken()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L221"
+    },
+    {
+      "community": 203,
+      "file_type": "code",
+      "id": "localpinverifier_verifylocalpin",
+      "label": "verifyLocalPin()",
+      "norm_label": "verifylocalpin()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L152"
+    },
+    {
+      "community": 203,
+      "file_type": "code",
+      "id": "localpinverifier_wraplocalstaffprooftoken",
+      "label": "wrapLocalStaffProofToken()",
+      "norm_label": "wraplocalstaffprooftoken()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L183"
+    },
+    {
+      "community": 203,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_security_localpinverifier_ts",
+      "label": "localPinVerifier.ts",
+      "norm_label": "localpinverifier.ts",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2030,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_reports_facts_ts",
       "label": "facts.ts",
@@ -219934,124 +220093,7 @@
       "source_location": "L1"
     },
     {
-      "community": 203,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_reviews_ts",
-      "label": "reviews.ts",
-      "norm_label": "reviews.ts",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 203,
-      "file_type": "code",
-      "id": "reviews_createreview",
-      "label": "createReview()",
-      "norm_label": "createreview()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 203,
-      "file_type": "code",
-      "id": "reviews_deletereview",
-      "label": "deleteReview()",
-      "norm_label": "deletereview()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L69"
-    },
-    {
-      "community": 203,
-      "file_type": "code",
-      "id": "reviews_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 203,
-      "file_type": "code",
-      "id": "reviews_getreviewbyorderitem",
-      "label": "getReviewByOrderItem()",
-      "norm_label": "getreviewbyorderitem()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 203,
-      "file_type": "code",
-      "id": "reviews_getreviewsbyproductid",
-      "label": "getReviewsByProductId()",
-      "norm_label": "getreviewsbyproductid()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L132"
-    },
-    {
-      "community": 203,
-      "file_type": "code",
-      "id": "reviews_getreviewsbyproductskuid",
-      "label": "getReviewsByProductSkuId()",
-      "norm_label": "getreviewsbyproductskuid()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L83"
-    },
-    {
-      "community": 203,
-      "file_type": "code",
-      "id": "reviews_getuserreviews",
-      "label": "getUserReviews()",
-      "norm_label": "getuserreviews()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L99"
-    },
-    {
-      "community": 203,
-      "file_type": "code",
-      "id": "reviews_getuserreviewsforproduct",
-      "label": "getUserReviewsForProduct()",
-      "norm_label": "getuserreviewsforproduct()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L113"
-    },
-    {
-      "community": 203,
-      "file_type": "code",
-      "id": "reviews_hasreviewfororderitem",
-      "label": "hasReviewForOrderItem()",
-      "norm_label": "hasreviewfororderitem()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L164"
-    },
-    {
-      "community": 203,
-      "file_type": "code",
-      "id": "reviews_hasuserreviewfororderitem",
-      "label": "hasUserReviewForOrderItem()",
-      "norm_label": "hasuserreviewfororderitem()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L183"
-    },
-    {
-      "community": 203,
-      "file_type": "code",
-      "id": "reviews_markreviewhelpful",
-      "label": "markReviewHelpful()",
-      "norm_label": "markreviewhelpful()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L148"
-    },
-    {
-      "community": 203,
-      "file_type": "code",
-      "id": "reviews_updatereview",
-      "label": "updateReview()",
-      "norm_label": "updatereview()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 2030,
+      "community": 2031,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_reports_index_ts",
       "label": "index.ts",
@@ -220060,7 +220102,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2031,
+      "community": 2032,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_reports_verificationruns_ts",
       "label": "verificationRuns.ts",
@@ -220069,7 +220111,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2032,
+      "community": 2033,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_index_ts",
       "label": "index.ts",
@@ -220078,7 +220120,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2033,
+      "community": 2034,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceappointment_ts",
       "label": "serviceAppointment.ts",
@@ -220087,7 +220129,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2034,
+      "community": 2035,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecase_ts",
       "label": "serviceCase.ts",
@@ -220096,7 +220138,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2035,
+      "community": 2036,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecaselineitem_ts",
       "label": "serviceCaseLineItem.ts",
@@ -220105,7 +220147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2036,
+      "community": 2037,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecatalog_ts",
       "label": "serviceCatalog.ts",
@@ -220114,7 +220156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2037,
+      "community": 2038,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceinventoryusage_ts",
       "label": "serviceInventoryUsage.ts",
@@ -220123,7 +220165,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2038,
+      "community": 2039,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_shareddemo_ts",
       "label": "sharedDemo.ts",
@@ -220132,7 +220174,124 @@
       "source_location": "L1"
     },
     {
-      "community": 2039,
+      "community": 204,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_reviews_ts",
+      "label": "reviews.ts",
+      "norm_label": "reviews.ts",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 204,
+      "file_type": "code",
+      "id": "reviews_createreview",
+      "label": "createReview()",
+      "norm_label": "createreview()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 204,
+      "file_type": "code",
+      "id": "reviews_deletereview",
+      "label": "deleteReview()",
+      "norm_label": "deletereview()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L69"
+    },
+    {
+      "community": 204,
+      "file_type": "code",
+      "id": "reviews_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 204,
+      "file_type": "code",
+      "id": "reviews_getreviewbyorderitem",
+      "label": "getReviewByOrderItem()",
+      "norm_label": "getreviewbyorderitem()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 204,
+      "file_type": "code",
+      "id": "reviews_getreviewsbyproductid",
+      "label": "getReviewsByProductId()",
+      "norm_label": "getreviewsbyproductid()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L132"
+    },
+    {
+      "community": 204,
+      "file_type": "code",
+      "id": "reviews_getreviewsbyproductskuid",
+      "label": "getReviewsByProductSkuId()",
+      "norm_label": "getreviewsbyproductskuid()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 204,
+      "file_type": "code",
+      "id": "reviews_getuserreviews",
+      "label": "getUserReviews()",
+      "norm_label": "getuserreviews()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L99"
+    },
+    {
+      "community": 204,
+      "file_type": "code",
+      "id": "reviews_getuserreviewsforproduct",
+      "label": "getUserReviewsForProduct()",
+      "norm_label": "getuserreviewsforproduct()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L113"
+    },
+    {
+      "community": 204,
+      "file_type": "code",
+      "id": "reviews_hasreviewfororderitem",
+      "label": "hasReviewForOrderItem()",
+      "norm_label": "hasreviewfororderitem()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L164"
+    },
+    {
+      "community": 204,
+      "file_type": "code",
+      "id": "reviews_hasuserreviewfororderitem",
+      "label": "hasUserReviewForOrderItem()",
+      "norm_label": "hasuserreviewfororderitem()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L183"
+    },
+    {
+      "community": 204,
+      "file_type": "code",
+      "id": "reviews_markreviewhelpful",
+      "label": "markReviewHelpful()",
+      "norm_label": "markreviewhelpful()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L148"
+    },
+    {
+      "community": 204,
+      "file_type": "code",
+      "id": "reviews_updatereview",
+      "label": "updateReview()",
+      "norm_label": "updatereview()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 2040,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_staffmessages_ts",
       "label": "staffMessages.ts",
@@ -220141,124 +220300,7 @@
       "source_location": "L1"
     },
     {
-      "community": 204,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 204,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 204,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 204,
-      "file_type": "code",
-      "id": "utils_formatdeliveryaddress",
-      "label": "formatDeliveryAddress()",
-      "norm_label": "formatdeliveryaddress()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 204,
-      "file_type": "code",
-      "id": "utils_getamountpaidfororder",
-      "label": "getAmountPaidForOrder()",
-      "norm_label": "getamountpaidfororder()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L191"
-    },
-    {
-      "community": 204,
-      "file_type": "code",
-      "id": "utils_getdiscountvalue",
-      "label": "getDiscountValue()",
-      "norm_label": "getdiscountvalue()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 204,
-      "file_type": "code",
-      "id": "utils_getonlineorderplacedat",
-      "label": "getOnlineOrderPlacedAt()",
-      "norm_label": "getonlineorderplacedat()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 204,
-      "file_type": "code",
-      "id": "utils_getorderamount",
-      "label": "getOrderAmount()",
-      "norm_label": "getorderamount()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 204,
-      "file_type": "code",
-      "id": "utils_getorderstate",
-      "label": "getOrderState()",
-      "norm_label": "getorderstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 204,
-      "file_type": "code",
-      "id": "utils_getpickupactionstate",
-      "label": "getPickupActionState()",
-      "norm_label": "getpickupactionstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 204,
-      "file_type": "code",
-      "id": "utils_getpotentialpoints",
-      "label": "getPotentialPoints()",
-      "norm_label": "getpotentialpoints()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 204,
-      "file_type": "code",
-      "id": "utils_getproductdiscountvalue",
-      "label": "getProductDiscountValue()",
-      "norm_label": "getproductdiscountvalue()",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 204,
-      "file_type": "code",
-      "id": "utils_shouldshowpickupexceptionaction",
-      "label": "shouldShowPickupExceptionAction()",
-      "norm_label": "shouldshowpickupexceptionaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 2040,
+      "community": 2041,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_cyclecountdraft_ts",
       "label": "cycleCountDraft.ts",
@@ -220267,7 +220309,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2041,
+      "community": 2042,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_index_ts",
       "label": "index.ts",
@@ -220276,7 +220318,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2042,
+      "community": 2043,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorder_ts",
       "label": "purchaseOrder.ts",
@@ -220285,7 +220327,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2043,
+      "community": 2044,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorderlineitem_ts",
       "label": "purchaseOrderLineItem.ts",
@@ -220294,7 +220336,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2044,
+      "community": 2045,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_receivingbatch_ts",
       "label": "receivingBatch.ts",
@@ -220303,7 +220345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2045,
+      "community": 2046,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_stockadjustmentbatch_ts",
       "label": "stockAdjustmentBatch.ts",
@@ -220312,7 +220354,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2046,
+      "community": 2047,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_vendor_ts",
       "label": "vendor.ts",
@@ -220321,7 +220363,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2047,
+      "community": 2048,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_analytics_ts",
       "label": "analytics.ts",
@@ -220330,21 +220372,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2048,
+      "community": 2049,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bag_ts",
       "label": "bag.ts",
       "norm_label": "bag.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/bag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2049,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_bagitem_ts",
-      "label": "bagItem.ts",
-      "norm_label": "bagitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/bagItem.ts",
       "source_location": "L1"
     },
     {
@@ -220467,6 +220500,15 @@
     {
       "community": 2050,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_bagitem_ts",
+      "label": "bagItem.ts",
+      "norm_label": "bagitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/bagItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2051,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
       "label": "checkoutSession.ts",
       "norm_label": "checkoutsession.ts",
@@ -220474,7 +220516,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2051,
+      "community": 2052,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsessionitem_ts",
       "label": "checkoutSessionItem.ts",
@@ -220483,7 +220525,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2052,
+      "community": 2053,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
       "label": "guest.ts",
@@ -220492,7 +220534,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2053,
+      "community": 2054,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
       "label": "index.ts",
@@ -220501,7 +220543,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2054,
+      "community": 2055,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
       "label": "offer.ts",
@@ -220510,7 +220552,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2055,
+      "community": 2056,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -220519,7 +220561,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2056,
+      "community": 2057,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -220528,7 +220570,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2057,
+      "community": 2058,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_review_ts",
       "label": "review.ts",
@@ -220537,21 +220579,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2058,
+      "community": 2059,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_rewards_ts",
       "label": "rewards.ts",
       "norm_label": "rewards.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/rewards.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2059,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/savedBag.ts",
       "source_location": "L1"
     },
     {
@@ -220674,6 +220707,15 @@
     {
       "community": 2060,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/savedBag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2061,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
       "norm_label": "savedbagitem.ts",
@@ -220681,7 +220723,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2061,
+      "community": 2062,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontsession_ts",
       "label": "storeFrontSession.ts",
@@ -220690,7 +220732,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2062,
+      "community": 2063,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
       "label": "storeFrontUser.ts",
@@ -220699,7 +220741,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2063,
+      "community": 2064,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
       "label": "storeFrontVerificationCode.ts",
@@ -220708,7 +220750,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2064,
+      "community": 2065,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -220717,7 +220759,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2065,
+      "community": 2066,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_services_orderemailservice_test_ts",
       "label": "orderEmailService.test.ts",
@@ -220726,7 +220768,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2066,
+      "community": 2067,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_authboundary_test_ts",
       "label": "authBoundary.test.ts",
@@ -220735,7 +220777,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2067,
+      "community": 2068,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_config_test_ts",
       "label": "config.test.ts",
@@ -220744,21 +220786,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2068,
+      "community": 2069,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_domainrestore_test_ts",
       "label": "domainRestore.test.ts",
       "norm_label": "domainrestore.test.ts",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2069,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_shareddemo_foundation_test_ts",
-      "label": "foundation.test.ts",
-      "norm_label": "foundation.test.ts",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/foundation.test.ts",
       "source_location": "L1"
     },
     {
@@ -220881,6 +220914,15 @@
     {
       "community": 2070,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_shareddemo_foundation_test_ts",
+      "label": "foundation.test.ts",
+      "norm_label": "foundation.test.ts",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/foundation.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2071,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_openingbaseline_test_ts",
       "label": "openingBaseline.test.ts",
       "norm_label": "openingbaseline.test.ts",
@@ -220888,7 +220930,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2071,
+      "community": 2072,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_policy_test_ts",
       "label": "policy.test.ts",
@@ -220897,7 +220939,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2072,
+      "community": 2073,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_public_test_ts",
       "label": "public.test.ts",
@@ -220906,7 +220948,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2073,
+      "community": 2074,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_serviceeffectboundarycoverage_test_ts",
       "label": "serviceEffectBoundaryCoverage.test.ts",
@@ -220915,7 +220957,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2074,
+      "community": 2075,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bag_ts",
       "label": "bag.ts",
@@ -220924,7 +220966,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2075,
+      "community": 2076,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -220933,7 +220975,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2076,
+      "community": 2077,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customer_ts",
       "label": "customer.ts",
@@ -220942,7 +220984,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2077,
+      "community": 2078,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_guest_ts",
       "label": "guest.ts",
@@ -220951,21 +220993,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2078,
+      "community": 2079,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_offers_test_ts",
       "label": "offers.test.ts",
       "norm_label": "offers.test.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/offers.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2079,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
-      "label": "onlineOrderUtilFns.ts",
-      "norm_label": "onlineorderutilfns.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderUtilFns.ts",
       "source_location": "L1"
     },
     {
@@ -221079,6 +221112,15 @@
     {
       "community": 2080,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
+      "label": "onlineOrderUtilFns.ts",
+      "norm_label": "onlineorderutilfns.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderUtilFns.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2081,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_orderoperations_test_ts",
       "label": "orderOperations.test.ts",
       "norm_label": "orderoperations.test.ts",
@@ -221086,7 +221128,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2081,
+      "community": 2082,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_paystackactions_ts",
       "label": "paystackActions.ts",
@@ -221095,7 +221137,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2082,
+      "community": 2083,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -221104,7 +221146,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2083,
+      "community": 2084,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -221113,7 +221155,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2084,
+      "community": 2085,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_userstoreactivity_test_ts",
       "label": "userStoreActivity.test.ts",
@@ -221122,7 +221164,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2085,
+      "community": 2086,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_users_ts",
       "label": "users.ts",
@@ -221131,7 +221173,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2086,
+      "community": 2087,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storetime_storetimeauthority_test_ts",
       "label": "storeTimeAuthority.test.ts",
@@ -221140,7 +221182,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2087,
+      "community": 2088,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_types_payment_ts",
       "label": "payment.ts",
@@ -221149,21 +221191,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2088,
+      "community": 2089,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_utils_test_ts",
       "label": "utils.test.ts",
       "norm_label": "utils.test.ts",
       "source_file": "packages/athena-webapp/convex/utils.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2089,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_test_ts",
-      "label": "posSession.test.ts",
-      "norm_label": "possession.test.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/posSession.test.ts",
       "source_location": "L1"
     },
     {
@@ -221277,6 +221310,15 @@
     {
       "community": 2090,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_test_ts",
+      "label": "posSession.test.ts",
+      "norm_label": "possession.test.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/posSession.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2091,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_purchaseorder_test_ts",
       "label": "purchaseOrder.test.ts",
       "norm_label": "purchaseorder.test.ts",
@@ -221284,7 +221326,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2091,
+      "community": 2092,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_test_ts",
       "label": "registerSession.test.ts",
@@ -221293,7 +221335,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2092,
+      "community": 2093,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_servicecase_test_ts",
       "label": "serviceCase.test.ts",
@@ -221302,7 +221344,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2093,
+      "community": 2094,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_presentation_test_ts",
       "label": "presentation.test.ts",
@@ -221311,7 +221353,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2094,
+      "community": 2095,
       "file_type": "code",
       "id": "packages_athena_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -221320,7 +221362,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2095,
+      "community": 2096,
       "file_type": "code",
       "id": "packages_athena_webapp_index_ts",
       "label": "index.ts",
@@ -221329,7 +221371,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2096,
+      "community": 2097,
       "file_type": "code",
       "id": "packages_athena_webapp_playwright_config_ts",
       "label": "playwright.config.ts",
@@ -221338,7 +221380,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2097,
+      "community": 2098,
       "file_type": "code",
       "id": "packages_athena_webapp_playwright_prod_config_ts",
       "label": "playwright.prod.config.ts",
@@ -221347,21 +221389,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2098,
+      "community": 2099,
       "file_type": "code",
       "id": "packages_athena_webapp_postcss_config_js",
       "label": "postcss.config.js",
       "norm_label": "postcss.config.js",
       "source_file": "packages/athena-webapp/postcss.config.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 2099,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_approvalpolicy_ts",
-      "label": "approvalPolicy.ts",
-      "norm_label": "approvalpolicy.ts",
-      "source_file": "packages/athena-webapp/shared/approvalPolicy.ts",
       "source_location": "L1"
     },
     {
@@ -221844,6 +221877,15 @@
     {
       "community": 2100,
       "file_type": "code",
+      "id": "packages_athena_webapp_shared_approvalpolicy_ts",
+      "label": "approvalPolicy.ts",
+      "norm_label": "approvalpolicy.ts",
+      "source_file": "packages/athena-webapp/shared/approvalPolicy.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2101,
+      "file_type": "code",
       "id": "packages_athena_webapp_shared_auth_ts",
       "label": "auth.ts",
       "norm_label": "auth.ts",
@@ -221851,7 +221893,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2101,
+      "community": 2102,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_commandresult_test_ts",
       "label": "commandResult.test.ts",
@@ -221860,7 +221902,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2102,
+      "community": 2103,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_currencyformatter_test_ts",
       "label": "currencyFormatter.test.ts",
@@ -221869,7 +221911,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2103,
+      "community": 2104,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_homepageranking_test_ts",
       "label": "homepageRanking.test.ts",
@@ -221878,7 +221920,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2104,
+      "community": 2105,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_intelligence_contextbundletypes_ts",
       "label": "contextBundleTypes.ts",
@@ -221887,7 +221929,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2105,
+      "community": 2106,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_intelligence_contexteventtypes_ts",
       "label": "contextEventTypes.ts",
@@ -221896,7 +221938,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2106,
+      "community": 2107,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_intelligence_contexttracking_test_ts",
       "label": "contextTracking.test.ts",
@@ -221905,7 +221947,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2107,
+      "community": 2108,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_intelligence_contexttypes_ts",
       "label": "contextTypes.ts",
@@ -221914,21 +221956,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2108,
+      "community": 2109,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_intelligence_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/athena-webapp/shared/intelligence/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2109,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_intelligence_providertypes_ts",
-      "label": "providerTypes.ts",
-      "norm_label": "providertypes.ts",
-      "source_file": "packages/athena-webapp/shared/intelligence/providerTypes.ts",
       "source_location": "L1"
     },
     {
@@ -222042,6 +222075,15 @@
     {
       "community": 2110,
       "file_type": "code",
+      "id": "packages_athena_webapp_shared_intelligence_providertypes_ts",
+      "label": "providerTypes.ts",
+      "norm_label": "providertypes.ts",
+      "source_file": "packages/athena-webapp/shared/intelligence/providerTypes.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2111,
+      "file_type": "code",
       "id": "packages_athena_webapp_shared_inventoryimportreviewpayload_test_ts",
       "label": "inventoryImportReviewPayload.test.ts",
       "norm_label": "inventoryimportreviewpayload.test.ts",
@@ -222049,7 +222091,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2111,
+      "community": 2112,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_inventoryimportsource_test_ts",
       "label": "inventoryImportSource.test.ts",
@@ -222058,7 +222100,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2112,
+      "community": 2113,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_pos_terminalruntimematerial_test_ts",
       "label": "terminalRuntimeMaterial.test.ts",
@@ -222067,7 +222109,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2113,
+      "community": 2114,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_posregistersessionactivitycontract_test_ts",
       "label": "posRegisterSessionActivityContract.test.ts",
@@ -222076,7 +222118,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2114,
+      "community": 2115,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_productdisplayname_test_ts",
       "label": "productDisplayName.test.ts",
@@ -222085,7 +222127,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2115,
+      "community": 2116,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_registersessionlifecyclepolicy_test_ts",
       "label": "registerSessionLifecyclePolicy.test.ts",
@@ -222094,7 +222136,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2116,
+      "community": 2117,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_registersessionstatus_test_ts",
       "label": "registerSessionStatus.test.ts",
@@ -222103,7 +222145,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2117,
+      "community": 2118,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_shareddemoregistererror_test_ts",
       "label": "sharedDemoRegisterError.test.ts",
@@ -222112,21 +222154,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2118,
+      "community": 2119,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_staffdisplayname_test_ts",
       "label": "staffDisplayName.test.ts",
       "norm_label": "staffdisplayname.test.ts",
       "source_file": "packages/athena-webapp/shared/staffDisplayName.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2119,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_storefrontvisibility_test_ts",
-      "label": "storefrontVisibility.test.ts",
-      "norm_label": "storefrontvisibility.test.ts",
-      "source_file": "packages/athena-webapp/shared/storefrontVisibility.test.ts",
       "source_location": "L1"
     },
     {
@@ -222240,6 +222273,15 @@
     {
       "community": 2120,
       "file_type": "code",
+      "id": "packages_athena_webapp_shared_storefrontvisibility_test_ts",
+      "label": "storefrontVisibility.test.ts",
+      "norm_label": "storefrontvisibility.test.ts",
+      "source_file": "packages/athena-webapp/shared/storefrontVisibility.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2121,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_approuter_ts",
       "label": "appRouter.ts",
       "norm_label": "approuter.ts",
@@ -222247,7 +222289,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2121,
+      "community": 2122,
       "file_type": "code",
       "id": "packages_athena_webapp_src_auth_convexauthurl_test_ts",
       "label": "convexAuthUrl.test.ts",
@@ -222256,7 +222298,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2122,
+      "community": 2123,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_genericcombobox_tsx",
       "label": "GenericComboBox.tsx",
@@ -222265,7 +222307,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2123,
+      "community": 2124,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_navbar_test_tsx",
       "label": "Navbar.test.tsx",
@@ -222274,7 +222316,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2124,
+      "community": 2125,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_navbar_tsx",
       "label": "Navbar.tsx",
@@ -222283,7 +222325,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2125,
+      "community": 2126,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationview_test_tsx",
       "label": "OrganizationView.test.tsx",
@@ -222292,7 +222334,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2126,
+      "community": 2127,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_protectedroute_test_tsx",
       "label": "ProtectedRoute.test.tsx",
@@ -222301,7 +222343,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2127,
+      "community": 2128,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeaccordion_tsx",
       "label": "StoreAccordion.tsx",
@@ -222310,21 +222352,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2128,
+      "community": 2129,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeview_test_tsx",
       "label": "StoreView.test.tsx",
       "norm_label": "storeview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/StoreView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2129,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_storesaccordion_tsx",
-      "label": "StoresAccordion.tsx",
-      "norm_label": "storesaccordion.tsx",
-      "source_file": "packages/athena-webapp/src/components/StoresAccordion.tsx",
       "source_location": "L1"
     },
     {
@@ -222438,6 +222471,15 @@
     {
       "community": 2130,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_storesaccordion_tsx",
+      "label": "StoresAccordion.tsx",
+      "norm_label": "storesaccordion.tsx",
+      "source_file": "packages/athena-webapp/src/components/StoresAccordion.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2131,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_themetoggle_tsx",
       "label": "ThemeToggle.tsx",
       "norm_label": "themetoggle.tsx",
@@ -222445,7 +222487,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2131,
+      "community": 2132,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_view_test_tsx",
       "label": "View.test.tsx",
@@ -222454,7 +222496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2132,
+      "community": 2133,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributestable_test_ts",
       "label": "AttributesTable.test.ts",
@@ -222463,7 +222505,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2133,
+      "community": 2134,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_defaultattributestogglegroup_tsx",
       "label": "DefaultAttributesToggleGroup.tsx",
@@ -222472,7 +222514,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2134,
+      "community": 2135,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -222481,7 +222523,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2135,
+      "community": 2136,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributesview_tsx",
       "label": "ProductAttributesView.tsx",
@@ -222490,7 +222532,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2136,
+      "community": 2137,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productcategorization_test_ts",
       "label": "ProductCategorization.test.ts",
@@ -222499,7 +222541,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2137,
+      "community": 2138,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productstock_test_ts",
       "label": "ProductStock.test.ts",
@@ -222508,21 +222550,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2138,
+      "community": 2139,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productview_test_tsx",
       "label": "ProductView.test.tsx",
       "norm_label": "productview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2139,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesview_test_tsx",
-      "label": "CopyImagesView.test.tsx",
-      "norm_label": "copyimagesview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -222636,6 +222669,15 @@
     {
       "community": 2140,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesview_test_tsx",
+      "label": "CopyImagesView.test.tsx",
+      "norm_label": "copyimagesview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2141,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
@@ -222643,7 +222685,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2141,
+      "community": 2142,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -222652,7 +222694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2142,
+      "community": 2143,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -222661,7 +222703,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2143,
+      "community": 2144,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -222670,7 +222712,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2144,
+      "community": 2145,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_types_ts",
       "label": "types.ts",
@@ -222679,7 +222721,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2145,
+      "community": 2146,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsview_test_tsx",
       "label": "AnalyticsView.test.tsx",
@@ -222688,7 +222730,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2146,
+      "community": 2147,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_conversionfunnelchart_tsx",
       "label": "ConversionFunnelChart.tsx",
@@ -222697,7 +222739,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2147,
+      "community": 2148,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_revenuechart_tsx",
       "label": "RevenueChart.tsx",
@@ -222706,21 +222748,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2148,
+      "community": 2149,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
       "label": "analytics-columns.tsx",
       "norm_label": "analytics-columns.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/analytics-columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2149,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
@@ -222834,6 +222867,15 @@
     {
       "community": 2150,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2151,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -222841,7 +222883,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2151,
+      "community": 2152,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -222850,7 +222892,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2152,
+      "community": 2153,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -222859,7 +222901,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2153,
+      "community": 2154,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -222868,7 +222910,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2154,
+      "community": 2155,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -222877,7 +222919,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2155,
+      "community": 2156,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -222886,7 +222928,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2156,
+      "community": 2157,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -222895,7 +222937,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2157,
+      "community": 2158,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -222904,21 +222946,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2158,
+      "community": 2159,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2159,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -223032,6 +223065,15 @@
     {
       "community": 2160,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2161,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -223039,7 +223081,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2161,
+      "community": 2162,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_chart_tsx",
       "label": "chart.tsx",
@@ -223048,7 +223090,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2162,
+      "community": 2163,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -223057,7 +223099,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2163,
+      "community": 2164,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -223066,7 +223108,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2164,
+      "community": 2165,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -223075,7 +223117,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2165,
+      "community": 2166,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_columns_tsx",
       "label": "columns.tsx",
@@ -223084,7 +223126,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2166,
+      "community": 2167,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_constants_ts",
       "label": "constants.ts",
@@ -223093,7 +223135,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2167,
+      "community": 2168,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -223102,21 +223144,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2168,
+      "community": 2169,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2169,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -223230,6 +223263,15 @@
     {
       "community": 2170,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2171,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_ts",
       "label": "data.ts",
       "norm_label": "data.ts",
@@ -223237,7 +223279,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2171,
+      "community": 2172,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -223246,7 +223288,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2172,
+      "community": 2173,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -223255,7 +223297,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2173,
+      "community": 2174,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -223264,7 +223306,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2174,
+      "community": 2175,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_columns_tsx",
       "label": "columns.tsx",
@@ -223273,7 +223315,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2175,
+      "community": 2176,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -223282,7 +223324,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2176,
+      "community": 2177,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -223291,7 +223333,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2177,
+      "community": 2178,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -223300,21 +223342,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2178,
+      "community": 2179,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2179,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_settings_appsettingsview_test_tsx",
-      "label": "AppSettingsView.test.tsx",
-      "norm_label": "appsettingsview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-settings/AppSettingsView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -223428,6 +223461,15 @@
     {
       "community": 2180,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_settings_appsettingsview_test_tsx",
+      "label": "AppSettingsView.test.tsx",
+      "norm_label": "appsettingsview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-settings/AppSettingsView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2181,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_sidebar_test_tsx",
       "label": "app-sidebar.test.tsx",
       "norm_label": "app-sidebar.test.tsx",
@@ -223435,7 +223477,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2181,
+      "community": 2182,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_assetscolumns_tsx",
       "label": "assetsColumns.tsx",
@@ -223444,7 +223486,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2182,
+      "community": 2183,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_constants_ts",
       "label": "constants.ts",
@@ -223453,7 +223495,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2183,
+      "community": 2184,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -223462,7 +223504,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2184,
+      "community": 2185,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -223471,7 +223513,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2185,
+      "community": 2186,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -223480,7 +223522,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2186,
+      "community": 2187,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_ts",
       "label": "data.ts",
@@ -223489,7 +223531,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2187,
+      "community": 2188,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_test_tsx",
       "label": "DefaultCatchBoundary.test.tsx",
@@ -223498,21 +223540,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2188,
+      "community": 2189,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
       "norm_label": "defaultcatchboundary.tsx",
       "source_file": "packages/athena-webapp/src/components/auth/DefaultCatchBoundary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2189,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_login_loginform_test_tsx",
-      "label": "LoginForm.test.tsx",
-      "norm_label": "loginform.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/LoginForm.test.tsx",
       "source_location": "L1"
     },
     {
@@ -223626,6 +223659,15 @@
     {
       "community": 2190,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_login_loginform_test_tsx",
+      "label": "LoginForm.test.tsx",
+      "norm_label": "loginform.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/LoginForm.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2191,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_posrecoverycodeform_test_tsx",
       "label": "PosRecoveryCodeForm.test.tsx",
       "norm_label": "posrecoverycodeform.test.tsx",
@@ -223633,7 +223675,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2191,
+      "community": 2192,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -223642,7 +223684,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2192,
+      "community": 2193,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -223651,7 +223693,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2193,
+      "community": 2194,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -223660,7 +223702,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2194,
+      "community": 2195,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -223669,7 +223711,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2195,
+      "community": 2196,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -223678,7 +223720,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2196,
+      "community": 2197,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_columns_tsx",
       "label": "columns.tsx",
@@ -223687,7 +223729,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2197,
+      "community": 2198,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_constants_ts",
       "label": "constants.ts",
@@ -223696,21 +223738,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2198,
+      "community": 2199,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
       "source_file": "packages/athena-webapp/src/components/base/table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -224184,6 +224217,15 @@
     {
       "community": 2200,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2201,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_test_tsx",
       "label": "data-table.test.tsx",
       "norm_label": "data-table.test.tsx",
@@ -224191,7 +224233,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2201,
+      "community": 2202,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -224200,7 +224242,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2202,
+      "community": 2203,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
       "label": "BulkOperationsPage.tsx",
@@ -224209,7 +224251,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2203,
+      "community": 2204,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_auth_test_tsx",
       "label": "CashControlsDashboard.auth.test.tsx",
@@ -224218,7 +224260,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2204,
+      "community": 2205,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_test_tsx",
       "label": "CashControlsDashboard.test.tsx",
@@ -224227,7 +224269,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2205,
+      "community": 2206,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsworkspaceheader_tsx",
       "label": "CashControlsWorkspaceHeader.tsx",
@@ -224236,7 +224278,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2206,
+      "community": 2207,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_auth_test_tsx",
       "label": "RegisterSessionView.auth.test.tsx",
@@ -224245,7 +224287,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2207,
+      "community": 2208,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_test_tsx",
       "label": "RegisterSessionView.test.tsx",
@@ -224254,21 +224296,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2208,
+      "community": 2209,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionsview_test_tsx",
       "label": "RegisterSessionsView.test.tsx",
       "norm_label": "registersessionsview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2209,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_formatreviewreason_test_ts",
-      "label": "formatReviewReason.test.ts",
-      "norm_label": "formatreviewreason.test.ts",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/formatReviewReason.test.ts",
       "source_location": "L1"
     },
     {
@@ -224382,6 +224415,15 @@
     {
       "community": 2210,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cash_controls_formatreviewreason_test_ts",
+      "label": "formatReviewReason.test.ts",
+      "norm_label": "formatreviewreason.test.ts",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/formatReviewReason.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2211,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessiontimestamps_test_ts",
       "label": "registerSessionTimestamps.test.ts",
       "norm_label": "registersessiontimestamps.test.ts",
@@ -224389,7 +224431,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2211,
+      "community": 2212,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_columns_tsx",
       "label": "columns.tsx",
@@ -224398,7 +224440,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2212,
+      "community": 2213,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -224407,7 +224449,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2213,
+      "community": 2214,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -224416,7 +224458,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2214,
+      "community": 2215,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_animateddatastate_test_tsx",
       "label": "AnimatedDataState.test.tsx",
@@ -224425,7 +224467,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2215,
+      "community": 2216,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_listpagination_test_tsx",
       "label": "ListPagination.test.tsx",
@@ -224434,7 +224476,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2216,
+      "community": 2217,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_listpagination_tsx",
       "label": "ListPagination.tsx",
@@ -224443,7 +224485,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2217,
+      "community": 2218,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_pageheader_test_tsx",
       "label": "PageHeader.test.tsx",
@@ -224452,21 +224494,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2218,
+      "community": 2219,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_pagelevelheader_test_tsx",
       "label": "PageLevelHeader.test.tsx",
       "norm_label": "pagelevelheader.test.tsx",
       "source_file": "packages/athena-webapp/src/components/common/PageLevelHeader.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2219,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_common_pagelevelheader_tsx",
-      "label": "PageLevelHeader.tsx",
-      "norm_label": "pagelevelheader.tsx",
-      "source_file": "packages/athena-webapp/src/components/common/PageLevelHeader.tsx",
       "source_location": "L1"
     },
     {
@@ -224580,6 +224613,15 @@
     {
       "community": 2220,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_common_pagelevelheader_tsx",
+      "label": "PageLevelHeader.tsx",
+      "norm_label": "pagelevelheader.tsx",
+      "source_file": "packages/athena-webapp/src/components/common/PageLevelHeader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2221,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
       "label": "MetricCard.tsx",
       "norm_label": "metriccard.tsx",
@@ -224587,7 +224629,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2221,
+      "community": 2222,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_docs_docsreportview_tsx",
       "label": "DocsReportView.tsx",
@@ -224596,7 +224638,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2222,
+      "community": 2223,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
       "label": "ExpenseCompletion.tsx",
@@ -224605,7 +224647,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2223,
+      "community": 2224,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_home_test_tsx",
       "label": "Home.test.tsx",
@@ -224614,7 +224656,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2224,
+      "community": 2225,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_homepageplacementproductimage_test_ts",
       "label": "HomepagePlacementProductImage.test.ts",
@@ -224623,7 +224665,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2225,
+      "community": 2226,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookimageuploader_test_tsx",
       "label": "ShopLookImageUploader.test.tsx",
@@ -224632,7 +224674,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2226,
+      "community": 2227,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_test_tsx",
       "label": "index.test.tsx",
@@ -224641,7 +224683,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2227,
+      "community": 2228,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_landing_story_demoday_test_ts",
       "label": "demoDay.test.ts",
@@ -224650,21 +224692,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2228,
+      "community": 2229,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_commandapprovaldialog_test_tsx",
       "label": "CommandApprovalDialog.test.tsx",
       "norm_label": "commandapprovaldialog.test.tsx",
       "source_file": "packages/athena-webapp/src/components/operations/CommandApprovalDialog.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2229,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_auth_test_tsx",
-      "label": "OperationsQueueView.auth.test.tsx",
-      "norm_label": "operationsqueueview.auth.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.auth.test.tsx",
       "source_location": "L1"
     },
     {
@@ -224778,6 +224811,15 @@
     {
       "community": 2230,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_operations_operationsqueueview_auth_test_tsx",
+      "label": "OperationsQueueView.auth.test.tsx",
+      "norm_label": "operationsqueueview.auth.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/OperationsQueueView.auth.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2231,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationssummarymetric_test_tsx",
       "label": "OperationsSummaryMetric.test.tsx",
       "norm_label": "operationssummarymetric.test.tsx",
@@ -224785,7 +224827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2231,
+      "community": 2232,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_skuactivitytimeline_test_tsx",
       "label": "SkuActivityTimeline.test.tsx",
@@ -224794,7 +224836,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2232,
+      "community": 2233,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_openworkinventoryreport_test_ts",
       "label": "openWorkInventoryReport.test.ts",
@@ -224803,7 +224845,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2233,
+      "community": 2234,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_skuactivitytimelineadapter_test_ts",
       "label": "skuActivityTimelineAdapter.test.ts",
@@ -224812,7 +224854,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2234,
+      "community": 2235,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_skuactivityuntrustedsalesadapter_test_ts",
       "label": "skuActivityUntrustedSalesAdapter.test.ts",
@@ -224821,7 +224863,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2235,
+      "community": 2236,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_useapprovedcommand_test_tsx",
       "label": "useApprovedCommand.test.tsx",
@@ -224830,7 +224872,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2236,
+      "community": 2237,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_customerdetailsview_test_tsx",
       "label": "CustomerDetailsView.test.tsx",
@@ -224839,7 +224881,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2237,
+      "community": 2238,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
       "label": "CustomerDetailsView.tsx",
@@ -224848,21 +224890,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2238,
+      "community": 2239,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderdetailsview_test_tsx",
       "label": "OrderDetailsView.test.tsx",
       "norm_label": "orderdetailsview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2239,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orderstatus_test_tsx",
-      "label": "OrderStatus.test.tsx",
-      "norm_label": "orderstatus.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderStatus.test.tsx",
       "source_location": "L1"
     },
     {
@@ -224967,6 +225000,15 @@
     {
       "community": 2240,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orderstatus_test_tsx",
+      "label": "OrderStatus.test.tsx",
+      "norm_label": "orderstatus.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderStatus.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2241,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_tsx",
       "label": "OrderStatus.tsx",
       "norm_label": "orderstatus.tsx",
@@ -224974,7 +225016,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2241,
+      "community": 2242,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -224983,7 +225025,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2242,
+      "community": 2243,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderview_test_tsx",
       "label": "OrderView.test.tsx",
@@ -224992,7 +225034,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2243,
+      "community": 2244,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersview_test_tsx",
       "label": "OrdersView.test.tsx",
@@ -225001,7 +225043,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2244,
+      "community": 2245,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_refundsview_test_tsx",
       "label": "RefundsView.test.tsx",
@@ -225010,7 +225052,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2245,
+      "community": 2246,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_test_tsx",
       "label": "ReturnExchangeView.test.tsx",
@@ -225019,7 +225061,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2246,
+      "community": 2247,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
       "label": "constants.ts",
@@ -225028,7 +225070,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2247,
+      "community": 2248,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -225037,21 +225079,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2248,
+      "community": 2249,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -225156,6 +225189,15 @@
     {
       "community": 2250,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2251,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_ts",
       "label": "data.ts",
       "norm_label": "data.ts",
@@ -225163,7 +225205,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2251,
+      "community": 2252,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_test_tsx",
       "label": "orderColumns.test.tsx",
@@ -225172,7 +225214,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2252,
+      "community": 2253,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_refundutils_test_ts",
       "label": "refundUtils.test.ts",
@@ -225181,7 +225223,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2253,
+      "community": 2254,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_utils_test_ts",
       "label": "utils.test.ts",
@@ -225190,7 +225232,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2254,
+      "community": 2255,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_constants_ts",
       "label": "constants.ts",
@@ -225199,7 +225241,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2255,
+      "community": 2256,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -225208,7 +225250,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2256,
+      "community": 2257,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -225217,7 +225259,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2257,
+      "community": 2258,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -225226,21 +225268,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2258,
+      "community": 2259,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2259,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data.ts",
       "source_location": "L1"
     },
     {
@@ -225345,6 +225378,15 @@
     {
       "community": 2260,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2261,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_invitecolumns_tsx",
       "label": "inviteColumns.tsx",
       "norm_label": "invitecolumns.tsx",
@@ -225352,7 +225394,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2261,
+      "community": 2262,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_constants_ts",
       "label": "constants.ts",
@@ -225361,7 +225403,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2262,
+      "community": 2263,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -225370,7 +225412,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2263,
+      "community": 2264,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -225379,7 +225421,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2264,
+      "community": 2265,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -225388,7 +225430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2265,
+      "community": 2266,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -225397,7 +225439,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2266,
+      "community": 2267,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
       "label": "data.ts",
@@ -225406,7 +225448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2267,
+      "community": 2268,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_memberscolumns_tsx",
       "label": "membersColumns.tsx",
@@ -225415,21 +225457,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2268,
+      "community": 2269,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_switcher_test_tsx",
       "label": "organization-switcher.test.tsx",
       "norm_label": "organization-switcher.test.tsx",
       "source_file": "packages/athena-webapp/src/components/organization-switcher.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2269,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
-      "label": "CashierView.tsx",
-      "norm_label": "cashierview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/CashierView.tsx",
       "source_location": "L1"
     },
     {
@@ -225534,6 +225567,15 @@
     {
       "community": 2270,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
+      "label": "CashierView.tsx",
+      "norm_label": "cashierview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/CashierView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2271,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_posregisterview_tsx",
       "label": "POSRegisterView.tsx",
       "norm_label": "posregisterview.tsx",
@@ -225541,7 +225583,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2271,
+      "community": 2272,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_paymentview_test_tsx",
       "label": "PaymentView.test.tsx",
@@ -225550,7 +225592,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2272,
+      "community": 2273,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pointofsaleview_test_tsx",
       "label": "PointOfSaleView.test.tsx",
@@ -225559,7 +225601,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2273,
+      "community": 2274,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productlookup_tsx",
       "label": "ProductLookup.tsx",
@@ -225568,7 +225610,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2274,
+      "community": 2275,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_registeractions_tsx",
       "label": "RegisterActions.tsx",
@@ -225577,7 +225619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2275,
+      "community": 2276,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_test_tsx",
       "label": "SessionManager.test.tsx",
@@ -225586,7 +225628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2276,
+      "community": 2277,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_tsx",
       "label": "SessionManager.tsx",
@@ -225595,7 +225637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2277,
+      "community": 2278,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_test_tsx",
       "label": "TotalsDisplay.test.tsx",
@@ -225604,21 +225646,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2278,
+      "community": 2279,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
       "label": "TotalsDisplay.tsx",
       "norm_label": "totalsdisplay.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2279,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_test_tsx",
-      "label": "ExpenseReportView.test.tsx",
-      "norm_label": "expensereportview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -225723,6 +225756,15 @@
     {
       "community": 2280,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_test_tsx",
+      "label": "ExpenseReportView.test.tsx",
+      "norm_label": "expensereportview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2281,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_test_ts",
       "label": "ExpenseReportsView.test.ts",
       "norm_label": "expensereportsview.test.ts",
@@ -225730,7 +225772,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2281,
+      "community": 2282,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_test_tsx",
       "label": "ExpenseReportsView.test.tsx",
@@ -225739,7 +225781,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2282,
+      "community": 2283,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportcolumns_tsx",
       "label": "expenseReportColumns.tsx",
@@ -225748,7 +225790,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2283,
+      "community": 2284,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_receipt_posreceiptsharecontrol_test_tsx",
       "label": "PosReceiptShareControl.test.tsx",
@@ -225757,7 +225799,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2284,
+      "community": 2285,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_posregisteropeningguard_test_tsx",
       "label": "POSRegisterOpeningGuard.test.tsx",
@@ -225766,7 +225808,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2285,
+      "community": 2286,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registeractionbar_test_tsx",
       "label": "RegisterActionBar.test.tsx",
@@ -225775,7 +225817,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2286,
+      "community": 2287,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registeractionbar_tsx",
       "label": "RegisterActionBar.tsx",
@@ -225784,7 +225826,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2287,
+      "community": 2288,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercheckoutpanel_test_tsx",
       "label": "RegisterCheckoutPanel.test.tsx",
@@ -225793,21 +225835,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2288,
+      "community": 2289,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_test_tsx",
       "label": "HeldSessionsList.test.tsx",
       "norm_label": "heldsessionslist.test.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2289,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_sessions_possessionsview_test_tsx",
-      "label": "POSSessionsView.test.tsx",
-      "norm_label": "possessionsview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -225912,6 +225945,15 @@
     {
       "community": 2290,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_sessions_possessionsview_test_tsx",
+      "label": "POSSessionsView.test.tsx",
+      "norm_label": "possessionsview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2291,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessions_possessioncolumns_tsx",
       "label": "posSessionColumns.tsx",
       "norm_label": "possessioncolumns.tsx",
@@ -225919,7 +225961,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2291,
+      "community": 2292,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_terminals_posterminaldetailview_test_tsx",
       "label": "POSTerminalDetailView.test.tsx",
@@ -225928,7 +225970,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2292,
+      "community": 2293,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_terminals_terminalhealthpresentation_test_ts",
       "label": "terminalHealthPresentation.test.ts",
@@ -225937,7 +225979,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2293,
+      "community": 2294,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_terminals_terminalhealthtypes_ts",
       "label": "terminalHealthTypes.ts",
@@ -225946,7 +225988,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2294,
+      "community": 2295,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_test_tsx",
       "label": "TransactionsView.test.tsx",
@@ -225955,7 +225997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2295,
+      "community": 2296,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_types_ts",
       "label": "types.ts",
@@ -225964,7 +226006,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2296,
+      "community": 2297,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_receivingview_test_tsx",
       "label": "ReceivingView.test.tsx",
@@ -225973,7 +226015,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2297,
+      "community": 2298,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
       "label": "AnalyticsInsights.tsx",
@@ -225982,21 +226024,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2298,
+      "community": 2299,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_attributesview_tsx",
       "label": "AttributesView.tsx",
       "norm_label": "attributesview.tsx",
       "source_file": "packages/athena-webapp/src/components/product/AttributesView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2299,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_detailsview_tsx",
-      "label": "DetailsView.tsx",
-      "norm_label": "detailsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/DetailsView.tsx",
       "source_location": "L1"
     },
     {
@@ -226452,6 +226485,15 @@
     {
       "community": 2300,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_detailsview_tsx",
+      "label": "DetailsView.tsx",
+      "norm_label": "detailsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/DetailsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2301,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_imagesview_test_tsx",
       "label": "ImagesView.test.tsx",
       "norm_label": "imagesview.test.tsx",
@@ -226459,7 +226501,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2301,
+      "community": 2302,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productdetailview_test_tsx",
       "label": "ProductDetailView.test.tsx",
@@ -226468,7 +226510,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2302,
+      "community": 2303,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productoperationaltimeline_test_tsx",
       "label": "ProductOperationalTimeline.test.tsx",
@@ -226477,7 +226519,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2303,
+      "community": 2304,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstockpresentation_test_ts",
       "label": "productStockPresentation.test.ts",
@@ -226486,7 +226528,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2304,
+      "community": 2305,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_archivedproducts_test_tsx",
       "label": "ArchivedProducts.test.tsx",
@@ -226495,7 +226537,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2305,
+      "community": 2306,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsubcategorytogglegroup_tsx",
       "label": "ProductSubcategoryToggleGroup.tsx",
@@ -226504,7 +226546,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2306,
+      "community": 2307,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productslistview_test_ts",
       "label": "ProductsListView.test.ts",
@@ -226513,7 +226555,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2307,
+      "community": 2308,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productslistview_test_tsx",
       "label": "ProductsListView.test.tsx",
@@ -226522,21 +226564,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2308,
+      "community": 2309,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproducts_tsx",
       "label": "StoreProducts.tsx",
       "norm_label": "storeproducts.tsx",
       "source_file": "packages/athena-webapp/src/components/products/StoreProducts.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_unresolvedproducts_test_tsx",
-      "label": "UnresolvedProducts.test.tsx",
-      "norm_label": "unresolvedproducts.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/UnresolvedProducts.test.tsx",
       "source_location": "L1"
     },
     {
@@ -226641,6 +226674,15 @@
     {
       "community": 2310,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_unresolvedproducts_test_tsx",
+      "label": "UnresolvedProducts.test.tsx",
+      "norm_label": "unresolvedproducts.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/UnresolvedProducts.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2311,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_unresolvedproducts_tsx",
       "label": "UnresolvedProducts.tsx",
       "norm_label": "unresolvedproducts.tsx",
@@ -226648,7 +226690,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2311,
+      "community": 2312,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproducts_tsx",
       "label": "ComplimentaryProducts.tsx",
@@ -226657,7 +226699,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2312,
+      "community": 2313,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductscolumn_tsx",
       "label": "complimentaryProductsColumn.tsx",
@@ -226666,7 +226708,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2313,
+      "community": 2314,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -226675,7 +226717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2314,
+      "community": 2315,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -226684,7 +226726,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2315,
+      "community": 2316,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_test_tsx",
       "label": "data-table-toolbar.test.tsx",
@@ -226693,7 +226735,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2316,
+      "community": 2317,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -226702,7 +226744,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2317,
+      "community": 2318,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_test_tsx",
       "label": "data-table.test.tsx",
@@ -226711,21 +226753,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2318,
+      "community": 2319,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_ts",
       "label": "data.ts",
       "norm_label": "data.ts",
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/data.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2319,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_productcolumns_tsx",
-      "label": "productColumns.tsx",
-      "norm_label": "productcolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/productColumns.tsx",
       "source_location": "L1"
     },
     {
@@ -226830,6 +226863,15 @@
     {
       "community": 2320,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_productcolumns_tsx",
+      "label": "productColumns.tsx",
+      "norm_label": "productcolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/productColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2321,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_test_tsx",
       "label": "PromoCodeHeader.test.tsx",
       "norm_label": "promocodeheader.test.tsx",
@@ -226837,7 +226879,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2321,
+      "community": 2322,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodes_tsx",
       "label": "PromoCodes.tsx",
@@ -226846,7 +226888,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2322,
+      "community": 2323,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_analytics_promocodeanalytics_tsx",
       "label": "PromoCodeAnalytics.tsx",
@@ -226855,7 +226897,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2323,
+      "community": 2324,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_captured_emails_columns_tsx",
       "label": "captured-emails-columns.tsx",
@@ -226864,7 +226906,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2324,
+      "community": 2325,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_test_ts",
       "label": "promoCodeMoney.test.ts",
@@ -226873,7 +226915,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2325,
+      "community": 2326,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -226882,7 +226924,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2326,
+      "community": 2327,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -226891,7 +226933,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2327,
+      "community": 2328,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -226900,21 +226942,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2328,
+      "community": 2329,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2329,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -227019,6 +227052,15 @@
     {
       "community": 2330,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2331,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
@@ -227026,7 +227068,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2331,
+      "community": 2332,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_constants_ts",
       "label": "constants.ts",
@@ -227035,7 +227077,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2332,
+      "community": 2333,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -227044,7 +227086,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2333,
+      "community": 2334,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -227053,7 +227095,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2334,
+      "community": 2335,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -227062,7 +227104,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2335,
+      "community": 2336,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_ts",
       "label": "data.ts",
@@ -227071,7 +227113,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2336,
+      "community": 2337,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_types_ts",
       "label": "types.ts",
@@ -227080,7 +227122,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2337,
+      "community": 2338,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_welcome_offer_card_tsx",
       "label": "welcome-offer-card.tsx",
@@ -227089,21 +227131,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2338,
+      "community": 2339,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_remote_assist_posremoteassistruntimehost_test_tsx",
       "label": "PosRemoteAssistRuntimeHost.test.tsx",
       "norm_label": "posremoteassistruntimehost.test.tsx",
       "source_file": "packages/athena-webapp/src/components/remote-assist/PosRemoteAssistRuntimeHost.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2339,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_remote_assist_remoteassistliveviewer_test_tsx",
-      "label": "RemoteAssistLiveViewer.test.tsx",
-      "norm_label": "remoteassistliveviewer.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/remote-assist/RemoteAssistLiveViewer.test.tsx",
       "source_location": "L1"
     },
     {
@@ -227208,6 +227241,15 @@
     {
       "community": 2340,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_remote_assist_remoteassistliveviewer_test_tsx",
+      "label": "RemoteAssistLiveViewer.test.tsx",
+      "norm_label": "remoteassistliveviewer.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/remote-assist/RemoteAssistLiveViewer.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2341,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_remote_assist_remoteassistruntimeshell_test_tsx",
       "label": "RemoteAssistRuntimeShell.test.tsx",
       "norm_label": "remoteassistruntimeshell.test.tsx",
@@ -227215,7 +227257,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2341,
+      "community": 2342,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_remote_assist_remoteassistsupportconsole_tsx",
       "label": "RemoteAssistSupportConsole.tsx",
@@ -227224,7 +227266,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2342,
+      "community": 2343,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_remote_assist_index_ts",
       "label": "index.ts",
@@ -227233,7 +227275,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2343,
+      "community": 2344,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportcalendar_test_tsx",
       "label": "ReportCalendar.test.tsx",
@@ -227242,7 +227284,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2344,
+      "community": 2345,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportcustomrangepanel_test_tsx",
       "label": "ReportCustomRangePanel.test.tsx",
@@ -227251,7 +227293,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2345,
+      "community": 2346,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportdaterangefield_test_tsx",
       "label": "ReportDateRangeField.test.tsx",
@@ -227260,7 +227302,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2346,
+      "community": 2347,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportsegmentedtabs_test_tsx",
       "label": "ReportSegmentedTabs.test.tsx",
@@ -227269,7 +227311,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2347,
+      "community": 2348,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportsegmentedtabs_tsx",
       "label": "ReportSegmentedTabs.tsx",
@@ -227278,21 +227320,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2348,
+      "community": 2349,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportskumixchart_test_tsx",
       "label": "ReportSkuMixChart.test.tsx",
       "norm_label": "reportskumixchart.test.tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportSkuMixChart.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2349,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reports_reportformat_test_ts",
-      "label": "reportFormat.test.ts",
-      "norm_label": "reportformat.test.ts",
-      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.test.ts",
       "source_location": "L1"
     },
     {
@@ -227397,6 +227430,15 @@
     {
       "community": 2350,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_reports_reportformat_test_ts",
+      "label": "reportFormat.test.ts",
+      "norm_label": "reportformat.test.ts",
+      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2351,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportperiodkeys_test_ts",
       "label": "reportPeriodKeys.test.ts",
       "norm_label": "reportperiodkeys.test.ts",
@@ -227404,7 +227446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2351,
+      "community": 2352,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportroutesearch_test_ts",
       "label": "reportRouteSearch.test.ts",
@@ -227413,7 +227455,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2352,
+      "community": 2353,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_ratingstars_tsx",
       "label": "RatingStars.tsx",
@@ -227422,7 +227464,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2353,
+      "community": 2354,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
       "label": "ReviewCard.tsx",
@@ -227431,7 +227473,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2354,
+      "community": 2355,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewmetadata_tsx",
       "label": "ReviewMetadata.tsx",
@@ -227440,7 +227482,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2355,
+      "community": 2356,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeform_tsx",
       "label": "ServiceIntakeForm.tsx",
@@ -227449,7 +227491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2356,
+      "community": 2357,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemoexperience_test_tsx",
       "label": "SharedDemoExperience.test.tsx",
@@ -227458,7 +227500,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2357,
+      "community": 2358,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemorestoreoverlay_test_tsx",
       "label": "SharedDemoRestoreOverlay.test.tsx",
@@ -227467,21 +227509,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2358,
+      "community": 2359,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemolocalbootstrap_test_ts",
       "label": "sharedDemoLocalBootstrap.test.ts",
       "norm_label": "shareddemolocalbootstrap.test.ts",
       "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLocalBootstrap.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2359,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_shared_demo_shareddemorestoreoverlay_test_ts",
-      "label": "sharedDemoRestoreOverlay.test.ts",
-      "norm_label": "shareddemorestoreoverlay.test.ts",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoRestoreOverlay.test.ts",
       "source_location": "L1"
     },
     {
@@ -227586,6 +227619,15 @@
     {
       "community": 2360,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_shared_demo_shareddemorestoreoverlay_test_ts",
+      "label": "sharedDemoRestoreOverlay.test.ts",
+      "norm_label": "shareddemorestoreoverlay.test.ts",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoRestoreOverlay.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2361,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemorestoreoverlay_tsx",
       "label": "sharedDemoRestoreOverlay.tsx",
       "norm_label": "shareddemorestoreoverlay.tsx",
@@ -227593,7 +227635,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2361,
+      "community": 2362,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_index_tsx",
       "label": "index.tsx",
@@ -227602,7 +227644,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2362,
+      "community": 2363,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_auth_staffauthenticationdialog_test_tsx",
       "label": "StaffAuthenticationDialog.test.tsx",
@@ -227611,7 +227653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2363,
+      "community": 2364,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_auth_staffpininput_tsx",
       "label": "StaffPinInput.tsx",
@@ -227620,7 +227662,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2364,
+      "community": 2365,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfound_test_tsx",
       "label": "NotFound.test.tsx",
@@ -227629,7 +227671,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2365,
+      "community": 2366,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_stock_ops_skusearchfilterbar_tsx",
       "label": "SkuSearchFilterBar.tsx",
@@ -227638,7 +227680,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2366,
+      "community": 2367,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_test_ts",
       "label": "FeesView.test.ts",
@@ -227647,7 +227689,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2367,
+      "community": 2368,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_fulfillmentview_test_tsx",
       "label": "FulfillmentView.test.tsx",
@@ -227656,21 +227698,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2368,
+      "community": 2369,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_test_tsx",
       "label": "MaintenanceView.test.tsx",
       "norm_label": "maintenanceview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2369,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_test_tsx",
-      "label": "MtnMomoView.test.tsx",
-      "norm_label": "mtnmomoview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -227775,6 +227808,15 @@
     {
       "community": 2370,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_test_tsx",
+      "label": "MtnMomoView.test.tsx",
+      "norm_label": "mtnmomoview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2371,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_test_tsx",
       "label": "useStoreConfigUpdate.test.tsx",
       "norm_label": "usestoreconfigupdate.test.tsx",
@@ -227782,7 +227824,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2371,
+      "community": 2372,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestorescheduleupdate_test_tsx",
       "label": "useStoreScheduleUpdate.test.tsx",
@@ -227791,7 +227833,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2372,
+      "community": 2373,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_index_tsx",
       "label": "index.tsx",
@@ -227800,7 +227842,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2373,
+      "community": 2374,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceview_test_tsx",
       "label": "WorkflowTraceView.test.tsx",
@@ -227809,7 +227851,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2374,
+      "community": 2375,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -227818,7 +227860,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2375,
+      "community": 2376,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_test_tsx",
       "label": "button.test.tsx",
@@ -227827,7 +227869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2376,
+      "community": 2377,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -227836,7 +227878,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2377,
+      "community": 2378,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
       "label": "calendar.test.tsx",
@@ -227845,21 +227887,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2378,
+      "community": 2379,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
       "norm_label": "card.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/card.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2379,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_checkbox_tsx",
-      "label": "checkbox.tsx",
-      "norm_label": "checkbox.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/checkbox.tsx",
       "source_location": "L1"
     },
     {
@@ -227964,6 +227997,15 @@
     {
       "community": 2380,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_checkbox_tsx",
+      "label": "checkbox.tsx",
+      "norm_label": "checkbox.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/checkbox.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2381,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_collapsible_tsx",
       "label": "collapsible.tsx",
       "norm_label": "collapsible.tsx",
@@ -227971,7 +228013,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2381,
+      "community": 2382,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -227980,7 +228022,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2382,
+      "community": 2383,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
@@ -227989,7 +228031,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2383,
+      "community": 2384,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
@@ -227998,7 +228040,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2384,
+      "community": 2385,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
@@ -228007,7 +228049,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2385,
+      "community": 2386,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -228016,7 +228058,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2386,
+      "community": 2387,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -228025,7 +228067,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2387,
+      "community": 2388,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -228034,21 +228076,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2388,
+      "community": 2389,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_test_tsx",
       "label": "input.test.tsx",
       "norm_label": "input.test.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/input.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2389,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_input_tsx",
-      "label": "input.tsx",
-      "norm_label": "input.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/input.tsx",
       "source_location": "L1"
     },
     {
@@ -228153,6 +228186,15 @@
     {
       "community": 2390,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_input_tsx",
+      "label": "input.tsx",
+      "norm_label": "input.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/input.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2391,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
       "norm_label": "action-modal.tsx",
@@ -228160,7 +228202,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2391,
+      "community": 2392,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_panel_header_tsx",
       "label": "panel-header.tsx",
@@ -228169,7 +228211,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2392,
+      "community": 2393,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -228178,7 +228220,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2393,
+      "community": 2394,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_primitives_test_tsx",
       "label": "primitives.test.tsx",
@@ -228187,7 +228229,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2394,
+      "community": 2395,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -228196,7 +228238,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2395,
+      "community": 2396,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -228205,7 +228247,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2396,
+      "community": 2397,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -228214,7 +228256,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2397,
+      "community": 2398,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -228223,21 +228265,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2398,
+      "community": 2399,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
       "norm_label": "sheet.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/sheet.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2399,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_switch_tsx",
-      "label": "switch.tsx",
-      "norm_label": "switch.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/switch.tsx",
       "source_location": "L1"
     },
     {
@@ -228693,6 +228726,15 @@
     {
       "community": 2400,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_switch_tsx",
+      "label": "switch.tsx",
+      "norm_label": "switch.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/switch.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2401,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_table_test_tsx",
       "label": "table.test.tsx",
       "norm_label": "table.test.tsx",
@@ -228700,7 +228742,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2401,
+      "community": 2402,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -228709,7 +228751,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2402,
+      "community": 2403,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -228718,7 +228760,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2403,
+      "community": 2404,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -228727,7 +228769,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2404,
+      "community": 2405,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -228736,7 +228778,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2405,
+      "community": 2406,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -228745,7 +228787,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2406,
+      "community": 2407,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
@@ -228754,7 +228796,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2407,
+      "community": 2408,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_upload_button_tsx",
       "label": "upload-button.tsx",
@@ -228763,21 +228805,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2408,
+      "community": 2409,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
       "label": "BagView.tsx",
       "norm_label": "bagview.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/BagView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2409,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/columns.tsx",
       "source_location": "L1"
     },
     {
@@ -228882,6 +228915,15 @@
     {
       "community": 2410,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2411,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
@@ -228889,7 +228931,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2411,
+      "community": 2412,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -228898,7 +228940,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2412,
+      "community": 2413,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -228907,7 +228949,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2413,
+      "community": 2414,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -228916,7 +228958,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2414,
+      "community": 2415,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
       "label": "data.ts",
@@ -228925,7 +228967,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2415,
+      "community": 2416,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
       "label": "bag-columns.tsx",
@@ -228934,7 +228976,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2416,
+      "community": 2417,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
       "label": "bags-table.tsx",
@@ -228943,7 +228985,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2417,
+      "community": 2418,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
       "label": "columns.tsx",
@@ -228952,21 +228994,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2418,
+      "community": 2419,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2419,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -229071,6 +229104,15 @@
     {
       "community": 2420,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2421,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
@@ -229078,7 +229120,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2421,
+      "community": 2422,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -229087,7 +229129,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2422,
+      "community": 2423,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
       "label": "LinkedAccounts.tsx",
@@ -229096,7 +229138,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2423,
+      "community": 2424,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
       "label": "TimelineEventCard.test.tsx",
@@ -229105,7 +229147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2424,
+      "community": 2425,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
       "label": "UserCheckoutSession.tsx",
@@ -229114,7 +229156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2425,
+      "community": 2426,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
       "label": "index.ts",
@@ -229123,7 +229165,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2426,
+      "community": 2427,
       "file_type": "code",
       "id": "packages_athena_webapp_src_config_test_ts",
       "label": "config.test.ts",
@@ -229132,7 +229174,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2427,
+      "community": 2428,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexttracking_docsworkspacetracking_test_ts",
       "label": "docsWorkspaceTracking.test.ts",
@@ -229141,21 +229183,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2428,
+      "community": 2429,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
       "label": "ThemeContext.tsx",
       "norm_label": "themecontext.tsx",
       "source_file": "packages/athena-webapp/src/contexts/ThemeContext.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2429,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_contexts_onlineordersessionoverlay_test_ts",
-      "label": "onlineOrderSessionOverlay.test.ts",
-      "norm_label": "onlineordersessionoverlay.test.ts",
-      "source_file": "packages/athena-webapp/src/contexts/onlineOrderSessionOverlay.test.ts",
       "source_location": "L1"
     },
     {
@@ -229260,6 +229293,15 @@
     {
       "community": 2430,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_contexts_onlineordersessionoverlay_test_ts",
+      "label": "onlineOrderSessionOverlay.test.ts",
+      "norm_label": "onlineordersessionoverlay.test.ts",
+      "source_file": "packages/athena-webapp/src/contexts/onlineOrderSessionOverlay.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2431,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_design_system_build_config_test_ts",
       "label": "design-system-build-config.test.ts",
       "norm_label": "design-system-build-config.test.ts",
@@ -229267,7 +229309,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2431,
+      "community": 2432,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_pagination_persistence_test_ts",
       "label": "use-pagination-persistence.test.ts",
@@ -229276,7 +229318,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2432,
+      "community": 2433,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
@@ -229285,7 +229327,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2433,
+      "community": 2434,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_test_tsx",
       "label": "useAuth.test.tsx",
@@ -229294,7 +229336,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2434,
+      "community": 2435,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_test_ts",
       "label": "useExpenseSessions.test.ts",
@@ -229303,7 +229345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2435,
+      "community": 2436,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactivestore_test_ts",
       "label": "useGetActiveStore.test.ts",
@@ -229312,7 +229354,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2436,
+      "community": 2437,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetterminal_test_ts",
       "label": "useGetTerminal.test.ts",
@@ -229321,7 +229363,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2437,
+      "community": 2438,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
@@ -229330,21 +229372,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2438,
+      "community": 2439,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useposproducts_test_ts",
       "label": "usePOSProducts.test.ts",
       "norm_label": "useposproducts.test.ts",
       "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2439,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useprotectedadminpagestate_test_tsx",
-      "label": "useProtectedAdminPageState.test.tsx",
-      "norm_label": "useprotectedadminpagestate.test.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/useProtectedAdminPageState.test.tsx",
       "source_location": "L1"
     },
     {
@@ -229440,6 +229473,15 @@
     {
       "community": 2440,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useprotectedadminpagestate_test_tsx",
+      "label": "useProtectedAdminPageState.test.tsx",
+      "norm_label": "useprotectedadminpagestate.test.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/useProtectedAdminPageState.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2441,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useshareddemocontext_test_ts",
       "label": "useSharedDemoContext.test.ts",
       "norm_label": "useshareddemocontext.test.ts",
@@ -229447,7 +229489,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2441,
+      "community": 2442,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usestoreoperatingclock_test_tsx",
       "label": "useStoreOperatingClock.test.tsx",
@@ -229456,7 +229498,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2442,
+      "community": 2443,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_access_capabilities_test_ts",
       "label": "capabilities.test.ts",
@@ -229465,7 +229507,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2443,
+      "community": 2444,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_messages_appmessagescontext_ts",
       "label": "AppMessagesContext.ts",
@@ -229474,7 +229516,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2444,
+      "community": 2445,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_messages_appmessagecommunicationpreferencecontext_ts",
       "label": "appMessageCommunicationPreferenceContext.ts",
@@ -229483,7 +229525,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2445,
+      "community": 2446,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_messages_index_ts",
       "label": "index.ts",
@@ -229492,7 +229534,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2446,
+      "community": 2447,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_update_appupdateactions_ts",
       "label": "appUpdateActions.ts",
@@ -229501,7 +229543,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2447,
+      "community": 2448,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_update_index_ts",
       "label": "index.ts",
@@ -229510,21 +229552,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2448,
+      "community": 2449,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_update_updatecommunicationpreferencecontext_ts",
       "label": "updateCommunicationPreferenceContext.ts",
       "norm_label": "updatecommunicationpreferencecontext.ts",
       "source_file": "packages/athena-webapp/src/lib/app-update/updateCommunicationPreferenceContext.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2449,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_app_update_updatecoordinator_test_ts",
-      "label": "updateCoordinator.test.ts",
-      "norm_label": "updatecoordinator.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/app-update/updateCoordinator.test.ts",
       "source_location": "L1"
     },
     {
@@ -229620,6 +229653,15 @@
     {
       "community": 2450,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_app_update_updatecoordinator_test_ts",
+      "label": "updateCoordinator.test.ts",
+      "norm_label": "updatecoordinator.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/app-update/updateCoordinator.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2451,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_aws_ts",
       "label": "aws.ts",
       "norm_label": "aws.ts",
@@ -229627,7 +229669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2451,
+      "community": 2452,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -229636,7 +229678,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2452,
+      "community": 2453,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -229645,7 +229687,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2453,
+      "community": 2454,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_docs_access_test_ts",
       "label": "access.test.ts",
@@ -229654,7 +229696,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2454,
+      "community": 2455,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_docs_content_test_ts",
       "label": "content.test.ts",
@@ -229663,7 +229705,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2455,
+      "community": 2456,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_docs_navigation_test_ts",
       "label": "navigation.test.ts",
@@ -229672,7 +229714,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2456,
+      "community": 2457,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_docs_parsing_test_ts",
       "label": "parsing.test.ts",
@@ -229681,7 +229723,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2457,
+      "community": 2458,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_docs_reportcontract_test_ts",
       "label": "reportContract.test.ts",
@@ -229690,21 +229732,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2458,
+      "community": 2459,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_docs_scrollprogress_test_ts",
       "label": "scrollProgress.test.ts",
       "norm_label": "scrollprogress.test.ts",
       "source_file": "packages/athena-webapp/src/lib/docs/scrollProgress.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2459,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_docs_virtual_docs_index_d_ts",
-      "label": "virtual-docs-index.d.ts",
-      "norm_label": "virtual-docs-index.d.ts",
-      "source_file": "packages/athena-webapp/src/lib/docs/virtual-docs-index.d.ts",
       "source_location": "L1"
     },
     {
@@ -229800,6 +229833,15 @@
     {
       "community": 2460,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_docs_virtual_docs_index_d_ts",
+      "label": "virtual-docs-index.d.ts",
+      "norm_label": "virtual-docs-index.d.ts",
+      "source_file": "packages/athena-webapp/src/lib/docs/virtual-docs-index.d.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2461,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_operatormessages_test_ts",
       "label": "operatorMessages.test.ts",
       "norm_label": "operatormessages.test.ts",
@@ -229807,7 +229849,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2461,
+      "community": 2462,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_test_ts",
       "label": "presentCommandToast.test.ts",
@@ -229816,7 +229858,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2462,
+      "community": 2463,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_test_ts",
       "label": "presentUnexpectedErrorToast.test.ts",
@@ -229825,7 +229867,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2463,
+      "community": 2464,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_test_ts",
       "label": "runCommand.test.ts",
@@ -229834,7 +229876,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2464,
+      "community": 2465,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -229843,7 +229885,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2465,
+      "community": 2466,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -229852,7 +229894,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2466,
+      "community": 2467,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_inventory_import_inventoryimportparser_test_ts",
       "label": "inventoryImportParser.test.ts",
@@ -229861,7 +229903,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2467,
+      "community": 2468,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_marketing_landingfunnelclient_test_ts",
       "label": "landingFunnelClient.test.ts",
@@ -229870,21 +229912,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2468,
+      "community": 2469,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_marketing_walkthroughprivacy_ts",
       "label": "walkthroughPrivacy.ts",
       "norm_label": "walkthroughprivacy.ts",
       "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughPrivacy.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2469,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_marketing_walkthroughrequestclient_test_ts",
-      "label": "walkthroughRequestClient.test.ts",
-      "norm_label": "walkthroughrequestclient.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.test.ts",
       "source_location": "L1"
     },
     {
@@ -229980,6 +230013,15 @@
     {
       "community": 2470,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_marketing_walkthroughrequestclient_test_ts",
+      "label": "walkthroughRequestClient.test.ts",
+      "norm_label": "walkthroughrequestclient.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2471,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_navigation_appentryroutes_test_ts",
       "label": "appEntryRoutes.test.ts",
       "norm_label": "appentryroutes.test.ts",
@@ -229987,7 +230029,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2471,
+      "community": 2472,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_navigation_storeentryroute_test_ts",
       "label": "storeEntryRoute.test.ts",
@@ -229996,7 +230038,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2472,
+      "community": 2473,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_operations_operatingdate_test_ts",
       "label": "operatingDate.test.ts",
@@ -230005,7 +230047,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2473,
+      "community": 2474,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_dto_ts",
       "label": "dto.ts",
@@ -230014,7 +230056,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2474,
+      "community": 2475,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_ports_ts",
       "label": "ports.ts",
@@ -230023,7 +230065,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2475,
+      "community": 2476,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_poslocalstoreport_ts",
       "label": "posLocalStorePort.ts",
@@ -230032,7 +230074,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2476,
+      "community": 2477,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_results_test_ts",
       "label": "results.test.ts",
@@ -230041,7 +230083,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2477,
+      "community": 2478,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_constants_ts",
       "label": "constants.ts",
@@ -230050,21 +230092,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2478,
+      "community": 2479,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
       "label": "displayAmounts.test.ts",
       "norm_label": "displayamounts.test.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2479,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_cart_test_ts",
-      "label": "cart.test.ts",
-      "norm_label": "cart.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.test.ts",
       "source_location": "L1"
     },
     {
@@ -230160,6 +230193,15 @@
     {
       "community": 2480,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_domain_cart_test_ts",
+      "label": "cart.test.ts",
+      "norm_label": "cart.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2481,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
@@ -230167,7 +230209,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2481,
+      "community": 2482,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_session_test_ts",
       "label": "session.test.ts",
@@ -230176,7 +230218,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2482,
+      "community": 2483,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_types_ts",
       "label": "types.ts",
@@ -230185,7 +230227,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2483,
+      "community": 2484,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_expensereceipt_test_ts",
       "label": "expenseReceipt.test.ts",
@@ -230194,7 +230236,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2484,
+      "community": 2485,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_test_ts",
       "label": "registerGateway.test.ts",
@@ -230203,7 +230245,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2485,
+      "community": 2486,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registerlifecycleauthoritygateway_test_ts",
       "label": "registerLifecycleAuthorityGateway.test.ts",
@@ -230212,7 +230254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2486,
+      "community": 2487,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_test_ts",
       "label": "sessionGateway.test.ts",
@@ -230221,7 +230263,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2487,
+      "community": 2488,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_drawerauthorityreconciliation_test_ts",
       "label": "drawerAuthorityReconciliation.test.ts",
@@ -230230,21 +230272,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2488,
+      "community": 2489,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_indexeddbposlocalstorageengine_test_ts",
       "label": "indexedDbPosLocalStorageEngine.test.ts",
       "norm_label": "indexeddbposlocalstorageengine.test.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/indexedDbPosLocalStorageEngine.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2489,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localposentrycontext_test_ts",
-      "label": "localPosEntryContext.test.ts",
-      "norm_label": "localposentrycontext.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosEntryContext.test.ts",
       "source_location": "L1"
     },
     {
@@ -230340,6 +230373,15 @@
     {
       "community": 2490,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localposentrycontext_test_ts",
+      "label": "localPosEntryContext.test.ts",
+      "norm_label": "localposentrycontext.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosEntryContext.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2491,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localposreadiness_test_ts",
       "label": "localPosReadiness.test.ts",
       "norm_label": "localposreadiness.test.ts",
@@ -230347,7 +230389,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2491,
+      "community": 2492,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalledgerpolicy_test_ts",
       "label": "posLocalLedgerPolicy.test.ts",
@@ -230356,7 +230398,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2492,
+      "community": 2493,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoragehealth_test_ts",
       "label": "posLocalStorageHealth.test.ts",
@@ -230365,7 +230407,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2493,
+      "community": 2494,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstorageruntime_test_ts",
       "label": "posLocalStorageRuntime.test.ts",
@@ -230374,7 +230416,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2494,
+      "community": 2495,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoreinitialization_test_ts",
       "label": "posLocalStoreInitialization.test.ts",
@@ -230383,7 +230425,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2495,
+      "community": 2496,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoremaintenance_test_ts",
       "label": "posLocalStoreMaintenance.test.ts",
@@ -230392,7 +230434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2496,
+      "community": 2497,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoremigrations_test_ts",
       "label": "posLocalStoreMigrations.test.ts",
@@ -230401,7 +230443,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2497,
+      "community": 2498,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoresnapshot_test_ts",
       "label": "posLocalStoreSnapshot.test.ts",
@@ -230410,21 +230452,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2498,
+      "community": 2499,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registercatalogpinruntime_test_ts",
       "label": "registerCatalogPinRuntime.test.ts",
       "norm_label": "registercatalogpinruntime.test.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2499,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registerlifecycleauthorityrollout_test_ts",
-      "label": "registerLifecycleAuthorityRollout.test.ts",
-      "norm_label": "registerlifecycleauthorityrollout.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerLifecycleAuthorityRollout.test.ts",
       "source_location": "L1"
     },
     {
@@ -230871,6 +230904,15 @@
     {
       "community": 2500,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registerlifecycleauthorityrollout_test_ts",
+      "label": "registerLifecycleAuthorityRollout.test.ts",
+      "norm_label": "registerlifecycleauthorityrollout.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerLifecycleAuthorityRollout.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2501,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registersessionauthoritybootstrap_test_ts",
       "label": "registerSessionAuthorityBootstrap.test.ts",
       "norm_label": "registersessionauthoritybootstrap.test.ts",
@@ -230878,7 +230920,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2501,
+      "community": 2502,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_saleblockerpolicy_test_ts",
       "label": "saleBlockerPolicy.test.ts",
@@ -230887,7 +230929,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2502,
+      "community": 2503,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_syncgapdiagnosis_test_ts",
       "label": "syncGapDiagnosis.test.ts",
@@ -230896,7 +230938,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2503,
+      "community": 2504,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_printattempttelemetry_test_ts",
       "label": "printAttemptTelemetry.test.ts",
@@ -230905,7 +230947,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2504,
+      "community": 2505,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_runtimecounters_test_ts",
       "label": "runtimeCounters.test.ts",
@@ -230914,7 +230956,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2505,
+      "community": 2506,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_telemetrybuffer_test_ts",
       "label": "telemetryBuffer.test.ts",
@@ -230923,7 +230965,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2506,
+      "community": 2507,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearch_test_ts",
       "label": "catalogSearch.test.ts",
@@ -230932,7 +230974,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2507,
+      "community": 2508,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearchpresentation_test_ts",
       "label": "catalogSearchPresentation.test.ts",
@@ -230941,21 +230983,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2508,
+      "community": 2509,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_registercashierpresence_test_ts",
       "label": "registerCashierPresence.test.ts",
       "norm_label": "registercashierpresence.test.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCashierPresence.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2509,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registercheckoutprojection_test_ts",
-      "label": "registerCheckoutProjection.test.ts",
-      "norm_label": "registercheckoutprojection.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.test.ts",
       "source_location": "L1"
     },
     {
@@ -231051,6 +231084,15 @@
     {
       "community": 2510,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registercheckoutprojection_test_ts",
+      "label": "registerCheckoutProjection.test.ts",
+      "norm_label": "registercheckoutprojection.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2511,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_registeruistate_test_ts",
       "label": "registerUiState.test.ts",
       "norm_label": "registeruistate.test.ts",
@@ -231058,7 +231100,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2511,
+      "community": 2512,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregistercheckoutdraftstate_test_ts",
       "label": "useRegisterCheckoutDraftState.test.ts",
@@ -231067,7 +231109,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2512,
+      "community": 2513,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_registersessioncode_test_ts",
       "label": "registerSessionCode.test.ts",
@@ -231076,7 +231118,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2513,
+      "community": 2514,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_syncstatuspresentation_test_ts",
       "label": "syncStatusPresentation.test.ts",
@@ -231085,7 +231127,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2514,
+      "community": 2515,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_productutils_test_ts",
       "label": "productUtils.test.ts",
@@ -231094,7 +231136,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2515,
+      "community": 2516,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_remote_assist_contract_test_ts",
       "label": "contract.test.ts",
@@ -231103,7 +231145,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2516,
+      "community": 2517,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_remote_assist_guardrails_test_ts",
       "label": "guardrails.test.ts",
@@ -231112,7 +231154,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2517,
+      "community": 2518,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_remote_assist_index_ts",
       "label": "index.ts",
@@ -231121,21 +231163,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2518,
+      "community": 2519,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_runtimebuildmetadata_test_ts",
       "label": "runtimeBuildMetadata.test.ts",
       "norm_label": "runtimebuildmetadata.test.ts",
       "source_file": "packages/athena-webapp/src/lib/runtimeBuildMetadata.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2519,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_category_ts",
-      "label": "category.ts",
-      "norm_label": "category.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/category.ts",
       "source_location": "L1"
     },
     {
@@ -231231,6 +231264,15 @@
     {
       "community": 2520,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_schemas_category_ts",
+      "label": "category.ts",
+      "norm_label": "category.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/category.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2521,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
       "norm_label": "product.ts",
@@ -231238,7 +231280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2521,
+      "community": 2522,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -231247,7 +231289,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2522,
+      "community": 2523,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -231256,7 +231298,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2523,
+      "community": 2524,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -231265,7 +231307,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2524,
+      "community": 2525,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_security_localpinverifier_test_ts",
       "label": "localPinVerifier.test.ts",
@@ -231274,7 +231316,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2525,
+      "community": 2526,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_sheetreturn_test_ts",
       "label": "sheetReturn.test.ts",
@@ -231283,7 +231325,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2526,
+      "community": 2527,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_stockops_skusearch_test_ts",
       "label": "skuSearch.test.ts",
@@ -231292,7 +231334,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2527,
+      "community": 2528,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
@@ -231301,21 +231343,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2528,
+      "community": 2529,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_traces_createworkflowtraceid_test_ts",
       "label": "createWorkflowTraceId.test.ts",
       "norm_label": "createworkflowtraceid.test.ts",
       "source_file": "packages/athena-webapp/src/lib/traces/createWorkflowTraceId.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2529,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_utils_test_ts",
-      "label": "utils.test.ts",
-      "norm_label": "utils.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/utils.test.ts",
       "source_location": "L1"
     },
     {
@@ -231411,6 +231444,15 @@
     {
       "community": 2530,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_utils_test_ts",
+      "label": "utils.test.ts",
+      "norm_label": "utils.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/utils.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2531,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_main_tsx",
       "label": "main.tsx",
       "norm_label": "main.tsx",
@@ -231418,7 +231460,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2531,
+      "community": 2532,
       "file_type": "code",
       "id": "packages_athena_webapp_src_offline_posappshellreadiness_test_ts",
       "label": "posAppShellReadiness.test.ts",
@@ -231427,7 +231469,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2532,
+      "community": 2533,
       "file_type": "code",
       "id": "packages_athena_webapp_src_offline_posappshellroutes_test_ts",
       "label": "posAppShellRoutes.test.ts",
@@ -231436,7 +231478,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2533,
+      "community": 2534,
       "file_type": "code",
       "id": "packages_athena_webapp_src_offline_posofflinereadiness_test_ts",
       "label": "posOfflineReadiness.test.ts",
@@ -231445,7 +231487,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2534,
+      "community": 2535,
       "file_type": "code",
       "id": "packages_athena_webapp_src_offline_registerposappshellserviceworker_test_ts",
       "label": "registerPosAppShellServiceWorker.test.ts",
@@ -231454,7 +231496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2535,
+      "community": 2536,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -231463,7 +231505,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2536,
+      "community": 2537,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_app_entry_route_tsx",
       "label": "-app-entry-route.tsx",
@@ -231472,7 +231514,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2537,
+      "community": 2538,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_privacy_page_tsx",
       "label": "-privacy-page.tsx",
@@ -231481,21 +231523,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2538,
+      "community": 2539,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_root_page_search_ts",
       "label": "-root-page-search.ts",
       "norm_label": "-root-page-search.ts",
       "source_file": "packages/athena-webapp/src/routes/-root-page-search.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2539,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_shared_demo_entry_tsx",
-      "label": "-shared-demo-entry.tsx",
-      "norm_label": "-shared-demo-entry.tsx",
-      "source_file": "packages/athena-webapp/src/routes/-shared-demo-entry.tsx",
       "source_location": "L1"
     },
     {
@@ -231591,6 +231624,15 @@
     {
       "community": 2540,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_shared_demo_entry_tsx",
+      "label": "-shared-demo-entry.tsx",
+      "norm_label": "-shared-demo-entry.tsx",
+      "source_file": "packages/athena-webapp/src/routes/-shared-demo-entry.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2541,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_walkthrough_page_tsx",
       "label": "-walkthrough-page.tsx",
       "norm_label": "-walkthrough-page.tsx",
@@ -231598,7 +231640,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2541,
+      "community": 2542,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_root_test_ts",
       "label": "__root.test.ts",
@@ -231607,7 +231649,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2542,
+      "community": 2543,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
       "label": "index.tsx",
@@ -231616,7 +231658,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2543,
+      "community": 2544,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
       "label": "index.tsx",
@@ -231625,7 +231667,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2544,
+      "community": 2545,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
       "label": "index.tsx",
@@ -231634,7 +231676,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2545,
+      "community": 2546,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
       "label": "$storeUrlSlug.tsx",
@@ -231643,7 +231685,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2546,
+      "community": 2547,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_app_settings_tsx",
       "label": "app-settings.tsx",
@@ -231652,7 +231694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2547,
+      "community": 2548,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
       "label": "assets.index.tsx",
@@ -231661,21 +231703,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2548,
+      "community": 2549,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
       "label": "bags.$bagId.tsx",
       "norm_label": "bags.$bagid.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.$bagId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2549,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
-      "label": "bags.index.tsx",
-      "norm_label": "bags.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.index.tsx",
       "source_location": "L1"
     },
     {
@@ -231771,6 +231804,15 @@
     {
       "community": 2550,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
+      "label": "bags.index.tsx",
+      "norm_label": "bags.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2551,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
@@ -231778,7 +231820,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2551,
+      "community": 2552,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
       "label": "checkout-sessions.index.tsx",
@@ -231787,7 +231829,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2552,
+      "community": 2553,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
       "label": "configuration.index.tsx",
@@ -231796,7 +231838,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2553,
+      "community": 2554,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
       "label": "dashboard.index.tsx",
@@ -231805,7 +231847,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2554,
+      "community": 2555,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
       "label": "home.tsx",
@@ -231814,7 +231856,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2555,
+      "community": 2556,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
       "label": "logs.$logId.tsx",
@@ -231823,7 +231865,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2556,
+      "community": 2557,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
       "label": "logs.index.tsx",
@@ -231832,7 +231874,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2557,
+      "community": 2558,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
       "label": "members.index.tsx",
@@ -231841,21 +231883,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2558,
+      "community": 2559,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_test_ts",
       "label": "index.test.ts",
       "norm_label": "index.test.ts",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/index.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2559,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_inventory_import_cost_overlay_search_ts",
-      "label": "-cost-overlay-search.ts",
-      "norm_label": "-cost-overlay-search.ts",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/inventory-import/-cost-overlay-search.ts",
       "source_location": "L1"
     },
     {
@@ -231951,6 +231984,15 @@
     {
       "community": 2560,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_inventory_import_cost_overlay_search_ts",
+      "label": "-cost-overlay-search.ts",
+      "norm_label": "-cost-overlay-search.ts",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/inventory-import/-cost-overlay-search.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2561,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_inventory_import_cost_overlay_test_ts",
       "label": "cost-overlay.test.ts",
       "norm_label": "cost-overlay.test.ts",
@@ -231958,7 +232000,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2561,
+      "community": 2562,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_inventory_import_cost_overlay_tsx",
       "label": "cost-overlay.tsx",
@@ -231967,7 +232009,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2562,
+      "community": 2563,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_inventory_import_review_tsx",
       "label": "review.tsx",
@@ -231976,7 +232018,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2563,
+      "community": 2564,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_inventory_import_test_tsx",
       "label": "inventory-import.test.tsx",
@@ -231985,7 +232027,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2564,
+      "community": 2565,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_inventory_import_tsx",
       "label": "inventory-import.tsx",
@@ -231994,7 +232036,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2565,
+      "community": 2566,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_sku_activity_test_tsx",
       "label": "sku-activity.test.tsx",
@@ -232003,7 +232045,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2566,
+      "community": 2567,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
       "label": "index.tsx",
@@ -232012,7 +232054,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2567,
+      "community": 2568,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
       "label": "all.index.tsx",
@@ -232021,21 +232063,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2568,
+      "community": 2569,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
       "label": "cancelled.index.tsx",
       "norm_label": "cancelled.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/cancelled.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2569,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
-      "label": "completed.index.tsx",
-      "norm_label": "completed.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/completed.index.tsx",
       "source_location": "L1"
     },
     {
@@ -232131,6 +232164,15 @@
     {
       "community": 2570,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
+      "label": "completed.index.tsx",
+      "norm_label": "completed.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/completed.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2571,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
@@ -232138,7 +232180,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2571,
+      "community": 2572,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
       "label": "open.index.tsx",
@@ -232147,7 +232189,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2572,
+      "community": 2573,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
       "label": "out-for-delivery.index.tsx",
@@ -232156,7 +232198,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2573,
+      "community": 2574,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
       "label": "ready.index.tsx",
@@ -232165,7 +232207,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2574,
+      "community": 2575,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
       "label": "refunded.index.tsx",
@@ -232174,7 +232216,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2575,
+      "community": 2576,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
       "label": "$reportId.tsx",
@@ -232183,7 +232225,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2576,
+      "community": 2577,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
       "label": "expense-reports.index.tsx",
@@ -232192,7 +232234,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2577,
+      "community": 2578,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_test_tsx",
       "label": "expense.index.test.tsx",
@@ -232201,21 +232243,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2578,
+      "community": 2579,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
       "label": "register.index.tsx",
       "norm_label": "register.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/register.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2579,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_sessions_index_tsx",
-      "label": "sessions.index.tsx",
-      "norm_label": "sessions.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/sessions.index.tsx",
       "source_location": "L1"
     },
     {
@@ -232311,6 +232344,15 @@
     {
       "community": 2580,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_sessions_index_tsx",
+      "label": "sessions.index.tsx",
+      "norm_label": "sessions.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/sessions.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2581,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_terminals_terminalid_tsx",
       "label": "$terminalId.tsx",
       "norm_label": "$terminalid.tsx",
@@ -232318,7 +232360,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2581,
+      "community": 2582,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_terminals_index_tsx",
       "label": "terminals.index.tsx",
@@ -232327,7 +232369,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2582,
+      "community": 2583,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
       "label": "$transactionId.tsx",
@@ -232336,7 +232378,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2583,
+      "community": 2584,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
       "label": "transactions.index.tsx",
@@ -232345,7 +232387,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2584,
+      "community": 2585,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_test_ts",
       "label": "procurement.index.test.ts",
@@ -232354,7 +232396,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2585,
+      "community": 2586,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
       "label": "edit.tsx",
@@ -232363,7 +232405,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2586,
+      "community": 2587,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
       "label": "index.tsx",
@@ -232372,7 +232414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2587,
+      "community": 2588,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_archived_tsx",
       "label": "archived.tsx",
@@ -232381,21 +232423,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2588,
+      "community": 2589,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
       "label": "new.tsx",
       "norm_label": "new.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/new.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2589,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
-      "label": "new.tsx",
-      "norm_label": "new.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/new.tsx",
       "source_location": "L1"
     },
     {
@@ -232491,6 +232524,15 @@
     {
       "community": 2590,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
+      "label": "new.tsx",
+      "norm_label": "new.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/new.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2591,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
       "label": "unresolved.tsx",
       "norm_label": "unresolved.tsx",
@@ -232498,7 +232540,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2591,
+      "community": 2592,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
       "label": "$promoCodeSlug.tsx",
@@ -232507,7 +232549,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2592,
+      "community": 2593,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
       "label": "index.tsx",
@@ -232516,7 +232558,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2593,
+      "community": 2594,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
       "label": "new.tsx",
@@ -232525,7 +232567,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2594,
+      "community": 2595,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_items_productskuid_test_ts",
       "label": "$productSkuId.test.ts",
@@ -232534,7 +232576,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2595,
+      "community": 2596,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_items_index_test_ts",
       "label": "index.test.ts",
@@ -232543,7 +232585,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2596,
+      "community": 2597,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_items_tsx",
       "label": "items.tsx",
@@ -232552,7 +232594,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2597,
+      "community": 2598,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_weekly_test_ts",
       "label": "weekly.test.ts",
@@ -232561,21 +232603,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2598,
+      "community": 2599,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_tsx",
       "label": "reports.tsx",
       "norm_label": "reports.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2599,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/index.tsx",
       "source_location": "L1"
     },
     {
@@ -233013,6 +233046,15 @@
     {
       "community": 2600,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2601,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
       "label": "new.index.tsx",
       "norm_label": "new.index.tsx",
@@ -233020,7 +233062,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2601,
+      "community": 2602,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_active_cases_index_tsx",
       "label": "active-cases.index.tsx",
@@ -233029,7 +233071,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2602,
+      "community": 2603,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_appointments_index_tsx",
       "label": "appointments.index.tsx",
@@ -233038,7 +233080,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2603,
+      "community": 2604,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_catalog_management_index_tsx",
       "label": "catalog-management.index.tsx",
@@ -233047,7 +233089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2604,
+      "community": 2605,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_index_tsx",
       "label": "index.tsx",
@@ -233056,7 +233098,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2605,
+      "community": 2606,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_intake_index_tsx",
       "label": "intake.index.tsx",
@@ -233065,7 +233107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2606,
+      "community": 2607,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_test_tsx",
       "label": "$traceId.test.tsx",
@@ -233074,7 +233116,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2607,
+      "community": 2608,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
       "label": "users.$userId.tsx",
@@ -233083,21 +233125,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2608,
+      "community": 2609,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2609,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_shell_test_tsx",
-      "label": "_authed-shell.test.tsx",
-      "norm_label": "_authed-shell.test.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed-shell.test.tsx",
       "source_location": "L1"
     },
     {
@@ -233193,6 +233226,15 @@
     {
       "community": 2610,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_shell_test_tsx",
+      "label": "_authed-shell.test.tsx",
+      "norm_label": "_authed-shell.test.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed-shell.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2611,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_test_tsx",
       "label": "_authed.test.tsx",
       "norm_label": "_authed.test.tsx",
@@ -233200,7 +233242,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2611,
+      "community": 2612,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_app_route_test_tsx",
       "label": "app.route.test.tsx",
@@ -233209,7 +233251,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2612,
+      "community": 2613,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_app_test_tsx",
       "label": "app.test.tsx",
@@ -233218,7 +233260,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2613,
+      "community": 2614,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_app_tsx",
       "label": "app.tsx",
@@ -233227,7 +233269,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2614,
+      "community": 2615,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_demo_test_tsx",
       "label": "demo.test.tsx",
@@ -233236,7 +233278,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2615,
+      "community": 2616,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_demo_tsx",
       "label": "demo.tsx",
@@ -233245,7 +233287,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2616,
+      "community": 2617,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_docs_index_tsx",
       "label": "docs.index.tsx",
@@ -233254,7 +233296,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2617,
+      "community": 2618,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_docs_reports_slug_tsx",
       "label": "docs.reports.$slug.tsx",
@@ -233263,21 +233305,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2618,
+      "community": 2619,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_docs_solutions_category_slug_test_tsx",
       "label": "docs.solutions.$category.$slug.test.tsx",
       "norm_label": "docs.solutions.$category.$slug.test.tsx",
       "source_file": "packages/athena-webapp/src/routes/docs.solutions.$category.$slug.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2619,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_docs_tsx",
-      "label": "docs.tsx",
-      "norm_label": "docs.tsx",
-      "source_file": "packages/athena-webapp/src/routes/docs.tsx",
       "source_location": "L1"
     },
     {
@@ -233373,6 +233406,15 @@
     {
       "community": 2620,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_docs_tsx",
+      "label": "docs.tsx",
+      "norm_label": "docs.tsx",
+      "source_file": "packages/athena-webapp/src/routes/docs.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2621,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_test_tsx",
       "label": "index.test.tsx",
       "norm_label": "index.test.tsx",
@@ -233380,7 +233422,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2621,
+      "community": 2622,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -233389,7 +233431,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2622,
+      "community": 2623,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
       "label": "join-team.index.tsx",
@@ -233398,7 +233440,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2623,
+      "community": 2624,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_landing_tsx",
       "label": "landing.tsx",
@@ -233407,7 +233449,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2624,
+      "community": 2625,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_test_tsx",
       "label": "_layout.index.test.tsx",
@@ -233416,7 +233458,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2625,
+      "community": 2626,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
       "label": "_layout.index.tsx",
@@ -233425,7 +233467,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2626,
+      "community": 2627,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_tsx",
       "label": "_layout.tsx",
@@ -233434,7 +233476,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2627,
+      "community": 2628,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_privacy_test_tsx",
       "label": "privacy.test.tsx",
@@ -233443,21 +233485,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2628,
+      "community": 2629,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_privacy_tsx",
       "label": "privacy.tsx",
       "norm_label": "privacy.tsx",
       "source_file": "packages/athena-webapp/src/routes/privacy.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2629,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_register_interest_tsx",
-      "label": "register-interest.tsx",
-      "norm_label": "register-interest.tsx",
-      "source_file": "packages/athena-webapp/src/routes/register-interest.tsx",
       "source_location": "L1"
     },
     {
@@ -233553,6 +233586,15 @@
     {
       "community": 2630,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_register_interest_tsx",
+      "label": "register-interest.tsx",
+      "norm_label": "register-interest.tsx",
+      "source_file": "packages/athena-webapp/src/routes/register-interest.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2631,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_walkthrough_test_tsx",
       "label": "walkthrough.test.tsx",
       "norm_label": "walkthrough.test.tsx",
@@ -233560,7 +233602,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2631,
+      "community": 2632,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_walkthrough_tsx",
       "label": "walkthrough.tsx",
@@ -233569,7 +233611,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2632,
+      "community": 2633,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
       "label": "StoresSettingsAccordion.tsx",
@@ -233578,7 +233620,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2633,
+      "community": 2634,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stores_expensestore_test_ts",
       "label": "expenseStore.test.ts",
@@ -233587,7 +233629,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2634,
+      "community": 2635,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -233596,7 +233638,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2635,
+      "community": 2636,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
       "label": "foundations-content.test.tsx",
@@ -233605,7 +233647,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2636,
+      "community": 2637,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
       "label": "Introduction.stories.tsx",
@@ -233614,7 +233656,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2637,
+      "community": 2638,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
       "label": "introduction-content.test.tsx",
@@ -233623,21 +233665,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2638,
+      "community": 2639,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
       "label": "introduction-content.tsx",
       "norm_label": "introduction-content.tsx",
       "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2639,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_patterns_adminshell_stories_tsx",
-      "label": "AdminShell.stories.tsx",
-      "norm_label": "adminshell.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Patterns/AdminShell.stories.tsx",
       "source_location": "L1"
     },
     {
@@ -233733,6 +233766,15 @@
     {
       "community": 2640,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_patterns_adminshell_stories_tsx",
+      "label": "AdminShell.stories.tsx",
+      "norm_label": "adminshell.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Patterns/AdminShell.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2641,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_view_stories_tsx",
       "label": "View.stories.tsx",
       "norm_label": "view.stories.tsx",
@@ -233740,7 +233782,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2641,
+      "community": 2642,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_test_tsx",
       "label": "admin-shell-patterns.test.tsx",
@@ -233749,7 +233791,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2642,
+      "community": 2643,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_view_patterns_test_tsx",
       "label": "view-patterns.test.tsx",
@@ -233758,7 +233800,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2643,
+      "community": 2644,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_surfaces_stories_tsx",
       "label": "Surfaces.stories.tsx",
@@ -233767,7 +233809,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2644,
+      "community": 2645,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
       "label": "DashboardWorkspace.stories.tsx",
@@ -233776,7 +233818,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2645,
+      "community": 2646,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
       "label": "DataWorkspace.stories.tsx",
@@ -233785,7 +233827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2646,
+      "community": 2647,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_settingsworkspace_stories_tsx",
       "label": "SettingsWorkspace.stories.tsx",
@@ -233794,7 +233836,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2647,
+      "community": 2648,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_test_tsx",
       "label": "reference-fixtures.test.tsx",
@@ -233803,21 +233845,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2648,
+      "community": 2649,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_operations_eodreviewfixtures_ts",
       "label": "eodReviewFixtures.ts",
       "norm_label": "eodreviewfixtures.ts",
       "source_file": "packages/athena-webapp/src/stories/operations/eodReviewFixtures.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2649,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_storybook_config_test_ts",
-      "label": "storybook-config.test.ts",
-      "norm_label": "storybook-config.test.ts",
-      "source_file": "packages/athena-webapp/src/stories/storybook-config.test.ts",
       "source_location": "L1"
     },
     {
@@ -233913,6 +233946,15 @@
     {
       "community": 2650,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_storybook_config_test_ts",
+      "label": "storybook-config.test.ts",
+      "norm_label": "storybook-config.test.ts",
+      "source_file": "packages/athena-webapp/src/stories/storybook-config.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2651,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_test_ts",
       "label": "storybook-theme-decorator.test.ts",
       "norm_label": "storybook-theme-decorator.test.ts",
@@ -233920,7 +233962,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2651,
+      "community": 2652,
       "file_type": "code",
       "id": "packages_athena_webapp_src_test_setup_ts",
       "label": "setup.ts",
@@ -233929,7 +233971,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2652,
+      "community": 2653,
       "file_type": "code",
       "id": "packages_athena_webapp_src_vite_env_d_ts",
       "label": "vite-env.d.ts",
@@ -233938,7 +233980,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2653,
+      "community": 2654,
       "file_type": "code",
       "id": "packages_athena_webapp_src_viteconfig_test_ts",
       "label": "viteConfig.test.ts",
@@ -233947,7 +233989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2654,
+      "community": 2655,
       "file_type": "code",
       "id": "packages_athena_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -233956,7 +233998,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2655,
+      "community": 2656,
       "file_type": "code",
       "id": "packages_athena_webapp_types_ts",
       "label": "types.ts",
@@ -233965,7 +234007,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2656,
+      "community": 2657,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -233974,7 +234016,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2657,
+      "community": 2658,
       "file_type": "code",
       "id": "packages_storefront_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -233983,21 +234025,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2658,
+      "community": 2659,
       "file_type": "code",
       "id": "packages_storefront_webapp_global_d_ts",
       "label": "global.d.ts",
       "norm_label": "global.d.ts",
       "source_file": "packages/storefront-webapp/global.d.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2659,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_playwright_config_ts",
-      "label": "playwright.config.ts",
-      "norm_label": "playwright.config.ts",
-      "source_file": "packages/storefront-webapp/playwright.config.ts",
       "source_location": "L1"
     },
     {
@@ -234093,6 +234126,15 @@
     {
       "community": 2660,
       "file_type": "code",
+      "id": "packages_storefront_webapp_playwright_config_ts",
+      "label": "playwright.config.ts",
+      "norm_label": "playwright.config.ts",
+      "source_file": "packages/storefront-webapp/playwright.config.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2661,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_test_ts",
       "label": "analytics.test.ts",
       "norm_label": "analytics.test.ts",
@@ -234100,7 +234142,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2661,
+      "community": 2662,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_homepagesnapshot_test_ts",
       "label": "homepageSnapshot.test.ts",
@@ -234109,7 +234151,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2662,
+      "community": 2663,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_trackingevents_test_ts",
       "label": "trackingEvents.test.ts",
@@ -234118,7 +234160,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2663,
+      "community": 2664,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_types_ts",
       "label": "types.ts",
@@ -234127,7 +234169,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2664,
+      "community": 2665,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
       "label": "HeartIconFilled.tsx",
@@ -234136,7 +234178,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2665,
+      "community": 2666,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -234145,7 +234187,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2666,
+      "community": 2667,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
       "label": "HomePage.test.tsx",
@@ -234154,7 +234196,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2667,
+      "community": 2668,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
       "label": "ProductCard.test.tsx",
@@ -234163,21 +234205,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2668,
+      "community": 2669,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_upsell_tsx",
       "label": "Upsell.tsx",
       "norm_label": "upsell.tsx",
       "source_file": "packages/storefront-webapp/src/components/Upsell.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2669,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_checkout_test_tsx",
-      "label": "Checkout.test.tsx",
-      "norm_label": "checkout.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/Checkout.test.tsx",
       "source_location": "L1"
     },
     {
@@ -234273,6 +234306,15 @@
     {
       "community": 2670,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_checkout_test_tsx",
+      "label": "Checkout.test.tsx",
+      "norm_label": "checkout.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/Checkout.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2671,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
       "label": "Checkout.tsx",
       "norm_label": "checkout.tsx",
@@ -234280,7 +234322,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2671,
+      "community": 2672,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
       "label": "CustomerInfoSection.tsx",
@@ -234289,7 +234331,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2672,
+      "community": 2673,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_schema_ts",
       "label": "schema.ts",
@@ -234298,7 +234340,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2673,
+      "community": 2674,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetailssection_tsx",
       "label": "DeliveryDetailsSection.tsx",
@@ -234307,7 +234349,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2674,
+      "community": 2675,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_test_ts",
       "label": "checkoutStorage.test.ts",
@@ -234316,7 +234358,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2675,
+      "community": 2676,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
       "label": "deliveryFees.test.ts",
@@ -234325,7 +234367,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2676,
+      "community": 2677,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
       "label": "deriveCheckoutState.test.ts",
@@ -234334,7 +234376,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2677,
+      "community": 2678,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
       "label": "billingDetailsSchema.ts",
@@ -234343,21 +234385,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2678,
+      "community": 2679,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
       "label": "checkoutFormSchema.ts",
       "norm_label": "checkoutformschema.ts",
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutFormSchema.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2679,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_customerdetailsschema_ts",
-      "label": "customerDetailsSchema.ts",
-      "norm_label": "customerdetailsschema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/customerDetailsSchema.ts",
       "source_location": "L1"
     },
     {
@@ -234453,6 +234486,15 @@
     {
       "community": 2680,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_customerdetailsschema_ts",
+      "label": "customerDetailsSchema.ts",
+      "norm_label": "customerdetailsschema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/customerDetailsSchema.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2681,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
       "label": "deliveryDetailsSchema.ts",
       "norm_label": "deliverydetailsschema.ts",
@@ -234460,7 +234502,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2681,
+      "community": 2682,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
       "label": "webOrderSchema.ts",
@@ -234469,7 +234511,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2682,
+      "community": 2683,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_types_ts",
       "label": "types.ts",
@@ -234478,7 +234520,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2683,
+      "community": 2684,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_utils_test_ts",
       "label": "utils.test.ts",
@@ -234487,7 +234529,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2684,
+      "community": 2685,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilterbar_tsx",
       "label": "ProductFilterBar.tsx",
@@ -234496,7 +234538,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2685,
+      "community": 2686,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_test_tsx",
       "label": "BestSellersSection.test.tsx",
@@ -234505,7 +234547,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2686,
+      "community": 2687,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
       "label": "HomeHero.tsx",
@@ -234514,7 +234556,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2687,
+      "community": 2688,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
       "label": "HomeHeroSection.tsx",
@@ -234523,21 +234565,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2688,
+      "community": 2689,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_test_ts",
       "label": "homePageContent.test.ts",
       "norm_label": "homepagecontent.test.ts",
       "source_file": "packages/storefront-webapp/src/components/home/homePageContent.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2689,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_mobilemenu_tsx",
-      "label": "MobileMenu.tsx",
-      "norm_label": "mobilemenu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileMenu.tsx",
       "source_location": "L1"
     },
     {
@@ -234633,6 +234666,15 @@
     {
       "community": 2690,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_mobilemenu_tsx",
+      "label": "MobileMenu.tsx",
+      "norm_label": "mobilemenu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileMenu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2691,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
@@ -234640,7 +234682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2691,
+      "community": 2692,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
       "label": "navBarConstants.ts",
@@ -234649,7 +234691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2692,
+      "community": 2693,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_about_tsx",
       "label": "About.tsx",
@@ -234658,7 +234700,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2693,
+      "community": 2694,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_aboutproduct_tsx",
       "label": "AboutProduct.tsx",
@@ -234667,7 +234709,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2694,
+      "community": 2695,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_test_tsx",
       "label": "ProductActions.test.tsx",
@@ -234676,7 +234718,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2695,
+      "community": 2696,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
       "label": "ProductInfo.tsx",
@@ -234685,7 +234727,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2696,
+      "community": 2697,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
       "label": "ProductReviews.tsx",
@@ -234694,7 +234736,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2697,
+      "community": 2698,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
       "label": "ProductsNavigationBar.tsx",
@@ -234703,21 +234745,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2698,
+      "community": 2699,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
       "label": "ErrorMessage.tsx",
       "norm_label": "errormessage.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ErrorMessage.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2699,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_existingreviewmessage_tsx",
-      "label": "ExistingReviewMessage.tsx",
-      "norm_label": "existingreviewmessage.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/ExistingReviewMessage.tsx",
       "source_location": "L1"
     },
     {
@@ -235155,6 +235188,15 @@
     {
       "community": 2700,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_reviews_existingreviewmessage_tsx",
+      "label": "ExistingReviewMessage.tsx",
+      "norm_label": "existingreviewmessage.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/ExistingReviewMessage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2701,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_test_tsx",
       "label": "OrderItem.test.tsx",
       "norm_label": "orderitem.test.tsx",
@@ -235162,7 +235204,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2701,
+      "community": 2702,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
       "label": "ReviewForm.tsx",
@@ -235171,7 +235213,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2702,
+      "community": 2703,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
       "label": "SuccessMessage.tsx",
@@ -235180,7 +235222,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2703,
+      "community": 2704,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_types_ts",
       "label": "types.ts",
@@ -235189,7 +235231,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2704,
+      "community": 2705,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
       "label": "SavedBag.tsx",
@@ -235198,7 +235240,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2705,
+      "community": 2706,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
       "label": "SavedIcon.tsx",
@@ -235207,7 +235249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2706,
+      "community": 2707,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_carticon_tsx",
       "label": "CartIcon.tsx",
@@ -235216,7 +235258,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2707,
+      "community": 2708,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
       "label": "ShoppingBag.test.tsx",
@@ -235225,21 +235267,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2708,
+      "community": 2709,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
       "norm_label": "empty-state.tsx",
       "source_file": "packages/storefront-webapp/src/components/states/empty/empty-state.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2709,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_test_tsx",
-      "label": "Maintenance.test.tsx",
-      "norm_label": "maintenance.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/maintenance/Maintenance.test.tsx",
       "source_location": "L1"
     },
     {
@@ -235335,6 +235368,15 @@
     {
       "community": 2710,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_test_tsx",
+      "label": "Maintenance.test.tsx",
+      "norm_label": "maintenance.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/maintenance/Maintenance.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2711,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_tsx",
       "label": "Maintenance.tsx",
       "norm_label": "maintenance.tsx",
@@ -235342,7 +235384,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2711,
+      "community": 2712,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
       "label": "AnimatedCard.tsx",
@@ -235351,7 +235393,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2712,
+      "community": 2713,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -235360,7 +235402,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2713,
+      "community": 2714,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
       "label": "alert.tsx",
@@ -235369,7 +235411,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2714,
+      "community": 2715,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
       "label": "breadcrumb.tsx",
@@ -235378,7 +235420,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2715,
+      "community": 2716,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -235387,7 +235429,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2716,
+      "community": 2717,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
@@ -235396,7 +235438,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2717,
+      "community": 2718,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
@@ -235405,21 +235447,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2718,
+      "community": 2719,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
       "norm_label": "command.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/command.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2719,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
-      "label": "context-menu.tsx",
-      "norm_label": "context-menu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/context-menu.tsx",
       "source_location": "L1"
     },
     {
@@ -235515,6 +235548,15 @@
     {
       "community": 2720,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
+      "label": "context-menu.tsx",
+      "norm_label": "context-menu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/context-menu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2721,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
       "norm_label": "dialog.tsx",
@@ -235522,7 +235564,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2721,
+      "community": 2722,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
@@ -235531,7 +235573,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2722,
+      "community": 2723,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -235540,7 +235582,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2723,
+      "community": 2724,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -235549,7 +235591,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2724,
+      "community": 2725,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
       "label": "image-with-fallback.tsx",
@@ -235558,7 +235600,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2725,
+      "community": 2726,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -235567,7 +235609,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2726,
+      "community": 2727,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_with_end_button_tsx",
       "label": "input-with-end-button.tsx",
@@ -235576,7 +235618,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2727,
+      "community": 2728,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -235585,21 +235627,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2728,
+      "community": 2729,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
       "norm_label": "label.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/label.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2729,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
-      "label": "LeaveAReviewModalForm.tsx",
-      "norm_label": "leaveareviewmodalform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModalForm.tsx",
       "source_location": "L1"
     },
     {
@@ -235695,6 +235728,15 @@
     {
       "community": 2730,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
+      "label": "LeaveAReviewModalForm.tsx",
+      "norm_label": "leaveareviewmodalform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModalForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2731,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
       "norm_label": "action-modal.tsx",
@@ -235702,7 +235744,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2731,
+      "community": 2732,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_animations_welcomebackmodalanimations_ts",
       "label": "welcomeBackModalAnimations.ts",
@@ -235711,7 +235753,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2732,
+      "community": 2733,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_index_ts",
       "label": "index.ts",
@@ -235720,7 +235762,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2733,
+      "community": 2734,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_types_ts",
       "label": "types.ts",
@@ -235729,7 +235771,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2734,
+      "community": 2735,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_navigation_menu_tsx",
       "label": "navigation-menu.tsx",
@@ -235738,7 +235780,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2735,
+      "community": 2736,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -235747,7 +235789,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2736,
+      "community": 2737,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -235756,7 +235798,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2737,
+      "community": 2738,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -235765,21 +235807,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2738,
+      "community": 2739,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
       "norm_label": "select.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/select.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2739,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
-      "label": "separator.tsx",
-      "norm_label": "separator.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/separator.tsx",
       "source_location": "L1"
     },
     {
@@ -235875,6 +235908,15 @@
     {
       "community": 2740,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
+      "label": "separator.tsx",
+      "norm_label": "separator.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/separator.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2741,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
       "norm_label": "sheet.tsx",
@@ -235882,7 +235924,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2741,
+      "community": 2742,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -235891,7 +235933,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2742,
+      "community": 2743,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -235900,7 +235942,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2743,
+      "community": 2744,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -235909,7 +235951,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2744,
+      "community": 2745,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -235918,7 +235960,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2745,
+      "community": 2746,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -235927,7 +235969,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2746,
+      "community": 2747,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
@@ -235936,7 +235978,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2747,
+      "community": 2748,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_config_ts",
       "label": "config.ts",
@@ -235945,21 +235987,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2748,
+      "community": 2749,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_test_tsx",
       "label": "StorefrontObservabilityProvider.test.tsx",
       "norm_label": "storefrontobservabilityprovider.test.tsx",
       "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2749,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
-      "label": "use-store-modal.tsx",
-      "norm_label": "use-store-modal.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/use-store-modal.tsx",
       "source_location": "L1"
     },
     {
@@ -236055,6 +236088,15 @@
     {
       "community": 2750,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
+      "label": "use-store-modal.tsx",
+      "norm_label": "use-store-modal.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/use-store-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2751,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
       "norm_label": "useorganizationmodal.tsx",
@@ -236062,7 +236104,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2751,
+      "community": 2752,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usequeryenabled_test_ts",
       "label": "useQueryEnabled.test.ts",
@@ -236071,7 +236113,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2752,
+      "community": 2753,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
       "label": "useStorefrontObservability.ts",
@@ -236080,7 +236122,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2753,
+      "community": 2754,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -236089,7 +236131,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2754,
+      "community": 2755,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -236098,7 +236140,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2755,
+      "community": 2756,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_feeutils_test_ts",
       "label": "feeUtils.test.ts",
@@ -236107,7 +236149,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2756,
+      "community": 2757,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -236116,7 +236158,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2757,
+      "community": 2758,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -236125,21 +236167,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2758,
+      "community": 2759,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
       "label": "maintenanceUtils.test.ts",
       "norm_label": "maintenanceutils.test.ts",
       "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2759,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/storefront-webapp/src/lib/mutations.ts/index.ts",
       "source_location": "L1"
     },
     {
@@ -236235,6 +236268,15 @@
     {
       "community": 2760,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/storefront-webapp/src/lib/mutations.ts/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2761,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_productutils_test_ts",
       "label": "productUtils.test.ts",
       "norm_label": "productutils.test.ts",
@@ -236242,7 +236284,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2761,
+      "community": 2762,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_store_ts",
       "label": "store.ts",
@@ -236251,7 +236293,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2762,
+      "community": 2763,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
       "label": "bag.ts",
@@ -236260,7 +236302,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2763,
+      "community": 2764,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
       "label": "bagItem.ts",
@@ -236269,7 +236311,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2764,
+      "community": 2765,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -236278,7 +236320,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2765,
+      "community": 2766,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_organization_ts",
       "label": "organization.ts",
@@ -236287,7 +236329,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2766,
+      "community": 2767,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
@@ -236296,7 +236338,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2767,
+      "community": 2768,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -236305,21 +236347,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2768,
+      "community": 2769,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
       "norm_label": "subcategory.ts",
       "source_file": "packages/storefront-webapp/src/lib/schemas/subcategory.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2769,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
-      "label": "user.ts",
-      "norm_label": "user.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/user.ts",
       "source_location": "L1"
     },
     {
@@ -236415,6 +236448,15 @@
     {
       "community": 2770,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
+      "label": "user.ts",
+      "norm_label": "user.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/user.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2771,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_states_ts",
       "label": "states.ts",
       "norm_label": "states.ts",
@@ -236422,7 +236464,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2771,
+      "community": 2772,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontcontextevents_test_ts",
       "label": "storefrontContextEvents.test.ts",
@@ -236431,7 +236473,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2772,
+      "community": 2773,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
       "label": "storefrontFailureObservability.test.ts",
@@ -236440,7 +236482,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2773,
+      "community": 2774,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
       "label": "storefrontJourneyEvents.test.ts",
@@ -236449,7 +236491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2774,
+      "community": 2775,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -236458,7 +236500,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2775,
+      "community": 2776,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -236467,7 +236509,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2776,
+      "community": 2777,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_test_ts",
       "label": "-homePageLoader.test.ts",
@@ -236476,7 +236518,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2777,
+      "community": 2778,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -236485,21 +236527,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2778,
+      "community": 2779,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_orderitemid_review_tsx",
       "label": "$orderItemId.review.tsx",
       "norm_label": "$orderitemid.review.tsx",
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/$orderItemId.review.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2779,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/index.tsx",
       "source_location": "L1"
     },
     {
@@ -236595,6 +236628,15 @@
     {
       "community": 2780,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2781,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
       "label": "$subcategorySlug.tsx",
       "norm_label": "$subcategoryslug.tsx",
@@ -236602,7 +236644,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2781,
+      "community": 2782,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
       "label": "index.tsx",
@@ -236611,7 +236653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2782,
+      "community": 2783,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
       "label": "rewards.index.tsx",
@@ -236620,7 +236662,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2783,
+      "community": 2784,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
       "label": "shop.saved.index.tsx",
@@ -236629,7 +236671,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2784,
+      "community": 2785,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
       "label": "bag.index.tsx",
@@ -236638,7 +236680,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2785,
+      "community": 2786,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_complete_tsx",
       "label": "complete.tsx",
@@ -236647,7 +236689,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2786,
+      "community": 2787,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_incomplete_tsx",
       "label": "incomplete.tsx",
@@ -236656,7 +236698,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2787,
+      "community": 2788,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_index_tsx",
       "label": "index.tsx",
@@ -236665,21 +236707,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2788,
+      "community": 2789,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pending_tsx",
       "label": "pending.tsx",
       "norm_label": "pending.tsx",
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pending.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2789,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_tailwind_config_js",
-      "label": "tailwind.config.js",
-      "norm_label": "tailwind.config.js",
-      "source_file": "packages/storefront-webapp/tailwind.config.js",
       "source_location": "L1"
     },
     {
@@ -236775,6 +236808,15 @@
     {
       "community": 2790,
       "file_type": "code",
+      "id": "packages_storefront_webapp_tailwind_config_js",
+      "label": "tailwind.config.js",
+      "norm_label": "tailwind.config.js",
+      "source_file": "packages/storefront-webapp/tailwind.config.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 2791,
+      "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_storefront_boot_e2e_ts",
       "label": "storefront-boot.e2e.ts",
       "norm_label": "storefront-boot.e2e.ts",
@@ -236782,7 +236824,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2791,
+      "community": 2792,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -236791,7 +236833,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2792,
+      "community": 2793,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
@@ -236800,7 +236842,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2793,
+      "community": 2794,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_index_js",
       "label": "index.js",
@@ -236809,7 +236851,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2794,
+      "community": 2795,
       "file_type": "code",
       "id": "scripts_check_register_session_authority_writers_test_ts",
       "label": "check-register-session-authority-writers.test.ts",
@@ -236818,7 +236860,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2795,
+      "community": 2796,
       "file_type": "code",
       "id": "scripts_delivery_documentation_check_test_ts",
       "label": "delivery-documentation-check.test.ts",
@@ -236827,7 +236869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2796,
+      "community": 2797,
       "file_type": "code",
       "id": "scripts_harness_app_registry_test_ts",
       "label": "harness-app-registry.test.ts",
@@ -236836,7 +236878,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2797,
+      "community": 2798,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_athena_runtime_app_test_ts",
       "label": "athena-runtime-app.test.ts",
@@ -236845,21 +236887,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2798,
+      "community": 2799,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_test_ts",
       "label": "storefront-runtime-api.test.ts",
       "norm_label": "storefront-runtime-api.test.ts",
       "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2799,
-      "file_type": "code",
-      "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_test_ts",
-      "label": "valkey-runtime-app.test.ts",
-      "norm_label": "valkey-runtime-app.test.ts",
-      "source_file": "scripts/harness-behavior-fixtures/valkey-runtime-app.test.ts",
       "source_location": "L1"
     },
     {
@@ -237288,6 +237321,15 @@
     {
       "community": 2800,
       "file_type": "code",
+      "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_test_ts",
+      "label": "valkey-runtime-app.test.ts",
+      "norm_label": "valkey-runtime-app.test.ts",
+      "source_file": "scripts/harness-behavior-fixtures/valkey-runtime-app.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2801,
+      "file_type": "code",
       "id": "scripts_harness_behavior_scenarios_test_ts",
       "label": "harness-behavior-scenarios.test.ts",
       "norm_label": "harness-behavior-scenarios.test.ts",
@@ -237295,7 +237337,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2801,
+      "community": 2802,
       "file_type": "code",
       "id": "scripts_harness_execution_context_test_ts",
       "label": "harness-execution-context.test.ts",
@@ -237304,7 +237346,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2802,
+      "community": 2803,
       "file_type": "code",
       "id": "scripts_harness_gate_registry_test_ts",
       "label": "harness-gate-registry.test.ts",
@@ -237313,7 +237355,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2803,
+      "community": 2804,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_test_ts",
       "label": "harness-repo-validation.test.ts",
@@ -237322,7 +237364,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2804,
+      "community": 2805,
       "file_type": "code",
       "id": "scripts_operational_work_repair_test_ts",
       "label": "operational-work-repair.test.ts",
@@ -237331,7 +237373,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2805,
+      "community": 2806,
       "file_type": "code",
       "id": "tools_screen_redact_extension_background_js",
       "label": "background.js",
@@ -237340,7 +237382,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2806,
+      "community": 2807,
       "file_type": "code",
       "id": "tools_screen_redact_extension_popup_js",
       "label": "popup.js",
@@ -242049,87 +242091,6 @@
     {
       "community": 318,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "productutils_getpreferredsku",
-      "label": "getPreferredSku()",
-      "norm_label": "getpreferredsku()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L82"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "productutils_sortskusbyavailabilitythenlength",
-      "label": "sortSkusByAvailabilityThenLength()",
-      "norm_label": "sortskusbyavailabilitythenlength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
       "id": "applyremoteassistcontrolintent_applyacceptedcontrolresult",
       "label": "applyAcceptedControlResult()",
       "norm_label": "applyacceptedcontrolresult()",
@@ -242137,7 +242098,7 @@
       "source_location": "L84"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_applykeyevent",
       "label": "applyKeyEvent()",
@@ -242146,7 +242107,7 @@
       "source_location": "L155"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_applypointerevent",
       "label": "applyPointerEvent()",
@@ -242155,7 +242116,7 @@
       "source_location": "L116"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_applyremoteassistcontrolintent",
       "label": "applyRemoteAssistControlIntent()",
@@ -242164,7 +242125,7 @@
       "source_location": "L17"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_getrecentcontrolresult",
       "label": "getRecentControlResult()",
@@ -242173,7 +242134,7 @@
       "source_location": "L95"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_getremoteassistcontroltarget",
       "label": "getRemoteAssistControlTarget()",
@@ -242182,7 +242143,7 @@
       "source_location": "L145"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_prepareremoteassistcontrolintent",
       "label": "prepareRemoteAssistControlIntent()",
@@ -242191,7 +242152,7 @@
       "source_location": "L27"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_remembercontrolresult",
       "label": "rememberControlResult()",
@@ -242200,13 +242161,94 @@
       "source_location": "L101"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_remote_assist_runtime_applyremoteassistcontrolintent_ts",
       "label": "applyRemoteAssistControlIntent.ts",
       "norm_label": "applyremoteassistcontrolintent.ts",
       "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_offline_posofflinereadiness_ts",
+      "label": "posOfflineReadiness.ts",
+      "norm_label": "posofflinereadiness.ts",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "posofflinereadiness_buildposofflinereadinesssummary",
+      "label": "buildPosOfflineReadinessSummary()",
+      "norm_label": "buildposofflinereadinesssummary()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L152"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "posofflinereadiness_buildsignal",
+      "label": "buildSignal()",
+      "norm_label": "buildsignal()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L178"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "posofflinereadiness_formatage",
+      "label": "formatAge()",
+      "norm_label": "formatage()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L290"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsignaldescription",
+      "label": "getSignalDescription()",
+      "norm_label": "getsignaldescription()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L221"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsignalstatus",
+      "label": "getSignalStatus()",
+      "norm_label": "getsignalstatus()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L201"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsummarydescription",
+      "label": "getSummaryDescription()",
+      "norm_label": "getsummarydescription()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L262"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsummarytitle",
+      "label": "getSummaryTitle()",
+      "norm_label": "getsummarytitle()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L256"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "posofflinereadiness_isreadylike",
+      "label": "isReadyLike()",
+      "norm_label": "isreadylike()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L286"
     },
     {
       "community": 32,
@@ -242535,87 +242577,6 @@
     {
       "community": 320,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_offline_posofflinereadiness_ts",
-      "label": "posOfflineReadiness.ts",
-      "norm_label": "posofflinereadiness.ts",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "posofflinereadiness_buildposofflinereadinesssummary",
-      "label": "buildPosOfflineReadinessSummary()",
-      "norm_label": "buildposofflinereadinesssummary()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L152"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "posofflinereadiness_buildsignal",
-      "label": "buildSignal()",
-      "norm_label": "buildsignal()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L178"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "posofflinereadiness_formatage",
-      "label": "formatAge()",
-      "norm_label": "formatage()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L290"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsignaldescription",
-      "label": "getSignalDescription()",
-      "norm_label": "getsignaldescription()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L221"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsignalstatus",
-      "label": "getSignalStatus()",
-      "norm_label": "getsignalstatus()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L201"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsummarydescription",
-      "label": "getSummaryDescription()",
-      "norm_label": "getsummarydescription()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L262"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsummarytitle",
-      "label": "getSummaryTitle()",
-      "norm_label": "getsummarytitle()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L256"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "posofflinereadiness_isreadylike",
-      "label": "isReadyLike()",
-      "norm_label": "isreadylike()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L286"
-    },
-    {
-      "community": 321,
-      "file_type": "code",
       "id": "foundations_content_colorrolecard",
       "label": "ColorRoleCard()",
       "norm_label": "colorrolecard()",
@@ -242623,7 +242584,7 @@
       "source_location": "L222"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "foundations_content_densitycard",
       "label": "DensityCard()",
@@ -242632,7 +242593,7 @@
       "source_location": "L283"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "foundations_content_detailviewrolecard",
       "label": "DetailViewRoleCard()",
@@ -242641,7 +242602,7 @@
       "source_location": "L363"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "foundations_content_hslvar",
       "label": "hslVar()",
@@ -242650,7 +242611,7 @@
       "source_location": "L214"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "foundations_content_motioncard",
       "label": "MotionCard()",
@@ -242659,7 +242620,7 @@
       "source_location": "L342"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "foundations_content_spacetokenrow",
       "label": "SpaceTokenRow()",
@@ -242668,7 +242629,7 @@
       "source_location": "L265"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "foundations_content_textvar",
       "label": "textVar()",
@@ -242677,7 +242638,7 @@
       "source_location": "L218"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "foundations_content_typespecimencard",
       "label": "TypeSpecimenCard()",
@@ -242686,7 +242647,7 @@
       "source_location": "L246"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_foundations_content_tsx",
       "label": "foundations-content.tsx",
@@ -242695,7 +242656,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -242704,7 +242665,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -242713,7 +242674,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "versionchecker_buildidfromscripts",
       "label": "buildIdFromScripts()",
@@ -242722,7 +242683,7 @@
       "source_location": "L192"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "versionchecker_createversionchecker",
       "label": "createVersionChecker()",
@@ -242731,7 +242692,7 @@
       "source_location": "L16"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "versionchecker_getinitialdeploybuildid",
       "label": "getInitialDeployBuildId()",
@@ -242740,7 +242701,7 @@
       "source_location": "L135"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "versionchecker_readdeploybuildid",
       "label": "readDeployBuildId()",
@@ -242749,7 +242710,7 @@
       "source_location": "L141"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "versionchecker_readdocumentscriptsources",
       "label": "readDocumentScriptSources()",
@@ -242758,7 +242719,7 @@
       "source_location": "L174"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "versionchecker_readentryhtmlscripts",
       "label": "readEntryHtmlScripts()",
@@ -242767,13 +242728,94 @@
       "source_location": "L151"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "versionchecker_readscriptsources",
       "label": "readScriptSources()",
       "norm_label": "readscriptsources()",
       "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
       "source_location": "L182"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
+      "id": "productutils_getpreferredsku",
+      "label": "getPreferredSku()",
+      "norm_label": "getpreferredsku()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L82"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
+      "id": "productutils_sortskusbyavailabilitythenlength",
+      "label": "sortSkusByAvailabilityThenLength()",
+      "norm_label": "sortskusbyavailabilitythenlength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L59"
     },
     {
       "community": 323,
@@ -264540,51 +264582,6 @@
     {
       "community": 556,
       "file_type": "code",
-      "id": "currency_formatstoredamount",
-      "label": "formatStoredAmount()",
-      "norm_label": "formatstoredamount()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 556,
-      "file_type": "code",
-      "id": "currency_todisplayamount",
-      "label": "toDisplayAmount()",
-      "norm_label": "todisplayamount()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 556,
-      "file_type": "code",
-      "id": "currency_topesewas",
-      "label": "toPesewas()",
-      "norm_label": "topesewas()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 556,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 556,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 557,
-      "file_type": "code",
       "id": "packages_athena_webapp_convex_marketing_walkthroughrequestnotifications_ts",
       "label": "walkthroughRequestNotifications.ts",
       "norm_label": "walkthroughrequestnotifications.ts",
@@ -264592,7 +264589,7 @@
       "source_location": "L1"
     },
     {
-      "community": 557,
+      "community": 556,
       "file_type": "code",
       "id": "walkthroughrequestnotifications_boundedauditvalue",
       "label": "boundedAuditValue()",
@@ -264601,7 +264598,7 @@
       "source_location": "L27"
     },
     {
-      "community": 557,
+      "community": 556,
       "file_type": "code",
       "id": "walkthroughrequestnotifications_classifydeliveryresult",
       "label": "classifyDeliveryResult()",
@@ -264610,7 +264607,7 @@
       "source_location": "L13"
     },
     {
-      "community": 557,
+      "community": 556,
       "file_type": "code",
       "id": "walkthroughrequestnotifications_isdeliberateretryeligible",
       "label": "isDeliberateRetryEligible()",
@@ -264619,7 +264616,7 @@
       "source_location": "L20"
     },
     {
-      "community": 557,
+      "community": 556,
       "file_type": "code",
       "id": "walkthroughrequestnotifications_nextbackoffms",
       "label": "nextBackoffMs()",
@@ -264628,7 +264625,7 @@
       "source_location": "L12"
     },
     {
-      "community": 558,
+      "community": 557,
       "file_type": "code",
       "id": "backfillreportingcyclestart_test_createctx",
       "label": "createCtx()",
@@ -264637,7 +264634,7 @@
       "source_location": "L80"
     },
     {
-      "community": 558,
+      "community": 557,
       "file_type": "code",
       "id": "backfillreportingcyclestart_test_createstoreverificationctx",
       "label": "createStoreVerificationCtx()",
@@ -264646,7 +264643,7 @@
       "source_location": "L29"
     },
     {
-      "community": 558,
+      "community": 557,
       "file_type": "code",
       "id": "backfillreportingcyclestart_test_finishbackfill",
       "label": "finishBackfill()",
@@ -264655,7 +264652,7 @@
       "source_location": "L118"
     },
     {
-      "community": 558,
+      "community": 557,
       "file_type": "code",
       "id": "backfillreportingcyclestart_test_finishverification",
       "label": "finishVerification()",
@@ -264664,7 +264661,7 @@
       "source_location": "L139"
     },
     {
-      "community": 558,
+      "community": 557,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_backfillreportingcyclestart_test_ts",
       "label": "backfillReportingCycleStart.test.ts",
@@ -264673,7 +264670,7 @@
       "source_location": "L1"
     },
     {
-      "community": 559,
+      "community": 558,
       "file_type": "code",
       "id": "backfillstoretimezoneauthority_backfillstoretimezoneauthoritywithctx",
       "label": "backfillStoreTimezoneAuthorityWithCtx()",
@@ -264682,7 +264679,7 @@
       "source_location": "L127"
     },
     {
-      "community": 559,
+      "community": 558,
       "file_type": "code",
       "id": "backfillstoretimezoneauthority_buildrow",
       "label": "buildRow()",
@@ -264691,7 +264688,7 @@
       "source_location": "L47"
     },
     {
-      "community": 559,
+      "community": 558,
       "file_type": "code",
       "id": "backfillstoretimezoneauthority_listschedulesforstore",
       "label": "listSchedulesForStore()",
@@ -264700,7 +264697,7 @@
       "source_location": "L35"
     },
     {
-      "community": 559,
+      "community": 558,
       "file_type": "code",
       "id": "backfillstoretimezoneauthority_normalizelimit",
       "label": "normalizeLimit()",
@@ -264709,12 +264706,57 @@
       "source_location": "L28"
     },
     {
-      "community": 559,
+      "community": 558,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_backfillstoretimezoneauthority_ts",
       "label": "backfillStoreTimezoneAuthority.ts",
       "norm_label": "backfillstoretimezoneauthority.ts",
       "source_file": "packages/athena-webapp/convex/migrations/backfillStoreTimezoneAuthority.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 559,
+      "file_type": "code",
+      "id": "dispatch_recordnotificationfailureeventwithctx",
+      "label": "recordNotificationFailureEventWithCtx()",
+      "norm_label": "recordnotificationfailureeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/notifications/dispatch.ts",
+      "source_location": "L400"
+    },
+    {
+      "community": 559,
+      "file_type": "code",
+      "id": "dispatch_recordterminaldeliveryfailureevent",
+      "label": "recordTerminalDeliveryFailureEvent()",
+      "norm_label": "recordterminaldeliveryfailureevent()",
+      "source_file": "packages/athena-webapp/convex/notifications/dispatch.ts",
+      "source_location": "L427"
+    },
+    {
+      "community": 559,
+      "file_type": "code",
+      "id": "dispatch_resolverecipients",
+      "label": "resolveRecipients()",
+      "norm_label": "resolverecipients()",
+      "source_file": "packages/athena-webapp/convex/notifications/dispatch.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 559,
+      "file_type": "code",
+      "id": "dispatch_suppressintentwithctx",
+      "label": "suppressIntentWithCtx()",
+      "norm_label": "suppressintentwithctx()",
+      "source_file": "packages/athena-webapp/convex/notifications/dispatch.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 559,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_notifications_dispatch_ts",
+      "label": "dispatch.ts",
+      "norm_label": "dispatch.ts",
+      "source_file": "packages/athena-webapp/convex/notifications/dispatch.ts",
       "source_location": "L1"
     },
     {
@@ -264963,51 +265005,6 @@
     {
       "community": 560,
       "file_type": "code",
-      "id": "dispatch_recordnotificationfailureeventwithctx",
-      "label": "recordNotificationFailureEventWithCtx()",
-      "norm_label": "recordnotificationfailureeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/notifications/dispatch.ts",
-      "source_location": "L400"
-    },
-    {
-      "community": 560,
-      "file_type": "code",
-      "id": "dispatch_recordterminaldeliveryfailureevent",
-      "label": "recordTerminalDeliveryFailureEvent()",
-      "norm_label": "recordterminaldeliveryfailureevent()",
-      "source_file": "packages/athena-webapp/convex/notifications/dispatch.ts",
-      "source_location": "L427"
-    },
-    {
-      "community": 560,
-      "file_type": "code",
-      "id": "dispatch_resolverecipients",
-      "label": "resolveRecipients()",
-      "norm_label": "resolverecipients()",
-      "source_file": "packages/athena-webapp/convex/notifications/dispatch.ts",
-      "source_location": "L53"
-    },
-    {
-      "community": 560,
-      "file_type": "code",
-      "id": "dispatch_suppressintentwithctx",
-      "label": "suppressIntentWithCtx()",
-      "norm_label": "suppressintentwithctx()",
-      "source_file": "packages/athena-webapp/convex/notifications/dispatch.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 560,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_notifications_dispatch_ts",
-      "label": "dispatch.ts",
-      "norm_label": "dispatch.ts",
-      "source_file": "packages/athena-webapp/convex/notifications/dispatch.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 561,
-      "file_type": "code",
       "id": "packages_athena_webapp_convex_notifications_registry_test_ts",
       "label": "registry.test.ts",
       "norm_label": "registry.test.ts",
@@ -265015,7 +265012,7 @@
       "source_location": "L1"
     },
     {
-      "community": 561,
+      "community": 560,
       "file_type": "code",
       "id": "registry_test_dedupekey",
       "label": "dedupeKey()",
@@ -265024,7 +265021,7 @@
       "source_location": "L558"
     },
     {
-      "community": 561,
+      "community": 560,
       "file_type": "code",
       "id": "registry_test_keyfor",
       "label": "keyFor()",
@@ -265033,7 +265030,7 @@
       "source_location": "L733"
     },
     {
-      "community": 561,
+      "community": 560,
       "file_type": "code",
       "id": "registry_test_prepare",
       "label": "prepare()",
@@ -265042,7 +265039,7 @@
       "source_location": "L48"
     },
     {
-      "community": 561,
+      "community": 560,
       "file_type": "code",
       "id": "registry_test_stubctx",
       "label": "stubCtx()",
@@ -265051,7 +265048,7 @@
       "source_location": "L29"
     },
     {
-      "community": 562,
+      "community": 561,
       "file_type": "code",
       "id": "adapters_createnormaluseroperationadapter",
       "label": "createNormalUserOperationAdapter()",
@@ -265060,7 +265057,7 @@
       "source_location": "L13"
     },
     {
-      "community": 562,
+      "community": 561,
       "file_type": "code",
       "id": "adapters_createpublicoperationadapter",
       "label": "createPublicOperationAdapter()",
@@ -265069,7 +265066,7 @@
       "source_location": "L41"
     },
     {
-      "community": 562,
+      "community": 561,
       "file_type": "code",
       "id": "adapters_isadmitted",
       "label": "isAdmitted()",
@@ -265078,7 +265075,7 @@
       "source_location": "L115"
     },
     {
-      "community": 562,
+      "community": 561,
       "file_type": "code",
       "id": "adapters_resolveoperationadmission",
       "label": "resolveOperationAdmission()",
@@ -265087,7 +265084,7 @@
       "source_location": "L59"
     },
     {
-      "community": 562,
+      "community": 561,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_adapters_ts",
       "label": "adapters.ts",
@@ -265096,7 +265093,7 @@
       "source_location": "L1"
     },
     {
-      "community": 563,
+      "community": 562,
       "file_type": "code",
       "id": "approvalrequesterchallenges_consumeapprovalrequesterchallengewithctx",
       "label": "consumeApprovalRequesterChallengeWithCtx()",
@@ -265105,7 +265102,7 @@
       "source_location": "L97"
     },
     {
-      "community": 563,
+      "community": 562,
       "file_type": "code",
       "id": "approvalrequesterchallenges_createapprovalrequesterchallengewithctx",
       "label": "createApprovalRequesterChallengeWithCtx()",
@@ -265114,7 +265111,7 @@
       "source_location": "L55"
     },
     {
-      "community": 563,
+      "community": 562,
       "file_type": "code",
       "id": "approvalrequesterchallenges_invalidapprovalrequesterchallengeresult",
       "label": "invalidApprovalRequesterChallengeResult()",
@@ -265123,7 +265120,7 @@
       "source_location": "L37"
     },
     {
-      "community": 563,
+      "community": 562,
       "file_type": "code",
       "id": "approvalrequesterchallenges_torequesterbinding",
       "label": "toRequesterBinding()",
@@ -265132,7 +265129,7 @@
       "source_location": "L44"
     },
     {
-      "community": 563,
+      "community": 562,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequesterchallenges_ts",
       "label": "approvalRequesterChallenges.ts",
@@ -265141,7 +265138,7 @@
       "source_location": "L1"
     },
     {
-      "community": 564,
+      "community": 563,
       "file_type": "code",
       "id": "customerprofiles_compactrecord",
       "label": "compactRecord()",
@@ -265150,7 +265147,7 @@
       "source_location": "L24"
     },
     {
-      "community": 564,
+      "community": 563,
       "file_type": "code",
       "id": "customerprofiles_ensurecustomerprofilefromsourceswithctx",
       "label": "ensureCustomerProfileFromSourcesWithCtx()",
@@ -265159,7 +265156,7 @@
       "source_location": "L207"
     },
     {
-      "community": 564,
+      "community": 563,
       "file_type": "code",
       "id": "customerprofiles_findexistingprofile",
       "label": "findExistingProfile()",
@@ -265168,7 +265165,7 @@
       "source_location": "L45"
     },
     {
-      "community": 564,
+      "community": 563,
       "file_type": "code",
       "id": "customerprofiles_loadcustomersources",
       "label": "loadCustomerSources()",
@@ -265177,7 +265174,7 @@
       "source_location": "L30"
     },
     {
-      "community": 564,
+      "community": 563,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_customerprofiles_ts",
       "label": "customerProfiles.ts",
@@ -265186,7 +265183,7 @@
       "source_location": "L1"
     },
     {
-      "community": 565,
+      "community": 564,
       "file_type": "code",
       "id": "operationalworkitems_test_approvalrequest",
       "label": "approvalRequest()",
@@ -265195,7 +265192,7 @@
       "source_location": "L46"
     },
     {
-      "community": 565,
+      "community": 564,
       "file_type": "code",
       "id": "operationalworkitems_test_createqueuecontext",
       "label": "createQueueContext()",
@@ -265204,7 +265201,7 @@
       "source_location": "L59"
     },
     {
-      "community": 565,
+      "community": 564,
       "file_type": "code",
       "id": "operationalworkitems_test_gethandler",
       "label": "getHandler()",
@@ -265213,7 +265210,7 @@
       "source_location": "L25"
     },
     {
-      "community": 565,
+      "community": 564,
       "file_type": "code",
       "id": "operationalworkitems_test_workitem",
       "label": "workItem()",
@@ -265222,7 +265219,7 @@
       "source_location": "L31"
     },
     {
-      "community": 565,
+      "community": 564,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalworkitems_test_ts",
       "label": "operationalWorkItems.test.ts",
@@ -265231,7 +265228,7 @@
       "source_location": "L1"
     },
     {
-      "community": 566,
+      "community": 565,
       "file_type": "code",
       "id": "oweddailyclosesweep_completedoperatingdatesforstore",
       "label": "completedOperatingDatesForStore()",
@@ -265240,7 +265237,7 @@
       "source_location": "L149"
     },
     {
-      "community": 566,
+      "community": 565,
       "file_type": "code",
       "id": "oweddailyclosesweep_daysbetweenoperatingdates",
       "label": "daysBetweenOperatingDates()",
@@ -265249,7 +265246,7 @@
       "source_location": "L354"
     },
     {
-      "community": 566,
+      "community": 565,
       "file_type": "code",
       "id": "oweddailyclosesweep_listenabledeodpolicies",
       "label": "listEnabledEodPolicies()",
@@ -265258,7 +265255,7 @@
       "source_location": "L135"
     },
     {
-      "community": 566,
+      "community": 565,
       "file_type": "code",
       "id": "oweddailyclosesweep_selectoweddailyclosedates",
       "label": "selectOwedDailyCloseDates()",
@@ -265267,7 +265264,7 @@
       "source_location": "L84"
     },
     {
-      "community": 566,
+      "community": 565,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "label": "owedDailyCloseSweep.ts",
@@ -265276,7 +265273,7 @@
       "source_location": "L1"
     },
     {
-      "community": 567,
+      "community": 566,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_paymenttotals_ts",
       "label": "paymentTotals.ts",
@@ -265285,7 +265282,7 @@
       "source_location": "L1"
     },
     {
-      "community": 567,
+      "community": 566,
       "file_type": "code",
       "id": "paymenttotals_buildpaymenttotals",
       "label": "buildPaymentTotals()",
@@ -265294,7 +265291,7 @@
       "source_location": "L50"
     },
     {
-      "community": 567,
+      "community": 566,
       "file_type": "code",
       "id": "paymenttotals_listtransactionpayments",
       "label": "listTransactionPayments()",
@@ -265303,7 +265300,7 @@
       "source_location": "L11"
     },
     {
-      "community": 567,
+      "community": 566,
       "file_type": "code",
       "id": "paymenttotals_transactioncashdelta",
       "label": "transactionCashDelta()",
@@ -265312,7 +265309,7 @@
       "source_location": "L81"
     },
     {
-      "community": 567,
+      "community": 566,
       "file_type": "code",
       "id": "paymenttotals_transactionpaymenttotals",
       "label": "transactionPaymentTotals()",
@@ -265321,7 +265318,7 @@
       "source_location": "L25"
     },
     {
-      "community": 568,
+      "community": 567,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffcredentials_test_ts",
       "label": "staffCredentials.test.ts",
@@ -265330,7 +265327,7 @@
       "source_location": "L1"
     },
     {
-      "community": 568,
+      "community": 567,
       "file_type": "code",
       "id": "staffcredentials_test_admissionawareauth",
       "label": "admissionAwareAuth()",
@@ -265339,7 +265336,7 @@
       "source_location": "L256"
     },
     {
-      "community": 568,
+      "community": 567,
       "file_type": "code",
       "id": "staffcredentials_test_createrestoredproofvalidationctx",
       "label": "createRestoredProofValidationCtx()",
@@ -265348,7 +265345,7 @@
       "source_location": "L271"
     },
     {
-      "community": 568,
+      "community": 567,
       "file_type": "code",
       "id": "staffcredentials_test_createstaffcredentialsmutationctx",
       "label": "createStaffCredentialsMutationCtx()",
@@ -265357,7 +265354,7 @@
       "source_location": "L81"
     },
     {
-      "community": 568,
+      "community": 567,
       "file_type": "code",
       "id": "staffcredentials_test_gethandler",
       "label": "getHandler()",
@@ -265366,7 +265363,7 @@
       "source_location": "L267"
     },
     {
-      "community": 569,
+      "community": 568,
       "file_type": "code",
       "id": "assigncustomer_test_customerprofile",
       "label": "customerProfile()",
@@ -265375,7 +265372,7 @@
       "source_location": "L319"
     },
     {
-      "community": 569,
+      "community": 568,
       "file_type": "code",
       "id": "assigncustomer_test_guest",
       "label": "guest()",
@@ -265384,7 +265381,7 @@
       "source_location": "L346"
     },
     {
-      "community": 569,
+      "community": 568,
       "file_type": "code",
       "id": "assigncustomer_test_poscustomer",
       "label": "posCustomer()",
@@ -265393,7 +265390,7 @@
       "source_location": "L303"
     },
     {
-      "community": 569,
+      "community": 568,
       "file_type": "code",
       "id": "assigncustomer_test_storefrontuser",
       "label": "storeFrontUser()",
@@ -265402,13 +265399,58 @@
       "source_location": "L333"
     },
     {
-      "community": 569,
+      "community": 568,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_test_ts",
       "label": "assignCustomer.test.ts",
       "norm_label": "assigncustomer.test.ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.test.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 569,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_registerlifecycleauthority_ts",
+      "label": "registerLifecycleAuthority.ts",
+      "norm_label": "registerlifecycleauthority.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/registerLifecycleAuthority.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 569,
+      "file_type": "code",
+      "id": "registerlifecycleauthority_acknowledgeregisterlifecycleauthority",
+      "label": "acknowledgeRegisterLifecycleAuthority()",
+      "norm_label": "acknowledgeregisterlifecycleauthority()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/registerLifecycleAuthority.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 569,
+      "file_type": "code",
+      "id": "registerlifecycleauthority_equivalentacknowledgement",
+      "label": "equivalentAcknowledgement()",
+      "norm_label": "equivalentacknowledgement()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/registerLifecycleAuthority.ts",
+      "source_location": "L124"
+    },
+    {
+      "community": 569,
+      "file_type": "code",
+      "id": "registerlifecycleauthority_isrevision",
+      "label": "isRevision()",
+      "norm_label": "isrevision()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/registerLifecycleAuthority.ts",
+      "source_location": "L153"
+    },
+    {
+      "community": 569,
+      "file_type": "code",
+      "id": "registerlifecycleauthority_normalizesafemetadata",
+      "label": "normalizeSafeMetadata()",
+      "norm_label": "normalizesafemetadata()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/registerLifecycleAuthority.ts",
+      "source_location": "L145"
     },
     {
       "community": 57,
@@ -265656,51 +265698,6 @@
     {
       "community": 570,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_registerlifecycleauthority_ts",
-      "label": "registerLifecycleAuthority.ts",
-      "norm_label": "registerlifecycleauthority.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/registerLifecycleAuthority.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 570,
-      "file_type": "code",
-      "id": "registerlifecycleauthority_acknowledgeregisterlifecycleauthority",
-      "label": "acknowledgeRegisterLifecycleAuthority()",
-      "norm_label": "acknowledgeregisterlifecycleauthority()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/registerLifecycleAuthority.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 570,
-      "file_type": "code",
-      "id": "registerlifecycleauthority_equivalentacknowledgement",
-      "label": "equivalentAcknowledgement()",
-      "norm_label": "equivalentacknowledgement()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/registerLifecycleAuthority.ts",
-      "source_location": "L124"
-    },
-    {
-      "community": 570,
-      "file_type": "code",
-      "id": "registerlifecycleauthority_isrevision",
-      "label": "isRevision()",
-      "norm_label": "isrevision()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/registerLifecycleAuthority.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 570,
-      "file_type": "code",
-      "id": "registerlifecycleauthority_normalizesafemetadata",
-      "label": "normalizeSafeMetadata()",
-      "norm_label": "normalizesafemetadata()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/registerLifecycleAuthority.ts",
-      "source_location": "L145"
-    },
-    {
-      "community": 571,
-      "file_type": "code",
       "id": "correctionpolicy_builddecision",
       "label": "buildDecision()",
       "norm_label": "builddecision()",
@@ -265708,7 +265705,7 @@
       "source_location": "L107"
     },
     {
-      "community": 571,
+      "community": 570,
       "file_type": "code",
       "id": "correctionpolicy_classifycorrectionintent",
       "label": "classifyCorrectionIntent()",
@@ -265717,7 +265714,7 @@
       "source_location": "L117"
     },
     {
-      "community": 571,
+      "community": 570,
       "file_type": "code",
       "id": "correctionpolicy_issupportedcorrectionintent",
       "label": "isSupportedCorrectionIntent()",
@@ -265726,7 +265723,7 @@
       "source_location": "L91"
     },
     {
-      "community": 571,
+      "community": 570,
       "file_type": "code",
       "id": "correctionpolicy_isunsupportedhighriskcorrectionintent",
       "label": "isUnsupportedHighRiskCorrectionIntent()",
@@ -265735,7 +265732,7 @@
       "source_location": "L99"
     },
     {
-      "community": 571,
+      "community": 570,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_corrections_correctionpolicy_ts",
       "label": "correctionPolicy.ts",
@@ -265744,7 +265741,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 571,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_reconcilesequencegaps_ts",
       "label": "reconcileSequenceGaps.ts",
@@ -265753,7 +265750,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 571,
       "file_type": "code",
       "id": "reconcilesequencegaps_collectterminalevidence",
       "label": "collectTerminalEvidence()",
@@ -265762,7 +265759,7 @@
       "source_location": "L185"
     },
     {
-      "community": 572,
+      "community": 571,
       "file_type": "code",
       "id": "reconcilesequencegaps_issuegapprobe",
       "label": "issueGapProbe()",
@@ -265771,7 +265768,7 @@
       "source_location": "L249"
     },
     {
-      "community": 572,
+      "community": 571,
       "file_type": "code",
       "id": "reconcilesequencegaps_listheldeventsforcursor",
       "label": "listHeldEventsForCursor()",
@@ -265780,7 +265777,7 @@
       "source_location": "L156"
     },
     {
-      "community": 572,
+      "community": 571,
       "file_type": "code",
       "id": "reconcilesequencegaps_skipsequencegap",
       "label": "skipSequenceGap()",
@@ -265789,7 +265786,7 @@
       "source_location": "L295"
     },
     {
-      "community": 573,
+      "community": 572,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminaloperationalstate_policy_test_ts",
       "label": "policy.test.ts",
@@ -265798,7 +265795,7 @@
       "source_location": "L1"
     },
     {
-      "community": 573,
+      "community": 572,
       "file_type": "code",
       "id": "policy_test_baseinput",
       "label": "baseInput()",
@@ -265807,7 +265804,7 @@
       "source_location": "L1225"
     },
     {
-      "community": 573,
+      "community": 572,
       "file_type": "code",
       "id": "policy_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -265816,7 +265813,7 @@
       "source_location": "L1329"
     },
     {
-      "community": 573,
+      "community": 572,
       "file_type": "code",
       "id": "policy_test_buildruntimestatus",
       "label": "buildRuntimeStatus()",
@@ -265825,7 +265822,7 @@
       "source_location": "L1287"
     },
     {
-      "community": 573,
+      "community": 572,
       "file_type": "code",
       "id": "policy_test_emptysyncevidence",
       "label": "emptySyncEvidence()",
@@ -265834,7 +265831,7 @@
       "source_location": "L1267"
     },
     {
-      "community": 574,
+      "community": 573,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_terminalrecoveryrepository_test_ts",
       "label": "terminalRecoveryRepository.test.ts",
@@ -265843,7 +265840,7 @@
       "source_location": "L1"
     },
     {
-      "community": 574,
+      "community": 573,
       "file_type": "code",
       "id": "terminalrecoveryrepository_test_buildctx",
       "label": "buildCtx()",
@@ -265852,7 +265849,7 @@
       "source_location": "L381"
     },
     {
-      "community": 574,
+      "community": 573,
       "file_type": "code",
       "id": "terminalrecoveryrepository_test_buildqueryctx",
       "label": "buildQueryCtx()",
@@ -265861,7 +265858,7 @@
       "source_location": "L469"
     },
     {
-      "community": 574,
+      "community": 573,
       "file_type": "code",
       "id": "terminalrecoveryrepository_test_filterrows",
       "label": "filterRows()",
@@ -265870,7 +265867,7 @@
       "source_location": "L483"
     },
     {
-      "community": 574,
+      "community": 573,
       "file_type": "code",
       "id": "terminalrecoveryrepository_test_orderedrows",
       "label": "orderedRows()",
@@ -265879,7 +265876,7 @@
       "source_location": "L492"
     },
     {
-      "community": 575,
+      "community": 574,
       "file_type": "code",
       "id": "customers_requireposcustomeraccessbyid",
       "label": "requirePosCustomerAccessById()",
@@ -265888,7 +265885,7 @@
       "source_location": "L76"
     },
     {
-      "community": 575,
+      "community": 574,
       "file_type": "code",
       "id": "customers_requireposcustomerreadaccessbyid",
       "label": "requirePosCustomerReadAccessById()",
@@ -265897,7 +265894,7 @@
       "source_location": "L123"
     },
     {
-      "community": 575,
+      "community": 574,
       "file_type": "code",
       "id": "customers_requireposcustomerstoreaccess",
       "label": "requirePosCustomerStoreAccess()",
@@ -265906,7 +265903,7 @@
       "source_location": "L53"
     },
     {
-      "community": 575,
+      "community": 574,
       "file_type": "code",
       "id": "customers_requireposcustomerstorereadaccess",
       "label": "requirePosCustomerStoreReadAccess()",
@@ -265915,7 +265912,7 @@
       "source_location": "L99"
     },
     {
-      "community": 575,
+      "community": 574,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_customers_ts",
       "label": "customers.ts",
@@ -265924,7 +265921,7 @@
       "source_location": "L1"
     },
     {
-      "community": 576,
+      "community": 575,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_posrecoverycodes_test_ts",
       "label": "posRecoveryCodes.test.ts",
@@ -265933,7 +265930,7 @@
       "source_location": "L1"
     },
     {
-      "community": 576,
+      "community": 575,
       "file_type": "code",
       "id": "posrecoverycodes_test_buildctx",
       "label": "buildCtx()",
@@ -265942,7 +265939,7 @@
       "source_location": "L565"
     },
     {
-      "community": 576,
+      "community": 575,
       "file_type": "code",
       "id": "posrecoverycodes_test_createfilter",
       "label": "createFilter()",
@@ -265951,7 +265948,7 @@
       "source_location": "L669"
     },
     {
-      "community": 576,
+      "community": 575,
       "file_type": "code",
       "id": "posrecoverycodes_test_createquery",
       "label": "createQuery()",
@@ -265960,7 +265957,7 @@
       "source_location": "L642"
     },
     {
-      "community": 576,
+      "community": 575,
       "file_type": "code",
       "id": "posrecoverycodes_test_gethandler",
       "label": "getHandler()",
@@ -265969,7 +265966,7 @@
       "source_location": "L25"
     },
     {
-      "community": 577,
+      "community": 576,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_telemetry_test_ts",
       "label": "telemetry.test.ts",
@@ -265978,7 +265975,7 @@
       "source_location": "L1"
     },
     {
-      "community": 577,
+      "community": 576,
       "file_type": "code",
       "id": "telemetry_test_baseevent",
       "label": "baseEvent()",
@@ -265987,7 +265984,7 @@
       "source_location": "L106"
     },
     {
-      "community": 577,
+      "community": 576,
       "file_type": "code",
       "id": "telemetry_test_createctx",
       "label": "createCtx()",
@@ -265996,7 +265993,7 @@
       "source_location": "L34"
     },
     {
-      "community": 577,
+      "community": 576,
       "file_type": "code",
       "id": "telemetry_test_gethandler",
       "label": "getHandler()",
@@ -266005,7 +266002,7 @@
       "source_location": "L24"
     },
     {
-      "community": 577,
+      "community": 576,
       "file_type": "code",
       "id": "telemetry_test_storedevent",
       "label": "storedEvent()",
@@ -266014,7 +266011,7 @@
       "source_location": "L371"
     },
     {
-      "community": 578,
+      "community": 577,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_ts",
       "label": "transactions.ts",
@@ -266023,7 +266020,7 @@
       "source_location": "L1"
     },
     {
-      "community": 578,
+      "community": 577,
       "file_type": "code",
       "id": "transactions_mapcorrectionerror",
       "label": "mapCorrectionError()",
@@ -266032,7 +266029,7 @@
       "source_location": "L339"
     },
     {
-      "community": 578,
+      "community": 577,
       "file_type": "code",
       "id": "transactions_redactpospulsesummary",
       "label": "redactPosPulseSummary()",
@@ -266041,7 +266038,7 @@
       "source_location": "L307"
     },
     {
-      "community": 578,
+      "community": 577,
       "file_type": "code",
       "id": "transactions_requirepostransactionaccess",
       "label": "requirePosTransactionAccess()",
@@ -266050,7 +266047,7 @@
       "source_location": "L93"
     },
     {
-      "community": 578,
+      "community": 577,
       "file_type": "code",
       "id": "transactions_requirepostransactionstoreaccess",
       "label": "requirePosTransactionStoreAccess()",
@@ -266059,7 +266056,7 @@
       "source_location": "L64"
     },
     {
-      "community": 579,
+      "community": 578,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_application_policy_ts",
       "label": "policy.ts",
@@ -266068,7 +266065,7 @@
       "source_location": "L1"
     },
     {
-      "community": 579,
+      "community": 578,
       "file_type": "code",
       "id": "policy_denied",
       "label": "denied()",
@@ -266077,7 +266074,7 @@
       "source_location": "L96"
     },
     {
-      "community": 579,
+      "community": 578,
       "file_type": "code",
       "id": "policy_evaluateremoteassistpolicy",
       "label": "evaluateRemoteAssistPolicy()",
@@ -266086,7 +266083,7 @@
       "source_location": "L31"
     },
     {
-      "community": 579,
+      "community": 578,
       "file_type": "code",
       "id": "policy_isclientfresh",
       "label": "isClientFresh()",
@@ -266095,13 +266092,58 @@
       "source_location": "L88"
     },
     {
-      "community": 579,
+      "community": 578,
       "file_type": "code",
       "id": "policy_policydecisiontocommandresult",
       "label": "policyDecisionToCommandResult()",
       "norm_label": "policydecisiontocommandresult()",
       "source_file": "packages/athena-webapp/convex/remoteAssist/application/policy.ts",
       "source_location": "L76"
+    },
+    {
+      "community": 579,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_remoteassist_infrastructure_remoteassistreadrepository_ts",
+      "label": "remoteAssistReadRepository.ts",
+      "norm_label": "remoteassistreadrepository.ts",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/infrastructure/remoteAssistReadRepository.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 579,
+      "file_type": "code",
+      "id": "remoteassistreadrepository_compareremoteassistsessionforsupportview",
+      "label": "compareRemoteAssistSessionForSupportView()",
+      "norm_label": "compareremoteassistsessionforsupportview()",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/infrastructure/remoteAssistReadRepository.ts",
+      "source_location": "L88"
+    },
+    {
+      "community": 579,
+      "file_type": "code",
+      "id": "remoteassistreadrepository_createremoteassistreadrepository",
+      "label": "createRemoteAssistReadRepository()",
+      "norm_label": "createremoteassistreadrepository()",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/infrastructure/remoteAssistReadRepository.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 579,
+      "file_type": "code",
+      "id": "remoteassistreadrepository_toremoteassistclient",
+      "label": "toRemoteAssistClient()",
+      "norm_label": "toremoteassistclient()",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/infrastructure/remoteAssistReadRepository.ts",
+      "source_location": "L108"
+    },
+    {
+      "community": 579,
+      "file_type": "code",
+      "id": "remoteassistreadrepository_toremoteassistsession",
+      "label": "toRemoteAssistSession()",
+      "norm_label": "toremoteassistsession()",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/infrastructure/remoteAssistReadRepository.ts",
+      "source_location": "L121"
     },
     {
       "community": 58,
@@ -266349,51 +266391,6 @@
     {
       "community": 580,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_remoteassist_infrastructure_remoteassistreadrepository_ts",
-      "label": "remoteAssistReadRepository.ts",
-      "norm_label": "remoteassistreadrepository.ts",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/infrastructure/remoteAssistReadRepository.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 580,
-      "file_type": "code",
-      "id": "remoteassistreadrepository_compareremoteassistsessionforsupportview",
-      "label": "compareRemoteAssistSessionForSupportView()",
-      "norm_label": "compareremoteassistsessionforsupportview()",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/infrastructure/remoteAssistReadRepository.ts",
-      "source_location": "L88"
-    },
-    {
-      "community": 580,
-      "file_type": "code",
-      "id": "remoteassistreadrepository_createremoteassistreadrepository",
-      "label": "createRemoteAssistReadRepository()",
-      "norm_label": "createremoteassistreadrepository()",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/infrastructure/remoteAssistReadRepository.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 580,
-      "file_type": "code",
-      "id": "remoteassistreadrepository_toremoteassistclient",
-      "label": "toRemoteAssistClient()",
-      "norm_label": "toremoteassistclient()",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/infrastructure/remoteAssistReadRepository.ts",
-      "source_location": "L108"
-    },
-    {
-      "community": 580,
-      "file_type": "code",
-      "id": "remoteassistreadrepository_toremoteassistsession",
-      "label": "toRemoteAssistSession()",
-      "norm_label": "toremoteassistsession()",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/infrastructure/remoteAssistReadRepository.ts",
-      "source_location": "L121"
-    },
-    {
-      "community": 581,
-      "file_type": "code",
       "id": "fingerprint_factfingerprint",
       "label": "factFingerprint()",
       "norm_label": "factfingerprint()",
@@ -266401,7 +266398,7 @@
       "source_location": "L86"
     },
     {
-      "community": 581,
+      "community": 580,
       "file_type": "code",
       "id": "fingerprint_fingerprintpayload",
       "label": "fingerprintPayload()",
@@ -266410,7 +266407,7 @@
       "source_location": "L33"
     },
     {
-      "community": 581,
+      "community": 580,
       "file_type": "code",
       "id": "fingerprint_matchesstoredfingerprint",
       "label": "matchesStoredFingerprint()",
@@ -266419,7 +266416,7 @@
       "source_location": "L103"
     },
     {
-      "community": 581,
+      "community": 580,
       "file_type": "code",
       "id": "fingerprint_stablestringhash",
       "label": "stableStringHash()",
@@ -266428,7 +266425,7 @@
       "source_location": "L72"
     },
     {
-      "community": 581,
+      "community": 580,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_fingerprint_ts",
       "label": "fingerprint.ts",
@@ -266437,7 +266434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 582,
+      "community": 581,
       "file_type": "code",
       "id": "foldday_test_fact",
       "label": "fact()",
@@ -266446,7 +266443,7 @@
       "source_location": "L78"
     },
     {
-      "community": 582,
+      "community": 581,
       "file_type": "code",
       "id": "foldday_test_receipt",
       "label": "receipt()",
@@ -266455,7 +266452,7 @@
       "source_location": "L757"
     },
     {
-      "community": 582,
+      "community": 581,
       "file_type": "code",
       "id": "foldday_test_sale",
       "label": "sale()",
@@ -266464,7 +266461,7 @@
       "source_location": "L97"
     },
     {
-      "community": 582,
+      "community": 581,
       "file_type": "code",
       "id": "foldday_test_shuffle",
       "label": "shuffle()",
@@ -266473,7 +266470,7 @@
       "source_location": "L108"
     },
     {
-      "community": 582,
+      "community": 581,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_foldday_test_ts",
       "label": "foldDay.test.ts",
@@ -266482,7 +266479,7 @@
       "source_location": "L1"
     },
     {
-      "community": 583,
+      "community": 582,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_servicecases_test_ts",
       "label": "serviceCases.test.ts",
@@ -266491,7 +266488,7 @@
       "source_location": "L1"
     },
     {
-      "community": 583,
+      "community": 582,
       "file_type": "code",
       "id": "servicecases_test_createinventoryusagectx",
       "label": "createInventoryUsageCtx()",
@@ -266500,7 +266497,7 @@
       "source_location": "L77"
     },
     {
-      "community": 583,
+      "community": 582,
       "file_type": "code",
       "id": "servicecases_test_expectindex",
       "label": "expectIndex()",
@@ -266509,7 +266506,7 @@
       "source_location": "L66"
     },
     {
-      "community": 583,
+      "community": 582,
       "file_type": "code",
       "id": "servicecases_test_gethandler",
       "label": "getHandler()",
@@ -266518,7 +266515,7 @@
       "source_location": "L73"
     },
     {
-      "community": 583,
+      "community": 582,
       "file_type": "code",
       "id": "servicecases_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -266527,7 +266524,7 @@
       "source_location": "L59"
     },
     {
-      "community": 584,
+      "community": 583,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_services_paystackservice_ts",
       "label": "paystackService.ts",
@@ -266536,7 +266533,7 @@
       "source_location": "L1"
     },
     {
-      "community": 584,
+      "community": 583,
       "file_type": "code",
       "id": "paystackservice_getpaystackheaders",
       "label": "getPaystackHeaders()",
@@ -266545,7 +266542,7 @@
       "source_location": "L11"
     },
     {
-      "community": 584,
+      "community": 583,
       "file_type": "code",
       "id": "paystackservice_initializetransaction",
       "label": "initializeTransaction()",
@@ -266554,7 +266551,7 @@
       "source_location": "L21"
     },
     {
-      "community": 584,
+      "community": 583,
       "file_type": "code",
       "id": "paystackservice_initiaterefund",
       "label": "initiateRefund()",
@@ -266563,7 +266560,7 @@
       "source_location": "L87"
     },
     {
-      "community": 584,
+      "community": 583,
       "file_type": "code",
       "id": "paystackservice_verifytransaction",
       "label": "verifyTransaction()",
@@ -266572,7 +266569,7 @@
       "source_location": "L65"
     },
     {
-      "community": 585,
+      "community": 584,
       "file_type": "code",
       "id": "admission_test_admissioncontext",
       "label": "admissionContext()",
@@ -266581,7 +266578,7 @@
       "source_location": "L17"
     },
     {
-      "community": 585,
+      "community": 584,
       "file_type": "code",
       "id": "admission_test_configureadmissionenvironment",
       "label": "configureAdmissionEnvironment()",
@@ -266590,7 +266587,7 @@
       "source_location": "L60"
     },
     {
-      "community": 585,
+      "community": 584,
       "file_type": "code",
       "id": "admission_test_contextwith",
       "label": "contextWith()",
@@ -266599,7 +266596,7 @@
       "source_location": "L120"
     },
     {
-      "community": 585,
+      "community": 584,
       "file_type": "code",
       "id": "admission_test_invoke",
       "label": "invoke()",
@@ -266608,7 +266605,7 @@
       "source_location": "L14"
     },
     {
-      "community": 585,
+      "community": 584,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_admission_test_ts",
       "label": "admission.test.ts",
@@ -266617,7 +266614,7 @@
       "source_location": "L1"
     },
     {
-      "community": 586,
+      "community": 585,
       "file_type": "code",
       "id": "config_calculateshareddemoexpectedcash",
       "label": "calculateSharedDemoExpectedCash()",
@@ -266626,7 +266623,7 @@
       "source_location": "L23"
     },
     {
-      "community": 586,
+      "community": 585,
       "file_type": "code",
       "id": "config_isshareddemoenabled",
       "label": "isSharedDemoEnabled()",
@@ -266635,7 +266632,7 @@
       "source_location": "L33"
     },
     {
-      "community": 586,
+      "community": 585,
       "file_type": "code",
       "id": "config_readruntimeshareddemoconfig",
       "label": "readRuntimeSharedDemoConfig()",
@@ -266644,7 +266641,7 @@
       "source_location": "L59"
     },
     {
-      "community": 586,
+      "community": 585,
       "file_type": "code",
       "id": "config_readshareddemoconfig",
       "label": "readSharedDemoConfig()",
@@ -266653,7 +266650,7 @@
       "source_location": "L40"
     },
     {
-      "community": 586,
+      "community": 585,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_config_ts",
       "label": "config.ts",
@@ -266662,7 +266659,7 @@
       "source_location": "L1"
     },
     {
-      "community": 587,
+      "community": 586,
       "file_type": "code",
       "id": "openingbaseline_buildshareddemoopeningbaseline",
       "label": "buildSharedDemoOpeningBaseline()",
@@ -266671,7 +266668,7 @@
       "source_location": "L63"
     },
     {
-      "community": 587,
+      "community": 586,
       "file_type": "code",
       "id": "openingbaseline_buildshareddemostoredayevent",
       "label": "buildSharedDemoStoreDayEvent()",
@@ -266680,7 +266677,7 @@
       "source_location": "L105"
     },
     {
-      "community": 587,
+      "community": 586,
       "file_type": "code",
       "id": "openingbaseline_rollshareddemoopeningbaselinewithctx",
       "label": "rollSharedDemoOpeningBaselineWithCtx()",
@@ -266689,7 +266686,7 @@
       "source_location": "L132"
     },
     {
-      "community": 587,
+      "community": 586,
       "file_type": "code",
       "id": "openingbaseline_shareddemooperatingdaterange",
       "label": "sharedDemoOperatingDateRange()",
@@ -266698,7 +266695,7 @@
       "source_location": "L21"
     },
     {
-      "community": 587,
+      "community": 586,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_openingbaseline_ts",
       "label": "openingBaseline.ts",
@@ -266707,7 +266704,7 @@
       "source_location": "L1"
     },
     {
-      "community": 588,
+      "community": 587,
       "file_type": "code",
       "id": "operationadapter_createshareddemooperationadapter",
       "label": "createSharedDemoOperationAdapter()",
@@ -266716,7 +266713,7 @@
       "source_location": "L18"
     },
     {
-      "community": 588,
+      "community": 587,
       "file_type": "code",
       "id": "operationadapter_isrecognizedshareddemoactorerror",
       "label": "isRecognizedSharedDemoActorError()",
@@ -266725,7 +266722,7 @@
       "source_location": "L100"
     },
     {
-      "community": 588,
+      "community": 587,
       "file_type": "code",
       "id": "operationadapter_shareddemodenialerror",
       "label": "sharedDemoDenialError()",
@@ -266734,7 +266731,7 @@
       "source_location": "L124"
     },
     {
-      "community": 588,
+      "community": 587,
       "file_type": "code",
       "id": "operationadapter_shareddemodenied",
       "label": "sharedDemoDenied()",
@@ -266743,7 +266740,7 @@
       "source_location": "L108"
     },
     {
-      "community": 588,
+      "community": 587,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_operationadapter_ts",
       "label": "operationAdapter.ts",
@@ -266752,7 +266749,7 @@
       "source_location": "L1"
     },
     {
-      "community": 589,
+      "community": 588,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_ts",
       "label": "storefrontObservabilityReport.ts",
@@ -266761,7 +266758,7 @@
       "source_location": "L1"
     },
     {
-      "community": 589,
+      "community": 588,
       "file_type": "code",
       "id": "storefrontobservabilityreport_buildstorefrontobservabilityreport",
       "label": "buildStorefrontObservabilityReport()",
@@ -266770,7 +266767,7 @@
       "source_location": "L124"
     },
     {
-      "community": 589,
+      "community": 588,
       "file_type": "code",
       "id": "storefrontobservabilityreport_getnonemptystring",
       "label": "getNonEmptyString()",
@@ -266779,7 +266776,7 @@
       "source_location": "L67"
     },
     {
-      "community": 589,
+      "community": 588,
       "file_type": "code",
       "id": "storefrontobservabilityreport_gettrafficsource",
       "label": "getTrafficSource()",
@@ -266788,13 +266785,58 @@
       "source_location": "L106"
     },
     {
-      "community": 589,
+      "community": 588,
       "file_type": "code",
       "id": "storefrontobservabilityreport_normalizestorefrontobservabilityevent",
       "label": "normalizeStorefrontObservabilityEvent()",
       "norm_label": "normalizestorefrontobservabilityevent()",
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
       "source_location": "L73"
+    },
+    {
+      "community": 589,
+      "file_type": "code",
+      "id": "onlineorder_buildlookup",
+      "label": "buildLookup()",
+      "norm_label": "buildlookup()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/onlineOrder.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 589,
+      "file_type": "code",
+      "id": "onlineorder_buildonlineordertraceseed",
+      "label": "buildOnlineOrderTraceSeed()",
+      "norm_label": "buildonlineordertraceseed()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/onlineOrder.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 589,
+      "file_type": "code",
+      "id": "onlineorder_buildsafeexternalreferenceref",
+      "label": "buildSafeExternalReferenceRef()",
+      "norm_label": "buildsafeexternalreferenceref()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/onlineOrder.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 589,
+      "file_type": "code",
+      "id": "onlineorder_stablefingerprint",
+      "label": "stableFingerprint()",
+      "norm_label": "stablefingerprint()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/onlineOrder.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 589,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_adapters_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/onlineOrder.ts",
+      "source_location": "L1"
     },
     {
       "community": 59,
@@ -267033,51 +267075,6 @@
     {
       "community": 590,
       "file_type": "code",
-      "id": "onlineorder_buildlookup",
-      "label": "buildLookup()",
-      "norm_label": "buildlookup()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/onlineOrder.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 590,
-      "file_type": "code",
-      "id": "onlineorder_buildonlineordertraceseed",
-      "label": "buildOnlineOrderTraceSeed()",
-      "norm_label": "buildonlineordertraceseed()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/onlineOrder.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 590,
-      "file_type": "code",
-      "id": "onlineorder_buildsafeexternalreferenceref",
-      "label": "buildSafeExternalReferenceRef()",
-      "norm_label": "buildsafeexternalreferenceref()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/onlineOrder.ts",
-      "source_location": "L53"
-    },
-    {
-      "community": 590,
-      "file_type": "code",
-      "id": "onlineorder_stablefingerprint",
-      "label": "stableFingerprint()",
-      "norm_label": "stablefingerprint()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/onlineOrder.ts",
-      "source_location": "L43"
-    },
-    {
-      "community": 590,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_adapters_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/onlineOrder.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 591,
-      "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_queryusage_test_ts",
       "label": "queryUsage.test.ts",
       "norm_label": "queryusage.test.ts",
@@ -267085,7 +267082,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 590,
       "file_type": "code",
       "id": "queryusage_test_comparebyfields",
       "label": "compareByFields()",
@@ -267094,7 +267091,7 @@
       "source_location": "L102"
     },
     {
-      "community": 591,
+      "community": 590,
       "file_type": "code",
       "id": "queryusage_test_createadmintracereadctx",
       "label": "createAdminTraceReadCtx()",
@@ -267103,7 +267100,7 @@
       "source_location": "L220"
     },
     {
-      "community": 591,
+      "community": 590,
       "file_type": "code",
       "id": "queryusage_test_createtestctx",
       "label": "createTestCtx()",
@@ -267112,7 +267109,7 @@
       "source_location": "L118"
     },
     {
-      "community": 591,
+      "community": 590,
       "file_type": "code",
       "id": "queryusage_test_deniedauthorizer",
       "label": "deniedAuthorizer()",
@@ -267121,7 +267118,7 @@
       "source_location": "L1071"
     },
     {
-      "community": 592,
+      "community": 591,
       "file_type": "code",
       "id": "appsettingsview_appearancelabel",
       "label": "appearanceLabel()",
@@ -267130,7 +267127,7 @@
       "source_location": "L38"
     },
     {
-      "community": 592,
+      "community": 591,
       "file_type": "code",
       "id": "appsettingsview_cn",
       "label": "cn()",
@@ -267139,7 +267136,7 @@
       "source_location": "L154"
     },
     {
-      "community": 592,
+      "community": 591,
       "file_type": "code",
       "id": "appsettingsview_selectthememode",
       "label": "selectThemeMode()",
@@ -267148,7 +267145,7 @@
       "source_location": "L85"
     },
     {
-      "community": 592,
+      "community": 591,
       "file_type": "code",
       "id": "appsettingsview_transitiontimelabel",
       "label": "transitionTimeLabel()",
@@ -267157,7 +267154,7 @@
       "source_location": "L42"
     },
     {
-      "community": 592,
+      "community": 591,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_settings_appsettingsview_tsx",
       "label": "AppSettingsView.tsx",
@@ -267166,7 +267163,7 @@
       "source_location": "L1"
     },
     {
-      "community": 593,
+      "community": 592,
       "file_type": "code",
       "id": "dashboard_getperiodrange",
       "label": "getPeriodRange()",
@@ -267175,7 +267172,7 @@
       "source_location": "L19"
     },
     {
-      "community": 593,
+      "community": 592,
       "file_type": "code",
       "id": "dashboard_loadingsection",
       "label": "LoadingSection()",
@@ -267184,7 +267181,7 @@
       "source_location": "L49"
     },
     {
-      "community": 593,
+      "community": 592,
       "file_type": "code",
       "id": "dashboard_renderproductssection",
       "label": "renderProductsSection()",
@@ -267193,7 +267190,7 @@
       "source_location": "L341"
     },
     {
-      "community": 593,
+      "community": 592,
       "file_type": "code",
       "id": "dashboard_rendersalessection",
       "label": "renderSalesSection()",
@@ -267202,7 +267199,7 @@
       "source_location": "L321"
     },
     {
-      "community": 593,
+      "community": 592,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
       "label": "Dashboard.tsx",
@@ -267211,7 +267208,7 @@
       "source_location": "L1"
     },
     {
-      "community": 594,
+      "community": 593,
       "file_type": "code",
       "id": "docsscrolltotop_cancel",
       "label": "cancel()",
@@ -267220,7 +267217,7 @@
       "source_location": "L87"
     },
     {
-      "community": 594,
+      "community": 593,
       "file_type": "code",
       "id": "docsscrolltotop_handleclick",
       "label": "handleClick()",
@@ -267229,7 +267226,7 @@
       "source_location": "L103"
     },
     {
-      "community": 594,
+      "community": 593,
       "file_type": "code",
       "id": "docsscrolltotop_read",
       "label": "read()",
@@ -267238,7 +267235,7 @@
       "source_location": "L37"
     },
     {
-      "community": 594,
+      "community": 593,
       "file_type": "code",
       "id": "docsscrolltotop_schedule",
       "label": "schedule()",
@@ -267247,7 +267244,7 @@
       "source_location": "L59"
     },
     {
-      "community": 594,
+      "community": 593,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_docs_docsscrolltotop_tsx",
       "label": "DocsScrollToTop.tsx",
@@ -267256,7 +267253,7 @@
       "source_location": "L1"
     },
     {
-      "community": 595,
+      "community": 594,
       "file_type": "code",
       "id": "herosectiontabs_handledisplaytypechange",
       "label": "handleDisplayTypeChange()",
@@ -267265,7 +267262,7 @@
       "source_location": "L61"
     },
     {
-      "community": 595,
+      "community": 594,
       "file_type": "code",
       "id": "herosectiontabs_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -267274,7 +267271,7 @@
       "source_location": "L57"
     },
     {
-      "community": 595,
+      "community": 594,
       "file_type": "code",
       "id": "herosectiontabs_handleoverlaytoggle",
       "label": "handleOverlayToggle()",
@@ -267283,7 +267280,7 @@
       "source_location": "L98"
     },
     {
-      "community": 595,
+      "community": 594,
       "file_type": "code",
       "id": "herosectiontabs_handletexttoggle",
       "label": "handleTextToggle()",
@@ -267292,7 +267289,7 @@
       "source_location": "L134"
     },
     {
-      "community": 595,
+      "community": 594,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
       "label": "HeroSectionTabs.tsx",
@@ -267301,7 +267298,7 @@
       "source_location": "L1"
     },
     {
-      "community": 596,
+      "community": 595,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
       "label": "ReelUploader.tsx",
@@ -267310,7 +267307,7 @@
       "source_location": "L1"
     },
     {
-      "community": 596,
+      "community": 595,
       "file_type": "code",
       "id": "reeluploader_formatfilesize",
       "label": "formatFileSize()",
@@ -267319,7 +267316,7 @@
       "source_location": "L38"
     },
     {
-      "community": 596,
+      "community": 595,
       "file_type": "code",
       "id": "reeluploader_handlefileselect",
       "label": "handleFileSelect()",
@@ -267328,7 +267325,7 @@
       "source_location": "L64"
     },
     {
-      "community": 596,
+      "community": 595,
       "file_type": "code",
       "id": "reeluploader_handleupload",
       "label": "handleUpload()",
@@ -267337,7 +267334,7 @@
       "source_location": "L135"
     },
     {
-      "community": 596,
+      "community": 595,
       "file_type": "code",
       "id": "reeluploader_validatefile",
       "label": "validateFile()",
@@ -267346,7 +267343,7 @@
       "source_location": "L43"
     },
     {
-      "community": 597,
+      "community": 596,
       "file_type": "code",
       "id": "activityview_iscreatedaction",
       "label": "isCreatedAction()",
@@ -267355,7 +267352,7 @@
       "source_location": "L90"
     },
     {
-      "community": 597,
+      "community": 596,
       "file_type": "code",
       "id": "activityview_isfeedbackrequestaction",
       "label": "isFeedbackRequestAction()",
@@ -267364,7 +267361,7 @@
       "source_location": "L95"
     },
     {
-      "community": 597,
+      "community": 596,
       "file_type": "code",
       "id": "activityview_isrefundaction",
       "label": "isRefundAction()",
@@ -267373,7 +267370,7 @@
       "source_location": "L82"
     },
     {
-      "community": 597,
+      "community": 596,
       "file_type": "code",
       "id": "activityview_istransitionaction",
       "label": "isTransitionAction()",
@@ -267382,7 +267379,7 @@
       "source_location": "L85"
     },
     {
-      "community": 597,
+      "community": 596,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
       "label": "ActivityView.tsx",
@@ -267391,7 +267388,7 @@
       "source_location": "L1"
     },
     {
-      "community": 598,
+      "community": 597,
       "file_type": "code",
       "id": "orderitemsview_handlerequestfeedback",
       "label": "handleRequestFeedback()",
@@ -267400,7 +267397,7 @@
       "source_location": "L113"
     },
     {
-      "community": 598,
+      "community": 597,
       "file_type": "code",
       "id": "orderitemsview_handlerestockall",
       "label": "handleRestockAll()",
@@ -267409,7 +267406,7 @@
       "source_location": "L349"
     },
     {
-      "community": 598,
+      "community": 597,
       "file_type": "code",
       "id": "orderitemsview_handlereturnitemtostock",
       "label": "handleReturnItemToStock()",
@@ -267418,7 +267415,7 @@
       "source_location": "L86"
     },
     {
-      "community": 598,
+      "community": 597,
       "file_type": "code",
       "id": "orderitemsview_handleupdateorderitem",
       "label": "handleUpdateOrderItem()",
@@ -267427,7 +267424,7 @@
       "source_location": "L62"
     },
     {
-      "community": 598,
+      "community": 597,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
       "label": "OrderItemsView.tsx",
@@ -267436,7 +267433,7 @@
       "source_location": "L1"
     },
     {
-      "community": 599,
+      "community": 598,
       "file_type": "code",
       "id": "cashierauthdialog_test_buildlocalauthorityrecord",
       "label": "buildLocalAuthorityRecord()",
@@ -267445,7 +267442,7 @@
       "source_location": "L121"
     },
     {
-      "community": 599,
+      "community": 598,
       "file_type": "code",
       "id": "cashierauthdialog_test_renderdialog",
       "label": "renderDialog()",
@@ -267454,7 +267451,7 @@
       "source_location": "L152"
     },
     {
-      "community": 599,
+      "community": 598,
       "file_type": "code",
       "id": "cashierauthdialog_test_submitcredentials",
       "label": "submitCredentials()",
@@ -267463,7 +267460,7 @@
       "source_location": "L216"
     },
     {
-      "community": 599,
+      "community": 598,
       "file_type": "code",
       "id": "cashierauthdialog_test_submitlockedcashierpin",
       "label": "submitLockedCashierPin()",
@@ -267472,12 +267469,57 @@
       "source_location": "L208"
     },
     {
-      "community": 599,
+      "community": 598,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_test_tsx",
       "label": "CashierAuthDialog.test.tsx",
       "norm_label": "cashierauthdialog.test.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 599,
+      "file_type": "code",
+      "id": "ordersummary_test_getbalancedueamount",
+      "label": "getBalanceDueAmount()",
+      "norm_label": "getbalancedueamount()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
+      "source_location": "L49"
+    },
+    {
+      "community": 599,
+      "file_type": "code",
+      "id": "ordersummary_test_getbalanceduelabel",
+      "label": "getBalanceDueLabel()",
+      "norm_label": "getbalanceduelabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 599,
+      "file_type": "code",
+      "id": "ordersummary_test_getbalanceduepanel",
+      "label": "getBalanceDuePanel()",
+      "norm_label": "getbalanceduepanel()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
+      "source_location": "L75"
+    },
+    {
+      "community": 599,
+      "file_type": "code",
+      "id": "ordersummary_test_stripwhitespace",
+      "label": "stripWhitespace()",
+      "norm_label": "stripwhitespace()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 599,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_ordersummary_test_tsx",
+      "label": "OrderSummary.test.tsx",
+      "norm_label": "ordersummary.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
       "source_location": "L1"
     },
     {
@@ -268365,51 +268407,6 @@
     {
       "community": 600,
       "file_type": "code",
-      "id": "ordersummary_test_getbalancedueamount",
-      "label": "getBalanceDueAmount()",
-      "norm_label": "getbalancedueamount()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
-      "source_location": "L49"
-    },
-    {
-      "community": 600,
-      "file_type": "code",
-      "id": "ordersummary_test_getbalanceduelabel",
-      "label": "getBalanceDueLabel()",
-      "norm_label": "getbalanceduelabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 600,
-      "file_type": "code",
-      "id": "ordersummary_test_getbalanceduepanel",
-      "label": "getBalanceDuePanel()",
-      "norm_label": "getbalanceduepanel()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
-      "source_location": "L75"
-    },
-    {
-      "community": 600,
-      "file_type": "code",
-      "id": "ordersummary_test_stripwhitespace",
-      "label": "stripWhitespace()",
-      "norm_label": "stripwhitespace()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 600,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_ordersummary_test_tsx",
-      "label": "OrderSummary.test.tsx",
-      "norm_label": "ordersummary.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 601,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_test_tsx",
       "label": "POSSettingsView.test.tsx",
       "norm_label": "possettingsview.test.tsx",
@@ -268417,7 +268414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 601,
+      "community": 600,
       "file_type": "code",
       "id": "possettingsview_test_findtrigger",
       "label": "findTrigger()",
@@ -268426,7 +268423,7 @@
       "source_location": "L185"
     },
     {
-      "community": 601,
+      "community": 600,
       "file_type": "code",
       "id": "possettingsview_test_selectcontent",
       "label": "SelectContent()",
@@ -268435,7 +268432,7 @@
       "source_location": "L160"
     },
     {
-      "community": 601,
+      "community": 600,
       "file_type": "code",
       "id": "possettingsview_test_selectitem",
       "label": "SelectItem()",
@@ -268444,7 +268441,7 @@
       "source_location": "L163"
     },
     {
-      "community": 601,
+      "community": 600,
       "file_type": "code",
       "id": "possettingsview_test_selecttrigger",
       "label": "SelectTrigger()",
@@ -268453,7 +268450,7 @@
       "source_location": "L165"
     },
     {
-      "community": 602,
+      "community": 601,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productslistview_tsx",
       "label": "ProductsListView.tsx",
@@ -268462,7 +268459,7 @@
       "source_location": "L1"
     },
     {
-      "community": 602,
+      "community": 601,
       "file_type": "code",
       "id": "productslistview_handlecategorypageindexchange",
       "label": "handleCategoryPageIndexChange()",
@@ -268471,7 +268468,7 @@
       "source_location": "L220"
     },
     {
-      "community": 602,
+      "community": 601,
       "file_type": "code",
       "id": "productslistview_handleclearcache",
       "label": "handleClearCache()",
@@ -268480,7 +268477,7 @@
       "source_location": "L108"
     },
     {
-      "community": 602,
+      "community": 601,
       "file_type": "code",
       "id": "productslistview_handlestorefrontvisibilitychange",
       "label": "handleStorefrontVisibilityChange()",
@@ -268489,7 +268486,7 @@
       "source_location": "L87"
     },
     {
-      "community": 602,
+      "community": 601,
       "file_type": "code",
       "id": "productslistview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -268498,7 +268495,7 @@
       "source_location": "L33"
     },
     {
-      "community": 603,
+      "community": 602,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeview_tsx",
       "label": "PromoCodeView.tsx",
@@ -268507,7 +268504,7 @@
       "source_location": "L1"
     },
     {
-      "community": 603,
+      "community": 602,
       "file_type": "code",
       "id": "promocodeview_handleaddpromocode",
       "label": "handleAddPromoCode()",
@@ -268516,7 +268513,7 @@
       "source_location": "L158"
     },
     {
-      "community": 603,
+      "community": 602,
       "file_type": "code",
       "id": "promocodeview_handleupdatepromocode",
       "label": "handleUpdatePromoCode()",
@@ -268525,7 +268522,7 @@
       "source_location": "L231"
     },
     {
-      "community": 603,
+      "community": 602,
       "file_type": "code",
       "id": "promocodeview_updatehomepagediscountcode",
       "label": "updateHomepageDiscountCode()",
@@ -268534,7 +268531,7 @@
       "source_location": "L324"
     },
     {
-      "community": 603,
+      "community": 602,
       "file_type": "code",
       "id": "promocodeview_updateleaveareviewdiscountcode",
       "label": "updateLeaveAReviewDiscountCode()",
@@ -268543,7 +268540,7 @@
       "source_location": "L379"
     },
     {
-      "community": 604,
+      "community": 603,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportsoverviewview_test_tsx",
       "label": "ReportsOverviewView.test.tsx",
@@ -268552,7 +268549,7 @@
       "source_location": "L1"
     },
     {
-      "community": 604,
+      "community": 603,
       "file_type": "code",
       "id": "reportsoverviewview_test_expectanimatedmetrics",
       "label": "expectAnimatedMetrics()",
@@ -268561,7 +268558,7 @@
       "source_location": "L450"
     },
     {
-      "community": 604,
+      "community": 603,
       "file_type": "code",
       "id": "reportsoverviewview_test_harness",
       "label": "Harness()",
@@ -268570,7 +268567,7 @@
       "source_location": "L173"
     },
     {
-      "community": 604,
+      "community": 603,
       "file_type": "code",
       "id": "reportsoverviewview_test_linkedrange",
       "label": "linkedRange()",
@@ -268579,7 +268576,7 @@
       "source_location": "L584"
     },
     {
-      "community": 604,
+      "community": 603,
       "file_type": "code",
       "id": "reportsoverviewview_test_snapshot",
       "label": "snapshot()",
@@ -268588,7 +268585,7 @@
       "source_location": "L87"
     },
     {
-      "community": 605,
+      "community": 604,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportroutesearch_ts",
       "label": "reportRouteSearch.ts",
@@ -268597,7 +268594,7 @@
       "source_location": "L1"
     },
     {
-      "community": 605,
+      "community": 604,
       "file_type": "code",
       "id": "reportroutesearch_overviewsearchfromweeklyreturn",
       "label": "overviewSearchFromWeeklyReturn()",
@@ -268606,7 +268603,7 @@
       "source_location": "L148"
     },
     {
-      "community": 605,
+      "community": 604,
       "file_type": "code",
       "id": "reportroutesearch_parseunitssheetfocussearch",
       "label": "parseUnitsSheetFocusSearch()",
@@ -268615,7 +268612,7 @@
       "source_location": "L81"
     },
     {
-      "community": 605,
+      "community": 604,
       "file_type": "code",
       "id": "reportroutesearch_unitssheetfocussearchvalue",
       "label": "unitsSheetFocusSearchValue()",
@@ -268624,7 +268621,7 @@
       "source_location": "L72"
     },
     {
-      "community": 605,
+      "community": 604,
       "file_type": "code",
       "id": "reportroutesearch_weeklyreturnsearchfromoverview",
       "label": "weeklyReturnSearchFromOverview()",
@@ -268633,7 +268630,7 @@
       "source_location": "L125"
     },
     {
-      "community": 606,
+      "community": 605,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_pulse_storepulsesummaryview_tsx",
       "label": "StorePulseSummaryView.tsx",
@@ -268642,7 +268639,7 @@
       "source_location": "L1"
     },
     {
-      "community": 606,
+      "community": 605,
       "file_type": "code",
       "id": "storepulsesummaryview_formatcomparisonhelper",
       "label": "formatComparisonHelper()",
@@ -268651,7 +268648,7 @@
       "source_location": "L165"
     },
     {
-      "community": 606,
+      "community": 605,
       "file_type": "code",
       "id": "storepulsesummaryview_formatxaxistick",
       "label": "formatXAxisTick()",
@@ -268660,7 +268657,7 @@
       "source_location": "L379"
     },
     {
-      "community": 606,
+      "community": 605,
       "file_type": "code",
       "id": "storepulsesummaryview_gettrendvalue",
       "label": "getTrendValue()",
@@ -268669,7 +268666,7 @@
       "source_location": "L312"
     },
     {
-      "community": 606,
+      "community": 605,
       "file_type": "code",
       "id": "storepulsesummaryview_helper",
       "label": "helper()",
@@ -268678,7 +268675,7 @@
       "source_location": "L202"
     },
     {
-      "community": 607,
+      "community": 606,
       "file_type": "code",
       "id": "date_time_picker_handleclear",
       "label": "handleClear()",
@@ -268687,7 +268684,7 @@
       "source_location": "L101"
     },
     {
-      "community": 607,
+      "community": 606,
       "file_type": "code",
       "id": "date_time_picker_handledateselect",
       "label": "handleDateSelect()",
@@ -268696,7 +268693,7 @@
       "source_location": "L55"
     },
     {
-      "community": 607,
+      "community": 606,
       "file_type": "code",
       "id": "date_time_picker_handletimeblur",
       "label": "handleTimeBlur()",
@@ -268705,7 +268702,7 @@
       "source_location": "L77"
     },
     {
-      "community": 607,
+      "community": 606,
       "file_type": "code",
       "id": "date_time_picker_handletimechange",
       "label": "handleTimeChange()",
@@ -268714,7 +268711,7 @@
       "source_location": "L65"
     },
     {
-      "community": 607,
+      "community": 606,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
       "label": "date-time-picker.tsx",
@@ -268723,7 +268720,7 @@
       "source_location": "L1"
     },
     {
-      "community": 608,
+      "community": 607,
       "file_type": "code",
       "id": "custom_modal_example_basicmodalexample",
       "label": "BasicModalExample()",
@@ -268732,7 +268729,7 @@
       "source_location": "L7"
     },
     {
-      "community": 608,
+      "community": 607,
       "file_type": "code",
       "id": "custom_modal_example_customclosebuttonexample",
       "label": "CustomCloseButtonExample()",
@@ -268741,7 +268738,7 @@
       "source_location": "L69"
     },
     {
-      "community": 608,
+      "community": 607,
       "file_type": "code",
       "id": "custom_modal_example_custompositionmodalexample",
       "label": "CustomPositionModalExample()",
@@ -268750,7 +268747,7 @@
       "source_location": "L44"
     },
     {
-      "community": 608,
+      "community": 607,
       "file_type": "code",
       "id": "custom_modal_example_fullscreenmodalexample",
       "label": "FullScreenModalExample()",
@@ -268759,7 +268756,7 @@
       "source_location": "L103"
     },
     {
-      "community": 608,
+      "community": 607,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_example_tsx",
       "label": "custom-modal-example.tsx",
@@ -268768,7 +268765,7 @@
       "source_location": "L1"
     },
     {
-      "community": 609,
+      "community": 608,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpenselocalruntime_ts",
       "label": "useExpenseLocalRuntime.ts",
@@ -268777,7 +268774,7 @@
       "source_location": "L1"
     },
     {
-      "community": 609,
+      "community": 608,
       "file_type": "code",
       "id": "useexpenselocalruntime_createlocalid",
       "label": "createLocalId()",
@@ -268786,7 +268783,7 @@
       "source_location": "L23"
     },
     {
-      "community": 609,
+      "community": 608,
       "file_type": "code",
       "id": "useexpenselocalruntime_getexpenselocalstore",
       "label": "getExpenseLocalStore()",
@@ -268795,7 +268792,7 @@
       "source_location": "L12"
     },
     {
-      "community": 609,
+      "community": 608,
       "file_type": "code",
       "id": "useexpenselocalruntime_notifyexpenselocaleventappended",
       "label": "notifyExpenseLocalEventAppended()",
@@ -268804,13 +268801,58 @@
       "source_location": "L17"
     },
     {
-      "community": 609,
+      "community": 608,
       "file_type": "code",
       "id": "useexpenselocalruntime_useexpenselocalruntime",
       "label": "useExpenseLocalRuntime()",
       "norm_label": "useexpenselocalruntime()",
       "source_file": "packages/athena-webapp/src/hooks/useExpenseLocalRuntime.ts",
       "source_location": "L31"
+    },
+    {
+      "community": 609,
+      "file_type": "code",
+      "id": "appmessagesprovider_appmessagesprovider",
+      "label": "AppMessagesProvider()",
+      "norm_label": "appmessagesprovider()",
+      "source_file": "packages/athena-webapp/src/lib/app-messages/AppMessagesProvider.tsx",
+      "source_location": "L28"
+    },
+    {
+      "community": 609,
+      "file_type": "code",
+      "id": "appmessagesprovider_areblockersequal",
+      "label": "areBlockersEqual()",
+      "norm_label": "areblockersequal()",
+      "source_file": "packages/athena-webapp/src/lib/app-messages/AppMessagesProvider.tsx",
+      "source_location": "L215"
+    },
+    {
+      "community": 609,
+      "file_type": "code",
+      "id": "appmessagesprovider_aremessagesequal",
+      "label": "areMessagesEqual()",
+      "norm_label": "aremessagesequal()",
+      "source_file": "packages/athena-webapp/src/lib/app-messages/AppMessagesProvider.tsx",
+      "source_location": "L185"
+    },
+    {
+      "community": 609,
+      "file_type": "code",
+      "id": "appmessagesprovider_getpreferredvariant",
+      "label": "getPreferredVariant()",
+      "norm_label": "getpreferredvariant()",
+      "source_file": "packages/athena-webapp/src/lib/app-messages/AppMessagesProvider.tsx",
+      "source_location": "L203"
+    },
+    {
+      "community": 609,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_app_messages_appmessagesprovider_tsx",
+      "label": "AppMessagesProvider.tsx",
+      "norm_label": "appmessagesprovider.tsx",
+      "source_file": "packages/athena-webapp/src/lib/app-messages/AppMessagesProvider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 61,
@@ -269040,51 +269082,6 @@
     {
       "community": 610,
       "file_type": "code",
-      "id": "appmessagesprovider_appmessagesprovider",
-      "label": "AppMessagesProvider()",
-      "norm_label": "appmessagesprovider()",
-      "source_file": "packages/athena-webapp/src/lib/app-messages/AppMessagesProvider.tsx",
-      "source_location": "L28"
-    },
-    {
-      "community": 610,
-      "file_type": "code",
-      "id": "appmessagesprovider_areblockersequal",
-      "label": "areBlockersEqual()",
-      "norm_label": "areblockersequal()",
-      "source_file": "packages/athena-webapp/src/lib/app-messages/AppMessagesProvider.tsx",
-      "source_location": "L215"
-    },
-    {
-      "community": 610,
-      "file_type": "code",
-      "id": "appmessagesprovider_aremessagesequal",
-      "label": "areMessagesEqual()",
-      "norm_label": "aremessagesequal()",
-      "source_file": "packages/athena-webapp/src/lib/app-messages/AppMessagesProvider.tsx",
-      "source_location": "L185"
-    },
-    {
-      "community": 610,
-      "file_type": "code",
-      "id": "appmessagesprovider_getpreferredvariant",
-      "label": "getPreferredVariant()",
-      "norm_label": "getpreferredvariant()",
-      "source_file": "packages/athena-webapp/src/lib/app-messages/AppMessagesProvider.tsx",
-      "source_location": "L203"
-    },
-    {
-      "community": 610,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_app_messages_appmessagesprovider_tsx",
-      "label": "AppMessagesProvider.tsx",
-      "norm_label": "appmessagesprovider.tsx",
-      "source_file": "packages/athena-webapp/src/lib/app-messages/AppMessagesProvider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 611,
-      "file_type": "code",
       "id": "appactionblockers_compareappactionblockers",
       "label": "compareAppActionBlockers()",
       "norm_label": "compareappactionblockers()",
@@ -269092,7 +269089,7 @@
       "source_location": "L41"
     },
     {
-      "community": 611,
+      "community": 610,
       "file_type": "code",
       "id": "appactionblockers_getselectedappactionblocker",
       "label": "getSelectedAppActionBlocker()",
@@ -269101,7 +269098,7 @@
       "source_location": "L26"
     },
     {
-      "community": 611,
+      "community": 610,
       "file_type": "code",
       "id": "appactionblockers_isvalidappactionblockerinput",
       "label": "isValidAppActionBlockerInput()",
@@ -269110,7 +269107,7 @@
       "source_location": "L30"
     },
     {
-      "community": 611,
+      "community": 610,
       "file_type": "code",
       "id": "appactionblockers_sortappactionblockers",
       "label": "sortAppActionBlockers()",
@@ -269119,7 +269116,7 @@
       "source_location": "L22"
     },
     {
-      "community": 611,
+      "community": 610,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_messages_appactionblockers_ts",
       "label": "appActionBlockers.ts",
@@ -269128,7 +269125,7 @@
       "source_location": "L1"
     },
     {
-      "community": 612,
+      "community": 611,
       "file_type": "code",
       "id": "appmessages_compareappmessages",
       "label": "compareAppMessages()",
@@ -269137,7 +269134,7 @@
       "source_location": "L39"
     },
     {
-      "community": 612,
+      "community": 611,
       "file_type": "code",
       "id": "appmessages_getselectedappmessage",
       "label": "getSelectedAppMessage()",
@@ -269146,7 +269143,7 @@
       "source_location": "L27"
     },
     {
-      "community": 612,
+      "community": 611,
       "file_type": "code",
       "id": "appmessages_isvalidappmessageinput",
       "label": "isValidAppMessageInput()",
@@ -269155,7 +269152,7 @@
       "source_location": "L31"
     },
     {
-      "community": 612,
+      "community": 611,
       "file_type": "code",
       "id": "appmessages_sortappmessages",
       "label": "sortAppMessages()",
@@ -269164,7 +269161,7 @@
       "source_location": "L23"
     },
     {
-      "community": 612,
+      "community": 611,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_messages_appmessages_ts",
       "label": "appMessages.ts",
@@ -269173,7 +269170,7 @@
       "source_location": "L1"
     },
     {
-      "community": 613,
+      "community": 612,
       "file_type": "code",
       "id": "appupdatereload_cleartrackedbeforeunloadhandlers",
       "label": "clearTrackedBeforeUnloadHandlers()",
@@ -269182,7 +269179,7 @@
       "source_location": "L85"
     },
     {
-      "community": 613,
+      "community": 612,
       "file_type": "code",
       "id": "appupdatereload_getcapture",
       "label": "getCapture()",
@@ -269191,7 +269188,7 @@
       "source_location": "L102"
     },
     {
-      "community": 613,
+      "community": 612,
       "file_type": "code",
       "id": "appupdatereload_installappupdateunloadpromptbypass",
       "label": "installAppUpdateUnloadPromptBypass()",
@@ -269200,7 +269197,7 @@
       "source_location": "L13"
     },
     {
-      "community": 613,
+      "community": 612,
       "file_type": "code",
       "id": "appupdatereload_reloadbrowserforappupdate",
       "label": "reloadBrowserForAppUpdate()",
@@ -269209,7 +269206,7 @@
       "source_location": "L74"
     },
     {
-      "community": 613,
+      "community": 612,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_update_appupdatereload_ts",
       "label": "appUpdateReload.ts",
@@ -269218,7 +269215,7 @@
       "source_location": "L1"
     },
     {
-      "community": 614,
+      "community": 613,
       "file_type": "code",
       "id": "browserfingerprint_buffertohex",
       "label": "bufferToHex()",
@@ -269227,7 +269224,7 @@
       "source_location": "L18"
     },
     {
-      "community": 614,
+      "community": 613,
       "file_type": "code",
       "id": "browserfingerprint_collectbrowserinfo",
       "label": "collectBrowserInfo()",
@@ -269236,7 +269233,7 @@
       "source_location": "L23"
     },
     {
-      "community": 614,
+      "community": 613,
       "file_type": "code",
       "id": "browserfingerprint_generatebrowserfingerprint",
       "label": "generateBrowserFingerprint()",
@@ -269245,7 +269242,7 @@
       "source_location": "L65"
     },
     {
-      "community": 614,
+      "community": 613,
       "file_type": "code",
       "id": "browserfingerprint_hashfingerprintsource",
       "label": "hashFingerprintSource()",
@@ -269254,7 +269251,7 @@
       "source_location": "L45"
     },
     {
-      "community": 614,
+      "community": 613,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_browserfingerprint_ts",
       "label": "browserFingerprint.ts",
@@ -269263,7 +269260,7 @@
       "source_location": "L1"
     },
     {
-      "community": 615,
+      "community": 614,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_ts",
       "label": "runCommand.ts",
@@ -269272,7 +269269,7 @@
       "source_location": "L1"
     },
     {
-      "community": 615,
+      "community": 614,
       "file_type": "code",
       "id": "runcommand_extracttraceid",
       "label": "extractTraceId()",
@@ -269281,7 +269278,7 @@
       "source_location": "L40"
     },
     {
-      "community": 615,
+      "community": 614,
       "file_type": "code",
       "id": "runcommand_getshareddemodenial",
       "label": "getSharedDemoDenial()",
@@ -269290,7 +269287,7 @@
       "source_location": "L48"
     },
     {
-      "community": 615,
+      "community": 614,
       "file_type": "code",
       "id": "runcommand_isapprovalrequiredresult",
       "label": "isApprovalRequiredResult()",
@@ -269299,7 +269296,7 @@
       "source_location": "L34"
     },
     {
-      "community": 615,
+      "community": 614,
       "file_type": "code",
       "id": "runcommand_runcommand",
       "label": "runCommand()",
@@ -269308,7 +269305,7 @@
       "source_location": "L68"
     },
     {
-      "community": 616,
+      "community": 615,
       "file_type": "code",
       "id": "imageutils_test_arraybuffer",
       "label": "arrayBuffer()",
@@ -269317,7 +269314,7 @@
       "source_location": "L78"
     },
     {
-      "community": 616,
+      "community": 615,
       "file_type": "code",
       "id": "imageutils_test_constructor",
       "label": "constructor()",
@@ -269326,7 +269323,7 @@
       "source_location": "L74"
     },
     {
-      "community": 616,
+      "community": 615,
       "file_type": "code",
       "id": "imageutils_test_mockimage",
       "label": "MockImage",
@@ -269335,7 +269332,7 @@
       "source_location": "L103"
     },
     {
-      "community": 616,
+      "community": 615,
       "file_type": "code",
       "id": "imageutils_test_mockimage_src",
       "label": ".src()",
@@ -269344,7 +269341,7 @@
       "source_location": "L109"
     },
     {
-      "community": 616,
+      "community": 615,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_test_ts",
       "label": "imageUtils.test.ts",
@@ -269353,7 +269350,7 @@
       "source_location": "L1"
     },
     {
-      "community": 617,
+      "community": 616,
       "file_type": "code",
       "id": "imageutils_convertimagestojpg",
       "label": "convertImagesToJpg()",
@@ -269362,7 +269359,7 @@
       "source_location": "L75"
     },
     {
-      "community": 617,
+      "community": 616,
       "file_type": "code",
       "id": "imageutils_convertimagestowebp",
       "label": "convertImagesToWebp()",
@@ -269371,7 +269368,7 @@
       "source_location": "L26"
     },
     {
-      "community": 617,
+      "community": 616,
       "file_type": "code",
       "id": "imageutils_converttojpg",
       "label": "convertToJpg()",
@@ -269380,7 +269377,7 @@
       "source_location": "L38"
     },
     {
-      "community": 617,
+      "community": 616,
       "file_type": "code",
       "id": "imageutils_getuploadimagesdata",
       "label": "getUploadImagesData()",
@@ -269389,7 +269386,7 @@
       "source_location": "L4"
     },
     {
-      "community": 617,
+      "community": 616,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_ts",
       "label": "imageUtils.ts",
@@ -269398,7 +269395,7 @@
       "source_location": "L1"
     },
     {
-      "community": 618,
+      "community": 617,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_ts",
       "label": "registerGateway.ts",
@@ -269407,7 +269404,7 @@
       "source_location": "L1"
     },
     {
-      "community": 618,
+      "community": 617,
       "file_type": "code",
       "id": "registergateway_mapregisterstatedto",
       "label": "mapRegisterStateDto()",
@@ -269416,7 +269413,7 @@
       "source_location": "L13"
     },
     {
-      "community": 618,
+      "community": 617,
       "file_type": "code",
       "id": "registergateway_mapterminaldto",
       "label": "mapTerminalDto()",
@@ -269425,7 +269422,7 @@
       "source_location": "L31"
     },
     {
-      "community": 618,
+      "community": 617,
       "file_type": "code",
       "id": "registergateway_useconvexregisterstate",
       "label": "useConvexRegisterState()",
@@ -269434,7 +269431,7 @@
       "source_location": "L37"
     },
     {
-      "community": 618,
+      "community": 617,
       "file_type": "code",
       "id": "registergateway_useconvexterminalbyfingerprint",
       "label": "useConvexTerminalByFingerprint()",
@@ -269443,7 +269440,7 @@
       "source_location": "L59"
     },
     {
-      "community": 619,
+      "community": 618,
       "file_type": "code",
       "id": "expenselocalcommandgateway_createexpenselocalcommandgateway",
       "label": "createExpenseLocalCommandGateway()",
@@ -269452,7 +269449,7 @@
       "source_location": "L55"
     },
     {
-      "community": 619,
+      "community": 618,
       "file_type": "code",
       "id": "expenselocalcommandgateway_itempayload",
       "label": "itemPayload()",
@@ -269461,7 +269458,7 @@
       "source_location": "L282"
     },
     {
-      "community": 619,
+      "community": 618,
       "file_type": "code",
       "id": "expenselocalcommandgateway_reasonpayload",
       "label": "reasonPayload()",
@@ -269470,7 +269467,7 @@
       "source_location": "L303"
     },
     {
-      "community": 619,
+      "community": 618,
       "file_type": "code",
       "id": "expenselocalcommandgateway_resolvestaffprooftoken",
       "label": "resolveStaffProofToken()",
@@ -269479,12 +269476,57 @@
       "source_location": "L310"
     },
     {
-      "community": 619,
+      "community": 618,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_expenselocalcommandgateway_ts",
       "label": "expenseLocalCommandGateway.ts",
       "norm_label": "expenselocalcommandgateway.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/expenseLocalCommandGateway.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 619,
+      "file_type": "code",
+      "id": "localcommandgateway_test_appendopendrawer",
+      "label": "appendOpenDrawer()",
+      "norm_label": "appendopendrawer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts",
+      "source_location": "L22"
+    },
+    {
+      "community": 619,
+      "file_type": "code",
+      "id": "localcommandgateway_test_blockdrawerauthority",
+      "label": "blockDrawerAuthority()",
+      "norm_label": "blockdrawerauthority()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts",
+      "source_location": "L34"
+    },
+    {
+      "community": 619,
+      "file_type": "code",
+      "id": "localcommandgateway_test_createblockedsalegateway",
+      "label": "createBlockedSaleGateway()",
+      "norm_label": "createblockedsalegateway()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 619,
+      "file_type": "code",
+      "id": "localcommandgateway_test_salecommandinput",
+      "label": "saleCommandInput()",
+      "norm_label": "salecommandinput()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 619,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localcommandgateway_test_ts",
+      "label": "localCommandGateway.test.ts",
+      "norm_label": "localcommandgateway.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts",
       "source_location": "L1"
     },
     {
@@ -269715,51 +269757,6 @@
     {
       "community": 620,
       "file_type": "code",
-      "id": "localcommandgateway_test_appendopendrawer",
-      "label": "appendOpenDrawer()",
-      "norm_label": "appendopendrawer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts",
-      "source_location": "L22"
-    },
-    {
-      "community": 620,
-      "file_type": "code",
-      "id": "localcommandgateway_test_blockdrawerauthority",
-      "label": "blockDrawerAuthority()",
-      "norm_label": "blockdrawerauthority()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts",
-      "source_location": "L34"
-    },
-    {
-      "community": 620,
-      "file_type": "code",
-      "id": "localcommandgateway_test_createblockedsalegateway",
-      "label": "createBlockedSaleGateway()",
-      "norm_label": "createblockedsalegateway()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 620,
-      "file_type": "code",
-      "id": "localcommandgateway_test_salecommandinput",
-      "label": "saleCommandInput()",
-      "norm_label": "salecommandinput()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 620,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localcommandgateway_test_ts",
-      "label": "localCommandGateway.test.ts",
-      "norm_label": "localcommandgateway.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 621,
-      "file_type": "code",
       "id": "localregisterreader_readlatestdrawerauthoritystate",
       "label": "readLatestDrawerAuthorityState()",
       "norm_label": "readlatestdrawerauthoritystate()",
@@ -269767,7 +269764,7 @@
       "source_location": "L325"
     },
     {
-      "community": 621,
+      "community": 620,
       "file_type": "code",
       "id": "localregisterreader_readprojectedlocalregistermodel",
       "label": "readProjectedLocalRegisterModel()",
@@ -269776,7 +269773,7 @@
       "source_location": "L129"
     },
     {
-      "community": 621,
+      "community": 620,
       "file_type": "code",
       "id": "localregisterreader_readscopedpagesorfallback",
       "label": "readScopedPagesOrFallback()",
@@ -269785,7 +269782,7 @@
       "source_location": "L266"
     },
     {
-      "community": 621,
+      "community": 620,
       "file_type": "code",
       "id": "localregisterreader_readscopedposlocalevents",
       "label": "readScopedPosLocalEvents()",
@@ -269794,7 +269791,7 @@
       "source_location": "L86"
     },
     {
-      "community": 621,
+      "community": 620,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localregisterreader_ts",
       "label": "localRegisterReader.ts",
@@ -269803,7 +269800,7 @@
       "source_location": "L1"
     },
     {
-      "community": 622,
+      "community": 621,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registerreadmodel_test_ts",
       "label": "registerReadModel.test.ts",
@@ -269812,7 +269809,7 @@
       "source_location": "L1"
     },
     {
-      "community": 622,
+      "community": 621,
       "file_type": "code",
       "id": "registerreadmodel_test_errorcodes",
       "label": "errorCodes()",
@@ -269821,7 +269818,7 @@
       "source_location": "L1565"
     },
     {
-      "community": 622,
+      "community": 621,
       "file_type": "code",
       "id": "registerreadmodel_test_event",
       "label": "event()",
@@ -269830,7 +269827,7 @@
       "source_location": "L1569"
     },
     {
-      "community": 622,
+      "community": 621,
       "file_type": "code",
       "id": "registerreadmodel_test_servicedraftevent",
       "label": "serviceDraftEvent()",
@@ -269839,7 +269836,7 @@
       "source_location": "L1611"
     },
     {
-      "community": 622,
+      "community": 621,
       "file_type": "code",
       "id": "registerreadmodel_test_servicedraftprelude",
       "label": "serviceDraftPrelude()",
@@ -269848,7 +269845,7 @@
       "source_location": "L1593"
     },
     {
-      "community": 623,
+      "community": 622,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_runtimereadiness_ts",
       "label": "runtimeReadiness.ts",
@@ -269857,7 +269854,7 @@
       "source_location": "L1"
     },
     {
-      "community": 623,
+      "community": 622,
       "file_type": "code",
       "id": "runtimereadiness_emptyposterminalruntimereadiness",
       "label": "emptyPosTerminalRuntimeReadiness()",
@@ -269866,7 +269863,7 @@
       "source_location": "L39"
     },
     {
-      "community": 623,
+      "community": 622,
       "file_type": "code",
       "id": "runtimereadiness_getruntimevisibleactiveregistersession",
       "label": "getRuntimeVisibleActiveRegisterSession()",
@@ -269875,7 +269872,7 @@
       "source_location": "L165"
     },
     {
-      "community": 623,
+      "community": 622,
       "file_type": "code",
       "id": "runtimereadiness_refreshterminalruntimereadiness",
       "label": "refreshTerminalRuntimeReadiness()",
@@ -269884,7 +269881,7 @@
       "source_location": "L51"
     },
     {
-      "community": 623,
+      "community": 622,
       "file_type": "code",
       "id": "runtimereadiness_toruntimeactiveregistersession",
       "label": "toRuntimeActiveRegisterSession()",
@@ -269893,7 +269890,7 @@
       "source_location": "L179"
     },
     {
-      "community": 624,
+      "community": 623,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_useregisterlifecycleauthorityruntime_ts",
       "label": "useRegisterLifecycleAuthorityRuntime.ts",
@@ -269902,7 +269899,7 @@
       "source_location": "L1"
     },
     {
-      "community": 624,
+      "community": 623,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_applysnapshot",
       "label": "applySnapshot()",
@@ -269911,7 +269908,7 @@
       "source_location": "L389"
     },
     {
-      "community": 624,
+      "community": 623,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_isregisterlifecyclerepairclassification",
       "label": "isRegisterLifecycleRepairClassification()",
@@ -269920,7 +269917,7 @@
       "source_location": "L554"
     },
     {
-      "community": 624,
+      "community": 623,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_toobservation",
       "label": "toObservation()",
@@ -269929,7 +269926,7 @@
       "source_location": "L523"
     },
     {
-      "community": 624,
+      "community": 623,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_useregisterlifecycleauthorityruntime",
       "label": "useRegisterLifecycleAuthorityRuntime()",
@@ -269938,7 +269935,7 @@
       "source_location": "L53"
     },
     {
-      "community": 625,
+      "community": 624,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_transactionutils_ts",
       "label": "transactionUtils.ts",
@@ -269947,7 +269944,7 @@
       "source_location": "L1"
     },
     {
-      "community": 625,
+      "community": 624,
       "file_type": "code",
       "id": "transactionutils_calculatechange",
       "label": "calculateChange()",
@@ -269956,7 +269953,7 @@
       "source_location": "L42"
     },
     {
-      "community": 625,
+      "community": 624,
       "file_type": "code",
       "id": "transactionutils_formatcurrency",
       "label": "formatCurrency()",
@@ -269965,7 +269962,7 @@
       "source_location": "L29"
     },
     {
-      "community": 625,
+      "community": 624,
       "file_type": "code",
       "id": "transactionutils_formattimestamp",
       "label": "formatTimestamp()",
@@ -269974,7 +269971,7 @@
       "source_location": "L49"
     },
     {
-      "community": 625,
+      "community": 624,
       "file_type": "code",
       "id": "transactionutils_generatetransactionnumber",
       "label": "generateTransactionNumber()",
@@ -269983,7 +269980,7 @@
       "source_location": "L14"
     },
     {
-      "community": 626,
+      "community": 625,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_runtimebuildmetadata_ts",
       "label": "runtimeBuildMetadata.ts",
@@ -269992,7 +269989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 626,
+      "community": 625,
       "file_type": "code",
       "id": "runtimebuildmetadata_getinitialruntimebuildmetadata",
       "label": "getInitialRuntimeBuildMetadata()",
@@ -270001,7 +269998,7 @@
       "source_location": "L16"
     },
     {
-      "community": 626,
+      "community": 625,
       "file_type": "code",
       "id": "runtimebuildmetadata_normalizedeploymetadata",
       "label": "normalizeDeployMetadata()",
@@ -270010,7 +270007,7 @@
       "source_location": "L49"
     },
     {
-      "community": 626,
+      "community": 625,
       "file_type": "code",
       "id": "runtimebuildmetadata_normalizemetadatavalue",
       "label": "normalizeMetadataValue()",
@@ -270019,7 +270016,7 @@
       "source_location": "L63"
     },
     {
-      "community": 626,
+      "community": 625,
       "file_type": "code",
       "id": "runtimebuildmetadata_readruntimebuildmetadata",
       "label": "readRuntimeBuildMetadata()",
@@ -270028,7 +270025,7 @@
       "source_location": "L32"
     },
     {
-      "community": 627,
+      "community": 626,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_timelineutils_ts",
       "label": "timelineUtils.ts",
@@ -270037,7 +270034,7 @@
       "source_location": "L1"
     },
     {
-      "community": 627,
+      "community": 626,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevent",
       "label": "enrichTimelineEvent()",
@@ -270046,7 +270043,7 @@
       "source_location": "L184"
     },
     {
-      "community": 627,
+      "community": 626,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevents",
       "label": "enrichTimelineEvents()",
@@ -270055,7 +270052,7 @@
       "source_location": "L200"
     },
     {
-      "community": 627,
+      "community": 626,
       "file_type": "code",
       "id": "timelineutils_gettimerangelabel",
       "label": "getTimeRangeLabel()",
@@ -270064,7 +270061,7 @@
       "source_location": "L244"
     },
     {
-      "community": 627,
+      "community": 626,
       "file_type": "code",
       "id": "timelineutils_groupeventsbytimeframe",
       "label": "groupEventsByTimeframe()",
@@ -270073,7 +270070,7 @@
       "source_location": "L206"
     },
     {
-      "community": 628,
+      "community": 627,
       "file_type": "code",
       "id": "packages_athena_webapp_src_offline_registerposappshellserviceworker_ts",
       "label": "registerPosAppShellServiceWorker.ts",
@@ -270082,7 +270079,7 @@
       "source_location": "L1"
     },
     {
-      "community": 628,
+      "community": 627,
       "file_type": "code",
       "id": "registerposappshellserviceworker_isposappshellserviceworkerregistration",
       "label": "isPosAppShellServiceWorkerRegistration()",
@@ -270091,7 +270088,7 @@
       "source_location": "L52"
     },
     {
-      "community": 628,
+      "community": 627,
       "file_type": "code",
       "id": "registerposappshellserviceworker_registerposappshellserviceworker",
       "label": "registerPosAppShellServiceWorker()",
@@ -270100,7 +270097,7 @@
       "source_location": "L6"
     },
     {
-      "community": 628,
+      "community": 627,
       "file_type": "code",
       "id": "registerposappshellserviceworker_resetposappshellserviceworkerregistrationfortest",
       "label": "resetPosAppShellServiceWorkerRegistrationForTest()",
@@ -270109,7 +270106,7 @@
       "source_location": "L20"
     },
     {
-      "community": 628,
+      "community": 627,
       "file_type": "code",
       "id": "registerposappshellserviceworker_unregisterposappshellserviceworkerfordev",
       "label": "unregisterPosAppShellServiceWorkerForDev()",
@@ -270118,7 +270115,7 @@
       "source_location": "L24"
     },
     {
-      "community": 629,
+      "community": 628,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -270127,7 +270124,7 @@
       "source_location": "L1"
     },
     {
-      "community": 629,
+      "community": 628,
       "file_type": "code",
       "id": "root_getathenadocumenttitle",
       "label": "getAthenaDocumentTitle()",
@@ -270136,7 +270133,7 @@
       "source_location": "L89"
     },
     {
-      "community": 629,
+      "community": 628,
       "file_type": "code",
       "id": "root_rootcomponent",
       "label": "RootComponent()",
@@ -270145,7 +270142,7 @@
       "source_location": "L62"
     },
     {
-      "community": 629,
+      "community": 628,
       "file_type": "code",
       "id": "root_rootdocument",
       "label": "RootDocument()",
@@ -270154,13 +270151,58 @@
       "source_location": "L72"
     },
     {
-      "community": 629,
+      "community": 628,
       "file_type": "code",
       "id": "root_rootnotfound",
       "label": "RootNotFound()",
       "norm_label": "rootnotfound()",
       "source_file": "packages/athena-webapp/src/routes/__root.tsx",
       "source_location": "L48"
+    },
+    {
+      "community": 629,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
+      "label": "$traceId.tsx",
+      "norm_label": "$traceid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 629,
+      "file_type": "code",
+      "id": "traceid_hasorgnotfoundpayload",
+      "label": "hasOrgNotFoundPayload()",
+      "norm_label": "hasorgnotfoundpayload()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 629,
+      "file_type": "code",
+      "id": "traceid_workflowtraceroute",
+      "label": "WorkflowTraceRoute()",
+      "norm_label": "workflowtraceroute()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L85"
+    },
+    {
+      "community": 629,
+      "file_type": "code",
+      "id": "traceid_workflowtraceroutecontent",
+      "label": "WorkflowTraceRouteContent()",
+      "norm_label": "workflowtraceroutecontent()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 629,
+      "file_type": "code",
+      "id": "traceid_workflowtracerouteshell",
+      "label": "WorkflowTraceRouteShell()",
+      "norm_label": "workflowtracerouteshell()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L50"
     },
     {
       "community": 63,
@@ -270390,51 +270432,6 @@
     {
       "community": 630,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
-      "label": "$traceId.tsx",
-      "norm_label": "$traceid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 630,
-      "file_type": "code",
-      "id": "traceid_hasorgnotfoundpayload",
-      "label": "hasOrgNotFoundPayload()",
-      "norm_label": "hasorgnotfoundpayload()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 630,
-      "file_type": "code",
-      "id": "traceid_workflowtraceroute",
-      "label": "WorkflowTraceRoute()",
-      "norm_label": "workflowtraceroute()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L85"
-    },
-    {
-      "community": 630,
-      "file_type": "code",
-      "id": "traceid_workflowtraceroutecontent",
-      "label": "WorkflowTraceRouteContent()",
-      "norm_label": "workflowtraceroutecontent()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 630,
-      "file_type": "code",
-      "id": "traceid_workflowtracerouteshell",
-      "label": "WorkflowTraceRouteShell()",
-      "norm_label": "workflowtracerouteshell()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 631,
-      "file_type": "code",
       "id": "expensestore_expensecartitemsourcekey",
       "label": "expenseCartItemSourceKey()",
       "norm_label": "expensecartitemsourcekey()",
@@ -270442,7 +270439,7 @@
       "source_location": "L179"
     },
     {
-      "community": 631,
+      "community": 630,
       "file_type": "code",
       "id": "expensestore_ispendingoptimisticexpensecartitem",
       "label": "isPendingOptimisticExpenseCartItem()",
@@ -270451,7 +270448,7 @@
       "source_location": "L197"
     },
     {
-      "community": 631,
+      "community": 630,
       "file_type": "code",
       "id": "expensestore_mapexpensesessioncartitemtocartitem",
       "label": "mapExpenseSessionCartItemToCartItem()",
@@ -270460,7 +270457,7 @@
       "source_location": "L213"
     },
     {
-      "community": 631,
+      "community": 630,
       "file_type": "code",
       "id": "expensestore_sessionitemrepresentscartitem",
       "label": "sessionItemRepresentsCartItem()",
@@ -270469,7 +270466,7 @@
       "source_location": "L201"
     },
     {
-      "community": 631,
+      "community": 630,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stores_expensestore_ts",
       "label": "expenseStore.ts",
@@ -270478,7 +270475,7 @@
       "source_location": "L1"
     },
     {
-      "community": 632,
+      "community": 631,
       "file_type": "code",
       "id": "analytics_getproductviewcount",
       "label": "getProductViewCount()",
@@ -270487,7 +270484,7 @@
       "source_location": "L93"
     },
     {
-      "community": 632,
+      "community": 631,
       "file_type": "code",
       "id": "analytics_logout",
       "label": "logout()",
@@ -270496,7 +270493,7 @@
       "source_location": "L75"
     },
     {
-      "community": 632,
+      "community": 631,
       "file_type": "code",
       "id": "analytics_postanalytics",
       "label": "postAnalytics()",
@@ -270505,7 +270502,7 @@
       "source_location": "L4"
     },
     {
-      "community": 632,
+      "community": 631,
       "file_type": "code",
       "id": "analytics_updateanalyticsowner",
       "label": "updateAnalyticsOwner()",
@@ -270514,7 +270511,7 @@
       "source_location": "L47"
     },
     {
-      "community": 632,
+      "community": 631,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_ts",
       "label": "analytics.ts",
@@ -270523,7 +270520,7 @@
       "source_location": "L1"
     },
     {
-      "community": 633,
+      "community": 632,
       "file_type": "code",
       "id": "category_getallcategories",
       "label": "getAllCategories()",
@@ -270532,7 +270529,7 @@
       "source_location": "L11"
     },
     {
-      "community": 633,
+      "community": 632,
       "file_type": "code",
       "id": "category_getallcategorieswithsubcategories",
       "label": "getAllCategoriesWithSubcategories()",
@@ -270541,7 +270538,7 @@
       "source_location": "L25"
     },
     {
-      "community": 633,
+      "community": 632,
       "file_type": "code",
       "id": "category_getbaseurl",
       "label": "getBaseUrl()",
@@ -270550,7 +270547,7 @@
       "source_location": "L9"
     },
     {
-      "community": 633,
+      "community": 632,
       "file_type": "code",
       "id": "category_getcategory",
       "label": "getCategory()",
@@ -270559,7 +270556,7 @@
       "source_location": "L39"
     },
     {
-      "community": 633,
+      "community": 632,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_category_ts",
       "label": "category.ts",
@@ -270568,7 +270565,7 @@
       "source_location": "L1"
     },
     {
-      "community": 634,
+      "community": 633,
       "file_type": "code",
       "id": "onlineorder_getbaseurl",
       "label": "getBaseUrl()",
@@ -270577,7 +270574,7 @@
       "source_location": "L4"
     },
     {
-      "community": 634,
+      "community": 633,
       "file_type": "code",
       "id": "onlineorder_getorder",
       "label": "getOrder()",
@@ -270586,7 +270583,7 @@
       "source_location": "L24"
     },
     {
-      "community": 634,
+      "community": 633,
       "file_type": "code",
       "id": "onlineorder_getorders",
       "label": "getOrders()",
@@ -270595,7 +270592,7 @@
       "source_location": "L6"
     },
     {
-      "community": 634,
+      "community": 633,
       "file_type": "code",
       "id": "onlineorder_updateordersowner",
       "label": "updateOrdersOwner()",
@@ -270604,7 +270601,7 @@
       "source_location": "L42"
     },
     {
-      "community": 634,
+      "community": 633,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -270613,7 +270610,7 @@
       "source_location": "L1"
     },
     {
-      "community": 635,
+      "community": 634,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefrontuser_ts",
       "label": "storeFrontUser.ts",
@@ -270622,7 +270619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 635,
+      "community": 634,
       "file_type": "code",
       "id": "storefrontuser_getactiveuser",
       "label": "getActiveUser()",
@@ -270631,7 +270628,7 @@
       "source_location": "L28"
     },
     {
-      "community": 635,
+      "community": 634,
       "file_type": "code",
       "id": "storefrontuser_getbaseurl",
       "label": "getBaseUrl()",
@@ -270640,7 +270637,7 @@
       "source_location": "L5"
     },
     {
-      "community": 635,
+      "community": 634,
       "file_type": "code",
       "id": "storefrontuser_getguest",
       "label": "getGuest()",
@@ -270649,7 +270646,7 @@
       "source_location": "L7"
     },
     {
-      "community": 635,
+      "community": 634,
       "file_type": "code",
       "id": "storefrontuser_updateuser",
       "label": "updateUser()",
@@ -270658,7 +270655,7 @@
       "source_location": "L46"
     },
     {
-      "community": 636,
+      "community": 635,
       "file_type": "code",
       "id": "homepage_enableprompts",
       "label": "enablePrompts()",
@@ -270667,7 +270664,7 @@
       "source_location": "L137"
     },
     {
-      "community": 636,
+      "community": 635,
       "file_type": "code",
       "id": "homepage_handleclickonleavereviewbutton",
       "label": "handleClickOnLeaveReviewButton()",
@@ -270676,7 +270673,7 @@
       "source_location": "L176"
     },
     {
-      "community": 636,
+      "community": 635,
       "file_type": "code",
       "id": "homepage_handlescroll",
       "label": "handleScroll()",
@@ -270685,7 +270682,7 @@
       "source_location": "L105"
     },
     {
-      "community": 636,
+      "community": 635,
       "file_type": "code",
       "id": "homepage_homepagereadyshell",
       "label": "HomePageReadyShell()",
@@ -270694,7 +270691,7 @@
       "source_location": "L31"
     },
     {
-      "community": 636,
+      "community": 635,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_tsx",
       "label": "HomePage.tsx",
@@ -270703,7 +270700,7 @@
       "source_location": "L1"
     },
     {
-      "community": 637,
+      "community": 636,
       "file_type": "code",
       "id": "homepagecontent_resolvehomepagecontent",
       "label": "resolveHomepageContent()",
@@ -270712,7 +270709,7 @@
       "source_location": "L102"
     },
     {
-      "community": 637,
+      "community": 636,
       "file_type": "code",
       "id": "homepagecontent_todisplayproduct",
       "label": "toDisplayProduct()",
@@ -270721,7 +270718,7 @@
       "source_location": "L70"
     },
     {
-      "community": 637,
+      "community": 636,
       "file_type": "code",
       "id": "homepagecontent_todisplaysku",
       "label": "toDisplaySku()",
@@ -270730,7 +270727,7 @@
       "source_location": "L54"
     },
     {
-      "community": 637,
+      "community": 636,
       "file_type": "code",
       "id": "homepagecontent_tofeatureditem",
       "label": "toFeaturedItem()",
@@ -270739,7 +270736,7 @@
       "source_location": "L78"
     },
     {
-      "community": 637,
+      "community": 636,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
       "label": "homePageContent.ts",
@@ -270748,7 +270745,7 @@
       "source_location": "L1"
     },
     {
-      "community": 638,
+      "community": 637,
       "file_type": "code",
       "id": "inventorylevelbadge_lowstockbadge",
       "label": "LowStockBadge()",
@@ -270757,7 +270754,7 @@
       "source_location": "L14"
     },
     {
-      "community": 638,
+      "community": 637,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastbadge",
       "label": "SellingFastBadge()",
@@ -270766,7 +270763,7 @@
       "source_location": "L22"
     },
     {
-      "community": 638,
+      "community": 637,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastsignal",
       "label": "SellingFastSignal()",
@@ -270775,7 +270772,7 @@
       "source_location": "L30"
     },
     {
-      "community": 638,
+      "community": 637,
       "file_type": "code",
       "id": "inventorylevelbadge_soldoutbadge",
       "label": "SoldOutBadge()",
@@ -270784,12 +270781,57 @@
       "source_location": "L3"
     },
     {
-      "community": 638,
+      "community": 637,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_inventorylevelbadge_tsx",
       "label": "InventoryLevelBadge.tsx",
       "norm_label": "inventorylevelbadge.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 638,
+      "file_type": "code",
+      "id": "currency_formatstoredamount",
+      "label": "formatStoredAmount()",
+      "norm_label": "formatstoredamount()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 638,
+      "file_type": "code",
+      "id": "currency_todisplayamount",
+      "label": "toDisplayAmount()",
+      "norm_label": "todisplayamount()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 638,
+      "file_type": "code",
+      "id": "currency_topesewas",
+      "label": "toPesewas()",
+      "norm_label": "topesewas()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 638,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 638,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
       "source_location": "L1"
     },
     {
@@ -283557,37 +283599,37 @@
     {
       "community": 839,
       "file_type": "code",
-      "id": "harness_test_collectharnesstesttargets",
-      "label": "collectHarnessTestTargets()",
-      "norm_label": "collectharnesstesttargets()",
-      "source_file": "scripts/harness-test.ts",
-      "source_location": "L26"
+      "id": "harness_test_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/harness-test.test.ts",
+      "source_location": "L21"
     },
     {
       "community": 839,
       "file_type": "code",
-      "id": "harness_test_parseharnesstestcliargs",
-      "label": "parseHarnessTestCliArgs()",
-      "norm_label": "parseharnesstestcliargs()",
-      "source_file": "scripts/harness-test.ts",
-      "source_location": "L72"
+      "id": "harness_test_test_rungit",
+      "label": "runGit()",
+      "norm_label": "rungit()",
+      "source_file": "scripts/harness-test.test.ts",
+      "source_location": "L27"
     },
     {
       "community": 839,
       "file_type": "code",
-      "id": "harness_test_runharnesstest",
-      "label": "runHarnessTest()",
-      "norm_label": "runharnesstest()",
-      "source_file": "scripts/harness-test.ts",
-      "source_location": "L36"
+      "id": "harness_test_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-test.test.ts",
+      "source_location": "L15"
     },
     {
       "community": 839,
       "file_type": "code",
-      "id": "scripts_harness_test_ts",
-      "label": "harness-test.ts",
-      "norm_label": "harness-test.ts",
-      "source_file": "scripts/harness-test.ts",
+      "id": "scripts_harness_test_test_ts",
+      "label": "harness-test.test.ts",
+      "norm_label": "harness-test.test.ts",
+      "source_file": "scripts/harness-test.test.ts",
       "source_location": "L1"
     },
     {
@@ -283791,6 +283833,42 @@
     {
       "community": 840,
       "file_type": "code",
+      "id": "harness_test_collectharnesstesttargets",
+      "label": "collectHarnessTestTargets()",
+      "norm_label": "collectharnesstesttargets()",
+      "source_file": "scripts/harness-test.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 840,
+      "file_type": "code",
+      "id": "harness_test_parseharnesstestcliargs",
+      "label": "parseHarnessTestCliArgs()",
+      "norm_label": "parseharnesstestcliargs()",
+      "source_file": "scripts/harness-test.ts",
+      "source_location": "L80"
+    },
+    {
+      "community": 840,
+      "file_type": "code",
+      "id": "harness_test_runharnesstest",
+      "label": "runHarnessTest()",
+      "norm_label": "runharnesstest()",
+      "source_file": "scripts/harness-test.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 840,
+      "file_type": "code",
+      "id": "scripts_harness_test_ts",
+      "label": "harness-test.ts",
+      "norm_label": "harness-test.ts",
+      "source_file": "scripts/harness-test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 841,
+      "file_type": "code",
       "id": "preview_worktree_test_makedir",
       "label": "makeDir()",
       "norm_label": "makedir()",
@@ -283798,7 +283876,7 @@
       "source_location": "L17"
     },
     {
-      "community": 840,
+      "community": 841,
       "file_type": "code",
       "id": "preview_worktree_test_previewoptions",
       "label": "previewOptions()",
@@ -283807,7 +283885,7 @@
       "source_location": "L23"
     },
     {
-      "community": 840,
+      "community": 841,
       "file_type": "code",
       "id": "preview_worktree_test_real",
       "label": "real()",
@@ -283816,7 +283894,7 @@
       "source_location": "L40"
     },
     {
-      "community": 840,
+      "community": 841,
       "file_type": "code",
       "id": "scripts_preview_worktree_test_ts",
       "label": "preview-worktree.test.ts",
@@ -283825,7 +283903,7 @@
       "source_location": "L1"
     },
     {
-      "community": 841,
+      "community": 842,
       "file_type": "code",
       "id": "scripts_worktree_bootstrap_check_ts",
       "label": "worktree-bootstrap-check.ts",
@@ -283834,7 +283912,7 @@
       "source_location": "L1"
     },
     {
-      "community": 841,
+      "community": 842,
       "file_type": "code",
       "id": "worktree_bootstrap_check_resolvegitpath",
       "label": "resolveGitPath()",
@@ -283843,7 +283921,7 @@
       "source_location": "L27"
     },
     {
-      "community": 841,
+      "community": 842,
       "file_type": "code",
       "id": "worktree_bootstrap_check_rungit",
       "label": "runGit()",
@@ -283852,7 +283930,7 @@
       "source_location": "L6"
     },
     {
-      "community": 841,
+      "community": 842,
       "file_type": "code",
       "id": "worktree_bootstrap_check_validateworktreebootstrap",
       "label": "validateWorktreeBootstrap()",
@@ -283861,7 +283939,7 @@
       "source_location": "L31"
     },
     {
-      "community": 842,
+      "community": 843,
       "file_type": "code",
       "id": "athenawebappevents_builddocsworkspaceappendargs",
       "label": "buildDocsWorkspaceAppendArgs()",
@@ -283870,7 +283948,7 @@
       "source_location": "L47"
     },
     {
-      "community": 842,
+      "community": 843,
       "file_type": "code",
       "id": "athenawebappevents_validatedocsworkspacevisit",
       "label": "validateDocsWorkspaceVisit()",
@@ -283879,7 +283957,7 @@
       "source_location": "L29"
     },
     {
-      "community": 842,
+      "community": 843,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_contexttracking_athenawebappevents_ts",
       "label": "athenaWebappEvents.ts",
@@ -283888,7 +283966,7 @@
       "source_location": "L1"
     },
     {
-      "community": 843,
+      "community": 844,
       "file_type": "code",
       "id": "contextbundles_test_contextevent",
       "label": "contextEvent()",
@@ -283897,7 +283975,7 @@
       "source_location": "L12"
     },
     {
-      "community": 843,
+      "community": 844,
       "file_type": "code",
       "id": "contextbundles_test_readcompactevents",
       "label": "readCompactEvents()",
@@ -283906,7 +283984,7 @@
       "source_location": "L298"
     },
     {
-      "community": 843,
+      "community": 844,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_contexttracking_contextbundles_test_ts",
       "label": "contextBundles.test.ts",
@@ -283915,7 +283993,7 @@
       "source_location": "L1"
     },
     {
-      "community": 844,
+      "community": 845,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_contexttracking_shareddemoactioncapture_ts",
       "label": "sharedDemoActionCapture.ts",
@@ -283924,7 +284002,7 @@
       "source_location": "L1"
     },
     {
-      "community": 844,
+      "community": 845,
       "file_type": "code",
       "id": "shareddemoactioncapture_buildshareddemoactionappendargs",
       "label": "buildSharedDemoActionAppendArgs()",
@@ -283933,7 +284011,7 @@
       "source_location": "L17"
     },
     {
-      "community": 844,
+      "community": 845,
       "file_type": "code",
       "id": "shareddemoactioncapture_captureshareddemoadmittedactionwithctx",
       "label": "captureSharedDemoAdmittedActionWithCtx()",
@@ -283942,7 +284020,7 @@
       "source_location": "L55"
     },
     {
-      "community": 845,
+      "community": 846,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_contexttracking_shareddemoevents_ts",
       "label": "sharedDemoEvents.ts",
@@ -283951,7 +284029,7 @@
       "source_location": "L1"
     },
     {
-      "community": 845,
+      "community": 846,
       "file_type": "code",
       "id": "shareddemoevents_buildshareddemoactivityappendargs",
       "label": "buildSharedDemoActivityAppendArgs()",
@@ -283960,7 +284038,7 @@
       "source_location": "L70"
     },
     {
-      "community": 845,
+      "community": 846,
       "file_type": "code",
       "id": "shareddemoevents_validateshareddemoactivity",
       "label": "validateSharedDemoActivity()",
@@ -283969,7 +284047,7 @@
       "source_location": "L51"
     },
     {
-      "community": 846,
+      "community": 847,
       "file_type": "code",
       "id": "convexauditscript_test_createcommandshimbin",
       "label": "createCommandShimBin()",
@@ -283978,7 +284056,7 @@
       "source_location": "L10"
     },
     {
-      "community": 846,
+      "community": 847,
       "file_type": "code",
       "id": "convexauditscript_test_resolvebunexecutable",
       "label": "resolveBunExecutable()",
@@ -283987,7 +284065,7 @@
       "source_location": "L21"
     },
     {
-      "community": 846,
+      "community": 847,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convexauditscript_test_ts",
       "label": "convexAuditScript.test.ts",
@@ -283996,7 +284074,7 @@
       "source_location": "L1"
     },
     {
-      "community": 847,
+      "community": 848,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_public_ts",
       "label": "public.ts",
@@ -284005,7 +284083,7 @@
       "source_location": "L1"
     },
     {
-      "community": 847,
+      "community": 848,
       "file_type": "code",
       "id": "public_resolverecipient",
       "label": "resolveRecipient()",
@@ -284014,7 +284092,7 @@
       "source_location": "L57"
     },
     {
-      "community": 847,
+      "community": 848,
       "file_type": "code",
       "id": "public_topublicreceipttransaction",
       "label": "toPublicReceiptTransaction()",
@@ -284023,7 +284101,7 @@
       "source_location": "L29"
     },
     {
-      "community": 848,
+      "community": 849,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_whatsappclient_ts",
       "label": "whatsappClient.ts",
@@ -284032,7 +284110,7 @@
       "source_location": "L1"
     },
     {
-      "community": 848,
+      "community": 849,
       "file_type": "code",
       "id": "whatsappclient_providererrorcategory",
       "label": "providerErrorCategory()",
@@ -284041,40 +284119,13 @@
       "source_location": "L20"
     },
     {
-      "community": 848,
+      "community": 849,
       "file_type": "code",
       "id": "whatsappclient_sendwhatsappreceipttemplate",
       "label": "sendWhatsAppReceiptTemplate()",
       "norm_label": "sendwhatsappreceipttemplate()",
       "source_file": "packages/athena-webapp/convex/customerMessaging/whatsappClient.ts",
       "source_location": "L27"
-    },
-    {
-      "community": 849,
-      "file_type": "code",
-      "id": "approvalrequestpending_buildapprovalrequestpendingsubject",
-      "label": "buildApprovalRequestPendingSubject()",
-      "norm_label": "buildapprovalrequestpendingsubject()",
-      "source_file": "packages/athena-webapp/convex/emails/ApprovalRequestPending.tsx",
-      "source_location": "L170"
-    },
-    {
-      "community": 849,
-      "file_type": "code",
-      "id": "approvalrequestpending_getapprovalrequestdescriptor",
-      "label": "getApprovalRequestDescriptor()",
-      "norm_label": "getapprovalrequestdescriptor()",
-      "source_file": "packages/athena-webapp/convex/emails/ApprovalRequestPending.tsx",
-      "source_location": "L156"
-    },
-    {
-      "community": 849,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_approvalrequestpending_tsx",
-      "label": "ApprovalRequestPending.tsx",
-      "norm_label": "approvalrequestpending.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/ApprovalRequestPending.tsx",
-      "source_location": "L1"
     },
     {
       "community": 85,
@@ -284277,6 +284328,33 @@
     {
       "community": 850,
       "file_type": "code",
+      "id": "approvalrequestpending_buildapprovalrequestpendingsubject",
+      "label": "buildApprovalRequestPendingSubject()",
+      "norm_label": "buildapprovalrequestpendingsubject()",
+      "source_file": "packages/athena-webapp/convex/emails/ApprovalRequestPending.tsx",
+      "source_location": "L170"
+    },
+    {
+      "community": 850,
+      "file_type": "code",
+      "id": "approvalrequestpending_getapprovalrequestdescriptor",
+      "label": "getApprovalRequestDescriptor()",
+      "norm_label": "getapprovalrequestdescriptor()",
+      "source_file": "packages/athena-webapp/convex/emails/ApprovalRequestPending.tsx",
+      "source_location": "L156"
+    },
+    {
+      "community": 850,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_approvalrequestpending_tsx",
+      "label": "ApprovalRequestPending.tsx",
+      "norm_label": "approvalrequestpending.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/ApprovalRequestPending.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 851,
+      "file_type": "code",
       "id": "discountcode_chunkproducts",
       "label": "chunkProducts()",
       "norm_label": "chunkproducts()",
@@ -284284,7 +284362,7 @@
       "source_location": "L98"
     },
     {
-      "community": 850,
+      "community": 851,
       "file_type": "code",
       "id": "discountcode_productcard",
       "label": "ProductCard()",
@@ -284293,7 +284371,7 @@
       "source_location": "L33"
     },
     {
-      "community": 850,
+      "community": 851,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
       "label": "DiscountCode.tsx",
@@ -284302,7 +284380,7 @@
       "source_location": "L1"
     },
     {
-      "community": 851,
+      "community": 852,
       "file_type": "code",
       "id": "discountreminder_chunkproducts",
       "label": "chunkProducts()",
@@ -284311,7 +284389,7 @@
       "source_location": "L85"
     },
     {
-      "community": 851,
+      "community": 852,
       "file_type": "code",
       "id": "discountreminder_productcard",
       "label": "ProductCard()",
@@ -284320,7 +284398,7 @@
       "source_location": "L31"
     },
     {
-      "community": 851,
+      "community": 852,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
       "label": "DiscountReminder.tsx",
@@ -284329,7 +284407,7 @@
       "source_location": "L1"
     },
     {
-      "community": 852,
+      "community": 853,
       "file_type": "code",
       "id": "neworderadmin_formatstatus",
       "label": "formatStatus()",
@@ -284338,7 +284416,7 @@
       "source_location": "L264"
     },
     {
-      "community": 852,
+      "community": 853,
       "file_type": "code",
       "id": "neworderadmin_neworderadminpreview",
       "label": "NewOrderAdminPreview()",
@@ -284347,7 +284425,7 @@
       "source_location": "L270"
     },
     {
-      "community": 852,
+      "community": 853,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_neworderadmin_tsx",
       "label": "NewOrderAdmin.tsx",
@@ -284356,7 +284434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 853,
+      "community": 854,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_posterminalhealthalert_tsx",
       "label": "PosTerminalHealthAlert.tsx",
@@ -284365,7 +284443,7 @@
       "source_location": "L1"
     },
     {
-      "community": 853,
+      "community": 854,
       "file_type": "code",
       "id": "posterminalhealthalert_posterminalhealthalert",
       "label": "PosTerminalHealthAlert()",
@@ -284374,7 +284452,7 @@
       "source_location": "L34"
     },
     {
-      "community": 853,
+      "community": 854,
       "file_type": "code",
       "id": "posterminalhealthalert_posterminalhealthalertpreview",
       "label": "PosTerminalHealthAlertPreview()",
@@ -284383,7 +284461,7 @@
       "source_location": "L84"
     },
     {
-      "community": 854,
+      "community": 855,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_weeklymanagerreport_tsx",
       "label": "WeeklyManagerReport.tsx",
@@ -284392,7 +284470,7 @@
       "source_location": "L1"
     },
     {
-      "community": 854,
+      "community": 855,
       "file_type": "code",
       "id": "weeklymanagerreport_weeklymanagerreport",
       "label": "WeeklyManagerReport()",
@@ -284401,7 +284479,7 @@
       "source_location": "L139"
     },
     {
-      "community": 854,
+      "community": 855,
       "file_type": "code",
       "id": "weeklymanagerreport_weeklymanagerreportpreview",
       "label": "WeeklyManagerReportPreview()",
@@ -284410,7 +284488,7 @@
       "source_location": "L143"
     },
     {
-      "community": 855,
+      "community": 856,
       "file_type": "code",
       "id": "featureditem_test_gethandler",
       "label": "getHandler()",
@@ -284419,7 +284497,7 @@
       "source_location": "L12"
     },
     {
-      "community": 855,
+      "community": 856,
       "file_type": "code",
       "id": "featureditem_test_makecreatectx",
       "label": "makeCreateCtx()",
@@ -284428,7 +284506,7 @@
       "source_location": "L16"
     },
     {
-      "community": 855,
+      "community": 856,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_featureditem_test_ts",
       "label": "featuredItem.test.ts",
@@ -284437,7 +284515,7 @@
       "source_location": "L1"
     },
     {
-      "community": 856,
+      "community": 857,
       "file_type": "code",
       "id": "inventoryholds_test_buildhold",
       "label": "buildHold()",
@@ -284446,7 +284524,7 @@
       "source_location": "L829"
     },
     {
-      "community": 856,
+      "community": 857,
       "file_type": "code",
       "id": "inventoryholds_test_createdb",
       "label": "createDb()",
@@ -284455,7 +284533,7 @@
       "source_location": "L51"
     },
     {
-      "community": 856,
+      "community": 857,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_test_ts",
       "label": "inventoryHolds.test.ts",
@@ -284464,7 +284542,7 @@
       "source_location": "L1"
     },
     {
-      "community": 857,
+      "community": 858,
       "file_type": "code",
       "id": "organizations_test_seedorganization",
       "label": "seedOrganization()",
@@ -284473,7 +284551,7 @@
       "source_location": "L39"
     },
     {
-      "community": 857,
+      "community": 858,
       "file_type": "code",
       "id": "organizations_test_weeklyrowcounts",
       "label": "weeklyRowCounts()",
@@ -284482,7 +284560,7 @@
       "source_location": "L21"
     },
     {
-      "community": 857,
+      "community": 858,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizations_test_ts",
       "label": "organizations.test.ts",
@@ -284491,7 +284569,7 @@
       "source_location": "L1"
     },
     {
-      "community": 858,
+      "community": 859,
       "file_type": "code",
       "id": "organizations_removeorganizationbatchwithctx",
       "label": "removeOrganizationBatchWithCtx()",
@@ -284500,7 +284578,7 @@
       "source_location": "L19"
     },
     {
-      "community": 858,
+      "community": 859,
       "file_type": "code",
       "id": "organizations_removeorganizationwithctx",
       "label": "removeOrganizationWithCtx()",
@@ -284509,40 +284587,13 @@
       "source_location": "L72"
     },
     {
-      "community": 858,
+      "community": 859,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizations_ts",
       "label": "organizations.ts",
       "norm_label": "organizations.ts",
       "source_file": "packages/athena-webapp/convex/inventory/organizations.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 859,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_possessionitems_test_ts",
-      "label": "posSessionItems.test.ts",
-      "norm_label": "possessionitems.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessionItems.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 859,
-      "file_type": "code",
-      "id": "possessionitems_test_buildctx",
-      "label": "buildCtx()",
-      "norm_label": "buildctx()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessionItems.test.ts",
-      "source_location": "L237"
-    },
-    {
-      "community": 859,
-      "file_type": "code",
-      "id": "possessionitems_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/inventory/posSessionItems.test.ts",
-      "source_location": "L41"
     },
     {
       "community": 86,
@@ -284745,6 +284796,33 @@
     {
       "community": 860,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_possessionitems_test_ts",
+      "label": "posSessionItems.test.ts",
+      "norm_label": "possessionitems.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessionItems.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 860,
+      "file_type": "code",
+      "id": "possessionitems_test_buildctx",
+      "label": "buildCtx()",
+      "norm_label": "buildctx()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessionItems.test.ts",
+      "source_location": "L237"
+    },
+    {
+      "community": 860,
+      "file_type": "code",
+      "id": "possessionitems_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/inventory/posSessionItems.test.ts",
+      "source_location": "L41"
+    },
+    {
+      "community": 861,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
       "label": "sessionQueryIndexes.test.ts",
       "norm_label": "sessionqueryindexes.test.ts",
@@ -284752,7 +284830,7 @@
       "source_location": "L1"
     },
     {
-      "community": 860,
+      "community": 861,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readprojectfile",
       "label": "readProjectFile()",
@@ -284761,7 +284839,7 @@
       "source_location": "L6"
     },
     {
-      "community": 860,
+      "community": 861,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readsourceslice",
       "label": "readSourceSlice()",
@@ -284770,7 +284848,7 @@
       "source_location": "L9"
     },
     {
-      "community": 861,
+      "community": 862,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_storestestsupport_ts",
       "label": "storesTestSupport.ts",
@@ -284779,7 +284857,7 @@
       "source_location": "L1"
     },
     {
-      "community": 861,
+      "community": 862,
       "file_type": "code",
       "id": "storestestsupport_cycledate",
       "label": "cycleDate()",
@@ -284788,7 +284866,7 @@
       "source_location": "L20"
     },
     {
-      "community": 861,
+      "community": 862,
       "file_type": "code",
       "id": "storestestsupport_seedweeklyrowsfordeletiontest",
       "label": "seedWeeklyRowsForDeletionTest()",
@@ -284797,7 +284875,7 @@
       "source_location": "L26"
     },
     {
-      "community": 862,
+      "community": 863,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_taxonomyskusearchrefresh_test_ts",
       "label": "taxonomySkuSearchRefresh.test.ts",
@@ -284806,7 +284884,7 @@
       "source_location": "L1"
     },
     {
-      "community": 862,
+      "community": 863,
       "file_type": "code",
       "id": "taxonomyskusearchrefresh_test_createctx",
       "label": "createCtx()",
@@ -284815,7 +284893,7 @@
       "source_location": "L47"
     },
     {
-      "community": 862,
+      "community": 863,
       "file_type": "code",
       "id": "taxonomyskusearchrefresh_test_gethandler",
       "label": "getHandler()",
@@ -284824,7 +284902,7 @@
       "source_location": "L43"
     },
     {
-      "community": 863,
+      "community": 864,
       "file_type": "code",
       "id": "deficitledger_createcandidatedeficitledgerwithctx",
       "label": "createCandidateDeficitLedgerWithCtx()",
@@ -284833,7 +284911,7 @@
       "source_location": "L66"
     },
     {
-      "community": 863,
+      "community": 864,
       "file_type": "code",
       "id": "deficitledger_ensureactivedeficitledgerwithctx",
       "label": "ensureActiveDeficitLedgerWithCtx()",
@@ -284842,7 +284920,7 @@
       "source_location": "L4"
     },
     {
-      "community": 863,
+      "community": 864,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventoryledger_deficitledger_ts",
       "label": "deficitLedger.ts",
@@ -284851,7 +284929,7 @@
       "source_location": "L1"
     },
     {
-      "community": 864,
+      "community": 865,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_returnvalidatorcontract_test_ts",
       "label": "returnValidatorContract.test.ts",
@@ -284860,7 +284938,7 @@
       "source_location": "L1"
     },
     {
-      "community": 864,
+      "community": 865,
       "file_type": "code",
       "id": "returnvalidatorcontract_test_definitionfor",
       "label": "definitionFor()",
@@ -284869,7 +284947,7 @@
       "source_location": "L13"
     },
     {
-      "community": 864,
+      "community": 865,
       "file_type": "code",
       "id": "returnvalidatorcontract_test_serializedvalidatorfor",
       "label": "serializedValidatorFor()",
@@ -284878,7 +284956,7 @@
       "source_location": "L9"
     },
     {
-      "community": 865,
+      "community": 866,
       "file_type": "code",
       "id": "analyticsutils_calculateactivitytrend",
       "label": "calculateActivityTrend()",
@@ -284887,7 +284965,7 @@
       "source_location": "L43"
     },
     {
-      "community": 865,
+      "community": 866,
       "file_type": "code",
       "id": "analyticsutils_calculatedevicedistribution",
       "label": "calculateDeviceDistribution()",
@@ -284896,7 +284974,7 @@
       "source_location": "L11"
     },
     {
-      "community": 865,
+      "community": 866,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_utils_analyticsutils_ts",
       "label": "analyticsUtils.ts",
@@ -284905,7 +284983,7 @@
       "source_location": "L1"
     },
     {
-      "community": 866,
+      "community": 867,
       "file_type": "code",
       "id": "index_test_getrenderedverificationemailprops",
       "label": "getRenderedVerificationEmailProps()",
@@ -284914,7 +284992,7 @@
       "source_location": "L22"
     },
     {
-      "community": 866,
+      "community": 867,
       "file_type": "code",
       "id": "index_test_getrequestbody",
       "label": "getRequestBody()",
@@ -284923,7 +285001,7 @@
       "source_location": "L15"
     },
     {
-      "community": 866,
+      "community": 867,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mailersend_index_test_tsx",
       "label": "index.test.tsx",
@@ -284932,7 +285010,7 @@
       "source_location": "L1"
     },
     {
-      "community": 867,
+      "community": 868,
       "file_type": "code",
       "id": "landingfunnelevents_appendfunnelaggregatewithctx",
       "label": "appendFunnelAggregateWithCtx()",
@@ -284941,7 +285019,7 @@
       "source_location": "L20"
     },
     {
-      "community": 867,
+      "community": 868,
       "file_type": "code",
       "id": "landingfunnelevents_appendfunneleventwithctx",
       "label": "appendFunnelEventWithCtx()",
@@ -284950,7 +285028,7 @@
       "source_location": "L10"
     },
     {
-      "community": 867,
+      "community": 868,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_marketing_landingfunnelevents_ts",
       "label": "landingFunnelEvents.ts",
@@ -284959,7 +285037,7 @@
       "source_location": "L1"
     },
     {
-      "community": 868,
+      "community": 869,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_marketing_walkthroughnormalization_ts",
       "label": "walkthroughNormalization.ts",
@@ -284968,7 +285046,7 @@
       "source_location": "L1"
     },
     {
-      "community": 868,
+      "community": 869,
       "file_type": "code",
       "id": "walkthroughnormalization_normalizewalkthroughemail",
       "label": "normalizeWalkthroughEmail()",
@@ -284977,39 +285055,12 @@
       "source_location": "L8"
     },
     {
-      "community": 868,
+      "community": 869,
       "file_type": "code",
       "id": "walkthroughnormalization_normalizewalkthroughtext",
       "label": "normalizeWalkthroughText()",
       "norm_label": "normalizewalkthroughtext()",
       "source_file": "packages/athena-webapp/convex/marketing/walkthroughNormalization.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 869,
-      "file_type": "code",
-      "id": "backfillathenausernormalizedemail_test_context",
-      "label": "context()",
-      "norm_label": "context()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillAthenaUserNormalizedEmail.test.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 869,
-      "file_type": "code",
-      "id": "backfillathenausernormalizedemail_test_finishrun",
-      "label": "finishRun()",
-      "norm_label": "finishrun()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillAthenaUserNormalizedEmail.test.ts",
-      "source_location": "L94"
-    },
-    {
-      "community": 869,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_migrations_backfillathenausernormalizedemail_test_ts",
-      "label": "backfillAthenaUserNormalizedEmail.test.ts",
-      "norm_label": "backfillathenausernormalizedemail.test.ts",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillAthenaUserNormalizedEmail.test.ts",
       "source_location": "L1"
     },
     {
@@ -285213,6 +285264,33 @@
     {
       "community": 870,
       "file_type": "code",
+      "id": "backfillathenausernormalizedemail_test_context",
+      "label": "context()",
+      "norm_label": "context()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillAthenaUserNormalizedEmail.test.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 870,
+      "file_type": "code",
+      "id": "backfillathenausernormalizedemail_test_finishrun",
+      "label": "finishRun()",
+      "norm_label": "finishrun()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillAthenaUserNormalizedEmail.test.ts",
+      "source_location": "L94"
+    },
+    {
+      "community": 870,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_migrations_backfillathenausernormalizedemail_test_ts",
+      "label": "backfillAthenaUserNormalizedEmail.test.ts",
+      "norm_label": "backfillathenausernormalizedemail.test.ts",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillAthenaUserNormalizedEmail.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 871,
+      "file_type": "code",
       "id": "emit_emitnotificationwithctx",
       "label": "emitNotificationWithCtx()",
       "norm_label": "emitnotificationwithctx()",
@@ -285220,7 +285298,7 @@
       "source_location": "L38"
     },
     {
-      "community": 870,
+      "community": 871,
       "file_type": "code",
       "id": "emit_schedulenotificationwithctx",
       "label": "scheduleNotificationWithCtx()",
@@ -285229,7 +285307,7 @@
       "source_location": "L21"
     },
     {
-      "community": 870,
+      "community": 871,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_notifications_emit_ts",
       "label": "emit.ts",
@@ -285238,7 +285316,7 @@
       "source_location": "L1"
     },
     {
-      "community": 871,
+      "community": 872,
       "file_type": "code",
       "id": "actionadmission_admitactionoperationwithctx",
       "label": "admitActionOperationWithCtx()",
@@ -285247,7 +285325,7 @@
       "source_location": "L29"
     },
     {
-      "community": 871,
+      "community": 872,
       "file_type": "code",
       "id": "actionadmission_findoperationdefinition",
       "label": "findOperationDefinition()",
@@ -285256,7 +285334,7 @@
       "source_location": "L9"
     },
     {
-      "community": 871,
+      "community": 872,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_actionadmission_ts",
       "label": "actionAdmission.ts",
@@ -285265,7 +285343,7 @@
       "source_location": "L1"
     },
     {
-      "community": 872,
+      "community": 873,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_publicquery_ts",
       "label": "publicQuery.ts",
@@ -285274,7 +285352,7 @@
       "source_location": "L1"
     },
     {
-      "community": 872,
+      "community": 873,
       "file_type": "code",
       "id": "publicquery_admitpublicquery",
       "label": "admitPublicQuery()",
@@ -285283,7 +285361,7 @@
       "source_location": "L24"
     },
     {
-      "community": 872,
+      "community": 873,
       "file_type": "code",
       "id": "publicquery_withoperationreadadmission",
       "label": "withOperationReadAdmission()",
@@ -285292,7 +285370,7 @@
       "source_location": "L43"
     },
     {
-      "community": 873,
+      "community": 874,
       "file_type": "code",
       "id": "approvalrequesthelpers_test_listintents",
       "label": "listIntents()",
@@ -285301,7 +285379,7 @@
       "source_location": "L43"
     },
     {
-      "community": 873,
+      "community": 874,
       "file_type": "code",
       "id": "approvalrequesthelpers_test_seedorgstore",
       "label": "seedOrgStore()",
@@ -285310,7 +285388,7 @@
       "source_location": "L23"
     },
     {
-      "community": 873,
+      "community": 874,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequesthelpers_test_ts",
       "label": "approvalRequestHelpers.test.ts",
@@ -285319,7 +285397,7 @@
       "source_location": "L1"
     },
     {
-      "community": 874,
+      "community": 875,
       "file_type": "code",
       "id": "approvalrequesthelpers_buildapprovalrequest",
       "label": "buildApprovalRequest()",
@@ -285328,7 +285406,7 @@
       "source_location": "L21"
     },
     {
-      "community": 874,
+      "community": 875,
       "file_type": "code",
       "id": "approvalrequesthelpers_insertapprovalrequestwithctx",
       "label": "insertApprovalRequestWithCtx()",
@@ -285337,7 +285415,7 @@
       "source_location": "L39"
     },
     {
-      "community": 874,
+      "community": 875,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequesthelpers_ts",
       "label": "approvalRequestHelpers.ts",
@@ -285346,7 +285424,7 @@
       "source_location": "L1"
     },
     {
-      "community": 875,
+      "community": 876,
       "file_type": "code",
       "id": "managerelevations_test_createmanagerelevationsctx",
       "label": "createManagerElevationsCtx()",
@@ -285355,7 +285433,7 @@
       "source_location": "L27"
     },
     {
-      "community": 875,
+      "community": 876,
       "file_type": "code",
       "id": "managerelevations_test_startargs",
       "label": "startArgs()",
@@ -285364,7 +285442,7 @@
       "source_location": "L178"
     },
     {
-      "community": 875,
+      "community": 876,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_managerelevations_test_ts",
       "label": "managerElevations.test.ts",
@@ -285373,7 +285451,7 @@
       "source_location": "L1"
     },
     {
-      "community": 876,
+      "community": 877,
       "file_type": "code",
       "id": "oweddailyclosesweep_integration_test_seedcompletedclose",
       "label": "seedCompletedClose()",
@@ -285382,7 +285460,7 @@
       "source_location": "L60"
     },
     {
-      "community": 876,
+      "community": 877,
       "file_type": "code",
       "id": "oweddailyclosesweep_integration_test_seedstore",
       "label": "seedStore()",
@@ -285391,7 +285469,7 @@
       "source_location": "L22"
     },
     {
-      "community": 876,
+      "community": 877,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_oweddailyclosesweep_integration_test_ts",
       "label": "owedDailyCloseSweep.integration.test.ts",
@@ -285400,7 +285478,7 @@
       "source_location": "L1"
     },
     {
-      "community": 877,
+      "community": 878,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_skuactivity_test_ts",
       "label": "skuActivity.test.ts",
@@ -285409,7 +285487,7 @@
       "source_location": "L1"
     },
     {
-      "community": 877,
+      "community": 878,
       "file_type": "code",
       "id": "skuactivity_test_createindexeddb",
       "label": "createIndexedDb()",
@@ -285418,7 +285496,7 @@
       "source_location": "L95"
     },
     {
-      "community": 877,
+      "community": 878,
       "file_type": "code",
       "id": "skuactivity_test_gethandler",
       "label": "getHandler()",
@@ -285427,7 +285505,7 @@
       "source_location": "L37"
     },
     {
-      "community": 878,
+      "community": 879,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffmessages_test_ts",
       "label": "staffMessages.test.ts",
@@ -285436,7 +285514,7 @@
       "source_location": "L1"
     },
     {
-      "community": 878,
+      "community": 879,
       "file_type": "code",
       "id": "staffmessages_test_context",
       "label": "context()",
@@ -285445,40 +285523,13 @@
       "source_location": "L33"
     },
     {
-      "community": 878,
+      "community": 879,
       "file_type": "code",
       "id": "staffmessages_test_invoke",
       "label": "invoke()",
       "norm_label": "invoke()",
       "source_file": "packages/athena-webapp/convex/operations/staffMessages.test.ts",
       "source_location": "L30"
-    },
-    {
-      "community": 879,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
-      "label": "staffProfiles.test.ts",
-      "norm_label": "staffprofiles.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 879,
-      "file_type": "code",
-      "id": "staffprofiles_test_createstaffprofilesmutationctx",
-      "label": "createStaffProfilesMutationCtx()",
-      "norm_label": "createstaffprofilesmutationctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 879,
-      "file_type": "code",
-      "id": "staffprofiles_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
-      "source_location": "L143"
     },
     {
       "community": 88,
@@ -285672,6 +285723,33 @@
     {
       "community": 880,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_staffprofiles_test_ts",
+      "label": "staffProfiles.test.ts",
+      "norm_label": "staffprofiles.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 880,
+      "file_type": "code",
+      "id": "staffprofiles_test_createstaffprofilesmutationctx",
+      "label": "createStaffProfilesMutationCtx()",
+      "norm_label": "createstaffprofilesmutationctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 880,
+      "file_type": "code",
+      "id": "staffprofiles_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.test.ts",
+      "source_location": "L143"
+    },
+    {
+      "community": 881,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffroles_ts",
       "label": "staffRoles.ts",
       "norm_label": "staffroles.ts",
@@ -285679,7 +285757,7 @@
       "source_location": "L1"
     },
     {
-      "community": 880,
+      "community": 881,
       "file_type": "code",
       "id": "staffroles_derivedefaultoperationalroles",
       "label": "deriveDefaultOperationalRoles()",
@@ -285688,7 +285766,7 @@
       "source_location": "L21"
     },
     {
-      "community": 880,
+      "community": 881,
       "file_type": "code",
       "id": "staffroles_uniqueoperationalroles",
       "label": "uniqueOperationalRoles()",
@@ -285697,7 +285775,7 @@
       "source_location": "L31"
     },
     {
-      "community": 881,
+      "community": 882,
       "file_type": "code",
       "id": "apploginemailallowlist_isathenaapploginemailapproved",
       "label": "isAthenaAppLoginEmailApproved()",
@@ -285706,7 +285784,7 @@
       "source_location": "L21"
     },
     {
-      "community": 881,
+      "community": 882,
       "file_type": "code",
       "id": "apploginemailallowlist_normalizeathenaapploginemail",
       "label": "normalizeAthenaAppLoginEmail()",
@@ -285715,7 +285793,7 @@
       "source_location": "L17"
     },
     {
-      "community": 881,
+      "community": 882,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_apploginemailallowlist_ts",
       "label": "appLoginEmailAllowlist.ts",
@@ -285724,7 +285802,7 @@
       "source_location": "L1"
     },
     {
-      "community": 882,
+      "community": 883,
       "file_type": "code",
       "id": "index_listtransactions",
       "label": "listTransactions()",
@@ -285733,7 +285811,7 @@
       "source_location": "L7"
     },
     {
-      "community": 882,
+      "community": 883,
       "file_type": "code",
       "id": "index_verifytransaction",
       "label": "verifyTransaction()",
@@ -285742,7 +285820,7 @@
       "source_location": "L109"
     },
     {
-      "community": 882,
+      "community": 883,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_paystack_index_ts",
       "label": "index.ts",
@@ -285751,7 +285829,7 @@
       "source_location": "L1"
     },
     {
-      "community": 883,
+      "community": 884,
       "file_type": "code",
       "id": "correcttransactionpaymentmethod_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -285760,7 +285838,7 @@
       "source_location": "L101"
     },
     {
-      "community": 883,
+      "community": 884,
       "file_type": "code",
       "id": "correcttransactionpaymentmethod_test_runapprovedcashtocardcorrection",
       "label": "runApprovedCashToCardCorrection()",
@@ -285769,7 +285847,7 @@
       "source_location": "L346"
     },
     {
-      "community": 883,
+      "community": 884,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_correcttransactionpaymentmethod_test_ts",
       "label": "correctTransactionPaymentMethod.test.ts",
@@ -285778,7 +285856,7 @@
       "source_location": "L1"
     },
     {
-      "community": 884,
+      "community": 885,
       "file_type": "code",
       "id": "deadletter_test_baseargs",
       "label": "baseArgs()",
@@ -285787,7 +285865,7 @@
       "source_location": "L44"
     },
     {
-      "community": 884,
+      "community": 885,
       "file_type": "code",
       "id": "deadletter_test_seed",
       "label": "seed()",
@@ -285796,7 +285874,7 @@
       "source_location": "L14"
     },
     {
-      "community": 884,
+      "community": 885,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_deadletter_test_ts",
       "label": "deadLetter.test.ts",
@@ -285805,7 +285883,7 @@
       "source_location": "L1"
     },
     {
-      "community": 885,
+      "community": 886,
       "file_type": "code",
       "id": "finalizedlineageremediation_test_closedregisterreplayconflict",
       "label": "closedRegisterReplayConflict()",
@@ -285814,7 +285892,7 @@
       "source_location": "L78"
     },
     {
-      "community": 885,
+      "community": 886,
       "file_type": "code",
       "id": "finalizedlineageremediation_test_repairconflict",
       "label": "repairConflict()",
@@ -285823,7 +285901,7 @@
       "source_location": "L62"
     },
     {
-      "community": 885,
+      "community": 886,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_finalizedlineageremediation_test_ts",
       "label": "finalizedLineageRemediation.test.ts",
@@ -285832,7 +285910,7 @@
       "source_location": "L1"
     },
     {
-      "community": 886,
+      "community": 887,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_reconcilesequencegaps_test_ts",
       "label": "reconcileSequenceGaps.test.ts",
@@ -285841,7 +285919,7 @@
       "source_location": "L1"
     },
     {
-      "community": 886,
+      "community": 887,
       "file_type": "code",
       "id": "reconcilesequencegaps_test_readcursor",
       "label": "readCursor()",
@@ -285850,7 +285928,7 @@
       "source_location": "L156"
     },
     {
-      "community": 886,
+      "community": 887,
       "file_type": "code",
       "id": "reconcilesequencegaps_test_seedwedgedterminal",
       "label": "seedWedgedTerminal()",
@@ -285859,7 +285937,7 @@
       "source_location": "L32"
     },
     {
-      "community": 887,
+      "community": 888,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_resolvelocalsyncreview_ts",
       "label": "resolveLocalSyncReview.ts",
@@ -285868,7 +285946,7 @@
       "source_location": "L1"
     },
     {
-      "community": 887,
+      "community": 888,
       "file_type": "code",
       "id": "resolvelocalsyncreview_resolvelocalsyncreview",
       "label": "resolveLocalSyncReview()",
@@ -285877,7 +285955,7 @@
       "source_location": "L40"
     },
     {
-      "community": 887,
+      "community": 888,
       "file_type": "code",
       "id": "resolvelocalsyncreview_resolvelocalsyncreviewwithctx",
       "label": "resolveLocalSyncReviewWithCtx()",
@@ -285886,7 +285964,7 @@
       "source_location": "L80"
     },
     {
-      "community": 888,
+      "community": 889,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_sequencegappolicy_test_ts",
       "label": "sequenceGapPolicy.test.ts",
@@ -285895,7 +285973,7 @@
       "source_location": "L1"
     },
     {
-      "community": 888,
+      "community": 889,
       "file_type": "code",
       "id": "sequencegappolicy_test_decide",
       "label": "decide()",
@@ -285904,40 +285982,13 @@
       "source_location": "L26"
     },
     {
-      "community": 888,
+      "community": 889,
       "file_type": "code",
       "id": "sequencegappolicy_test_gap",
       "label": "gap()",
       "norm_label": "gap()",
       "source_file": "packages/athena-webapp/convex/pos/application/sync/sequenceGapPolicy.test.ts",
       "source_location": "L16"
-    },
-    {
-      "community": 889,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sync_terminalsyncsecret_ts",
-      "label": "terminalSyncSecret.ts",
-      "norm_label": "terminalsyncsecret.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/terminalSyncSecret.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 889,
-      "file_type": "code",
-      "id": "terminalsyncsecret_hashposterminalsyncsecret",
-      "label": "hashPosTerminalSyncSecret()",
-      "norm_label": "hashposterminalsyncsecret()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/terminalSyncSecret.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 889,
-      "file_type": "code",
-      "id": "terminalsyncsecret_tohex",
-      "label": "toHex()",
-      "norm_label": "tohex()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/terminalSyncSecret.ts",
-      "source_location": "L1"
     },
     {
       "community": 89,
@@ -286131,6 +286182,33 @@
     {
       "community": 890,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_sync_terminalsyncsecret_ts",
+      "label": "terminalSyncSecret.ts",
+      "norm_label": "terminalsyncsecret.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/terminalSyncSecret.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 890,
+      "file_type": "code",
+      "id": "terminalsyncsecret_hashposterminalsyncsecret",
+      "label": "hashPosTerminalSyncSecret()",
+      "norm_label": "hashposterminalsyncsecret()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/terminalSyncSecret.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 890,
+      "file_type": "code",
+      "id": "terminalsyncsecret_tohex",
+      "label": "toHex()",
+      "norm_label": "tohex()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/terminalSyncSecret.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 891,
+      "file_type": "code",
       "id": "collectterminaloperationalfacts_collectterminaloperationalfacts",
       "label": "collectTerminalOperationalFacts()",
       "norm_label": "collectterminaloperationalfacts()",
@@ -286138,7 +286216,7 @@
       "source_location": "L13"
     },
     {
-      "community": 890,
+      "community": 891,
       "file_type": "code",
       "id": "collectterminaloperationalfacts_toregistersessionlink",
       "label": "toRegisterSessionLink()",
@@ -286147,7 +286225,7 @@
       "source_location": "L61"
     },
     {
-      "community": 890,
+      "community": 891,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminaloperationalstate_collectterminaloperationalfacts_ts",
       "label": "collectTerminalOperationalFacts.ts",
@@ -286156,7 +286234,7 @@
       "source_location": "L1"
     },
     {
-      "community": 891,
+      "community": 892,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_resolveterminalcloudrepair_ts",
       "label": "resolveTerminalCloudRepair.ts",
@@ -286165,7 +286243,7 @@
       "source_location": "L1"
     },
     {
-      "community": 891,
+      "community": 892,
       "file_type": "code",
       "id": "resolveterminalcloudrepair_resolveterminalcloudrepair",
       "label": "resolveTerminalCloudRepair()",
@@ -286174,7 +286252,7 @@
       "source_location": "L25"
     },
     {
-      "community": 891,
+      "community": 892,
       "file_type": "code",
       "id": "resolveterminalcloudrepair_selectlatestsafeduplicateopenconflict",
       "label": "selectLatestSafeDuplicateOpenConflict()",
@@ -286183,7 +286261,7 @@
       "source_location": "L192"
     },
     {
-      "community": 892,
+      "community": 893,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminalruntime_postruntimestatussideeffects_ts",
       "label": "postRuntimeStatusSideEffects.ts",
@@ -286192,7 +286270,7 @@
       "source_location": "L1"
     },
     {
-      "community": 892,
+      "community": 893,
       "file_type": "code",
       "id": "postruntimestatussideeffects_reportremoteassistpresencediagnosticonly",
       "label": "reportRemoteAssistPresenceDiagnosticOnly()",
@@ -286201,7 +286279,7 @@
       "source_location": "L49"
     },
     {
-      "community": 892,
+      "community": 893,
       "file_type": "code",
       "id": "postruntimestatussideeffects_runacceptedruntimestatussideeffects",
       "label": "runAcceptedRuntimeStatusSideEffects()",
@@ -286210,7 +286288,7 @@
       "source_location": "L21"
     },
     {
-      "community": 893,
+      "community": 894,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminalruntime_terminalhealthalerts_ts",
       "label": "terminalHealthAlerts.ts",
@@ -286219,7 +286297,7 @@
       "source_location": "L1"
     },
     {
-      "community": 893,
+      "community": 894,
       "file_type": "code",
       "id": "terminalhealthalerts_classifyterminalhealthalertconditions",
       "label": "classifyTerminalHealthAlertConditions()",
@@ -286228,7 +286306,7 @@
       "source_location": "L52"
     },
     {
-      "community": 893,
+      "community": 894,
       "file_type": "code",
       "id": "terminalhealthalerts_resolveterminalhealthalerttransitions",
       "label": "resolveTerminalHealthAlertTransitions()",
@@ -286237,7 +286315,7 @@
       "source_location": "L78"
     },
     {
-      "community": 894,
+      "community": 895,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_transactionadjustments_test_ts",
       "label": "transactionAdjustments.test.ts",
@@ -286246,7 +286324,7 @@
       "source_location": "L1"
     },
     {
-      "community": 894,
+      "community": 895,
       "file_type": "code",
       "id": "transactionadjustments_test_querywithcollect",
       "label": "queryWithCollect()",
@@ -286255,7 +286333,7 @@
       "source_location": "L11"
     },
     {
-      "community": 894,
+      "community": 895,
       "file_type": "code",
       "id": "transactionadjustments_test_querywithfirst",
       "label": "queryWithFirst()",
@@ -286264,7 +286342,7 @@
       "source_location": "L22"
     },
     {
-      "community": 895,
+      "community": 896,
       "file_type": "code",
       "id": "errors_posservererror",
       "label": "PosServerError",
@@ -286273,7 +286351,7 @@
       "source_location": "L8"
     },
     {
-      "community": 895,
+      "community": 896,
       "file_type": "code",
       "id": "errors_posservererror_constructor",
       "label": ".constructor()",
@@ -286282,7 +286360,7 @@
       "source_location": "L9"
     },
     {
-      "community": 895,
+      "community": 896,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_errors_ts",
       "label": "errors.ts",
@@ -286291,7 +286369,7 @@
       "source_location": "L1"
     },
     {
-      "community": 896,
+      "community": 897,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_sessionrules_ts",
       "label": "sessionRules.ts",
@@ -286300,7 +286378,7 @@
       "source_location": "L1"
     },
     {
-      "community": 896,
+      "community": 897,
       "file_type": "code",
       "id": "sessionrules_deriveregisterphase",
       "label": "deriveRegisterPhase()",
@@ -286309,7 +286387,7 @@
       "source_location": "L7"
     },
     {
-      "community": 896,
+      "community": 897,
       "file_type": "code",
       "id": "sessionrules_selectresumablesession",
       "label": "selectResumableSession()",
@@ -286318,7 +286396,7 @@
       "source_location": "L29"
     },
     {
-      "community": 897,
+      "community": 898,
       "file_type": "code",
       "id": "inventoryholdgateway_test_createctx",
       "label": "createCtx()",
@@ -286327,7 +286405,7 @@
       "source_location": "L16"
     },
     {
-      "community": 897,
+      "community": 898,
       "file_type": "code",
       "id": "inventoryholdgateway_test_createlegacypatchctx",
       "label": "createLegacyPatchCtx()",
@@ -286336,7 +286414,7 @@
       "source_location": "L22"
     },
     {
-      "community": 897,
+      "community": 898,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_test_ts",
       "label": "inventoryHoldGateway.test.ts",
@@ -286345,7 +286423,7 @@
       "source_location": "L1"
     },
     {
-      "community": 898,
+      "community": 899,
       "file_type": "code",
       "id": "inventoryholdgateway_assertobjectshapedholdargs",
       "label": "assertObjectShapedHoldArgs()",
@@ -286354,7 +286432,7 @@
       "source_location": "L43"
     },
     {
-      "community": 898,
+      "community": 899,
       "file_type": "code",
       "id": "inventoryholdgateway_createinventoryholdgateway",
       "label": "createInventoryHoldGateway()",
@@ -286363,40 +286441,13 @@
       "source_location": "L24"
     },
     {
-      "community": 898,
+      "community": 899,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_inventoryholdgateway_ts",
       "label": "inventoryHoldGateway.ts",
       "norm_label": "inventoryholdgateway.ts",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 899,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_paymentallocationservice_ts",
-      "label": "paymentAllocationService.ts",
-      "norm_label": "paymentallocationservice.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/paymentAllocationService.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 899,
-      "file_type": "code",
-      "id": "paymentallocationservice_recordretailsalepaymentallocations",
-      "label": "recordRetailSalePaymentAllocations()",
-      "norm_label": "recordretailsalepaymentallocations()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/paymentAllocationService.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 899,
-      "file_type": "code",
-      "id": "paymentallocationservice_recordretailvoidpaymentallocations",
-      "label": "recordRetailVoidPaymentAllocations()",
-      "norm_label": "recordretailvoidpaymentallocations()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/paymentAllocationService.ts",
-      "source_location": "L46"
     },
     {
       "community": 9,
@@ -287130,6 +287181,33 @@
     {
       "community": 900,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_integrations_paymentallocationservice_ts",
+      "label": "paymentAllocationService.ts",
+      "norm_label": "paymentallocationservice.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/paymentAllocationService.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 900,
+      "file_type": "code",
+      "id": "paymentallocationservice_recordretailsalepaymentallocations",
+      "label": "recordRetailSalePaymentAllocations()",
+      "norm_label": "recordretailsalepaymentallocations()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/paymentAllocationService.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 900,
+      "file_type": "code",
+      "id": "paymentallocationservice_recordretailvoidpaymentallocations",
+      "label": "recordRetailVoidPaymentAllocations()",
+      "norm_label": "recordretailvoidpaymentallocations()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/integrations/paymentAllocationService.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 901,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registerlifecycleauthoritystatusrepository_ts",
       "label": "registerLifecycleAuthorityStatusRepository.ts",
       "norm_label": "registerlifecycleauthoritystatusrepository.ts",
@@ -287137,7 +287215,7 @@
       "source_location": "L1"
     },
     {
-      "community": 900,
+      "community": 901,
       "file_type": "code",
       "id": "registerlifecycleauthoritystatusrepository_createregisterlifecycleauthoritystatusreadrepository",
       "label": "createRegisterLifecycleAuthorityStatusReadRepository()",
@@ -287146,7 +287224,7 @@
       "source_location": "L26"
     },
     {
-      "community": 900,
+      "community": 901,
       "file_type": "code",
       "id": "registerlifecycleauthoritystatusrepository_createregisterlifecycleauthoritystatusrepository",
       "label": "createRegisterLifecycleAuthorityStatusRepository()",
@@ -287155,7 +287233,7 @@
       "source_location": "L39"
     },
     {
-      "community": 901,
+      "community": 902,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_ts",
       "label": "registerSessionRepository.ts",
@@ -287164,7 +287242,7 @@
       "source_location": "L1"
     },
     {
-      "community": 901,
+      "community": 902,
       "file_type": "code",
       "id": "registersessionrepository_getactiveregistersessionforregisterstate",
       "label": "getActiveRegisterSessionForRegisterState()",
@@ -287173,7 +287251,7 @@
       "source_location": "L60"
     },
     {
-      "community": 901,
+      "community": 902,
       "file_type": "code",
       "id": "registersessionrepository_mapregistersessiontocashdrawersummary",
       "label": "mapRegisterSessionToCashDrawerSummary()",
@@ -287182,7 +287260,7 @@
       "source_location": "L25"
     },
     {
-      "community": 902,
+      "community": 903,
       "file_type": "code",
       "id": "catalog_test_buildctx",
       "label": "buildCtx()",
@@ -287191,7 +287269,7 @@
       "source_location": "L2643"
     },
     {
-      "community": 902,
+      "community": 903,
       "file_type": "code",
       "id": "catalog_test_gethandler",
       "label": "getHandler()",
@@ -287200,7 +287278,7 @@
       "source_location": "L126"
     },
     {
-      "community": 902,
+      "community": 903,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_catalog_test_ts",
       "label": "catalog.test.ts",
@@ -287209,7 +287287,7 @@
       "source_location": "L1"
     },
     {
-      "community": 903,
+      "community": 904,
       "file_type": "code",
       "id": "customers_test_buildctx",
       "label": "buildCtx()",
@@ -287218,7 +287296,7 @@
       "source_location": "L73"
     },
     {
-      "community": 903,
+      "community": 904,
       "file_type": "code",
       "id": "customers_test_gethandler",
       "label": "getHandler()",
@@ -287227,7 +287305,7 @@
       "source_location": "L69"
     },
     {
-      "community": 903,
+      "community": 904,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_customers_test_ts",
       "label": "customers.test.ts",
@@ -287236,7 +287314,7 @@
       "source_location": "L1"
     },
     {
-      "community": 904,
+      "community": 905,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_sync_shareddemo_test_ts",
       "label": "sync.sharedDemo.test.ts",
@@ -287245,7 +287323,7 @@
       "source_location": "L1"
     },
     {
-      "community": 904,
+      "community": 905,
       "file_type": "code",
       "id": "sync_shareddemo_test_invoke",
       "label": "invoke()",
@@ -287254,7 +287332,7 @@
       "source_location": "L39"
     },
     {
-      "community": 904,
+      "community": 905,
       "file_type": "code",
       "id": "sync_shareddemo_test_invokeactivity",
       "label": "invokeActivity()",
@@ -287263,7 +287341,7 @@
       "source_location": "L46"
     },
     {
-      "community": 905,
+      "community": 906,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_application_policy_test_ts",
       "label": "policy.test.ts",
@@ -287272,7 +287350,7 @@
       "source_location": "L1"
     },
     {
-      "community": 905,
+      "community": 906,
       "file_type": "code",
       "id": "policy_test_buildactor",
       "label": "buildActor()",
@@ -287281,7 +287359,7 @@
       "source_location": "L93"
     },
     {
-      "community": 905,
+      "community": 906,
       "file_type": "code",
       "id": "policy_test_buildclient",
       "label": "buildClient()",
@@ -287290,7 +287368,7 @@
       "source_location": "L104"
     },
     {
-      "community": 906,
+      "community": 907,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_infrastructure_remoteassistrepository_test_ts",
       "label": "remoteAssistRepository.test.ts",
@@ -287299,7 +287377,7 @@
       "source_location": "L1"
     },
     {
-      "community": 906,
+      "community": 907,
       "file_type": "code",
       "id": "remoteassistrepository_test_buildclient",
       "label": "buildClient()",
@@ -287308,7 +287386,7 @@
       "source_location": "L98"
     },
     {
-      "community": 906,
+      "community": 907,
       "file_type": "code",
       "id": "remoteassistrepository_test_buildctx",
       "label": "buildCtx()",
@@ -287317,7 +287395,7 @@
       "source_location": "L79"
     },
     {
-      "community": 907,
+      "community": 908,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_infrastructure_transport_remoteassisttransportprovider_ts",
       "label": "RemoteAssistTransportProvider.ts",
@@ -287326,7 +287404,7 @@
       "source_location": "L1"
     },
     {
-      "community": 907,
+      "community": 908,
       "file_type": "code",
       "id": "remoteassisttransportprovider_buildremoteassisttransportcredentialcontext",
       "label": "buildRemoteAssistTransportCredentialContext()",
@@ -287335,7 +287413,7 @@
       "source_location": "L27"
     },
     {
-      "community": 907,
+      "community": 908,
       "file_type": "code",
       "id": "remoteassisttransportprovider_buildremoteassisttransportroomid",
       "label": "buildRemoteAssistTransportRoomId()",
@@ -287344,7 +287422,7 @@
       "source_location": "L62"
     },
     {
-      "community": 908,
+      "community": 909,
       "file_type": "code",
       "id": "operatingday_test_seedstore",
       "label": "seedStore()",
@@ -287353,7 +287431,7 @@
       "source_location": "L18"
     },
     {
-      "community": 908,
+      "community": 909,
       "file_type": "code",
       "id": "operatingday_test_seedtimezoneversion",
       "label": "seedTimezoneVersion()",
@@ -287362,39 +287440,12 @@
       "source_location": "L45"
     },
     {
-      "community": 908,
+      "community": 909,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_operatingday_test_ts",
       "label": "operatingDay.test.ts",
       "norm_label": "operatingday.test.ts",
       "source_file": "packages/athena-webapp/convex/reports/operatingDay.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 909,
-      "file_type": "code",
-      "id": "overview_test_day",
-      "label": "day()",
-      "norm_label": "day()",
-      "source_file": "packages/athena-webapp/convex/reports/overview.test.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 909,
-      "file_type": "code",
-      "id": "overview_test_dayfields",
-      "label": "dayFields()",
-      "norm_label": "dayfields()",
-      "source_file": "packages/athena-webapp/convex/reports/overview.test.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 909,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_overview_test_ts",
-      "label": "overview.test.ts",
-      "norm_label": "overview.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/overview.test.ts",
       "source_location": "L1"
     },
     {
@@ -287589,6 +287640,33 @@
     {
       "community": 910,
       "file_type": "code",
+      "id": "overview_test_day",
+      "label": "day()",
+      "norm_label": "day()",
+      "source_file": "packages/athena-webapp/convex/reports/overview.test.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 910,
+      "file_type": "code",
+      "id": "overview_test_dayfields",
+      "label": "dayFields()",
+      "norm_label": "dayfields()",
+      "source_file": "packages/athena-webapp/convex/reports/overview.test.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 910,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_reports_overview_test_ts",
+      "label": "overview.test.ts",
+      "norm_label": "overview.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/overview.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 911,
+      "file_type": "code",
       "id": "catalogappointments_test_createappointmentmutationctx",
       "label": "createAppointmentMutationCtx()",
       "norm_label": "createappointmentmutationctx()",
@@ -287596,7 +287674,7 @@
       "source_location": "L815"
     },
     {
-      "community": 910,
+      "community": 911,
       "file_type": "code",
       "id": "catalogappointments_test_gethandler",
       "label": "getHandler()",
@@ -287605,7 +287683,7 @@
       "source_location": "L32"
     },
     {
-      "community": 910,
+      "community": 911,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalogappointments_test_ts",
       "label": "catalogAppointments.test.ts",
@@ -287614,7 +287692,7 @@
       "source_location": "L1"
     },
     {
-      "community": 911,
+      "community": 912,
       "file_type": "code",
       "id": "coverage_test_exportedfunctionsource",
       "label": "exportedFunctionSource()",
@@ -287623,7 +287701,7 @@
       "source_location": "L20"
     },
     {
-      "community": 911,
+      "community": 912,
       "file_type": "code",
       "id": "coverage_test_sourcefiles",
       "label": "sourceFiles()",
@@ -287632,7 +287710,7 @@
       "source_location": "L10"
     },
     {
-      "community": 911,
+      "community": 912,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_coverage_test_ts",
       "label": "coverage.test.ts",
@@ -287641,7 +287719,7 @@
       "source_location": "L1"
     },
     {
-      "community": 912,
+      "community": 913,
       "file_type": "code",
       "id": "foundation_requirenondemofoundationexternalrefs",
       "label": "requireNonDemoFoundationExternalRefs()",
@@ -287650,7 +287728,7 @@
       "source_location": "L26"
     },
     {
-      "community": 912,
+      "community": 913,
       "file_type": "code",
       "id": "foundation_requirenondemofoundationmutation",
       "label": "requireNonDemoFoundationMutation()",
@@ -287659,7 +287737,7 @@
       "source_location": "L7"
     },
     {
-      "community": 912,
+      "community": 913,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_foundation_ts",
       "label": "foundation.ts",
@@ -287668,7 +287746,7 @@
       "source_location": "L1"
     },
     {
-      "community": 913,
+      "community": 914,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_public_ts",
       "label": "public.ts",
@@ -287677,7 +287755,7 @@
       "source_location": "L1"
     },
     {
-      "community": 913,
+      "community": 914,
       "file_type": "code",
       "id": "public_resolveshareddemolifecycleadmission",
       "label": "resolveSharedDemoLifecycleAdmission()",
@@ -287686,7 +287764,7 @@
       "source_location": "L110"
     },
     {
-      "community": 913,
+      "community": 914,
       "file_type": "code",
       "id": "public_selectshareddemoregisterbootstraprecords",
       "label": "selectSharedDemoRegisterBootstrapRecords()",
@@ -287695,7 +287773,7 @@
       "source_location": "L32"
     },
     {
-      "community": 914,
+      "community": 915,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_readboundary_test_ts",
       "label": "readBoundary.test.ts",
@@ -287704,7 +287782,7 @@
       "source_location": "L1"
     },
     {
-      "community": 914,
+      "community": 915,
       "file_type": "code",
       "id": "readboundary_test_demoreadctx",
       "label": "demoReadCtx()",
@@ -287713,7 +287791,7 @@
       "source_location": "L181"
     },
     {
-      "community": 914,
+      "community": 915,
       "file_type": "code",
       "id": "readboundary_test_invoke",
       "label": "invoke()",
@@ -287722,7 +287800,7 @@
       "source_location": "L33"
     },
     {
-      "community": 915,
+      "community": 916,
       "file_type": "code",
       "id": "cyclecountdrafts_test_createcyclecountdraftctx",
       "label": "createCycleCountDraftCtx()",
@@ -287731,7 +287809,7 @@
       "source_location": "L74"
     },
     {
-      "community": 915,
+      "community": 916,
       "file_type": "code",
       "id": "cyclecountdrafts_test_gethandler",
       "label": "getHandler()",
@@ -287740,7 +287818,7 @@
       "source_location": "L47"
     },
     {
-      "community": 915,
+      "community": 916,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_cyclecountdrafts_test_ts",
       "label": "cycleCountDrafts.test.ts",
@@ -287749,7 +287827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 916,
+      "community": 917,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_purchaseorders_test_ts",
       "label": "purchaseOrders.test.ts",
@@ -287758,7 +287836,7 @@
       "source_location": "L1"
     },
     {
-      "community": 916,
+      "community": 917,
       "file_type": "code",
       "id": "purchaseorders_test_createpurchaseordermutationctx",
       "label": "createPurchaseOrderMutationCtx()",
@@ -287767,7 +287845,7 @@
       "source_location": "L33"
     },
     {
-      "community": 916,
+      "community": 917,
       "file_type": "code",
       "id": "purchaseorders_test_getsource",
       "label": "getSource()",
@@ -287776,7 +287854,7 @@
       "source_location": "L29"
     },
     {
-      "community": 917,
+      "community": 918,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_receiving_test_ts",
       "label": "receiving.test.ts",
@@ -287785,7 +287863,7 @@
       "source_location": "L1"
     },
     {
-      "community": 917,
+      "community": 918,
       "file_type": "code",
       "id": "receiving_test_createreceivingmutationctx",
       "label": "createReceivingMutationCtx()",
@@ -287794,7 +287872,7 @@
       "source_location": "L32"
     },
     {
-      "community": 917,
+      "community": 918,
       "file_type": "code",
       "id": "receiving_test_getsource",
       "label": "getSource()",
@@ -287803,7 +287881,7 @@
       "source_location": "L28"
     },
     {
-      "community": 918,
+      "community": 919,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_test_ts",
       "label": "vendors.test.ts",
@@ -287812,7 +287890,7 @@
       "source_location": "L1"
     },
     {
-      "community": 918,
+      "community": 919,
       "file_type": "code",
       "id": "vendors_test_createvendormutationctx",
       "label": "createVendorMutationCtx()",
@@ -287821,40 +287899,13 @@
       "source_location": "L26"
     },
     {
-      "community": 918,
+      "community": 919,
       "file_type": "code",
       "id": "vendors_test_getsource",
       "label": "getSource()",
       "norm_label": "getsource()",
       "source_file": "packages/athena-webapp/convex/stockOps/vendors.test.ts",
       "source_location": "L22"
-    },
-    {
-      "community": 919,
-      "file_type": "code",
-      "id": "analytics_test_emptycontext",
-      "label": "emptyContext()",
-      "norm_label": "emptycontext()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.test.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 919,
-      "file_type": "code",
-      "id": "analytics_test_handler",
-      "label": "handler()",
-      "norm_label": "handler()",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.test.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 919,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_analytics_test_ts",
-      "label": "analytics.test.ts",
-      "norm_label": "analytics.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/analytics.test.ts",
-      "source_location": "L1"
     },
     {
       "community": 92,
@@ -288048,6 +288099,33 @@
     {
       "community": 920,
       "file_type": "code",
+      "id": "analytics_test_emptycontext",
+      "label": "emptyContext()",
+      "norm_label": "emptycontext()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.test.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 920,
+      "file_type": "code",
+      "id": "analytics_test_handler",
+      "label": "handler()",
+      "norm_label": "handler()",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.test.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 920,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_analytics_test_ts",
+      "label": "analytics.test.ts",
+      "norm_label": "analytics.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/analytics.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 921,
+      "file_type": "code",
       "id": "errorfoundation_test_gethandler",
       "label": "getHandler()",
       "norm_label": "gethandler()",
@@ -288055,7 +288133,7 @@
       "source_location": "L44"
     },
     {
-      "community": 920,
+      "community": 921,
       "file_type": "code",
       "id": "errorfoundation_test_getsource",
       "label": "getSource()",
@@ -288064,7 +288142,7 @@
       "source_location": "L40"
     },
     {
-      "community": 920,
+      "community": 921,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_errorfoundation_test_ts",
       "label": "errorFoundation.test.ts",
@@ -288073,7 +288151,7 @@
       "source_location": "L1"
     },
     {
-      "community": 921,
+      "community": 922,
       "file_type": "code",
       "id": "bag_listbagitems",
       "label": "listBagItems()",
@@ -288082,7 +288160,7 @@
       "source_location": "L7"
     },
     {
-      "community": 921,
+      "community": 922,
       "file_type": "code",
       "id": "bag_loadbagwithitems",
       "label": "loadBagWithItems()",
@@ -288091,7 +288169,7 @@
       "source_location": "L14"
     },
     {
-      "community": 921,
+      "community": 922,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_bag_ts",
       "label": "bag.ts",
@@ -288100,7 +288178,7 @@
       "source_location": "L1"
     },
     {
-      "community": 922,
+      "community": 923,
       "file_type": "code",
       "id": "onlineorderitem_schedulecatalogsummarydirtymarker",
       "label": "scheduleCatalogSummaryDirtyMarker()",
@@ -288109,7 +288187,7 @@
       "source_location": "L20"
     },
     {
-      "community": 922,
+      "community": 923,
       "file_type": "code",
       "id": "onlineorderitem_updateonlineorderitem",
       "label": "updateOnlineOrderItem()",
@@ -288118,7 +288196,7 @@
       "source_location": "L45"
     },
     {
-      "community": 922,
+      "community": 923,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -288127,7 +288205,7 @@
       "source_location": "L1"
     },
     {
-      "community": 923,
+      "community": 924,
       "file_type": "code",
       "id": "onlineordertracing_test_buildctx",
       "label": "buildCtx()",
@@ -288136,7 +288214,7 @@
       "source_location": "L54"
     },
     {
-      "community": 923,
+      "community": 924,
       "file_type": "code",
       "id": "onlineordertracing_test_buildorder",
       "label": "buildOrder()",
@@ -288145,7 +288223,7 @@
       "source_location": "L20"
     },
     {
-      "community": 923,
+      "community": 924,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineordertracing_test_ts",
       "label": "onlineOrderTracing.test.ts",
@@ -288154,7 +288232,7 @@
       "source_location": "L1"
     },
     {
-      "community": 924,
+      "community": 925,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_payment_ts",
       "label": "payment.ts",
@@ -288163,7 +288241,7 @@
       "source_location": "L1"
     },
     {
-      "community": 924,
+      "community": 925,
       "file_type": "code",
       "id": "payment_addscheduledruncandidate",
       "label": "addScheduledRunCandidate()",
@@ -288172,7 +288250,7 @@
       "source_location": "L61"
     },
     {
-      "community": 924,
+      "community": 925,
       "file_type": "code",
       "id": "payment_recordpaymentscheduledrunevidence",
       "label": "recordPaymentScheduledRunEvidence()",
@@ -288181,7 +288259,7 @@
       "source_location": "L85"
     },
     {
-      "community": 925,
+      "community": 926,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_user_ts",
       "label": "user.ts",
@@ -288190,7 +288268,7 @@
       "source_location": "L1"
     },
     {
-      "community": 925,
+      "community": 926,
       "file_type": "code",
       "id": "user_assertstorefrontactormatchesstore",
       "label": "assertStoreFrontActorMatchesStore()",
@@ -288199,7 +288277,7 @@
       "source_location": "L38"
     },
     {
-      "community": 925,
+      "community": 926,
       "file_type": "code",
       "id": "user_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -288208,7 +288286,7 @@
       "source_location": "L16"
     },
     {
-      "community": 926,
+      "community": 927,
       "file_type": "code",
       "id": "orderreturnexchange_buildlookup",
       "label": "buildLookup()",
@@ -288217,7 +288295,7 @@
       "source_location": "L68"
     },
     {
-      "community": 926,
+      "community": 927,
       "file_type": "code",
       "id": "orderreturnexchange_buildorderreturnexchangetraceseed",
       "label": "buildOrderReturnExchangeTraceSeed()",
@@ -288226,7 +288304,7 @@
       "source_location": "L89"
     },
     {
-      "community": 926,
+      "community": 927,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_orderreturnexchange_ts",
       "label": "orderReturnExchange.ts",
@@ -288235,7 +288313,7 @@
       "source_location": "L1"
     },
     {
-      "community": 927,
+      "community": 928,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_ts",
       "label": "registerSession.ts",
@@ -288244,7 +288322,7 @@
       "source_location": "L1"
     },
     {
-      "community": 927,
+      "community": 928,
       "file_type": "code",
       "id": "registersession_buildregistersessiontraceseed",
       "label": "buildRegisterSessionTraceSeed()",
@@ -288253,7 +288331,7 @@
       "source_location": "L45"
     },
     {
-      "community": 927,
+      "community": 928,
       "file_type": "code",
       "id": "registersession_formatregistersessionlabel",
       "label": "formatRegisterSessionLabel()",
@@ -288262,7 +288340,7 @@
       "source_location": "L37"
     },
     {
-      "community": 928,
+      "community": 929,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_servicecase_ts",
       "label": "serviceCase.ts",
@@ -288271,7 +288349,7 @@
       "source_location": "L1"
     },
     {
-      "community": 928,
+      "community": 929,
       "file_type": "code",
       "id": "servicecase_addlookup",
       "label": "addLookup()",
@@ -288280,40 +288358,13 @@
       "source_location": "L38"
     },
     {
-      "community": 928,
+      "community": 929,
       "file_type": "code",
       "id": "servicecase_buildservicecasetraceseed",
       "label": "buildServiceCaseTraceSeed()",
       "norm_label": "buildservicecasetraceseed()",
       "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/serviceCase.ts",
       "source_location": "L62"
-    },
-    {
-      "community": 929,
-      "file_type": "code",
-      "id": "currencyformatter_currencydisplaysymbol",
-      "label": "currencyDisplaySymbol()",
-      "norm_label": "currencydisplaysymbol()",
-      "source_file": "packages/athena-webapp/shared/currencyFormatter.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 929,
-      "file_type": "code",
-      "id": "currencyformatter_currencyformatter",
-      "label": "currencyFormatter()",
-      "norm_label": "currencyformatter()",
-      "source_file": "packages/athena-webapp/shared/currencyFormatter.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 929,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_currencyformatter_ts",
-      "label": "currencyFormatter.ts",
-      "norm_label": "currencyformatter.ts",
-      "source_file": "packages/athena-webapp/shared/currencyFormatter.ts",
-      "source_location": "L1"
     },
     {
       "community": 93,
@@ -288507,6 +288558,33 @@
     {
       "community": 930,
       "file_type": "code",
+      "id": "currencyformatter_currencydisplaysymbol",
+      "label": "currencyDisplaySymbol()",
+      "norm_label": "currencydisplaysymbol()",
+      "source_file": "packages/athena-webapp/shared/currencyFormatter.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 930,
+      "file_type": "code",
+      "id": "currencyformatter_currencyformatter",
+      "label": "currencyFormatter()",
+      "norm_label": "currencyformatter()",
+      "source_file": "packages/athena-webapp/shared/currencyFormatter.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 930,
+      "file_type": "code",
+      "id": "packages_athena_webapp_shared_currencyformatter_ts",
+      "label": "currencyFormatter.ts",
+      "norm_label": "currencyformatter.ts",
+      "source_file": "packages/athena-webapp/shared/currencyFormatter.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 931,
+      "file_type": "code",
       "id": "packages_athena_webapp_shared_posterminalloginmode_ts",
       "label": "posTerminalLoginMode.ts",
       "norm_label": "posterminalloginmode.ts",
@@ -288514,7 +288592,7 @@
       "source_location": "L1"
     },
     {
-      "community": 930,
+      "community": 931,
       "file_type": "code",
       "id": "posterminalloginmode_isposonlyterminalloginmode",
       "label": "isPosOnlyTerminalLoginMode()",
@@ -288523,7 +288601,7 @@
       "source_location": "L16"
     },
     {
-      "community": 930,
+      "community": 931,
       "file_type": "code",
       "id": "posterminalloginmode_normalizeposterminalloginmode",
       "label": "normalizePosTerminalLoginMode()",
@@ -288532,7 +288610,7 @@
       "source_location": "L8"
     },
     {
-      "community": 931,
+      "community": 932,
       "file_type": "code",
       "id": "app_test_getupdatedetectedcallback",
       "label": "getUpdateDetectedCallback()",
@@ -288541,7 +288619,7 @@
       "source_location": "L214"
     },
     {
-      "community": 931,
+      "community": 932,
       "file_type": "code",
       "id": "app_test_handle",
       "label": "handle()",
@@ -288550,7 +288628,7 @@
       "source_location": "L79"
     },
     {
-      "community": 931,
+      "community": 932,
       "file_type": "code",
       "id": "packages_athena_webapp_src_app_test_tsx",
       "label": "App.test.tsx",
@@ -288559,7 +288637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 932,
+      "community": 933,
       "file_type": "code",
       "id": "app_reportversioncheckerupdate",
       "label": "reportVersionCheckerUpdate()",
@@ -288568,7 +288646,7 @@
       "source_location": "L105"
     },
     {
-      "community": 932,
+      "community": 933,
       "file_type": "code",
       "id": "app_stageversioncheckerupdate",
       "label": "stageVersionCheckerUpdate()",
@@ -288577,7 +288655,7 @@
       "source_location": "L67"
     },
     {
-      "community": 932,
+      "community": 933,
       "file_type": "code",
       "id": "packages_athena_webapp_src_app_tsx",
       "label": "App.tsx",
@@ -288586,7 +288664,7 @@
       "source_location": "L1"
     },
     {
-      "community": 933,
+      "community": 934,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -288595,7 +288673,7 @@
       "source_location": "L1"
     },
     {
-      "community": 933,
+      "community": 934,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_view_tsx",
       "label": "View.tsx",
@@ -288604,7 +288682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 933,
+      "community": 934,
       "file_type": "code",
       "id": "view_view",
       "label": "View()",
@@ -288613,7 +288691,7 @@
       "source_location": "L4"
     },
     {
-      "community": 934,
+      "community": 935,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailability_tsx",
       "label": "ProductAvailability.tsx",
@@ -288622,7 +288700,7 @@
       "source_location": "L1"
     },
     {
-      "community": 934,
+      "community": 935,
       "file_type": "code",
       "id": "productavailability_productavailability",
       "label": "ProductAvailability()",
@@ -288631,7 +288709,7 @@
       "source_location": "L19"
     },
     {
-      "community": 934,
+      "community": 935,
       "file_type": "code",
       "id": "productavailability_productavailabilityview",
       "label": "ProductAvailabilityView()",
@@ -288640,7 +288718,7 @@
       "source_location": "L5"
     },
     {
-      "community": 935,
+      "community": 936,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_sheetprovider_tsx",
       "label": "SheetProvider.tsx",
@@ -288649,7 +288727,7 @@
       "source_location": "L1"
     },
     {
-      "community": 935,
+      "community": 936,
       "file_type": "code",
       "id": "sheetprovider_sheetprovider",
       "label": "SheetProvider()",
@@ -288658,7 +288736,7 @@
       "source_location": "L19"
     },
     {
-      "community": 935,
+      "community": 936,
       "file_type": "code",
       "id": "sheetprovider_usesheet",
       "label": "useSheet()",
@@ -288667,7 +288745,7 @@
       "source_location": "L11"
     },
     {
-      "community": 936,
+      "community": 937,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_wigtype_tsx",
       "label": "WigType.tsx",
@@ -288676,7 +288754,7 @@
       "source_location": "L1"
     },
     {
-      "community": 936,
+      "community": 937,
       "file_type": "code",
       "id": "wigtype_wigtype",
       "label": "WigType()",
@@ -288685,7 +288763,7 @@
       "source_location": "L22"
     },
     {
-      "community": 936,
+      "community": 937,
       "file_type": "code",
       "id": "wigtype_wigtypeview",
       "label": "WigTypeView()",
@@ -288694,7 +288772,7 @@
       "source_location": "L8"
     },
     {
-      "community": 937,
+      "community": 938,
       "file_type": "code",
       "id": "copyimagesprovider_copyimagesprovider",
       "label": "CopyImagesProvider()",
@@ -288703,7 +288781,7 @@
       "source_location": "L21"
     },
     {
-      "community": 937,
+      "community": 938,
       "file_type": "code",
       "id": "copyimagesprovider_usecopyimages",
       "label": "useCopyImages()",
@@ -288712,7 +288790,7 @@
       "source_location": "L13"
     },
     {
-      "community": 937,
+      "community": 938,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesprovider_tsx",
       "label": "CopyImagesProvider.tsx",
@@ -288721,7 +288799,7 @@
       "source_location": "L1"
     },
     {
-      "community": 938,
+      "community": 939,
       "file_type": "code",
       "id": "analyticstopusers_analyticstopusers",
       "label": "AnalyticsTopUsers()",
@@ -288730,7 +288808,7 @@
       "source_location": "L100"
     },
     {
-      "community": 938,
+      "community": 939,
       "file_type": "code",
       "id": "analyticstopusers_processanalyticstousers",
       "label": "processAnalyticsToUsers()",
@@ -288739,39 +288817,12 @@
       "source_location": "L10"
     },
     {
-      "community": 938,
+      "community": 939,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticstopusers_tsx",
       "label": "AnalyticsTopUsers.tsx",
       "norm_label": "analyticstopusers.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 939,
-      "file_type": "code",
-      "id": "analyticsview_formatmetric",
-      "label": "formatMetric()",
-      "norm_label": "formatmetric()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 939,
-      "file_type": "code",
-      "id": "analyticsview_storefrontsignalcard",
-      "label": "StorefrontSignalCard()",
-      "norm_label": "storefrontsignalcard()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
-      "source_location": "L21"
-    },
-    {
-      "community": 939,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analyticsview_tsx",
-      "label": "AnalyticsView.tsx",
-      "norm_label": "analyticsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
       "source_location": "L1"
     },
     {
@@ -288966,6 +289017,33 @@
     {
       "community": 940,
       "file_type": "code",
+      "id": "analyticsview_formatmetric",
+      "label": "formatMetric()",
+      "norm_label": "formatmetric()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 940,
+      "file_type": "code",
+      "id": "analyticsview_storefrontsignalcard",
+      "label": "StorefrontSignalCard()",
+      "norm_label": "storefrontsignalcard()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
+      "source_location": "L21"
+    },
+    {
+      "community": 940,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analyticsview_tsx",
+      "label": "AnalyticsView.tsx",
+      "norm_label": "analyticsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 941,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storeinsights_tsx",
       "label": "StoreInsights.tsx",
       "norm_label": "storeinsights.tsx",
@@ -288973,7 +289051,7 @@
       "source_location": "L1"
     },
     {
-      "community": 940,
+      "community": 941,
       "file_type": "code",
       "id": "storeinsights_handledismiss",
       "label": "handleDismiss()",
@@ -288982,7 +289060,7 @@
       "source_location": "L102"
     },
     {
-      "community": 940,
+      "community": 941,
       "file_type": "code",
       "id": "storeinsights_handlegenerate",
       "label": "handleGenerate()",
@@ -288991,7 +289069,7 @@
       "source_location": "L85"
     },
     {
-      "community": 941,
+      "community": 942,
       "file_type": "code",
       "id": "log_items_provider_logitemsprovider",
       "label": "LogItemsProvider()",
@@ -289000,7 +289078,7 @@
       "source_location": "L15"
     },
     {
-      "community": 941,
+      "community": 942,
       "file_type": "code",
       "id": "log_items_provider_uselogitems",
       "label": "useLogItems()",
@@ -289009,7 +289087,7 @@
       "source_location": "L39"
     },
     {
-      "community": 941,
+      "community": 942,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_log_items_provider_tsx",
       "label": "log-items-provider.tsx",
@@ -289018,7 +289096,7 @@
       "source_location": "L1"
     },
     {
-      "community": 942,
+      "community": 943,
       "file_type": "code",
       "id": "appmessagehost_test_testmessage",
       "label": "TestMessage()",
@@ -289027,7 +289105,7 @@
       "source_location": "L36"
     },
     {
-      "community": 942,
+      "community": 943,
       "file_type": "code",
       "id": "appmessagehost_test_toastpreference",
       "label": "ToastPreference()",
@@ -289036,7 +289114,7 @@
       "source_location": "L27"
     },
     {
-      "community": 942,
+      "community": 943,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_messages_appmessagehost_test_tsx",
       "label": "AppMessageHost.test.tsx",
@@ -289045,7 +289123,7 @@
       "source_location": "L1"
     },
     {
-      "community": 943,
+      "community": 944,
       "file_type": "code",
       "id": "index_header",
       "label": "Header()",
@@ -289054,7 +289132,7 @@
       "source_location": "L15"
     },
     {
-      "community": 943,
+      "community": 944,
       "file_type": "code",
       "id": "index_storeassets",
       "label": "StoreAssets()",
@@ -289063,7 +289141,7 @@
       "source_location": "L23"
     },
     {
-      "community": 943,
+      "community": 944,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_index_tsx",
       "label": "index.tsx",
@@ -289072,7 +289150,7 @@
       "source_location": "L1"
     },
     {
-      "community": 944,
+      "community": 945,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_posrecoverycodeform_tsx",
       "label": "PosRecoveryCodeForm.tsx",
@@ -289081,7 +289159,7 @@
       "source_location": "L1"
     },
     {
-      "community": 944,
+      "community": 945,
       "file_type": "code",
       "id": "posrecoverycodeform_handleauthsyncfailed",
       "label": "handleAuthSyncFailed()",
@@ -289090,7 +289168,7 @@
       "source_location": "L42"
     },
     {
-      "community": 944,
+      "community": 945,
       "file_type": "code",
       "id": "posrecoverycodeform_handlesubmit",
       "label": "handleSubmit()",
@@ -289099,7 +289177,7 @@
       "source_location": "L65"
     },
     {
-      "community": 945,
+      "community": 946,
       "file_type": "code",
       "id": "index_getposredirectfromseed",
       "label": "getPosRedirectFromSeed()",
@@ -289108,7 +289186,7 @@
       "source_location": "L26"
     },
     {
-      "community": 945,
+      "community": 946,
       "file_type": "code",
       "id": "index_getposroutescope",
       "label": "getPosRouteScope()",
@@ -289117,7 +289195,7 @@
       "source_location": "L13"
     },
     {
-      "community": 945,
+      "community": 946,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_index_tsx",
       "label": "index.tsx",
@@ -289126,7 +289204,7 @@
       "source_location": "L1"
     },
     {
-      "community": 946,
+      "community": 947,
       "file_type": "code",
       "id": "fadein_fadein",
       "label": "FadeIn()",
@@ -289135,7 +289213,7 @@
       "source_location": "L3"
     },
     {
-      "community": 946,
+      "community": 947,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -289144,7 +289222,7 @@
       "source_location": "L1"
     },
     {
-      "community": 946,
+      "community": 947,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_fadein_tsx",
       "label": "FadeIn.tsx",
@@ -289153,7 +289231,7 @@
       "source_location": "L1"
     },
     {
-      "community": 947,
+      "community": 948,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
       "label": "PageHeader.tsx",
@@ -289162,7 +289240,7 @@
       "source_location": "L1"
     },
     {
-      "community": 947,
+      "community": 948,
       "file_type": "code",
       "id": "pageheader_getremoteassistbackcontrolprops",
       "label": "getRemoteAssistBackControlProps()",
@@ -289171,7 +289249,7 @@
       "source_location": "L8"
     },
     {
-      "community": 947,
+      "community": 948,
       "file_type": "code",
       "id": "pageheader_pageheader",
       "label": "PageHeader()",
@@ -289180,7 +289258,7 @@
       "source_location": "L25"
     },
     {
-      "community": 948,
+      "community": 949,
       "file_type": "code",
       "id": "home_handlereadinessjump",
       "label": "handleReadinessJump()",
@@ -289189,7 +289267,7 @@
       "source_location": "L112"
     },
     {
-      "community": 948,
+      "community": 949,
       "file_type": "code",
       "id": "home_homepagesettingssection",
       "label": "HomepageSettingsSection()",
@@ -289198,39 +289276,12 @@
       "source_location": "L29"
     },
     {
-      "community": 948,
+      "community": 949,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_home_tsx",
       "label": "Home.tsx",
       "norm_label": "home.tsx",
       "source_file": "packages/athena-webapp/src/components/homepage/Home.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 949,
-      "file_type": "code",
-      "id": "homepageplacementproductimage_getskuimageurl",
-      "label": "getSkuImageUrl()",
-      "norm_label": "getskuimageurl()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HomepagePlacementProductImage.tsx",
-      "source_location": "L48"
-    },
-    {
-      "community": 949,
-      "file_type": "code",
-      "id": "homepageplacementproductimage_homepageplacementproductimage",
-      "label": "HomepagePlacementProductImage()",
-      "norm_label": "homepageplacementproductimage()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HomepagePlacementProductImage.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 949,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_homepageplacementproductimage_tsx",
-      "label": "HomepagePlacementProductImage.tsx",
-      "norm_label": "homepageplacementproductimage.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/HomepagePlacementProductImage.tsx",
       "source_location": "L1"
     },
     {
@@ -289425,6 +289476,33 @@
     {
       "community": 950,
       "file_type": "code",
+      "id": "homepageplacementproductimage_getskuimageurl",
+      "label": "getSkuImageUrl()",
+      "norm_label": "getskuimageurl()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HomepagePlacementProductImage.tsx",
+      "source_location": "L48"
+    },
+    {
+      "community": 950,
+      "file_type": "code",
+      "id": "homepageplacementproductimage_homepageplacementproductimage",
+      "label": "HomepagePlacementProductImage()",
+      "norm_label": "homepageplacementproductimage()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HomepagePlacementProductImage.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 950,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_homepageplacementproductimage_tsx",
+      "label": "HomepagePlacementProductImage.tsx",
+      "norm_label": "homepageplacementproductimage.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/HomepagePlacementProductImage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 951,
+      "file_type": "code",
       "id": "homepageproductpickerdialog_test_buildskusearchresult",
       "label": "buildSkuSearchResult()",
       "norm_label": "buildskusearchresult()",
@@ -289432,7 +289510,7 @@
       "source_location": "L84"
     },
     {
-      "community": 950,
+      "community": 951,
       "file_type": "code",
       "id": "homepageproductpickerdialog_test_pickerharness",
       "label": "PickerHarness()",
@@ -289441,7 +289519,7 @@
       "source_location": "L121"
     },
     {
-      "community": 950,
+      "community": 951,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_homepageproductpickerdialog_test_tsx",
       "label": "HomepageProductPickerDialog.test.tsx",
@@ -289450,7 +289528,7 @@
       "source_location": "L1"
     },
     {
-      "community": 951,
+      "community": 952,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
       "label": "ShopLook.tsx",
@@ -289459,7 +289537,7 @@
       "source_location": "L1"
     },
     {
-      "community": 951,
+      "community": 952,
       "file_type": "code",
       "id": "shoplook_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -289468,7 +289546,7 @@
       "source_location": "L64"
     },
     {
-      "community": 951,
+      "community": 952,
       "file_type": "code",
       "id": "shoplook_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -289477,7 +289555,7 @@
       "source_location": "L76"
     },
     {
-      "community": 952,
+      "community": 953,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_videoplayer_tsx",
       "label": "VideoPlayer.tsx",
@@ -289486,7 +289564,7 @@
       "source_location": "L1"
     },
     {
-      "community": 952,
+      "community": 953,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_videoplayer_tsx",
       "label": "VideoPlayer.tsx",
@@ -289495,7 +289573,7 @@
       "source_location": "L1"
     },
     {
-      "community": 952,
+      "community": 953,
       "file_type": "code",
       "id": "videoplayer_videoplayer",
       "label": "VideoPlayer()",
@@ -289504,7 +289582,7 @@
       "source_location": "L9"
     },
     {
-      "community": 953,
+      "community": 954,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_landing_walkthroughrequestform_test_tsx",
       "label": "WalkthroughRequestForm.test.tsx",
@@ -289513,7 +289591,7 @@
       "source_location": "L1"
     },
     {
-      "community": 953,
+      "community": 954,
       "file_type": "code",
       "id": "walkthroughrequestform_test_fillvalidform",
       "label": "fillValidForm()",
@@ -289522,7 +289600,7 @@
       "source_location": "L13"
     },
     {
-      "community": 953,
+      "community": 954,
       "file_type": "code",
       "id": "walkthroughrequestform_test_submit",
       "label": "submit()",
@@ -289531,7 +289609,7 @@
       "source_location": "L79"
     },
     {
-      "community": 954,
+      "community": 955,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_landing_story_registersessionscene_tsx",
       "label": "RegisterSessionScene.tsx",
@@ -289540,7 +289618,7 @@
       "source_location": "L1"
     },
     {
-      "community": 954,
+      "community": 955,
       "file_type": "code",
       "id": "registersessionscene_exhibitcommandunavailable",
       "label": "exhibitCommandUnavailable()",
@@ -289549,7 +289627,7 @@
       "source_location": "L14"
     },
     {
-      "community": 954,
+      "community": 955,
       "file_type": "code",
       "id": "registersessionscene_registersessionscene",
       "label": "RegisterSessionScene()",
@@ -289558,7 +289636,7 @@
       "source_location": "L25"
     },
     {
-      "community": 955,
+      "community": 956,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_landing_story_usesceneanimation_ts",
       "label": "useSceneAnimation.ts",
@@ -289567,7 +289645,7 @@
       "source_location": "L1"
     },
     {
-      "community": 955,
+      "community": 956,
       "file_type": "code",
       "id": "usesceneanimation_animateamount",
       "label": "animateAmount()",
@@ -289576,7 +289654,7 @@
       "source_location": "L44"
     },
     {
-      "community": 955,
+      "community": 956,
       "file_type": "code",
       "id": "usesceneanimation_usesceneanimation",
       "label": "useSceneAnimation()",
@@ -289585,7 +289663,7 @@
       "source_location": "L9"
     },
     {
-      "community": 956,
+      "community": 957,
       "file_type": "code",
       "id": "dailyoperationsview_test_gettodayrefreshcalls",
       "label": "getTodayRefreshCalls()",
@@ -289594,7 +289672,7 @@
       "source_location": "L4242"
     },
     {
-      "community": 956,
+      "community": 957,
       "file_type": "code",
       "id": "dailyoperationsview_test_rendercurrentstate",
       "label": "renderCurrentState()",
@@ -289603,7 +289681,7 @@
       "source_location": "L2458"
     },
     {
-      "community": 956,
+      "community": 957,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_dailyoperationsview_test_tsx",
       "label": "DailyOperationsView.test.tsx",
@@ -289612,7 +289690,7 @@
       "source_location": "L1"
     },
     {
-      "community": 957,
+      "community": 958,
       "file_type": "code",
       "id": "orderdetailsview_handlemarkpaymentcollected",
       "label": "handleMarkPaymentCollected()",
@@ -289621,7 +289699,7 @@
       "source_location": "L57"
     },
     {
-      "community": 957,
+      "community": 958,
       "file_type": "code",
       "id": "orderdetailsview_verifiedbadge",
       "label": "VerifiedBadge()",
@@ -289630,7 +289708,7 @@
       "source_location": "L24"
     },
     {
-      "community": 957,
+      "community": 958,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
       "label": "OrderDetailsView.tsx",
@@ -289639,7 +289717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 958,
+      "community": 959,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_pickupdetailsview_tsx",
       "label": "PickupDetailsView.tsx",
@@ -289648,7 +289726,7 @@
       "source_location": "L1"
     },
     {
-      "community": 958,
+      "community": 959,
       "file_type": "code",
       "id": "pickupdetailsview_deliverydetails",
       "label": "DeliveryDetails()",
@@ -289657,40 +289735,13 @@
       "source_location": "L71"
     },
     {
-      "community": 958,
+      "community": 959,
       "file_type": "code",
       "id": "pickupdetailsview_pickupdetailsview",
       "label": "PickupDetailsView()",
       "norm_label": "pickupdetailsview()",
       "source_file": "packages/athena-webapp/src/components/orders/PickupDetailsView.tsx",
       "source_location": "L9"
-    },
-    {
-      "community": 959,
-      "file_type": "code",
-      "id": "index_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L119"
-    },
-    {
-      "community": 959,
-      "file_type": "code",
-      "id": "index_sectionheader",
-      "label": "SectionHeader()",
-      "norm_label": "sectionheader()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 959,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L1"
     },
     {
       "community": 96,
@@ -289884,6 +289935,33 @@
     {
       "community": 960,
       "file_type": "code",
+      "id": "index_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L119"
+    },
+    {
+      "community": 960,
+      "file_type": "code",
+      "id": "index_sectionheader",
+      "label": "SectionHeader()",
+      "norm_label": "sectionheader()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 960,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 961,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
       "label": "SearchResultsSection.tsx",
       "norm_label": "searchresultssection.tsx",
@@ -289891,7 +289969,7 @@
       "source_location": "L1"
     },
     {
-      "community": 960,
+      "community": 961,
       "file_type": "code",
       "id": "searchresultssection_handlequickaddproductshortcut",
       "label": "handleQuickAddProductShortcut()",
@@ -289900,7 +289978,7 @@
       "source_location": "L90"
     },
     {
-      "community": 960,
+      "community": 961,
       "file_type": "code",
       "id": "searchresultssection_handlequickaddvariantshortcut",
       "label": "handleQuickAddVariantShortcut()",
@@ -289909,7 +289987,7 @@
       "source_location": "L57"
     },
     {
-      "community": 961,
+      "community": 962,
       "file_type": "code",
       "id": "expensecompletionpanel_expensecompletionpanel",
       "label": "ExpenseCompletionPanel()",
@@ -289918,7 +289996,7 @@
       "source_location": "L18"
     },
     {
-      "community": 961,
+      "community": 962,
       "file_type": "code",
       "id": "expensecompletionpanel_islocalexpensereportnumber",
       "label": "isLocalExpenseReportNumber()",
@@ -289927,7 +290005,7 @@
       "source_location": "L14"
     },
     {
-      "community": 961,
+      "community": 962,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_expensecompletionpanel_tsx",
       "label": "ExpenseCompletionPanel.tsx",
@@ -289936,7 +290014,7 @@
       "source_location": "L1"
     },
     {
-      "community": 962,
+      "community": 963,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sales_pulse_possalespulseview_test_tsx",
       "label": "POSSalesPulseView.test.tsx",
@@ -289945,7 +290023,7 @@
       "source_location": "L1"
     },
     {
-      "community": 962,
+      "community": 963,
       "file_type": "code",
       "id": "possalespulseview_test_buildtodaysummary",
       "label": "buildTodaySummary()",
@@ -289954,7 +290032,7 @@
       "source_location": "L41"
     },
     {
-      "community": 962,
+      "community": 963,
       "file_type": "code",
       "id": "possalespulseview_test_renderstorepulse",
       "label": "renderStorePulse()",
@@ -289963,7 +290041,7 @@
       "source_location": "L135"
     },
     {
-      "community": 963,
+      "community": 964,
       "file_type": "code",
       "id": "heldsessionslist_getsessioncartitemscount",
       "label": "getSessionCartItemsCount()",
@@ -289972,7 +290050,7 @@
       "source_location": "L36"
     },
     {
-      "community": 963,
+      "community": 964,
       "file_type": "code",
       "id": "heldsessionslist_hasexpired",
       "label": "hasExpired()",
@@ -289981,7 +290059,7 @@
       "source_location": "L32"
     },
     {
-      "community": 963,
+      "community": 964,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_tsx",
       "label": "HeldSessionsList.tsx",
@@ -289990,7 +290068,7 @@
       "source_location": "L1"
     },
     {
-      "community": 964,
+      "community": 965,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_terminals_posclienterrorspanel_tsx",
       "label": "PosClientErrorsPanel.tsx",
@@ -289999,7 +290077,7 @@
       "source_location": "L1"
     },
     {
-      "community": 964,
+      "community": 965,
       "file_type": "code",
       "id": "posclienterrorspanel_closesheet",
       "label": "closeSheet()",
@@ -290008,7 +290086,7 @@
       "source_location": "L94"
     },
     {
-      "community": 964,
+      "community": 965,
       "file_type": "code",
       "id": "posclienterrorspanel_posclienterrorsmetrictile",
       "label": "PosClientErrorsMetricTile()",
@@ -290017,7 +290095,7 @@
       "source_location": "L50"
     },
     {
-      "community": 965,
+      "community": 966,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_skuselector_tsx",
       "label": "SKUSelector.tsx",
@@ -290026,7 +290104,7 @@
       "source_location": "L1"
     },
     {
-      "community": 965,
+      "community": 966,
       "file_type": "code",
       "id": "skuselector_handlevariantchange",
       "label": "handleVariantChange()",
@@ -290035,7 +290113,7 @@
       "source_location": "L35"
     },
     {
-      "community": 965,
+      "community": 966,
       "file_type": "code",
       "id": "skuselector_variantequalityfn",
       "label": "variantEqualityFn()",
@@ -290044,7 +290122,7 @@
       "source_location": "L48"
     },
     {
-      "community": 966,
+      "community": 967,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productstablecontext_tsx",
       "label": "ProductsTableContext.tsx",
@@ -290053,7 +290131,7 @@
       "source_location": "L1"
     },
     {
-      "community": 966,
+      "community": 967,
       "file_type": "code",
       "id": "productstablecontext_productstableprovider",
       "label": "ProductsTableProvider()",
@@ -290062,7 +290140,7 @@
       "source_location": "L16"
     },
     {
-      "community": 966,
+      "community": 967,
       "file_type": "code",
       "id": "productstablecontext_useproductstablestate",
       "label": "useProductsTableState()",
@@ -290071,7 +290149,7 @@
       "source_location": "L60"
     },
     {
-      "community": 967,
+      "community": 968,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproductsview_tsx",
       "label": "StoreProductsView.tsx",
@@ -290080,7 +290158,7 @@
       "source_location": "L1"
     },
     {
-      "community": 967,
+      "community": 968,
       "file_type": "code",
       "id": "storeproductsview_navigation",
       "label": "Navigation()",
@@ -290089,7 +290167,7 @@
       "source_location": "L45"
     },
     {
-      "community": 967,
+      "community": 968,
       "file_type": "code",
       "id": "storeproductsview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -290098,7 +290176,7 @@
       "source_location": "L19"
     },
     {
-      "community": 968,
+      "community": 969,
       "file_type": "code",
       "id": "addcomplimentaryproduct_addcomplimentaryproduct",
       "label": "AddComplimentaryProduct()",
@@ -290107,7 +290185,7 @@
       "source_location": "L128"
     },
     {
-      "community": 968,
+      "community": 969,
       "file_type": "code",
       "id": "addcomplimentaryproduct_handleaddcomplimentaryproducts",
       "label": "handleAddComplimentaryProducts()",
@@ -290116,39 +290194,12 @@
       "source_location": "L40"
     },
     {
-      "community": 968,
+      "community": 969,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_addcomplimentaryproduct_tsx",
       "label": "AddComplimentaryProduct.tsx",
       "norm_label": "addcomplimentaryproduct.tsx",
       "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 969,
-      "file_type": "code",
-      "id": "color_picker_handleblur",
-      "label": "handleBlur()",
-      "norm_label": "handleblur()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
-      "source_location": "L24"
-    },
-    {
-      "community": 969,
-      "file_type": "code",
-      "id": "color_picker_handleinputchange",
-      "label": "handleInputChange()",
-      "norm_label": "handleinputchange()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 969,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_modals_color_picker_tsx",
-      "label": "color-picker.tsx",
-      "norm_label": "color-picker.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
       "source_location": "L1"
     },
     {
@@ -290343,6 +290394,33 @@
     {
       "community": 970,
       "file_type": "code",
+      "id": "color_picker_handleblur",
+      "label": "handleBlur()",
+      "norm_label": "handleblur()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
+      "source_location": "L24"
+    },
+    {
+      "community": 970,
+      "file_type": "code",
+      "id": "color_picker_handleinputchange",
+      "label": "handleInputChange()",
+      "norm_label": "handleinputchange()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 970,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_modals_color_picker_tsx",
+      "label": "color-picker.tsx",
+      "norm_label": "color-picker.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 971,
+      "file_type": "code",
       "id": "currency_provider_currencyprovider",
       "label": "CurrencyProvider()",
       "norm_label": "currencyprovider()",
@@ -290350,7 +290428,7 @@
       "source_location": "L25"
     },
     {
-      "community": 970,
+      "community": 971,
       "file_type": "code",
       "id": "currency_provider_usestorecurrency",
       "label": "useStoreCurrency()",
@@ -290359,7 +290437,7 @@
       "source_location": "L17"
     },
     {
-      "community": 970,
+      "community": 971,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_providers_currency_provider_tsx",
       "label": "currency-provider.tsx",
@@ -290368,7 +290446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 971,
+      "community": 972,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportcustomrangepanel_tsx",
       "label": "ReportCustomRangePanel.tsx",
@@ -290377,7 +290455,7 @@
       "source_location": "L1"
     },
     {
-      "community": 971,
+      "community": 972,
       "file_type": "code",
       "id": "reportcustomrangepanel_reportcustomrangepanel",
       "label": "ReportCustomRangePanel()",
@@ -290386,7 +290464,7 @@
       "source_location": "L76"
     },
     {
-      "community": 971,
+      "community": 972,
       "file_type": "code",
       "id": "reportcustomrangepanel_reportdatefield",
       "label": "ReportDateField()",
@@ -290395,7 +290473,7 @@
       "source_location": "L25"
     },
     {
-      "community": 972,
+      "community": 973,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportdaterangefield_tsx",
       "label": "ReportDateRangeField.tsx",
@@ -290404,7 +290482,7 @@
       "source_location": "L1"
     },
     {
-      "community": 972,
+      "community": 973,
       "file_type": "code",
       "id": "reportdaterangefield_getdaterangepresets",
       "label": "getDateRangePresets()",
@@ -290413,7 +290491,7 @@
       "source_location": "L25"
     },
     {
-      "community": 972,
+      "community": 973,
       "file_type": "code",
       "id": "reportdaterangefield_reportdaterangefield",
       "label": "ReportDateRangeField()",
@@ -290422,7 +290500,7 @@
       "source_location": "L34"
     },
     {
-      "community": 973,
+      "community": 974,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportfreshness_tsx",
       "label": "ReportFreshness.tsx",
@@ -290431,7 +290509,7 @@
       "source_location": "L1"
     },
     {
-      "community": 973,
+      "community": 974,
       "file_type": "code",
       "id": "reportfreshness_reportfreshness",
       "label": "ReportFreshness()",
@@ -290440,7 +290518,7 @@
       "source_location": "L24"
     },
     {
-      "community": 973,
+      "community": 974,
       "file_type": "code",
       "id": "reportfreshness_reportlastupdated",
       "label": "ReportLastUpdated()",
@@ -290449,7 +290527,7 @@
       "source_location": "L10"
     },
     {
-      "community": 974,
+      "community": 975,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportperiodmetrics_tsx",
       "label": "ReportPeriodMetrics.tsx",
@@ -290458,7 +290536,7 @@
       "source_location": "L1"
     },
     {
-      "community": 974,
+      "community": 975,
       "file_type": "code",
       "id": "reportperiodmetrics_comparison",
       "label": "comparison()",
@@ -290467,7 +290545,7 @@
       "source_location": "L231"
     },
     {
-      "community": 974,
+      "community": 975,
       "file_type": "code",
       "id": "reportperiodmetrics_comparisonhelper",
       "label": "comparisonHelper()",
@@ -290476,7 +290554,7 @@
       "source_location": "L97"
     },
     {
-      "community": 975,
+      "community": 976,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportsitemsperformance_tsx",
       "label": "ReportsItemsPerformance.tsx",
@@ -290485,7 +290563,7 @@
       "source_location": "L1"
     },
     {
-      "community": 975,
+      "community": 976,
       "file_type": "code",
       "id": "reportsitemsperformance_cn",
       "label": "cn()",
@@ -290494,7 +290572,7 @@
       "source_location": "L116"
     },
     {
-      "community": 975,
+      "community": 976,
       "file_type": "code",
       "id": "reportsitemsperformance_priorperiodtotals",
       "label": "priorPeriodTotals()",
@@ -290503,7 +290581,7 @@
       "source_location": "L287"
     },
     {
-      "community": 976,
+      "community": 977,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportsoverviewview_tsx",
       "label": "ReportsOverviewView.tsx",
@@ -290512,7 +290590,7 @@
       "source_location": "L1"
     },
     {
-      "community": 976,
+      "community": 977,
       "file_type": "code",
       "id": "reportsoverviewview_cn",
       "label": "cn()",
@@ -290521,7 +290599,7 @@
       "source_location": "L143"
     },
     {
-      "community": 976,
+      "community": 977,
       "file_type": "code",
       "id": "reportsoverviewview_comparisonfor",
       "label": "comparisonFor()",
@@ -290530,7 +290608,7 @@
       "source_location": "L33"
     },
     {
-      "community": 977,
+      "community": 978,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportsweeklyview_test_tsx",
       "label": "ReportsWeeklyView.test.tsx",
@@ -290539,7 +290617,7 @@
       "source_location": "L1"
     },
     {
-      "community": 977,
+      "community": 978,
       "file_type": "code",
       "id": "reportsweeklyview_test_installmovementqueries",
       "label": "installMovementQueries()",
@@ -290548,7 +290626,7 @@
       "source_location": "L60"
     },
     {
-      "community": 977,
+      "community": 978,
       "file_type": "code",
       "id": "reportsweeklyview_test_params",
       "label": "params()",
@@ -290557,7 +290635,7 @@
       "source_location": "L169"
     },
     {
-      "community": 978,
+      "community": 979,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_usereportsshareddemomode_ts",
       "label": "useReportsSharedDemoMode.ts",
@@ -290566,7 +290644,7 @@
       "source_location": "L1"
     },
     {
-      "community": 978,
+      "community": 979,
       "file_type": "code",
       "id": "usereportsshareddemomode_usereportsshareddemomode",
       "label": "useReportsSharedDemoMode()",
@@ -290575,40 +290653,13 @@
       "source_location": "L35"
     },
     {
-      "community": 978,
+      "community": 979,
       "file_type": "code",
       "id": "usereportsshareddemomode_useshareddemolivereportsday",
       "label": "useSharedDemoLiveReportsDay()",
       "norm_label": "useshareddemolivereportsday()",
       "source_file": "packages/athena-webapp/src/components/reports/useReportsSharedDemoMode.ts",
       "source_location": "L65"
-    },
-    {
-      "community": 979,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_test_tsx",
-      "label": "ServiceAppointmentsView.test.tsx",
-      "norm_label": "serviceappointmentsview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 979,
-      "file_type": "code",
-      "id": "serviceappointmentsview_test_choosedatetime",
-      "label": "chooseDateTime()",
-      "norm_label": "choosedatetime()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.test.tsx",
-      "source_location": "L76"
-    },
-    {
-      "community": 979,
-      "file_type": "code",
-      "id": "serviceappointmentsview_test_chooseselectoption",
-      "label": "chooseSelectOption()",
-      "norm_label": "chooseselectoption()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.test.tsx",
-      "source_location": "L67"
     },
     {
       "community": 98,
@@ -290793,6 +290844,33 @@
     {
       "community": 980,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_test_tsx",
+      "label": "ServiceAppointmentsView.test.tsx",
+      "norm_label": "serviceappointmentsview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 980,
+      "file_type": "code",
+      "id": "serviceappointmentsview_test_choosedatetime",
+      "label": "chooseDateTime()",
+      "norm_label": "choosedatetime()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.test.tsx",
+      "source_location": "L76"
+    },
+    {
+      "community": 980,
+      "file_type": "code",
+      "id": "serviceappointmentsview_test_chooseselectoption",
+      "label": "chooseSelectOption()",
+      "norm_label": "chooseselectoption()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceAppointmentsView.test.tsx",
+      "source_location": "L67"
+    },
+    {
+      "community": 981,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_test_tsx",
       "label": "ServiceIntakeView.test.tsx",
       "norm_label": "serviceintakeview.test.tsx",
@@ -290800,7 +290878,7 @@
       "source_location": "L1"
     },
     {
-      "community": 980,
+      "community": 981,
       "file_type": "code",
       "id": "serviceintakeview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -290809,7 +290887,7 @@
       "source_location": "L78"
     },
     {
-      "community": 980,
+      "community": 981,
       "file_type": "code",
       "id": "serviceintakeview_test_chooseservicecatalogoption",
       "label": "chooseServiceCatalogOption()",
@@ -290818,7 +290896,7 @@
       "source_location": "L87"
     },
     {
-      "community": 981,
+      "community": 982,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_tsx",
       "label": "ServiceIntakeView.tsx",
@@ -290827,7 +290905,7 @@
       "source_location": "L1"
     },
     {
-      "community": 981,
+      "community": 982,
       "file_type": "code",
       "id": "serviceintakeview_serviceintakeview",
       "label": "ServiceIntakeView()",
@@ -290836,7 +290914,7 @@
       "source_location": "L228"
     },
     {
-      "community": 981,
+      "community": 982,
       "file_type": "code",
       "id": "serviceintakeview_serviceintakeviewcontent",
       "label": "ServiceIntakeViewContent()",
@@ -290845,7 +290923,7 @@
       "source_location": "L89"
     },
     {
-      "community": 982,
+      "community": 983,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemotransactionsfixture_test_ts",
       "label": "sharedDemoTransactionsFixture.test.ts",
@@ -290854,7 +290932,7 @@
       "source_location": "L1"
     },
     {
-      "community": 982,
+      "community": 983,
       "file_type": "code",
       "id": "shareddemotransactionsfixture_test_operatingdatefortimestamp",
       "label": "operatingDateForTimestamp()",
@@ -290863,7 +290941,7 @@
       "source_location": "L28"
     },
     {
-      "community": 982,
+      "community": 983,
       "file_type": "code",
       "id": "shareddemotransactionsfixture_test_shiftoperatingdate",
       "label": "shiftOperatingDate()",
@@ -290872,7 +290950,7 @@
       "source_location": "L18"
     },
     {
-      "community": 983,
+      "community": 984,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_staffmanagement_test_tsx",
       "label": "StaffManagement.test.tsx",
@@ -290881,7 +290959,7 @@
       "source_location": "L1"
     },
     {
-      "community": 983,
+      "community": 984,
       "file_type": "code",
       "id": "staffmanagement_test_chooserole",
       "label": "chooseRole()",
@@ -290890,7 +290968,7 @@
       "source_location": "L181"
     },
     {
-      "community": 983,
+      "community": 984,
       "file_type": "code",
       "id": "staffmanagement_test_mockconvex",
       "label": "mockConvex()",
@@ -290899,7 +290977,7 @@
       "source_location": "L124"
     },
     {
-      "community": 984,
+      "community": 985,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_auth_staffauthenticationdialog_tsx",
       "label": "StaffAuthenticationDialog.tsx",
@@ -290908,7 +290986,7 @@
       "source_location": "L1"
     },
     {
-      "community": 984,
+      "community": 985,
       "file_type": "code",
       "id": "staffauthenticationdialog_handlekeydown",
       "label": "handleKeyDown()",
@@ -290917,7 +290995,7 @@
       "source_location": "L241"
     },
     {
-      "community": 984,
+      "community": 985,
       "file_type": "code",
       "id": "staffauthenticationdialog_switchtodifferentcashier",
       "label": "switchToDifferentCashier()",
@@ -290926,7 +291004,7 @@
       "source_location": "L247"
     },
     {
-      "community": 985,
+      "community": 986,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -290935,7 +291013,7 @@
       "source_location": "L1"
     },
     {
-      "community": 985,
+      "community": 986,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_singlelineerror_tsx",
       "label": "SingleLineError.tsx",
@@ -290944,7 +291022,7 @@
       "source_location": "L1"
     },
     {
-      "community": 985,
+      "community": 986,
       "file_type": "code",
       "id": "singlelineerror_singlelineerror",
       "label": "SingleLineError()",
@@ -290953,7 +291031,7 @@
       "source_location": "L3"
     },
     {
-      "community": 986,
+      "community": 987,
       "file_type": "code",
       "id": "index_errorpage",
       "label": "ErrorPage()",
@@ -290962,7 +291040,7 @@
       "source_location": "L9"
     },
     {
-      "community": 986,
+      "community": 987,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -290971,7 +291049,7 @@
       "source_location": "L1"
     },
     {
-      "community": 986,
+      "community": 987,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_index_tsx",
       "label": "index.tsx",
@@ -290980,7 +291058,7 @@
       "source_location": "L1"
     },
     {
-      "community": 987,
+      "community": 988,
       "file_type": "code",
       "id": "app_skeleton_appskeleton",
       "label": "AppSkeleton()",
@@ -290989,7 +291067,7 @@
       "source_location": "L3"
     },
     {
-      "community": 987,
+      "community": 988,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -290998,7 +291076,7 @@
       "source_location": "L1"
     },
     {
-      "community": 987,
+      "community": 988,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_app_skeleton_tsx",
       "label": "app-skeleton.tsx",
@@ -291007,7 +291085,7 @@
       "source_location": "L1"
     },
     {
-      "community": 988,
+      "community": 989,
       "file_type": "code",
       "id": "dashboard_skeleton_dashboardskeleton",
       "label": "DashboardSkeleton()",
@@ -291016,7 +291094,7 @@
       "source_location": "L3"
     },
     {
-      "community": 988,
+      "community": 989,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
@@ -291025,40 +291103,13 @@
       "source_location": "L1"
     },
     {
-      "community": 988,
+      "community": 989,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_dashboard_skeleton_tsx",
       "label": "dashboard-skeleton.tsx",
       "norm_label": "dashboard-skeleton.tsx",
       "source_file": "packages/storefront-webapp/src/components/states/loading/dashboard-skeleton.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 989,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_loading_table_skeleton_tsx",
-      "label": "table-skeleton.tsx",
-      "norm_label": "table-skeleton.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/loading/table-skeleton.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 989,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_loading_table_skeleton_tsx",
-      "label": "table-skeleton.tsx",
-      "norm_label": "table-skeleton.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/loading/table-skeleton.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 989,
-      "file_type": "code",
-      "id": "table_skeleton_tableskeleton",
-      "label": "TableSkeleton()",
-      "norm_label": "tableskeleton()",
-      "source_file": "packages/storefront-webapp/src/components/states/loading/table-skeleton.tsx",
-      "source_location": "L3"
     },
     {
       "community": 99,
@@ -291243,6 +291294,33 @@
     {
       "community": 990,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_loading_table_skeleton_tsx",
+      "label": "table-skeleton.tsx",
+      "norm_label": "table-skeleton.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/loading/table-skeleton.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 990,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_loading_table_skeleton_tsx",
+      "label": "table-skeleton.tsx",
+      "norm_label": "table-skeleton.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/loading/table-skeleton.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 990,
+      "file_type": "code",
+      "id": "table_skeleton_tableskeleton",
+      "label": "TableSkeleton()",
+      "norm_label": "tableskeleton()",
+      "source_file": "packages/storefront-webapp/src/components/states/loading/table-skeleton.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 991,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
       "norm_label": "transactions-skeleton.tsx",
@@ -291250,7 +291328,7 @@
       "source_location": "L1"
     },
     {
-      "community": 990,
+      "community": 991,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_loading_transactions_skeleton_tsx",
       "label": "transactions-skeleton.tsx",
@@ -291259,7 +291337,7 @@
       "source_location": "L1"
     },
     {
-      "community": 990,
+      "community": 991,
       "file_type": "code",
       "id": "transactions_skeleton_transactionsskeleton",
       "label": "TransactionsSkeleton()",
@@ -291268,7 +291346,7 @@
       "source_location": "L3"
     },
     {
-      "community": 991,
+      "community": 992,
       "file_type": "code",
       "id": "notfound_notfound",
       "label": "NotFound()",
@@ -291277,7 +291355,7 @@
       "source_location": "L4"
     },
     {
-      "community": 991,
+      "community": 992,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -291286,7 +291364,7 @@
       "source_location": "L1"
     },
     {
-      "community": 991,
+      "community": 992,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_not_found_notfound_tsx",
       "label": "NotFound.tsx",
@@ -291295,7 +291373,7 @@
       "source_location": "L1"
     },
     {
-      "community": 992,
+      "community": 993,
       "file_type": "code",
       "id": "notificationsview_test_buildstate",
       "label": "buildState()",
@@ -291304,7 +291382,7 @@
       "source_location": "L64"
     },
     {
-      "community": 992,
+      "community": 993,
       "file_type": "code",
       "id": "notificationsview_test_row",
       "label": "row()",
@@ -291313,7 +291391,7 @@
       "source_location": "L48"
     },
     {
-      "community": 992,
+      "community": 993,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_notificationsview_test_tsx",
       "label": "NotificationsView.test.tsx",
@@ -291322,7 +291400,7 @@
       "source_location": "L1"
     },
     {
-      "community": 993,
+      "community": 994,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceroutelink_tsx",
       "label": "WorkflowTraceRouteLink.tsx",
@@ -291331,7 +291409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 993,
+      "community": 994,
       "file_type": "code",
       "id": "workflowtraceroutelink_getworkflowtraceroutetarget",
       "label": "getWorkflowTraceRouteTarget()",
@@ -291340,7 +291418,7 @@
       "source_location": "L23"
     },
     {
-      "community": 993,
+      "community": 994,
       "file_type": "code",
       "id": "workflowtraceroutelink_workflowtraceroutelink",
       "label": "WorkflowTraceRouteLink()",
@@ -291349,7 +291427,7 @@
       "source_location": "L41"
     },
     {
-      "community": 994,
+      "community": 995,
       "file_type": "code",
       "id": "app_context_menu_appcontextmenu",
       "label": "AppContextMenu()",
@@ -291358,7 +291436,7 @@
       "source_location": "L20"
     },
     {
-      "community": 994,
+      "community": 995,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
@@ -291367,7 +291445,7 @@
       "source_location": "L1"
     },
     {
-      "community": 994,
+      "community": 995,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_app_context_menu_tsx",
       "label": "app-context-menu.tsx",
@@ -291376,7 +291454,7 @@
       "source_location": "L1"
     },
     {
-      "community": 995,
+      "community": 996,
       "file_type": "code",
       "id": "badge_badge",
       "label": "Badge()",
@@ -291385,7 +291463,7 @@
       "source_location": "L30"
     },
     {
-      "community": 995,
+      "community": 996,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
@@ -291394,7 +291472,7 @@
       "source_location": "L1"
     },
     {
-      "community": 995,
+      "community": 996,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_badge_tsx",
       "label": "badge.tsx",
@@ -291403,7 +291481,7 @@
       "source_location": "L1"
     },
     {
-      "community": 996,
+      "community": 997,
       "file_type": "code",
       "id": "calendar_calendar",
       "label": "Calendar()",
@@ -291412,7 +291490,7 @@
       "source_location": "L12"
     },
     {
-      "community": 996,
+      "community": 997,
       "file_type": "code",
       "id": "calendar_cn",
       "label": "cn()",
@@ -291421,7 +291499,7 @@
       "source_location": "L201"
     },
     {
-      "community": 996,
+      "community": 997,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_tsx",
       "label": "calendar.tsx",
@@ -291430,7 +291508,7 @@
       "source_location": "L1"
     },
     {
-      "community": 997,
+      "community": 998,
       "file_type": "code",
       "id": "loading_button_loadingbutton",
       "label": "LoadingButton()",
@@ -291439,7 +291517,7 @@
       "source_location": "L9"
     },
     {
-      "community": 997,
+      "community": 998,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -291448,7 +291526,7 @@
       "source_location": "L1"
     },
     {
-      "community": 997,
+      "community": 998,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_loading_button_tsx",
       "label": "loading-button.tsx",
@@ -291457,7 +291535,7 @@
       "source_location": "L1"
     },
     {
-      "community": 998,
+      "community": 999,
       "file_type": "code",
       "id": "modal_onchange",
       "label": "onChange()",
@@ -291466,7 +291544,7 @@
       "source_location": "L38"
     },
     {
-      "community": 998,
+      "community": 999,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
@@ -291475,39 +291553,12 @@
       "source_location": "L1"
     },
     {
-      "community": 998,
+      "community": 999,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modal_tsx",
       "label": "modal.tsx",
       "norm_label": "modal.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 999,
-      "file_type": "code",
-      "id": "alert_modal_alertmodal",
-      "label": "AlertModal()",
-      "norm_label": "alertmodal()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/alert-modal.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 999,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modals_alert_modal_tsx",
-      "label": "alert-modal.tsx",
-      "norm_label": "alert-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/alert-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 999,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_alert_modal_tsx",
-      "label": "alert-modal.tsx",
-      "norm_label": "alert-modal.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/alert-modal.tsx",
       "source_location": "L1"
     }
   ]

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -23927,7 +23927,7 @@
       "relation": "calls",
       "source": "harness_review_identity_digestdeliverableentries",
       "source_file": "scripts/harness-review-identity.ts",
-      "source_location": "L154",
+      "source_location": "L171",
       "target": "harness_review_identity_computedeliverabletreeidentity",
       "weight": 1
     },
@@ -23939,8 +23939,20 @@
       "relation": "calls",
       "source": "harness_review_identity_parsetreeentries",
       "source_file": "scripts/harness-review-identity.ts",
-      "source_location": "L154",
+      "source_location": "L171",
       "target": "harness_review_identity_computedeliverabletreeidentity",
+      "weight": 1
+    },
+    {
+      "_src": "harness_review_identity_ispostgatevalidationneutralpath",
+      "_tgt": "harness_review_identity_normalizerepopath",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "harness_review_identity_normalizerepopath",
+      "source_file": "scripts/harness-review-identity.ts",
+      "source_location": "L91",
+      "target": "harness_review_identity_ispostgatevalidationneutralpath",
       "weight": 1
     },
     {
@@ -23951,7 +23963,7 @@
       "relation": "calls",
       "source": "harness_review_identity_normalizerepopath",
       "source_file": "scripts/harness-review-identity.ts",
-      "source_location": "L75",
+      "source_location": "L77",
       "target": "harness_review_identity_isreviewneutralpath",
       "weight": 1
     },
@@ -23963,7 +23975,7 @@
       "relation": "calls",
       "source": "harness_review_identity_test_git",
       "source_file": "scripts/harness-review-identity.test.ts",
-      "source_location": "L307",
+      "source_location": "L323",
       "target": "harness_review_identity_test_gitfixture",
       "weight": 1
     },
@@ -23975,7 +23987,7 @@
       "relation": "calls",
       "source": "harness_review_identity_test_git",
       "source_file": "scripts/harness-review-identity.test.ts",
-      "source_location": "L328",
+      "source_location": "L344",
       "target": "harness_review_identity_test_headtreeidentity",
       "weight": 1
     },
@@ -23987,7 +23999,7 @@
       "relation": "calls",
       "source": "harness_review_identity_test_createspawn",
       "source_file": "scripts/harness-review-identity.test.ts",
-      "source_location": "L43",
+      "source_location": "L44",
       "target": "harness_review_identity_test_identityfor",
       "weight": 1
     },
@@ -23999,7 +24011,7 @@
       "relation": "calls",
       "source": "harness_review_identity_test_lstreeoutput",
       "source_file": "scripts/harness-review-identity.test.ts",
-      "source_location": "L43",
+      "source_location": "L44",
       "target": "harness_review_identity_test_identityfor",
       "weight": 1
     },
@@ -139367,7 +139379,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_collectunstagedfiles",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L176",
+      "source_location": "L218",
       "target": "pre_push_validation_proof_assertprathenaproofready",
       "weight": 1
     },
@@ -139379,7 +139391,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_collectuntrackedfiles",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L177",
+      "source_location": "L219",
       "target": "pre_push_validation_proof_assertprathenaproofready",
       "weight": 1
     },
@@ -139391,7 +139403,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_formatpathlist",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L187",
+      "source_location": "L229",
       "target": "pre_push_validation_proof_assertprathenaproofready",
       "weight": 1
     },
@@ -139403,7 +139415,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_parseporcelainpaths",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L208",
+      "source_location": "L250",
       "target": "pre_push_validation_proof_assertprathenaproofready",
       "weight": 1
     },
@@ -139415,7 +139427,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_runcommand",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L171",
+      "source_location": "L213",
       "target": "pre_push_validation_proof_assertprathenaproofready",
       "weight": 1
     },
@@ -139427,7 +139439,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_normalizerepopath",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L242",
+      "source_location": "L284",
       "target": "pre_push_validation_proof_collectfilesunder",
       "weight": 1
     },
@@ -139439,7 +139451,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_hashvalidationwiring",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L342",
+      "source_location": "L384",
       "target": "pre_push_validation_proof_collectproofsnapshot",
       "weight": 1
     },
@@ -139451,7 +139463,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_readprathenascript",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L341",
+      "source_location": "L383",
       "target": "pre_push_validation_proof_collectproofsnapshot",
       "weight": 1
     },
@@ -139463,7 +139475,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_runcommand",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L335",
+      "source_location": "L377",
       "target": "pre_push_validation_proof_collectproofsnapshot",
       "weight": 1
     },
@@ -139475,7 +139487,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_runcommand",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L153",
+      "source_location": "L195",
       "target": "pre_push_validation_proof_collectuntrackedfiles",
       "weight": 1
     },
@@ -139487,7 +139499,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_collectfilesunder",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L277",
+      "source_location": "L319",
       "target": "pre_push_validation_proof_collectvalidationfingerprintpaths",
       "weight": 1
     },
@@ -139499,7 +139511,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_sortuniquepaths",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L261",
+      "source_location": "L303",
       "target": "pre_push_validation_proof_collectvalidationfingerprintpaths",
       "weight": 1
     },
@@ -139511,7 +139523,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_classifysnapshoterror",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L419",
+      "source_location": "L461",
       "target": "pre_push_validation_proof_evaluateprepushvalidationproof",
       "weight": 1
     },
@@ -139523,7 +139535,19 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_collectproofsnapshot",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L416",
+      "source_location": "L458",
+      "target": "pre_push_validation_proof_evaluateprepushvalidationproof",
+      "weight": 1
+    },
+    {
+      "_src": "pre_push_validation_proof_evaluateprepushvalidationproof",
+      "_tgt": "pre_push_validation_proof_collecttreechangedpaths",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "pre_push_validation_proof_collecttreechangedpaths",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L489",
       "target": "pre_push_validation_proof_evaluateprepushvalidationproof",
       "weight": 1
     },
@@ -139535,7 +139559,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_validateproofshape",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L435",
+      "source_location": "L477",
       "target": "pre_push_validation_proof_evaluateprepushvalidationproof",
       "weight": 1
     },
@@ -139547,7 +139571,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_collectvalidationfingerprintpaths",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L293",
+      "source_location": "L335",
       "target": "pre_push_validation_proof_hashvalidationwiring",
       "weight": 1
     },
@@ -139559,7 +139583,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_collectproofsnapshot",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L504",
+      "source_location": "L591",
       "target": "pre_push_validation_proof_recordprepushvalidationproof",
       "weight": 1
     },
@@ -139571,7 +139595,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_runcommand",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L521",
+      "source_location": "L608",
       "target": "pre_push_validation_proof_recordprepushvalidationproof",
       "weight": 1
     },
@@ -158255,7 +158279,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_identity_test_ts",
       "source_file": "scripts/harness-review-identity.test.ts",
-      "source_location": "L23",
+      "source_location": "L24",
       "target": "harness_review_identity_test_createspawn",
       "weight": 1
     },
@@ -158267,7 +158291,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_identity_test_ts",
       "source_file": "scripts/harness-review-identity.test.ts",
-      "source_location": "L247",
+      "source_location": "L263",
       "target": "harness_review_identity_test_entryfor",
       "weight": 1
     },
@@ -158279,7 +158303,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_identity_test_ts",
       "source_file": "scripts/harness-review-identity.test.ts",
-      "source_location": "L288",
+      "source_location": "L304",
       "target": "harness_review_identity_test_git",
       "weight": 1
     },
@@ -158291,7 +158315,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_identity_test_ts",
       "source_file": "scripts/harness-review-identity.test.ts",
-      "source_location": "L304",
+      "source_location": "L320",
       "target": "harness_review_identity_test_gitfixture",
       "weight": 1
     },
@@ -158303,7 +158327,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_identity_test_ts",
       "source_file": "scripts/harness-review-identity.test.ts",
-      "source_location": "L327",
+      "source_location": "L343",
       "target": "harness_review_identity_test_headtreeidentity",
       "weight": 1
     },
@@ -158315,7 +158339,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_identity_test_ts",
       "source_file": "scripts/harness-review-identity.test.ts",
-      "source_location": "L41",
+      "source_location": "L42",
       "target": "harness_review_identity_test_identityfor",
       "weight": 1
     },
@@ -158327,7 +158351,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_identity_test_ts",
       "source_file": "scripts/harness-review-identity.test.ts",
-      "source_location": "L16",
+      "source_location": "L17",
       "target": "harness_review_identity_test_lstreeoutput",
       "weight": 1
     },
@@ -158339,7 +158363,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_identity_ts",
       "source_file": "scripts/harness-review-identity.ts",
-      "source_location": "L132",
+      "source_location": "L149",
       "target": "harness_review_identity_computedeliverabletreeidentity",
       "weight": 1
     },
@@ -158351,8 +158375,20 @@
       "relation": "contains",
       "source": "scripts_harness_review_identity_ts",
       "source_file": "scripts/harness-review-identity.ts",
-      "source_location": "L108",
+      "source_location": "L125",
       "target": "harness_review_identity_digestdeliverableentries",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_harness_review_identity_ts",
+      "_tgt": "harness_review_identity_ispostgatevalidationneutralpath",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_harness_review_identity_ts",
+      "source_file": "scripts/harness-review-identity.ts",
+      "source_location": "L90",
+      "target": "harness_review_identity_ispostgatevalidationneutralpath",
       "weight": 1
     },
     {
@@ -158363,7 +158399,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_identity_ts",
       "source_file": "scripts/harness-review-identity.ts",
-      "source_location": "L74",
+      "source_location": "L76",
       "target": "harness_review_identity_isreviewneutralpath",
       "weight": 1
     },
@@ -158375,7 +158411,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_identity_ts",
       "source_file": "scripts/harness-review-identity.ts",
-      "source_location": "L70",
+      "source_location": "L72",
       "target": "harness_review_identity_normalizerepopath",
       "weight": 1
     },
@@ -158387,7 +158423,7 @@
       "relation": "contains",
       "source": "scripts_harness_review_identity_ts",
       "source_file": "scripts/harness-review-identity.ts",
-      "source_location": "L93",
+      "source_location": "L110",
       "target": "harness_review_identity_parsetreeentries",
       "weight": 1
     },
@@ -161171,7 +161207,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_test_ts",
       "source_file": "scripts/pre-push-validation-proof.test.ts",
-      "source_location": "L457",
+      "source_location": "L582",
       "target": "pre_push_validation_proof_test_log",
       "weight": 1
     },
@@ -161183,7 +161219,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_test_ts",
       "source_file": "scripts/pre-push-validation-proof.test.ts",
-      "source_location": "L457",
+      "source_location": "L582",
       "target": "pre_push_validation_proof_test_warn",
       "weight": 1
     },
@@ -161207,7 +161243,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L165",
+      "source_location": "L207",
       "target": "pre_push_validation_proof_assertprathenaproofready",
       "weight": 1
     },
@@ -161219,7 +161255,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L397",
+      "source_location": "L439",
       "target": "pre_push_validation_proof_classifysnapshoterror",
       "weight": 1
     },
@@ -161231,7 +161267,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L221",
+      "source_location": "L263",
       "target": "pre_push_validation_proof_collectfilesunder",
       "weight": 1
     },
@@ -161243,8 +161279,20 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L327",
+      "source_location": "L369",
       "target": "pre_push_validation_proof_collectproofsnapshot",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_pre_push_validation_proof_ts",
+      "_tgt": "pre_push_validation_proof_collecttreechangedpaths",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_pre_push_validation_proof_ts",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L125",
+      "target": "pre_push_validation_proof_collecttreechangedpaths",
       "weight": 1
     },
     {
@@ -161255,7 +161303,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L122",
+      "source_location": "L164",
       "target": "pre_push_validation_proof_collectunstagedfiles",
       "weight": 1
     },
@@ -161267,7 +161315,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L149",
+      "source_location": "L191",
       "target": "pre_push_validation_proof_collectuntrackedfiles",
       "weight": 1
     },
@@ -161279,7 +161327,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L257",
+      "source_location": "L299",
       "target": "pre_push_validation_proof_collectvalidationfingerprintpaths",
       "weight": 1
     },
@@ -161291,7 +161339,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L410",
+      "source_location": "L452",
       "target": "pre_push_validation_proof_evaluateprepushvalidationproof",
       "weight": 1
     },
@@ -161303,7 +161351,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L118",
+      "source_location": "L121",
       "target": "pre_push_validation_proof_formatpathlist",
       "weight": 1
     },
@@ -161315,7 +161363,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L286",
+      "source_location": "L328",
       "target": "pre_push_validation_proof_hashvalidationwiring",
       "weight": 1
     },
@@ -161327,7 +161375,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L74",
+      "source_location": "L77",
       "target": "pre_push_validation_proof_normalizerepopath",
       "weight": 1
     },
@@ -161339,7 +161387,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L109",
+      "source_location": "L112",
       "target": "pre_push_validation_proof_parseporcelainpaths",
       "weight": 1
     },
@@ -161351,7 +161399,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L310",
+      "source_location": "L352",
       "target": "pre_push_validation_proof_readprathenascript",
       "weight": 1
     },
@@ -161363,7 +161411,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L497",
+      "source_location": "L584",
       "target": "pre_push_validation_proof_recordprepushvalidationproof",
       "weight": 1
     },
@@ -161375,7 +161423,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L84",
+      "source_location": "L87",
       "target": "pre_push_validation_proof_runcommand",
       "weight": 1
     },
@@ -161387,7 +161435,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L78",
+      "source_location": "L81",
       "target": "pre_push_validation_proof_sortuniquepaths",
       "weight": 1
     },
@@ -161399,7 +161447,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L377",
+      "source_location": "L419",
       "target": "pre_push_validation_proof_validateproofshape",
       "weight": 1
     },
@@ -188289,163 +188337,172 @@
     {
       "community": 110,
       "file_type": "code",
-      "id": "closeouts_buildopeningfloatcorrectionapprovalrequirement",
-      "label": "buildOpeningFloatCorrectionApprovalRequirement()",
-      "norm_label": "buildopeningfloatcorrectionapprovalrequirement()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L294"
+      "id": "pre_push_validation_proof_assertprathenaproofready",
+      "label": "assertPrAthenaProofReady()",
+      "norm_label": "assertprathenaproofready()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L207"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "closeouts_buildregistercloseoutsubmittedtimelinemessage",
-      "label": "buildRegisterCloseoutSubmittedTimelineMessage()",
-      "norm_label": "buildregistercloseoutsubmittedtimelinemessage()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L135"
+      "id": "pre_push_validation_proof_classifysnapshoterror",
+      "label": "classifySnapshotError()",
+      "norm_label": "classifysnapshoterror()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L439"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "closeouts_buildregistercloseoutvariancetimelinemessage",
-      "label": "buildRegisterCloseoutVarianceTimelineMessage()",
-      "norm_label": "buildregistercloseoutvariancetimelinemessage()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L121"
+      "id": "pre_push_validation_proof_collectfilesunder",
+      "label": "collectFilesUnder()",
+      "norm_label": "collectfilesunder()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L263"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "closeouts_buildregistersessionvarianceapprovalrequirement",
-      "label": "buildRegisterSessionVarianceApprovalRequirement()",
-      "norm_label": "buildregistersessionvarianceapprovalrequirement()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "id": "pre_push_validation_proof_collectproofsnapshot",
+      "label": "collectProofSnapshot()",
+      "norm_label": "collectproofsnapshot()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L369"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "pre_push_validation_proof_collecttreechangedpaths",
+      "label": "collectTreeChangedPaths()",
+      "norm_label": "collecttreechangedpaths()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L125"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "pre_push_validation_proof_collectunstagedfiles",
+      "label": "collectUnstagedFiles()",
+      "norm_label": "collectunstagedfiles()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L164"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "pre_push_validation_proof_collectuntrackedfiles",
+      "label": "collectUntrackedFiles()",
+      "norm_label": "collectuntrackedfiles()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L191"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "pre_push_validation_proof_collectvalidationfingerprintpaths",
+      "label": "collectValidationFingerprintPaths()",
+      "norm_label": "collectvalidationfingerprintpaths()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L299"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "pre_push_validation_proof_evaluateprepushvalidationproof",
+      "label": "evaluatePrePushValidationProof()",
+      "norm_label": "evaluateprepushvalidationproof()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
       "source_location": "L452"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "closeouts_cancelpendingapprovalifneeded",
-      "label": "cancelPendingApprovalIfNeeded()",
-      "norm_label": "cancelpendingapprovalifneeded()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L699"
+      "id": "pre_push_validation_proof_formatpathlist",
+      "label": "formatPathList()",
+      "norm_label": "formatpathlist()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L121"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "closeouts_createapprovalrequesterbindingforcloseout",
-      "label": "createApprovalRequesterBindingForCloseout()",
-      "norm_label": "createapprovalrequesterbindingforcloseout()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L92"
+      "id": "pre_push_validation_proof_hashvalidationwiring",
+      "label": "hashValidationWiring()",
+      "norm_label": "hashvalidationwiring()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L328"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "closeouts_formatcloseoutvarianceamount",
-      "label": "formatCloseoutVarianceAmount()",
-      "norm_label": "formatcloseoutvarianceamount()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L79"
+      "id": "pre_push_validation_proof_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L77"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "closeouts_getlatestreopenedcloseoutrecord",
-      "label": "getLatestReopenedCloseoutRecord()",
-      "norm_label": "getlatestreopenedcloseoutrecord()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L422"
+      "id": "pre_push_validation_proof_parseporcelainpaths",
+      "label": "parsePorcelainPaths()",
+      "norm_label": "parseporcelainpaths()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L112"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "closeouts_listregistersessionsforcloseout",
-      "label": "listRegisterSessionsForCloseout()",
-      "norm_label": "listregistersessionsforcloseout()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L520"
+      "id": "pre_push_validation_proof_readprathenascript",
+      "label": "readPrAthenaScript()",
+      "norm_label": "readprathenascript()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L352"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "closeouts_liststaffnames",
-      "label": "listStaffNames()",
-      "norm_label": "liststaffnames()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L550"
+      "id": "pre_push_validation_proof_recordprepushvalidationproof",
+      "label": "recordPrePushValidationProof()",
+      "norm_label": "recordprepushvalidationproof()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L584"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "closeouts_omitundefined",
-      "label": "omitUndefined()",
-      "norm_label": "omitundefined()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L416"
+      "id": "pre_push_validation_proof_runcommand",
+      "label": "runCommand()",
+      "norm_label": "runcommand()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L87"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "closeouts_persistregistersessionworkflowtraceidbesteffort",
-      "label": "persistRegisterSessionWorkflowTraceIdBestEffort()",
-      "norm_label": "persistregistersessionworkflowtraceidbesteffort()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L430"
+      "id": "pre_push_validation_proof_sortuniquepaths",
+      "label": "sortUniquePaths()",
+      "norm_label": "sortuniquepaths()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L81"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "closeouts_requirecashcontrolsstoreaccess",
-      "label": "requireCashControlsStoreAccess()",
-      "norm_label": "requirecashcontrolsstoreaccess()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L602"
+      "id": "pre_push_validation_proof_validateproofshape",
+      "label": "validateProofShape()",
+      "norm_label": "validateproofshape()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L419"
     },
     {
       "community": 110,
       "file_type": "code",
-      "id": "closeouts_resolvecloseoutactorstaffprofileid",
-      "label": "resolveCloseoutActorStaffProfileId()",
-      "norm_label": "resolvecloseoutactorstaffprofileid()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L625"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "closeouts_staffprofilecanreviewcloseoutvariance",
-      "label": "staffProfileCanReviewCloseoutVariance()",
-      "norm_label": "staffprofilecanreviewcloseoutvariance()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L567"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "closeouts_submittedcloseoutpendingvoidsresult",
-      "label": "submittedCloseoutPendingVoidsResult()",
-      "norm_label": "submittedcloseoutpendingvoidsresult()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L507"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "closeouts_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
-      "source_location": "L411"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cashcontrols_closeouts_ts",
-      "label": "closeouts.ts",
-      "norm_label": "closeouts.ts",
-      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "id": "scripts_pre_push_validation_proof_ts",
+      "label": "pre-push-validation-proof.ts",
+      "norm_label": "pre-push-validation-proof.ts",
+      "source_file": "scripts/pre-push-validation-proof.ts",
       "source_location": "L1"
     },
     {
@@ -188721,163 +188778,163 @@
     {
       "community": 111,
       "file_type": "code",
-      "id": "actions_buildproviderregistry",
-      "label": "buildProviderRegistry()",
-      "norm_label": "buildproviderregistry()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L388"
+      "id": "closeouts_buildopeningfloatcorrectionapprovalrequirement",
+      "label": "buildOpeningFloatCorrectionApprovalRequirement()",
+      "norm_label": "buildopeningfloatcorrectionapprovalrequirement()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L294"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "actions_createintelligencerun",
-      "label": "createIntelligenceRun()",
-      "norm_label": "createintelligencerun()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L402"
+      "id": "closeouts_buildregistercloseoutsubmittedtimelinemessage",
+      "label": "buildRegisterCloseoutSubmittedTimelineMessage()",
+      "norm_label": "buildregistercloseoutsubmittedtimelinemessage()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L135"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "actions_defaultfakeoutput",
-      "label": "defaultFakeOutput()",
-      "norm_label": "defaultfakeoutput()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L586"
+      "id": "closeouts_buildregistercloseoutvariancetimelinemessage",
+      "label": "buildRegisterCloseoutVarianceTimelineMessage()",
+      "norm_label": "buildregistercloseoutvariancetimelinemessage()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L121"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "actions_failedgenerationresult",
-      "label": "failedGenerationResult()",
-      "norm_label": "failedgenerationresult()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L579"
+      "id": "closeouts_buildregistersessionvarianceapprovalrequirement",
+      "label": "buildRegisterSessionVarianceApprovalRequirement()",
+      "norm_label": "buildregistersessionvarianceapprovalrequirement()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L452"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "actions_failrunbesteffort",
-      "label": "failRunBestEffort()",
-      "norm_label": "failrunbesteffort()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L558"
+      "id": "closeouts_cancelpendingapprovalifneeded",
+      "label": "cancelPendingApprovalIfNeeded()",
+      "norm_label": "cancelpendingapprovalifneeded()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L699"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "actions_getbundlesnapshotfields",
-      "label": "getBundleSnapshotFields()",
-      "norm_label": "getbundlesnapshotfields()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L599"
+      "id": "closeouts_createapprovalrequesterbindingforcloseout",
+      "label": "createApprovalRequesterBindingForCloseout()",
+      "norm_label": "createapprovalrequesterbindingforcloseout()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L92"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "actions_getstoreinsightssnapshotfallback",
-      "label": "getStoreInsightsSnapshotFallback()",
-      "norm_label": "getstoreinsightssnapshotfallback()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L612"
+      "id": "closeouts_formatcloseoutvarianceamount",
+      "label": "formatCloseoutVarianceAmount()",
+      "norm_label": "formatcloseoutvarianceamount()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L79"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "actions_isactivitytrend",
-      "label": "isActivityTrend()",
-      "norm_label": "isactivitytrend()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L639"
+      "id": "closeouts_getlatestreopenedcloseoutrecord",
+      "label": "getLatestReopenedCloseoutRecord()",
+      "norm_label": "getlatestreopenedcloseoutrecord()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L422"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "actions_isdevicedistribution",
-      "label": "isDeviceDistribution()",
-      "norm_label": "isdevicedistribution()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L624"
+      "id": "closeouts_listregistersessionsforcloseout",
+      "label": "listRegisterSessionsForCloseout()",
+      "norm_label": "listregistersessionsforcloseout()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L520"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "actions_isinsightgenerationinprogresserror",
-      "label": "isInsightGenerationInProgressError()",
-      "norm_label": "isinsightgenerationinprogresserror()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L429"
+      "id": "closeouts_liststaffnames",
+      "label": "listStaffNames()",
+      "norm_label": "liststaffnames()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L550"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "actions_recordproviderfailure",
-      "label": "recordProviderFailure()",
-      "norm_label": "recordproviderfailure()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L522"
+      "id": "closeouts_omitundefined",
+      "label": "omitUndefined()",
+      "norm_label": "omitundefined()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L416"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "actions_recordproviderstarted",
-      "label": "recordProviderStarted()",
-      "norm_label": "recordproviderstarted()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L484"
+      "id": "closeouts_persistregistersessionworkflowtraceidbesteffort",
+      "label": "persistRegisterSessionWorkflowTraceIdBestEffort()",
+      "norm_label": "persistregistersessionworkflowtraceidbesteffort()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L430"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "actions_recordprovidersucceeded",
-      "label": "recordProviderSucceeded()",
-      "norm_label": "recordprovidersucceeded()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L505"
+      "id": "closeouts_requirecashcontrolsstoreaccess",
+      "label": "requireCashControlsStoreAccess()",
+      "norm_label": "requirecashcontrolsstoreaccess()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L602"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "actions_resolveproviderid",
-      "label": "resolveProviderId()",
-      "norm_label": "resolveproviderid()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L380"
+      "id": "closeouts_resolvecloseoutactorstaffprofileid",
+      "label": "resolveCloseoutActorStaffProfileId()",
+      "norm_label": "resolvecloseoutactorstaffprofileid()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L625"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "actions_resolveprovidermodel",
-      "label": "resolveProviderModel()",
-      "norm_label": "resolveprovidermodel()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L384"
+      "id": "closeouts_staffprofilecanreviewcloseoutvariance",
+      "label": "staffProfileCanReviewCloseoutVariance()",
+      "norm_label": "staffprofilecanreviewcloseoutvariance()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L567"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "actions_runstructuredprovider",
-      "label": "runStructuredProvider()",
-      "norm_label": "runstructuredprovider()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L436"
+      "id": "closeouts_submittedcloseoutpendingvoidsresult",
+      "label": "submittedCloseoutPendingVoidsResult()",
+      "norm_label": "submittedcloseoutpendingvoidsresult()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L507"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "actions_topersistedintelligenceerror",
-      "label": "toPersistedIntelligenceError()",
-      "norm_label": "topersistedintelligenceerror()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L547"
+      "id": "closeouts_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
+      "source_location": "L411"
     },
     {
       "community": 111,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_intelligence_capabilities_actions_ts",
-      "label": "actions.ts",
-      "norm_label": "actions.ts",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "id": "packages_athena_webapp_convex_cashcontrols_closeouts_ts",
+      "label": "closeouts.ts",
+      "norm_label": "closeouts.ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/closeouts.ts",
       "source_location": "L1"
     },
     {
@@ -189153,164 +189210,164 @@
     {
       "community": 112,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_weeklymanagerreportemail_ts",
-      "label": "weeklyManagerReportEmail.ts",
-      "norm_label": "weeklymanagerreportemail.ts",
-      "source_file": "packages/athena-webapp/convex/operations/weeklyManagerReportEmail.ts",
+      "id": "actions_buildproviderregistry",
+      "label": "buildProviderRegistry()",
+      "norm_label": "buildproviderregistry()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L388"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "actions_createintelligencerun",
+      "label": "createIntelligenceRun()",
+      "norm_label": "createintelligencerun()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L402"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "actions_defaultfakeoutput",
+      "label": "defaultFakeOutput()",
+      "norm_label": "defaultfakeoutput()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L586"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "actions_failedgenerationresult",
+      "label": "failedGenerationResult()",
+      "norm_label": "failedgenerationresult()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L579"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "actions_failrunbesteffort",
+      "label": "failRunBestEffort()",
+      "norm_label": "failrunbesteffort()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L558"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "actions_getbundlesnapshotfields",
+      "label": "getBundleSnapshotFields()",
+      "norm_label": "getbundlesnapshotfields()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L599"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "actions_getstoreinsightssnapshotfallback",
+      "label": "getStoreInsightsSnapshotFallback()",
+      "norm_label": "getstoreinsightssnapshotfallback()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L612"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "actions_isactivitytrend",
+      "label": "isActivityTrend()",
+      "norm_label": "isactivitytrend()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L639"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "actions_isdevicedistribution",
+      "label": "isDeviceDistribution()",
+      "norm_label": "isdevicedistribution()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L624"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "actions_isinsightgenerationinprogresserror",
+      "label": "isInsightGenerationInProgressError()",
+      "norm_label": "isinsightgenerationinprogresserror()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L429"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "actions_recordproviderfailure",
+      "label": "recordProviderFailure()",
+      "norm_label": "recordproviderfailure()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L522"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "actions_recordproviderstarted",
+      "label": "recordProviderStarted()",
+      "norm_label": "recordproviderstarted()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L484"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "actions_recordprovidersucceeded",
+      "label": "recordProviderSucceeded()",
+      "norm_label": "recordprovidersucceeded()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L505"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "actions_resolveproviderid",
+      "label": "resolveProviderId()",
+      "norm_label": "resolveproviderid()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L380"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "actions_resolveprovidermodel",
+      "label": "resolveProviderModel()",
+      "norm_label": "resolveprovidermodel()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L384"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "actions_runstructuredprovider",
+      "label": "runStructuredProvider()",
+      "norm_label": "runstructuredprovider()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L436"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "actions_topersistedintelligenceerror",
+      "label": "toPersistedIntelligenceError()",
+      "norm_label": "topersistedintelligenceerror()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L547"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_intelligence_capabilities_actions_ts",
+      "label": "actions.ts",
+      "norm_label": "actions.ts",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "weeklymanagerreportemail_amountcomparison",
-      "label": "amountComparison()",
-      "norm_label": "amountcomparison()",
-      "source_file": "packages/athena-webapp/convex/operations/weeklyManagerReportEmail.ts",
-      "source_location": "L458"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "weeklymanagerreportemail_buildacceptedweeklymanagerreportpayload",
-      "label": "buildAcceptedWeeklyManagerReportPayload()",
-      "norm_label": "buildacceptedweeklymanagerreportpayload()",
-      "source_file": "packages/athena-webapp/convex/operations/weeklyManagerReportEmail.ts",
-      "source_location": "L164"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "weeklymanagerreportemail_buildacceptedweeklytopitems",
-      "label": "buildAcceptedWeeklyTopItems()",
-      "norm_label": "buildacceptedweeklytopitems()",
-      "source_file": "packages/athena-webapp/convex/operations/weeklyManagerReportEmail.ts",
-      "source_location": "L109"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "weeklymanagerreportemail_buildweeklyreporturl",
-      "label": "buildWeeklyReportUrl()",
-      "norm_label": "buildweeklyreporturl()",
-      "source_file": "packages/athena-webapp/convex/operations/weeklyManagerReportEmail.ts",
-      "source_location": "L443"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "weeklymanagerreportemail_buildweeklytopmoversurl",
-      "label": "buildWeeklyTopMoversUrl()",
-      "norm_label": "buildweeklytopmoversurl()",
-      "source_file": "packages/athena-webapp/convex/operations/weeklyManagerReportEmail.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "weeklymanagerreportemail_countedcashvariancemessage",
-      "label": "countedCashVarianceMessage()",
-      "norm_label": "countedcashvariancemessage()",
-      "source_file": "packages/athena-webapp/convex/operations/weeklyManagerReportEmail.ts",
-      "source_location": "L489"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "weeklymanagerreportemail_coveragelabel",
-      "label": "coverageLabel()",
-      "norm_label": "coveragelabel()",
-      "source_file": "packages/athena-webapp/convex/operations/weeklyManagerReportEmail.ts",
-      "source_location": "L504"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "weeklymanagerreportemail_expenserankedsections",
-      "label": "expenseRankedSections()",
-      "norm_label": "expenserankedsections()",
-      "source_file": "packages/athena-webapp/convex/operations/weeklyManagerReportEmail.ts",
-      "source_location": "L531"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "weeklymanagerreportemail_formatdaterange",
-      "label": "formatDateRange()",
-      "norm_label": "formatdaterange()",
-      "source_file": "packages/athena-webapp/convex/operations/weeklyManagerReportEmail.ts",
-      "source_location": "L593"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "weeklymanagerreportemail_formatshortdate",
-      "label": "formatShortDate()",
-      "norm_label": "formatshortdate()",
-      "source_file": "packages/athena-webapp/convex/operations/weeklyManagerReportEmail.ts",
-      "source_location": "L613"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "weeklymanagerreportemail_formattime",
-      "label": "formatTime()",
-      "norm_label": "formattime()",
-      "source_file": "packages/athena-webapp/convex/operations/weeklyManagerReportEmail.ts",
-      "source_location": "L621"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "weeklymanagerreportemail_formatunits",
-      "label": "formatUnits()",
-      "norm_label": "formatunits()",
-      "source_file": "packages/athena-webapp/convex/operations/weeklyManagerReportEmail.ts",
-      "source_location": "L527"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "weeklymanagerreportemail_moneyfor",
-      "label": "moneyFor()",
-      "norm_label": "moneyfor()",
-      "source_file": "packages/athena-webapp/convex/operations/weeklyManagerReportEmail.ts",
-      "source_location": "L453"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "weeklymanagerreportemail_percentagecomparison",
-      "label": "percentageComparison()",
-      "norm_label": "percentagecomparison()",
-      "source_file": "packages/athena-webapp/convex/operations/weeklyManagerReportEmail.ts",
-      "source_location": "L467"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "weeklymanagerreportemail_scheduledcoveragelabel",
-      "label": "scheduledCoverageLabel()",
-      "norm_label": "scheduledcoveragelabel()",
-      "source_file": "packages/athena-webapp/convex/operations/weeklyManagerReportEmail.ts",
-      "source_location": "L516"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "weeklymanagerreportemail_titlecase",
-      "label": "titleCase()",
-      "norm_label": "titlecase()",
-      "source_file": "packages/athena-webapp/convex/operations/weeklyManagerReportEmail.ts",
-      "source_location": "L585"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "weeklymanagerreportemail_variancemessage",
-      "label": "varianceMessage()",
-      "norm_label": "variancemessage()",
-      "source_file": "packages/athena-webapp/convex/operations/weeklyManagerReportEmail.ts",
-      "source_location": "L477"
     },
     {
       "community": 1120,
@@ -189522,164 +189579,164 @@
     {
       "community": 113,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_pendingcheckoutreviewworklifecycle_ts",
-      "label": "pendingCheckoutReviewWorkLifecycle.ts",
-      "norm_label": "pendingcheckoutreviewworklifecycle.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts",
+      "id": "packages_athena_webapp_convex_operations_weeklymanagerreportemail_ts",
+      "label": "weeklyManagerReportEmail.ts",
+      "norm_label": "weeklymanagerreportemail.ts",
+      "source_file": "packages/athena-webapp/convex/operations/weeklyManagerReportEmail.ts",
       "source_location": "L1"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "pendingcheckoutreviewworklifecycle_assertcompletescan",
-      "label": "assertCompleteScan()",
-      "norm_label": "assertcompletescan()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts",
-      "source_location": "L43"
+      "id": "weeklymanagerreportemail_amountcomparison",
+      "label": "amountComparison()",
+      "norm_label": "amountcomparison()",
+      "source_file": "packages/athena-webapp/convex/operations/weeklyManagerReportEmail.ts",
+      "source_location": "L458"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "pendingcheckoutreviewworklifecycle_buildpendingcheckoutreviewworkitemmetadata",
-      "label": "buildPendingCheckoutReviewWorkItemMetadata()",
-      "norm_label": "buildpendingcheckoutreviewworkitemmetadata()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts",
-      "source_location": "L65"
+      "id": "weeklymanagerreportemail_buildacceptedweeklymanagerreportpayload",
+      "label": "buildAcceptedWeeklyManagerReportPayload()",
+      "norm_label": "buildacceptedweeklymanagerreportpayload()",
+      "source_file": "packages/athena-webapp/convex/operations/weeklyManagerReportEmail.ts",
+      "source_location": "L164"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "pendingcheckoutreviewworklifecycle_buildpendingcheckoutreviewworkitempriority",
-      "label": "buildPendingCheckoutReviewWorkItemPriority()",
-      "norm_label": "buildpendingcheckoutreviewworkitempriority()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts",
-      "source_location": "L51"
+      "id": "weeklymanagerreportemail_buildacceptedweeklytopitems",
+      "label": "buildAcceptedWeeklyTopItems()",
+      "norm_label": "buildacceptedweeklytopitems()",
+      "source_file": "packages/athena-webapp/convex/operations/weeklyManagerReportEmail.ts",
+      "source_location": "L109"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "pendingcheckoutreviewworklifecycle_buildpendingcheckoutreviewworkitemtitle",
-      "label": "buildPendingCheckoutReviewWorkItemTitle()",
-      "norm_label": "buildpendingcheckoutreviewworkitemtitle()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts",
-      "source_location": "L59"
+      "id": "weeklymanagerreportemail_buildweeklyreporturl",
+      "label": "buildWeeklyReportUrl()",
+      "norm_label": "buildweeklyreporturl()",
+      "source_file": "packages/athena-webapp/convex/operations/weeklyManagerReportEmail.ts",
+      "source_location": "L443"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "pendingcheckoutreviewworklifecycle_cancelpendingcheckoutreviewworkitem",
-      "label": "cancelPendingCheckoutReviewWorkItem()",
-      "norm_label": "cancelpendingcheckoutreviewworkitem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts",
-      "source_location": "L241"
+      "id": "weeklymanagerreportemail_buildweeklytopmoversurl",
+      "label": "buildWeeklyTopMoversUrl()",
+      "norm_label": "buildweeklytopmoversurl()",
+      "source_file": "packages/athena-webapp/convex/operations/weeklyManagerReportEmail.ts",
+      "source_location": "L153"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "pendingcheckoutreviewworklifecycle_ensurependingcheckoutreviewworkforunarchivedproduct",
-      "label": "ensurePendingCheckoutReviewWorkForUnarchivedProduct()",
-      "norm_label": "ensurependingcheckoutreviewworkforunarchivedproduct()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts",
-      "source_location": "L351"
+      "id": "weeklymanagerreportemail_countedcashvariancemessage",
+      "label": "countedCashVarianceMessage()",
+      "norm_label": "countedcashvariancemessage()",
+      "source_file": "packages/athena-webapp/convex/operations/weeklyManagerReportEmail.ts",
+      "source_location": "L489"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "pendingcheckoutreviewworklifecycle_getopenreviewworkitemfrompointer",
-      "label": "getOpenReviewWorkItemFromPointer()",
-      "norm_label": "getopenreviewworkitemfrompointer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts",
-      "source_location": "L185"
+      "id": "weeklymanagerreportemail_coveragelabel",
+      "label": "coverageLabel()",
+      "norm_label": "coveragelabel()",
+      "source_file": "packages/athena-webapp/convex/operations/weeklyManagerReportEmail.ts",
+      "source_location": "L504"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "pendingcheckoutreviewworklifecycle_getopenreviewworkitemsforstore",
-      "label": "getOpenReviewWorkItemsForStore()",
-      "norm_label": "getopenreviewworkitemsforstore()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts",
-      "source_location": "L144"
+      "id": "weeklymanagerreportemail_expenserankedsections",
+      "label": "expenseRankedSections()",
+      "norm_label": "expenserankedsections()",
+      "source_file": "packages/athena-webapp/convex/operations/weeklyManagerReportEmail.ts",
+      "source_location": "L531"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "pendingcheckoutreviewworklifecycle_getpendingcheckoutitemsforproduct",
-      "label": "getPendingCheckoutItemsForProduct()",
-      "norm_label": "getpendingcheckoutitemsforproduct()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts",
-      "source_location": "L95"
+      "id": "weeklymanagerreportemail_formatdaterange",
+      "label": "formatDateRange()",
+      "norm_label": "formatdaterange()",
+      "source_file": "packages/athena-webapp/convex/operations/weeklyManagerReportEmail.ts",
+      "source_location": "L593"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "pendingcheckoutreviewworklifecycle_getproductskusforproduct",
-      "label": "getProductSkusForProduct()",
-      "norm_label": "getproductskusforproduct()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts",
-      "source_location": "L82"
+      "id": "weeklymanagerreportemail_formatshortdate",
+      "label": "formatShortDate()",
+      "norm_label": "formatshortdate()",
+      "source_file": "packages/athena-webapp/convex/operations/weeklyManagerReportEmail.ts",
+      "source_location": "L613"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "pendingcheckoutreviewworklifecycle_groupopenreviewworkbypendingcheckoutitem",
-      "label": "groupOpenReviewWorkByPendingCheckoutItem()",
-      "norm_label": "groupopenreviewworkbypendingcheckoutitem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts",
-      "source_location": "L165"
+      "id": "weeklymanagerreportemail_formattime",
+      "label": "formatTime()",
+      "norm_label": "formattime()",
+      "source_file": "packages/athena-webapp/convex/operations/weeklyManagerReportEmail.ts",
+      "source_location": "L621"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "pendingcheckoutreviewworklifecycle_isactionablependingcheckoutitem",
-      "label": "isActionablePendingCheckoutItem()",
-      "norm_label": "isactionablependingcheckoutitem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts",
-      "source_location": "L434"
+      "id": "weeklymanagerreportemail_formatunits",
+      "label": "formatUnits()",
+      "norm_label": "formatunits()",
+      "source_file": "packages/athena-webapp/convex/operations/weeklyManagerReportEmail.ts",
+      "source_location": "L527"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "pendingcheckoutreviewworklifecycle_matchespendingcheckoutsource",
-      "label": "matchesPendingCheckoutSource()",
-      "norm_label": "matchespendingcheckoutsource()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts",
-      "source_location": "L32"
+      "id": "weeklymanagerreportemail_moneyfor",
+      "label": "moneyFor()",
+      "norm_label": "moneyfor()",
+      "source_file": "packages/athena-webapp/convex/operations/weeklyManagerReportEmail.ts",
+      "source_location": "L453"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "pendingcheckoutreviewworklifecycle_metadatastring",
-      "label": "metadataString()",
-      "norm_label": "metadatastring()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts",
-      "source_location": "L24"
+      "id": "weeklymanagerreportemail_percentagecomparison",
+      "label": "percentageComparison()",
+      "norm_label": "percentagecomparison()",
+      "source_file": "packages/athena-webapp/convex/operations/weeklyManagerReportEmail.ts",
+      "source_location": "L467"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "pendingcheckoutreviewworklifecycle_now",
-      "label": "now()",
-      "norm_label": "now()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts",
-      "source_location": "L20"
+      "id": "weeklymanagerreportemail_scheduledcoveragelabel",
+      "label": "scheduledCoverageLabel()",
+      "norm_label": "scheduledcoveragelabel()",
+      "source_file": "packages/athena-webapp/convex/operations/weeklyManagerReportEmail.ts",
+      "source_location": "L516"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "pendingcheckoutreviewworklifecycle_recordlifecycleevent",
-      "label": "recordLifecycleEvent()",
-      "norm_label": "recordlifecycleevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts",
-      "source_location": "L207"
+      "id": "weeklymanagerreportemail_titlecase",
+      "label": "titleCase()",
+      "norm_label": "titlecase()",
+      "source_file": "packages/athena-webapp/convex/operations/weeklyManagerReportEmail.ts",
+      "source_location": "L585"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "pendingcheckoutreviewworklifecycle_retirependingcheckoutreviewworkforarchivedproduct",
-      "label": "retirePendingCheckoutReviewWorkForArchivedProduct()",
-      "norm_label": "retirependingcheckoutreviewworkforarchivedproduct()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts",
-      "source_location": "L282"
+      "id": "weeklymanagerreportemail_variancemessage",
+      "label": "varianceMessage()",
+      "norm_label": "variancemessage()",
+      "source_file": "packages/athena-webapp/convex/operations/weeklyManagerReportEmail.ts",
+      "source_location": "L477"
     },
     {
       "community": 1130,
@@ -189864,164 +189921,164 @@
     {
       "community": 114,
       "file_type": "code",
-      "id": "customerrepository_createposcustomer",
-      "label": "createPosCustomer()",
-      "norm_label": "createposcustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L57"
+      "id": "packages_athena_webapp_convex_pos_application_commands_pendingcheckoutreviewworklifecycle_ts",
+      "label": "pendingCheckoutReviewWorkLifecycle.ts",
+      "norm_label": "pendingcheckoutreviewworklifecycle.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts",
+      "source_location": "L1"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "customerrepository_ensurecustomerprofilefromsources",
-      "label": "ensureCustomerProfileFromSources()",
-      "norm_label": "ensurecustomerprofilefromsources()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L240"
+      "id": "pendingcheckoutreviewworklifecycle_assertcompletescan",
+      "label": "assertCompleteScan()",
+      "norm_label": "assertcompletescan()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts",
+      "source_location": "L43"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "customerrepository_findcustomerbyemail",
-      "label": "findCustomerByEmail()",
-      "norm_label": "findcustomerbyemail()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L27"
+      "id": "pendingcheckoutreviewworklifecycle_buildpendingcheckoutreviewworkitemmetadata",
+      "label": "buildPendingCheckoutReviewWorkItemMetadata()",
+      "norm_label": "buildpendingcheckoutreviewworkitemmetadata()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts",
+      "source_location": "L65"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "customerrepository_findcustomerbyphone",
-      "label": "findCustomerByPhone()",
-      "norm_label": "findcustomerbyphone()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L42"
+      "id": "pendingcheckoutreviewworklifecycle_buildpendingcheckoutreviewworkitempriority",
+      "label": "buildPendingCheckoutReviewWorkItemPriority()",
+      "norm_label": "buildpendingcheckoutreviewworkitempriority()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts",
+      "source_location": "L51"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "customerrepository_findguestbyemail",
-      "label": "findGuestByEmail()",
-      "norm_label": "findguestbyemail()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L186"
+      "id": "pendingcheckoutreviewworklifecycle_buildpendingcheckoutreviewworkitemtitle",
+      "label": "buildPendingCheckoutReviewWorkItemTitle()",
+      "norm_label": "buildpendingcheckoutreviewworkitemtitle()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts",
+      "source_location": "L59"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "customerrepository_findguestbyphone",
-      "label": "findGuestByPhone()",
-      "norm_label": "findguestbyphone()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L222"
+      "id": "pendingcheckoutreviewworklifecycle_cancelpendingcheckoutreviewworkitem",
+      "label": "cancelPendingCheckoutReviewWorkItem()",
+      "norm_label": "cancelpendingcheckoutreviewworkitem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts",
+      "source_location": "L241"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "customerrepository_findposcustomerbyguest",
-      "label": "findPosCustomerByGuest()",
-      "norm_label": "findposcustomerbyguest()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L154"
+      "id": "pendingcheckoutreviewworklifecycle_ensurependingcheckoutreviewworkforunarchivedproduct",
+      "label": "ensurePendingCheckoutReviewWorkForUnarchivedProduct()",
+      "norm_label": "ensurependingcheckoutreviewworkforunarchivedproduct()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts",
+      "source_location": "L351"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "customerrepository_findposcustomerbystorefrontuser",
-      "label": "findPosCustomerByStoreFrontUser()",
-      "norm_label": "findposcustomerbystorefrontuser()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L142"
+      "id": "pendingcheckoutreviewworklifecycle_getopenreviewworkitemfrompointer",
+      "label": "getOpenReviewWorkItemFromPointer()",
+      "norm_label": "getopenreviewworkitemfrompointer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts",
+      "source_location": "L185"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "customerrepository_findstorefrontuserbyemail",
-      "label": "findStoreFrontUserByEmail()",
-      "norm_label": "findstorefrontuserbyemail()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L168"
+      "id": "pendingcheckoutreviewworklifecycle_getopenreviewworkitemsforstore",
+      "label": "getOpenReviewWorkItemsForStore()",
+      "norm_label": "getopenreviewworkitemsforstore()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts",
+      "source_location": "L144"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "customerrepository_findstorefrontuserbyphone",
-      "label": "findStoreFrontUserByPhone()",
-      "norm_label": "findstorefrontuserbyphone()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L204"
+      "id": "pendingcheckoutreviewworklifecycle_getpendingcheckoutitemsforproduct",
+      "label": "getPendingCheckoutItemsForProduct()",
+      "norm_label": "getpendingcheckoutitemsforproduct()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts",
+      "source_location": "L95"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "customerrepository_getguestbyid",
-      "label": "getGuestById()",
-      "norm_label": "getguestbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L135"
+      "id": "pendingcheckoutreviewworklifecycle_getproductskusforproduct",
+      "label": "getProductSkusForProduct()",
+      "norm_label": "getproductskusforproduct()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts",
+      "source_location": "L82"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "customerrepository_getposcustomerbyid",
-      "label": "getPosCustomerById()",
-      "norm_label": "getposcustomerbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "id": "pendingcheckoutreviewworklifecycle_groupopenreviewworkbypendingcheckoutitem",
+      "label": "groupOpenReviewWorkByPendingCheckoutItem()",
+      "norm_label": "groupopenreviewworkbypendingcheckoutitem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts",
+      "source_location": "L165"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "pendingcheckoutreviewworklifecycle_isactionablependingcheckoutitem",
+      "label": "isActionablePendingCheckoutItem()",
+      "norm_label": "isactionablependingcheckoutitem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts",
+      "source_location": "L434"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "pendingcheckoutreviewworklifecycle_matchespendingcheckoutsource",
+      "label": "matchesPendingCheckoutSource()",
+      "norm_label": "matchespendingcheckoutsource()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "pendingcheckoutreviewworklifecycle_metadatastring",
+      "label": "metadataString()",
+      "norm_label": "metadatastring()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "pendingcheckoutreviewworklifecycle_now",
+      "label": "now()",
+      "norm_label": "now()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts",
       "source_location": "L20"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "customerrepository_getstorefrontuserbyid",
-      "label": "getStoreFrontUserById()",
-      "norm_label": "getstorefrontuserbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L128"
+      "id": "pendingcheckoutreviewworklifecycle_recordlifecycleevent",
+      "label": "recordLifecycleEvent()",
+      "norm_label": "recordlifecycleevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts",
+      "source_location": "L207"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "customerrepository_listactivecustomersforstore",
-      "label": "listActiveCustomersForStore()",
-      "norm_label": "listactivecustomersforstore()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "customerrepository_listcompletedtransactionsforcustomer",
-      "label": "listCompletedTransactionsForCustomer()",
-      "norm_label": "listcompletedtransactionsforcustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L94"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "customerrepository_patchposcustomer",
-      "label": "patchPosCustomer()",
-      "norm_label": "patchposcustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L64"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "customerrepository_updatecustomerstats",
-      "label": "updateCustomerStats()",
-      "norm_label": "updatecustomerstats()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L72"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_customerrepository_ts",
-      "label": "customerRepository.ts",
-      "norm_label": "customerrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
-      "source_location": "L1"
+      "id": "pendingcheckoutreviewworklifecycle_retirependingcheckoutreviewworkforarchivedproduct",
+      "label": "retirePendingCheckoutReviewWorkForArchivedProduct()",
+      "norm_label": "retirependingcheckoutreviewworkforarchivedproduct()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts",
+      "source_location": "L282"
     },
     {
       "community": 1140,
@@ -190206,164 +190263,164 @@
     {
       "community": 115,
       "file_type": "code",
-      "id": "packages_athena_webapp_public_pos_app_shell_sw_js",
-      "label": "pos-app-shell-sw.js",
-      "norm_label": "pos-app-shell-sw.js",
-      "source_file": "packages/athena-webapp/public/pos-app-shell-sw.js",
+      "id": "customerrepository_createposcustomer",
+      "label": "createPosCustomer()",
+      "norm_label": "createposcustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "customerrepository_ensurecustomerprofilefromsources",
+      "label": "ensureCustomerProfileFromSources()",
+      "norm_label": "ensurecustomerprofilefromsources()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L240"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "customerrepository_findcustomerbyemail",
+      "label": "findCustomerByEmail()",
+      "norm_label": "findcustomerbyemail()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "customerrepository_findcustomerbyphone",
+      "label": "findCustomerByPhone()",
+      "norm_label": "findcustomerbyphone()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "customerrepository_findguestbyemail",
+      "label": "findGuestByEmail()",
+      "norm_label": "findguestbyemail()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L186"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "customerrepository_findguestbyphone",
+      "label": "findGuestByPhone()",
+      "norm_label": "findguestbyphone()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L222"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "customerrepository_findposcustomerbyguest",
+      "label": "findPosCustomerByGuest()",
+      "norm_label": "findposcustomerbyguest()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L154"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "customerrepository_findposcustomerbystorefrontuser",
+      "label": "findPosCustomerByStoreFrontUser()",
+      "norm_label": "findposcustomerbystorefrontuser()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L142"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "customerrepository_findstorefrontuserbyemail",
+      "label": "findStoreFrontUserByEmail()",
+      "norm_label": "findstorefrontuserbyemail()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L168"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "customerrepository_findstorefrontuserbyphone",
+      "label": "findStoreFrontUserByPhone()",
+      "norm_label": "findstorefrontuserbyphone()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L204"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "customerrepository_getguestbyid",
+      "label": "getGuestById()",
+      "norm_label": "getguestbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "customerrepository_getposcustomerbyid",
+      "label": "getPosCustomerById()",
+      "norm_label": "getposcustomerbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "customerrepository_getstorefrontuserbyid",
+      "label": "getStoreFrontUserById()",
+      "norm_label": "getstorefrontuserbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "customerrepository_listactivecustomersforstore",
+      "label": "listActiveCustomersForStore()",
+      "norm_label": "listactivecustomersforstore()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "customerrepository_listcompletedtransactionsforcustomer",
+      "label": "listCompletedTransactionsForCustomer()",
+      "norm_label": "listcompletedtransactionsforcustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L94"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "customerrepository_patchposcustomer",
+      "label": "patchPosCustomer()",
+      "norm_label": "patchposcustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L64"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "customerrepository_updatecustomerstats",
+      "label": "updateCustomerStats()",
+      "norm_label": "updatecustomerstats()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
+      "source_location": "L72"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_customerrepository_ts",
+      "label": "customerRepository.ts",
+      "norm_label": "customerrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/customerRepository.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "pos_app_shell_sw_cacheassetrequest",
-      "label": "cacheAssetRequest()",
-      "norm_label": "cacheassetrequest()",
-      "source_file": "packages/athena-webapp/public/pos-app-shell-sw.js",
-      "source_location": "L273"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "pos_app_shell_sw_cachefirstasset",
-      "label": "cacheFirstAsset()",
-      "norm_label": "cachefirstasset()",
-      "source_file": "packages/athena-webapp/public/pos-app-shell-sw.js",
-      "source_location": "L265"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "pos_app_shell_sw_cachelinkedshellassets",
-      "label": "cacheLinkedShellAssets()",
-      "norm_label": "cachelinkedshellassets()",
-      "source_file": "packages/athena-webapp/public/pos-app-shell-sw.js",
-      "source_location": "L294"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "pos_app_shell_sw_cachemoduledependencies",
-      "label": "cacheModuleDependencies()",
-      "norm_label": "cachemoduledependencies()",
-      "source_file": "packages/athena-webapp/public/pos-app-shell-sw.js",
-      "source_location": "L323"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "pos_app_shell_sw_isexcluded",
-      "label": "isExcluded()",
-      "norm_label": "isexcluded()",
-      "source_file": "packages/athena-webapp/public/pos-app-shell-sw.js",
-      "source_location": "L155"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "pos_app_shell_sw_ishtmlresponse",
-      "label": "isHtmlResponse()",
-      "norm_label": "ishtmlresponse()",
-      "source_file": "packages/athena-webapp/public/pos-app-shell-sw.js",
-      "source_location": "L290"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "pos_app_shell_sw_isjavascriptlikeresponse",
-      "label": "isJavaScriptLikeResponse()",
-      "norm_label": "isjavascriptlikeresponse()",
-      "source_file": "packages/athena-webapp/public/pos-app-shell-sw.js",
-      "source_location": "L397"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "pos_app_shell_sw_isposnavigation",
-      "label": "isPosNavigation()",
-      "norm_label": "isposnavigation()",
-      "source_file": "packages/athena-webapp/public/pos-app-shell-sw.js",
-      "source_location": "L132"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "pos_app_shell_sw_isstaticshellasset",
-      "label": "isStaticShellAsset()",
-      "norm_label": "isstaticshellasset()",
-      "source_file": "packages/athena-webapp/public/pos-app-shell-sw.js",
-      "source_location": "L141"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "pos_app_shell_sw_matchcached",
-      "label": "matchCached()",
-      "norm_label": "matchcached()",
-      "source_file": "packages/athena-webapp/public/pos-app-shell-sw.js",
-      "source_location": "L361"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "pos_app_shell_sw_networkfirstshell",
-      "label": "networkFirstShell()",
-      "norm_label": "networkfirstshell()",
-      "source_file": "packages/athena-webapp/public/pos-app-shell-sw.js",
-      "source_location": "L167"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "pos_app_shell_sw_reply",
-      "label": "reply()",
-      "norm_label": "reply()",
-      "source_file": "packages/athena-webapp/public/pos-app-shell-sw.js",
-      "source_location": "L83"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "pos_app_shell_sw_resolveshellassetreference",
-      "label": "resolveShellAssetReference()",
-      "norm_label": "resolveshellassetreference()",
-      "source_file": "packages/athena-webapp/public/pos-app-shell-sw.js",
-      "source_location": "L369"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "pos_app_shell_sw_shouldscanmoduleimports",
-      "label": "shouldScanModuleImports()",
-      "norm_label": "shouldscanmoduleimports()",
-      "source_file": "packages/athena-webapp/public/pos-app-shell-sw.js",
-      "source_location": "L385"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "pos_app_shell_sw_stagestaticshellassets",
-      "label": "stageStaticShellAssets()",
-      "norm_label": "stagestaticshellassets()",
-      "source_file": "packages/athena-webapp/public/pos-app-shell-sw.js",
-      "source_location": "L214"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "pos_app_shell_sw_unregisterlocaldevappshell",
-      "label": "unregisterLocalDevAppShell()",
-      "norm_label": "unregisterlocaldevappshell()",
-      "source_file": "packages/athena-webapp/public/pos-app-shell-sw.js",
-      "source_location": "L66"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "pos_app_shell_sw_warmposappshell",
-      "label": "warmPosAppShell()",
-      "norm_label": "warmposappshell()",
-      "source_file": "packages/athena-webapp/public/pos-app-shell-sw.js",
-      "source_location": "L189"
     },
     {
       "community": 1150,
@@ -190548,164 +190605,164 @@
     {
       "community": 116,
       "file_type": "code",
-      "id": "openworkinventoryreport_buildopenworkinventoryreportrows",
-      "label": "buildOpenWorkInventoryReportRows()",
-      "norm_label": "buildopenworkinventoryreportrows()",
-      "source_file": "packages/athena-webapp/src/components/operations/openWorkInventoryReport.ts",
-      "source_location": "L114"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "openworkinventoryreport_cleanvalue",
-      "label": "cleanValue()",
-      "norm_label": "cleanvalue()",
-      "source_file": "packages/athena-webapp/src/components/operations/openWorkInventoryReport.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "openworkinventoryreport_createbarcodedataurl",
-      "label": "createBarcodeDataUrl()",
-      "norm_label": "createbarcodedataurl()",
-      "source_file": "packages/athena-webapp/src/components/operations/openWorkInventoryReport.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "openworkinventoryreport_drawcolumnheaders",
-      "label": "drawColumnHeaders()",
-      "norm_label": "drawcolumnheaders()",
-      "source_file": "packages/athena-webapp/src/components/operations/openWorkInventoryReport.ts",
-      "source_location": "L209"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "openworkinventoryreport_drawreportfooter",
-      "label": "drawReportFooter()",
-      "norm_label": "drawreportfooter()",
-      "source_file": "packages/athena-webapp/src/components/operations/openWorkInventoryReport.ts",
-      "source_location": "L217"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "openworkinventoryreport_drawreportheader",
-      "label": "drawReportHeader()",
-      "norm_label": "drawreportheader()",
-      "source_file": "packages/athena-webapp/src/components/operations/openWorkInventoryReport.ts",
-      "source_location": "L169"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "openworkinventoryreport_drawreportrow",
-      "label": "drawReportRow()",
-      "norm_label": "drawreportrow()",
-      "source_file": "packages/athena-webapp/src/components/operations/openWorkInventoryReport.ts",
-      "source_location": "L230"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "openworkinventoryreport_exportopenworkinventorypdf",
-      "label": "exportOpenWorkInventoryPdf()",
-      "norm_label": "exportopenworkinventorypdf()",
-      "source_file": "packages/athena-webapp/src/components/operations/openWorkInventoryReport.ts",
-      "source_location": "L289"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "openworkinventoryreport_formatopenworkinventoryreporteyebrow",
-      "label": "formatOpenWorkInventoryReportEyebrow()",
-      "norm_label": "formatopenworkinventoryreporteyebrow()",
-      "source_file": "packages/athena-webapp/src/components/operations/openWorkInventoryReport.ts",
-      "source_location": "L39"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "openworkinventoryreport_formatopenworkinventoryreportitemcount",
-      "label": "formatOpenWorkInventoryReportItemCount()",
-      "norm_label": "formatopenworkinventoryreportitemcount()",
-      "source_file": "packages/athena-webapp/src/components/operations/openWorkInventoryReport.ts",
-      "source_location": "L43"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "openworkinventoryreport_formatopenworkinventoryreportprice",
-      "label": "formatOpenWorkInventoryReportPrice()",
-      "norm_label": "formatopenworkinventoryreportprice()",
-      "source_file": "packages/athena-webapp/src/components/operations/openWorkInventoryReport.ts",
-      "source_location": "L47"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "openworkinventoryreport_formatopenworkinventoryreportproductname",
-      "label": "formatOpenWorkInventoryReportProductName()",
-      "norm_label": "formatopenworkinventoryreportproductname()",
-      "source_file": "packages/athena-webapp/src/components/operations/openWorkInventoryReport.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "openworkinventoryreport_formatvariant",
-      "label": "formatVariant()",
-      "norm_label": "formatvariant()",
-      "source_file": "packages/athena-webapp/src/components/operations/openWorkInventoryReport.ts",
-      "source_location": "L104"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "openworkinventoryreport_loadfontasbase64",
-      "label": "loadFontAsBase64()",
-      "norm_label": "loadfontasbase64()",
-      "source_file": "packages/athena-webapp/src/components/operations/openWorkInventoryReport.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "openworkinventoryreport_registeropenworkinventoryreportfonts",
-      "label": "registerOpenWorkInventoryReportFonts()",
-      "norm_label": "registeropenworkinventoryreportfonts()",
-      "source_file": "packages/athena-webapp/src/components/operations/openWorkInventoryReport.ts",
-      "source_location": "L80"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "openworkinventoryreport_tofilenamedate",
-      "label": "toFilenameDate()",
-      "norm_label": "tofilenamedate()",
-      "source_file": "packages/athena-webapp/src/components/operations/openWorkInventoryReport.ts",
-      "source_location": "L146"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "openworkinventoryreport_toreportdate",
-      "label": "toReportDate()",
-      "norm_label": "toreportdate()",
-      "source_file": "packages/athena-webapp/src/components/operations/openWorkInventoryReport.ts",
-      "source_location": "L139"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_openworkinventoryreport_ts",
-      "label": "openWorkInventoryReport.ts",
-      "norm_label": "openworkinventoryreport.ts",
-      "source_file": "packages/athena-webapp/src/components/operations/openWorkInventoryReport.ts",
+      "id": "packages_athena_webapp_public_pos_app_shell_sw_js",
+      "label": "pos-app-shell-sw.js",
+      "norm_label": "pos-app-shell-sw.js",
+      "source_file": "packages/athena-webapp/public/pos-app-shell-sw.js",
       "source_location": "L1"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "pos_app_shell_sw_cacheassetrequest",
+      "label": "cacheAssetRequest()",
+      "norm_label": "cacheassetrequest()",
+      "source_file": "packages/athena-webapp/public/pos-app-shell-sw.js",
+      "source_location": "L273"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "pos_app_shell_sw_cachefirstasset",
+      "label": "cacheFirstAsset()",
+      "norm_label": "cachefirstasset()",
+      "source_file": "packages/athena-webapp/public/pos-app-shell-sw.js",
+      "source_location": "L265"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "pos_app_shell_sw_cachelinkedshellassets",
+      "label": "cacheLinkedShellAssets()",
+      "norm_label": "cachelinkedshellassets()",
+      "source_file": "packages/athena-webapp/public/pos-app-shell-sw.js",
+      "source_location": "L294"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "pos_app_shell_sw_cachemoduledependencies",
+      "label": "cacheModuleDependencies()",
+      "norm_label": "cachemoduledependencies()",
+      "source_file": "packages/athena-webapp/public/pos-app-shell-sw.js",
+      "source_location": "L323"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "pos_app_shell_sw_isexcluded",
+      "label": "isExcluded()",
+      "norm_label": "isexcluded()",
+      "source_file": "packages/athena-webapp/public/pos-app-shell-sw.js",
+      "source_location": "L155"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "pos_app_shell_sw_ishtmlresponse",
+      "label": "isHtmlResponse()",
+      "norm_label": "ishtmlresponse()",
+      "source_file": "packages/athena-webapp/public/pos-app-shell-sw.js",
+      "source_location": "L290"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "pos_app_shell_sw_isjavascriptlikeresponse",
+      "label": "isJavaScriptLikeResponse()",
+      "norm_label": "isjavascriptlikeresponse()",
+      "source_file": "packages/athena-webapp/public/pos-app-shell-sw.js",
+      "source_location": "L397"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "pos_app_shell_sw_isposnavigation",
+      "label": "isPosNavigation()",
+      "norm_label": "isposnavigation()",
+      "source_file": "packages/athena-webapp/public/pos-app-shell-sw.js",
+      "source_location": "L132"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "pos_app_shell_sw_isstaticshellasset",
+      "label": "isStaticShellAsset()",
+      "norm_label": "isstaticshellasset()",
+      "source_file": "packages/athena-webapp/public/pos-app-shell-sw.js",
+      "source_location": "L141"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "pos_app_shell_sw_matchcached",
+      "label": "matchCached()",
+      "norm_label": "matchcached()",
+      "source_file": "packages/athena-webapp/public/pos-app-shell-sw.js",
+      "source_location": "L361"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "pos_app_shell_sw_networkfirstshell",
+      "label": "networkFirstShell()",
+      "norm_label": "networkfirstshell()",
+      "source_file": "packages/athena-webapp/public/pos-app-shell-sw.js",
+      "source_location": "L167"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "pos_app_shell_sw_reply",
+      "label": "reply()",
+      "norm_label": "reply()",
+      "source_file": "packages/athena-webapp/public/pos-app-shell-sw.js",
+      "source_location": "L83"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "pos_app_shell_sw_resolveshellassetreference",
+      "label": "resolveShellAssetReference()",
+      "norm_label": "resolveshellassetreference()",
+      "source_file": "packages/athena-webapp/public/pos-app-shell-sw.js",
+      "source_location": "L369"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "pos_app_shell_sw_shouldscanmoduleimports",
+      "label": "shouldScanModuleImports()",
+      "norm_label": "shouldscanmoduleimports()",
+      "source_file": "packages/athena-webapp/public/pos-app-shell-sw.js",
+      "source_location": "L385"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "pos_app_shell_sw_stagestaticshellassets",
+      "label": "stageStaticShellAssets()",
+      "norm_label": "stagestaticshellassets()",
+      "source_file": "packages/athena-webapp/public/pos-app-shell-sw.js",
+      "source_location": "L214"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "pos_app_shell_sw_unregisterlocaldevappshell",
+      "label": "unregisterLocalDevAppShell()",
+      "norm_label": "unregisterlocaldevappshell()",
+      "source_file": "packages/athena-webapp/public/pos-app-shell-sw.js",
+      "source_location": "L66"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "pos_app_shell_sw_warmposappshell",
+      "label": "warmPosAppShell()",
+      "norm_label": "warmposappshell()",
+      "source_file": "packages/athena-webapp/public/pos-app-shell-sw.js",
+      "source_location": "L189"
     },
     {
       "community": 1160,
@@ -190890,164 +190947,164 @@
     {
       "community": 117,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontcontextevents_ts",
-      "label": "storefrontContextEvents.ts",
-      "norm_label": "storefrontcontextevents.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
+      "id": "openworkinventoryreport_buildopenworkinventoryreportrows",
+      "label": "buildOpenWorkInventoryReportRows()",
+      "norm_label": "buildopenworkinventoryreportrows()",
+      "source_file": "packages/athena-webapp/src/components/operations/openWorkInventoryReport.ts",
+      "source_location": "L114"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "openworkinventoryreport_cleanvalue",
+      "label": "cleanValue()",
+      "norm_label": "cleanvalue()",
+      "source_file": "packages/athena-webapp/src/components/operations/openWorkInventoryReport.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "openworkinventoryreport_createbarcodedataurl",
+      "label": "createBarcodeDataUrl()",
+      "norm_label": "createbarcodedataurl()",
+      "source_file": "packages/athena-webapp/src/components/operations/openWorkInventoryReport.ts",
+      "source_location": "L153"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "openworkinventoryreport_drawcolumnheaders",
+      "label": "drawColumnHeaders()",
+      "norm_label": "drawcolumnheaders()",
+      "source_file": "packages/athena-webapp/src/components/operations/openWorkInventoryReport.ts",
+      "source_location": "L209"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "openworkinventoryreport_drawreportfooter",
+      "label": "drawReportFooter()",
+      "norm_label": "drawreportfooter()",
+      "source_file": "packages/athena-webapp/src/components/operations/openWorkInventoryReport.ts",
+      "source_location": "L217"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "openworkinventoryreport_drawreportheader",
+      "label": "drawReportHeader()",
+      "norm_label": "drawreportheader()",
+      "source_file": "packages/athena-webapp/src/components/operations/openWorkInventoryReport.ts",
+      "source_location": "L169"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "openworkinventoryreport_drawreportrow",
+      "label": "drawReportRow()",
+      "norm_label": "drawreportrow()",
+      "source_file": "packages/athena-webapp/src/components/operations/openWorkInventoryReport.ts",
+      "source_location": "L230"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "openworkinventoryreport_exportopenworkinventorypdf",
+      "label": "exportOpenWorkInventoryPdf()",
+      "norm_label": "exportopenworkinventorypdf()",
+      "source_file": "packages/athena-webapp/src/components/operations/openWorkInventoryReport.ts",
+      "source_location": "L289"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "openworkinventoryreport_formatopenworkinventoryreporteyebrow",
+      "label": "formatOpenWorkInventoryReportEyebrow()",
+      "norm_label": "formatopenworkinventoryreporteyebrow()",
+      "source_file": "packages/athena-webapp/src/components/operations/openWorkInventoryReport.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "openworkinventoryreport_formatopenworkinventoryreportitemcount",
+      "label": "formatOpenWorkInventoryReportItemCount()",
+      "norm_label": "formatopenworkinventoryreportitemcount()",
+      "source_file": "packages/athena-webapp/src/components/operations/openWorkInventoryReport.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "openworkinventoryreport_formatopenworkinventoryreportprice",
+      "label": "formatOpenWorkInventoryReportPrice()",
+      "norm_label": "formatopenworkinventoryreportprice()",
+      "source_file": "packages/athena-webapp/src/components/operations/openWorkInventoryReport.ts",
+      "source_location": "L47"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "openworkinventoryreport_formatopenworkinventoryreportproductname",
+      "label": "formatOpenWorkInventoryReportProductName()",
+      "norm_label": "formatopenworkinventoryreportproductname()",
+      "source_file": "packages/athena-webapp/src/components/operations/openWorkInventoryReport.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "openworkinventoryreport_formatvariant",
+      "label": "formatVariant()",
+      "norm_label": "formatvariant()",
+      "source_file": "packages/athena-webapp/src/components/operations/openWorkInventoryReport.ts",
+      "source_location": "L104"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "openworkinventoryreport_loadfontasbase64",
+      "label": "loadFontAsBase64()",
+      "norm_label": "loadfontasbase64()",
+      "source_file": "packages/athena-webapp/src/components/operations/openWorkInventoryReport.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "openworkinventoryreport_registeropenworkinventoryreportfonts",
+      "label": "registerOpenWorkInventoryReportFonts()",
+      "norm_label": "registeropenworkinventoryreportfonts()",
+      "source_file": "packages/athena-webapp/src/components/operations/openWorkInventoryReport.ts",
+      "source_location": "L80"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "openworkinventoryreport_tofilenamedate",
+      "label": "toFilenameDate()",
+      "norm_label": "tofilenamedate()",
+      "source_file": "packages/athena-webapp/src/components/operations/openWorkInventoryReport.ts",
+      "source_location": "L146"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "openworkinventoryreport_toreportdate",
+      "label": "toReportDate()",
+      "norm_label": "toreportdate()",
+      "source_file": "packages/athena-webapp/src/components/operations/openWorkInventoryReport.ts",
+      "source_location": "L139"
+    },
+    {
+      "community": 117,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_operations_openworkinventoryreport_ts",
+      "label": "openWorkInventoryReport.ts",
+      "norm_label": "openworkinventoryreport.ts",
+      "source_file": "packages/athena-webapp/src/components/operations/openWorkInventoryReport.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "storefrontcontextevents_buildstorefrontcontextevent",
-      "label": "buildStorefrontContextEvent()",
-      "norm_label": "buildstorefrontcontextevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "storefrontcontextevents_buildstorefrontidempotencykey",
-      "label": "buildStorefrontIdempotencyKey()",
-      "norm_label": "buildstorefrontidempotencykey()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
-      "source_location": "L454"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "storefrontcontextevents_compactscalarpayload",
-      "label": "compactScalarPayload()",
-      "norm_label": "compactscalarpayload()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
-      "source_location": "L425"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "storefrontcontextevents_createstorefrontcontexttrackingenvelope",
-      "label": "createStorefrontContextTrackingEnvelope()",
-      "norm_label": "createstorefrontcontexttrackingenvelope()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
-      "source_location": "L131"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "storefrontcontextevents_createstorefrontrouteviewedcontextevent",
-      "label": "createStorefrontRouteViewedContextEvent()",
-      "norm_label": "createstorefrontrouteviewedcontextevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
-      "source_location": "L113"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "storefrontcontextevents_getcartchange",
-      "label": "getCartChange()",
-      "norm_label": "getcartchange()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
-      "source_location": "L332"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "storefrontcontextevents_getcartcontexteventinput",
-      "label": "getCartContextEventInput()",
-      "norm_label": "getcartcontexteventinput()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
-      "source_location": "L255"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "storefrontcontextevents_getcheckoutblocker",
-      "label": "getCheckoutBlocker()",
-      "norm_label": "getcheckoutblocker()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
-      "source_location": "L380"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "storefrontcontextevents_getcheckoutcontexteventinput",
-      "label": "getCheckoutContextEventInput()",
-      "norm_label": "getcheckoutcontexteventinput()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
-      "source_location": "L288"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "storefrontcontextevents_getcheckoutstate",
-      "label": "getCheckoutState()",
-      "norm_label": "getcheckoutstate()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
-      "source_location": "L345"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "storefrontcontextevents_getnumber",
-      "label": "getNumber()",
-      "norm_label": "getnumber()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
-      "source_location": "L450"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "storefrontcontextevents_getstorefrontcontexteventinput",
-      "label": "getStorefrontContextEventInput()",
-      "norm_label": "getstorefrontcontexteventinput()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
-      "source_location": "L167"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "storefrontcontextevents_getstring",
-      "label": "getString()",
-      "norm_label": "getstring()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
-      "source_location": "L446"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "storefrontcontextevents_issafescalarcontextvalue",
-      "label": "isSafeScalarContextValue()",
-      "norm_label": "issafescalarcontextvalue()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
-      "source_location": "L436"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "storefrontcontextevents_normalizekeypart",
-      "label": "normalizeKeyPart()",
-      "norm_label": "normalizekeypart()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
-      "source_location": "L468"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "storefrontcontextevents_trackstorefrontcontextevent",
-      "label": "trackStorefrontContextEvent()",
-      "norm_label": "trackstorefrontcontextevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
-      "source_location": "L221"
-    },
-    {
-      "community": 117,
-      "file_type": "code",
-      "id": "storefrontcontextevents_validatestorefrontcontextpayload",
-      "label": "validateStorefrontContextPayload()",
-      "norm_label": "validatestorefrontcontextpayload()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
-      "source_location": "L397"
     },
     {
       "community": 1170,
@@ -191232,164 +191289,164 @@
     {
       "community": 118,
       "file_type": "code",
-      "id": "delivery_run_telemetry_assertdeliveryruntelemetrycheck",
-      "label": "assertDeliveryRunTelemetryCheck()",
-      "norm_label": "assertdeliveryruntelemetrycheck()",
-      "source_file": "scripts/delivery-run-telemetry.ts",
-      "source_location": "L570"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "delivery_run_telemetry_builddeliveryruntelemetryrecord",
-      "label": "buildDeliveryRunTelemetryRecord()",
-      "norm_label": "builddeliveryruntelemetryrecord()",
-      "source_file": "scripts/delivery-run-telemetry.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "delivery_run_telemetry_collectchangedpathsfordiff",
-      "label": "collectChangedPathsForDiff()",
-      "norm_label": "collectchangedpathsfordiff()",
-      "source_file": "scripts/delivery-run-telemetry.ts",
-      "source_location": "L485"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "delivery_run_telemetry_collectdeliveryruntelemetryfindings",
-      "label": "collectDeliveryRunTelemetryFindings()",
-      "norm_label": "collectdeliveryruntelemetryfindings()",
-      "source_file": "scripts/delivery-run-telemetry.ts",
-      "source_location": "L384"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "delivery_run_telemetry_deliveryruntelemetrypath",
-      "label": "deliveryRunTelemetryPath()",
-      "norm_label": "deliveryruntelemetrypath()",
-      "source_file": "scripts/delivery-run-telemetry.ts",
-      "source_location": "L99"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "delivery_run_telemetry_evaluatedeliveryruntelemetrycheck",
-      "label": "evaluateDeliveryRunTelemetryCheck()",
-      "norm_label": "evaluatedeliveryruntelemetrycheck()",
-      "source_file": "scripts/delivery-run-telemetry.ts",
-      "source_location": "L516"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "delivery_run_telemetry_gitlines",
-      "label": "gitLines()",
-      "norm_label": "gitlines()",
-      "source_file": "scripts/delivery-run-telemetry.ts",
-      "source_location": "L452"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "delivery_run_telemetry_gitstdout",
-      "label": "gitStdout()",
-      "norm_label": "gitstdout()",
-      "source_file": "scripts/delivery-run-telemetry.ts",
-      "source_location": "L242"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "delivery_run_telemetry_istelemetryrecord",
-      "label": "isTelemetryRecord()",
-      "norm_label": "istelemetryrecord()",
-      "source_file": "scripts/delivery-run-telemetry.ts",
-      "source_location": "L148"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "delivery_run_telemetry_istelemetryrecordpath",
-      "label": "isTelemetryRecordPath()",
-      "norm_label": "istelemetryrecordpath()",
-      "source_file": "scripts/delivery-run-telemetry.ts",
-      "source_location": "L377"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "delivery_run_telemetry_parseargs",
-      "label": "parseArgs()",
-      "norm_label": "parseargs()",
-      "source_file": "scripts/delivery-run-telemetry.ts",
-      "source_location": "L583"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "delivery_run_telemetry_readdeliveryruntelemetryrecords",
-      "label": "readDeliveryRunTelemetryRecords()",
-      "norm_label": "readdeliveryruntelemetryrecords()",
-      "source_file": "scripts/delivery-run-telemetry.ts",
-      "source_location": "L182"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "delivery_run_telemetry_readlatestpassingdeliveryruntelemetry",
-      "label": "readLatestPassingDeliveryRunTelemetry()",
-      "norm_label": "readlatestpassingdeliveryruntelemetry()",
-      "source_file": "scripts/delivery-run-telemetry.ts",
-      "source_location": "L223"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "delivery_run_telemetry_readlocalledgerfingerprint",
-      "label": "readLocalLedgerFingerprint()",
-      "norm_label": "readlocalledgerfingerprint()",
-      "source_file": "scripts/delivery-run-telemetry.ts",
-      "source_location": "L502"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "delivery_run_telemetry_recorddeliveryruntelemetry",
-      "label": "recordDeliveryRunTelemetry()",
-      "norm_label": "recorddeliveryruntelemetry()",
-      "source_file": "scripts/delivery-run-telemetry.ts",
-      "source_location": "L265"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "delivery_run_telemetry_slugify",
-      "label": "slugify()",
-      "norm_label": "slugify()",
-      "source_file": "scripts/delivery-run-telemetry.ts",
-      "source_location": "L86"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "delivery_run_telemetry_writedeliveryruntelemetryrecord",
-      "label": "writeDeliveryRunTelemetryRecord()",
-      "norm_label": "writedeliveryruntelemetryrecord()",
-      "source_file": "scripts/delivery-run-telemetry.ts",
-      "source_location": "L108"
-    },
-    {
-      "community": 118,
-      "file_type": "code",
-      "id": "scripts_delivery_run_telemetry_ts",
-      "label": "delivery-run-telemetry.ts",
-      "norm_label": "delivery-run-telemetry.ts",
-      "source_file": "scripts/delivery-run-telemetry.ts",
+      "id": "packages_storefront_webapp_src_lib_storefrontcontextevents_ts",
+      "label": "storefrontContextEvents.ts",
+      "norm_label": "storefrontcontextevents.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "storefrontcontextevents_buildstorefrontcontextevent",
+      "label": "buildStorefrontContextEvent()",
+      "norm_label": "buildstorefrontcontextevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "storefrontcontextevents_buildstorefrontidempotencykey",
+      "label": "buildStorefrontIdempotencyKey()",
+      "norm_label": "buildstorefrontidempotencykey()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
+      "source_location": "L454"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "storefrontcontextevents_compactscalarpayload",
+      "label": "compactScalarPayload()",
+      "norm_label": "compactscalarpayload()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
+      "source_location": "L425"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "storefrontcontextevents_createstorefrontcontexttrackingenvelope",
+      "label": "createStorefrontContextTrackingEnvelope()",
+      "norm_label": "createstorefrontcontexttrackingenvelope()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
+      "source_location": "L131"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "storefrontcontextevents_createstorefrontrouteviewedcontextevent",
+      "label": "createStorefrontRouteViewedContextEvent()",
+      "norm_label": "createstorefrontrouteviewedcontextevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
+      "source_location": "L113"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "storefrontcontextevents_getcartchange",
+      "label": "getCartChange()",
+      "norm_label": "getcartchange()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
+      "source_location": "L332"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "storefrontcontextevents_getcartcontexteventinput",
+      "label": "getCartContextEventInput()",
+      "norm_label": "getcartcontexteventinput()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
+      "source_location": "L255"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "storefrontcontextevents_getcheckoutblocker",
+      "label": "getCheckoutBlocker()",
+      "norm_label": "getcheckoutblocker()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
+      "source_location": "L380"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "storefrontcontextevents_getcheckoutcontexteventinput",
+      "label": "getCheckoutContextEventInput()",
+      "norm_label": "getcheckoutcontexteventinput()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
+      "source_location": "L288"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "storefrontcontextevents_getcheckoutstate",
+      "label": "getCheckoutState()",
+      "norm_label": "getcheckoutstate()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
+      "source_location": "L345"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "storefrontcontextevents_getnumber",
+      "label": "getNumber()",
+      "norm_label": "getnumber()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
+      "source_location": "L450"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "storefrontcontextevents_getstorefrontcontexteventinput",
+      "label": "getStorefrontContextEventInput()",
+      "norm_label": "getstorefrontcontexteventinput()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
+      "source_location": "L167"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "storefrontcontextevents_getstring",
+      "label": "getString()",
+      "norm_label": "getstring()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
+      "source_location": "L446"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "storefrontcontextevents_issafescalarcontextvalue",
+      "label": "isSafeScalarContextValue()",
+      "norm_label": "issafescalarcontextvalue()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
+      "source_location": "L436"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "storefrontcontextevents_normalizekeypart",
+      "label": "normalizeKeyPart()",
+      "norm_label": "normalizekeypart()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
+      "source_location": "L468"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "storefrontcontextevents_trackstorefrontcontextevent",
+      "label": "trackStorefrontContextEvent()",
+      "norm_label": "trackstorefrontcontextevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
+      "source_location": "L221"
+    },
+    {
+      "community": 118,
+      "file_type": "code",
+      "id": "storefrontcontextevents_validatestorefrontcontextpayload",
+      "label": "validateStorefrontContextPayload()",
+      "norm_label": "validatestorefrontcontextpayload()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontContextEvents.ts",
+      "source_location": "L397"
     },
     {
       "community": 1180,
@@ -191574,163 +191631,163 @@
     {
       "community": 119,
       "file_type": "code",
-      "id": "graphify_wiki_builddegreeindex",
-      "label": "buildDegreeIndex()",
-      "norm_label": "builddegreeindex()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L152"
+      "id": "delivery_run_telemetry_assertdeliveryruntelemetrycheck",
+      "label": "assertDeliveryRunTelemetryCheck()",
+      "norm_label": "assertdeliveryruntelemetrycheck()",
+      "source_file": "scripts/delivery-run-telemetry.ts",
+      "source_location": "L570"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "graphify_wiki_buildhotspotlines",
-      "label": "buildHotspotLines()",
-      "norm_label": "buildhotspotlines()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L190"
+      "id": "delivery_run_telemetry_builddeliveryruntelemetryrecord",
+      "label": "buildDeliveryRunTelemetryRecord()",
+      "norm_label": "builddeliveryruntelemetryrecord()",
+      "source_file": "scripts/delivery-run-telemetry.ts",
+      "source_location": "L65"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "graphify_wiki_buildpackagepage",
-      "label": "buildPackagePage()",
-      "norm_label": "buildpackagepage()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L272"
+      "id": "delivery_run_telemetry_collectchangedpathsfordiff",
+      "label": "collectChangedPathsForDiff()",
+      "norm_label": "collectchangedpathsfordiff()",
+      "source_file": "scripts/delivery-run-telemetry.ts",
+      "source_location": "L485"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "graphify_wiki_buildrootindexpage",
-      "label": "buildRootIndexPage()",
-      "norm_label": "buildrootindexpage()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L227"
+      "id": "delivery_run_telemetry_collectdeliveryruntelemetryfindings",
+      "label": "collectDeliveryRunTelemetryFindings()",
+      "norm_label": "collectdeliveryruntelemetryfindings()",
+      "source_file": "scripts/delivery-run-telemetry.ts",
+      "source_location": "L384"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "graphify_wiki_collectrepocodefiles",
-      "label": "collectRepoCodeFiles()",
-      "norm_label": "collectrepocodefiles()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L88"
+      "id": "delivery_run_telemetry_deliveryruntelemetrypath",
+      "label": "deliveryRunTelemetryPath()",
+      "norm_label": "deliveryruntelemetrypath()",
+      "source_file": "scripts/delivery-run-telemetry.ts",
+      "source_location": "L99"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "graphify_wiki_comparehotspots",
-      "label": "compareHotspots()",
-      "norm_label": "comparehotspots()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L170"
+      "id": "delivery_run_telemetry_evaluatedeliveryruntelemetrycheck",
+      "label": "evaluateDeliveryRunTelemetryCheck()",
+      "norm_label": "evaluatedeliveryruntelemetrycheck()",
+      "source_file": "scripts/delivery-run-telemetry.ts",
+      "source_location": "L516"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "graphify_wiki_countcommunities",
-      "label": "countCommunities()",
-      "norm_label": "countcommunities()",
-      "source_file": "scripts/graphify-wiki.ts",
+      "id": "delivery_run_telemetry_gitlines",
+      "label": "gitLines()",
+      "norm_label": "gitlines()",
+      "source_file": "scripts/delivery-run-telemetry.ts",
+      "source_location": "L452"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "delivery_run_telemetry_gitstdout",
+      "label": "gitStdout()",
+      "norm_label": "gitstdout()",
+      "source_file": "scripts/delivery-run-telemetry.ts",
+      "source_location": "L242"
+    },
+    {
+      "community": 119,
+      "file_type": "code",
+      "id": "delivery_run_telemetry_istelemetryrecord",
+      "label": "isTelemetryRecord()",
+      "norm_label": "istelemetryrecord()",
+      "source_file": "scripts/delivery-run-telemetry.ts",
       "source_location": "L148"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "graphify_wiki_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L79"
+      "id": "delivery_run_telemetry_istelemetryrecordpath",
+      "label": "isTelemetryRecordPath()",
+      "norm_label": "istelemetryrecordpath()",
+      "source_file": "scripts/delivery-run-telemetry.ts",
+      "source_location": "L377"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "graphify_wiki_formatlist",
-      "label": "formatList()",
-      "norm_label": "formatlist()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L144"
+      "id": "delivery_run_telemetry_parseargs",
+      "label": "parseArgs()",
+      "norm_label": "parseargs()",
+      "source_file": "scripts/delivery-run-telemetry.ts",
+      "source_location": "L583"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "graphify_wiki_generategraphifywikipages",
-      "label": "generateGraphifyWikiPages()",
-      "norm_label": "generategraphifywikipages()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L339"
+      "id": "delivery_run_telemetry_readdeliveryruntelemetryrecords",
+      "label": "readDeliveryRunTelemetryRecords()",
+      "norm_label": "readdeliveryruntelemetryrecords()",
+      "source_file": "scripts/delivery-run-telemetry.ts",
+      "source_location": "L182"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "graphify_wiki_loadgraphifygraph",
-      "label": "loadGraphifyGraph()",
-      "norm_label": "loadgraphifygraph()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L213"
+      "id": "delivery_run_telemetry_readlatestpassingdeliveryruntelemetry",
+      "label": "readLatestPassingDeliveryRunTelemetry()",
+      "norm_label": "readlatestpassingdeliveryruntelemetry()",
+      "source_file": "scripts/delivery-run-telemetry.ts",
+      "source_location": "L223"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "graphify_wiki_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L127"
+      "id": "delivery_run_telemetry_readlocalledgerfingerprint",
+      "label": "readLocalLedgerFingerprint()",
+      "norm_label": "readlocalledgerfingerprint()",
+      "source_file": "scripts/delivery-run-telemetry.ts",
+      "source_location": "L502"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "graphify_wiki_readdir",
-      "label": "readDir()",
-      "norm_label": "readdir()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L122"
+      "id": "delivery_run_telemetry_recorddeliveryruntelemetry",
+      "label": "recordDeliveryRunTelemetry()",
+      "norm_label": "recorddeliveryruntelemetry()",
+      "source_file": "scripts/delivery-run-telemetry.ts",
+      "source_location": "L265"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "graphify_wiki_scorenode",
-      "label": "scoreNode()",
-      "norm_label": "scorenode()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L163"
+      "id": "delivery_run_telemetry_slugify",
+      "label": "slugify()",
+      "norm_label": "slugify()",
+      "source_file": "scripts/delivery-run-telemetry.ts",
+      "source_location": "L86"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "graphify_wiki_tomarkdownlink",
-      "label": "toMarkdownLink()",
-      "norm_label": "tomarkdownlink()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L131"
+      "id": "delivery_run_telemetry_writedeliveryruntelemetryrecord",
+      "label": "writeDeliveryRunTelemetryRecord()",
+      "norm_label": "writedeliveryruntelemetryrecord()",
+      "source_file": "scripts/delivery-run-telemetry.ts",
+      "source_location": "L108"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "graphify_wiki_tosourcelink",
-      "label": "toSourceLink()",
-      "norm_label": "tosourcelink()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L139"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "graphify_wiki_writegraphifywikipages",
-      "label": "writeGraphifyWikiPages()",
-      "norm_label": "writegraphifywikipages()",
-      "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L371"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "scripts_graphify_wiki_ts",
-      "label": "graphify-wiki.ts",
-      "norm_label": "graphify-wiki.ts",
-      "source_file": "scripts/graphify-wiki.ts",
+      "id": "scripts_delivery_run_telemetry_ts",
+      "label": "delivery-run-telemetry.ts",
+      "norm_label": "delivery-run-telemetry.ts",
+      "source_file": "scripts/delivery-run-telemetry.ts",
       "source_location": "L1"
     },
     {
@@ -192348,163 +192405,163 @@
     {
       "community": 120,
       "file_type": "code",
-      "id": "pre_push_validation_proof_assertprathenaproofready",
-      "label": "assertPrAthenaProofReady()",
-      "norm_label": "assertprathenaproofready()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L165"
+      "id": "graphify_wiki_builddegreeindex",
+      "label": "buildDegreeIndex()",
+      "norm_label": "builddegreeindex()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L152"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "pre_push_validation_proof_classifysnapshoterror",
-      "label": "classifySnapshotError()",
-      "norm_label": "classifysnapshoterror()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L397"
+      "id": "graphify_wiki_buildhotspotlines",
+      "label": "buildHotspotLines()",
+      "norm_label": "buildhotspotlines()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L190"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "pre_push_validation_proof_collectfilesunder",
-      "label": "collectFilesUnder()",
-      "norm_label": "collectfilesunder()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L221"
+      "id": "graphify_wiki_buildpackagepage",
+      "label": "buildPackagePage()",
+      "norm_label": "buildpackagepage()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L272"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "pre_push_validation_proof_collectproofsnapshot",
-      "label": "collectProofSnapshot()",
-      "norm_label": "collectproofsnapshot()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L327"
+      "id": "graphify_wiki_buildrootindexpage",
+      "label": "buildRootIndexPage()",
+      "norm_label": "buildrootindexpage()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L227"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "pre_push_validation_proof_collectunstagedfiles",
-      "label": "collectUnstagedFiles()",
-      "norm_label": "collectunstagedfiles()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
+      "id": "graphify_wiki_collectrepocodefiles",
+      "label": "collectRepoCodeFiles()",
+      "norm_label": "collectrepocodefiles()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L88"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "graphify_wiki_comparehotspots",
+      "label": "compareHotspots()",
+      "norm_label": "comparehotspots()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L170"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "graphify_wiki_countcommunities",
+      "label": "countCommunities()",
+      "norm_label": "countcommunities()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L148"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "graphify_wiki_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L79"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "graphify_wiki_formatlist",
+      "label": "formatList()",
+      "norm_label": "formatlist()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L144"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "graphify_wiki_generategraphifywikipages",
+      "label": "generateGraphifyWikiPages()",
+      "norm_label": "generategraphifywikipages()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L339"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "graphify_wiki_loadgraphifygraph",
+      "label": "loadGraphifyGraph()",
+      "norm_label": "loadgraphifygraph()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L213"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "graphify_wiki_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L127"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "graphify_wiki_readdir",
+      "label": "readDir()",
+      "norm_label": "readdir()",
+      "source_file": "scripts/graphify-wiki.ts",
       "source_location": "L122"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "pre_push_validation_proof_collectuntrackedfiles",
-      "label": "collectUntrackedFiles()",
-      "norm_label": "collectuntrackedfiles()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L149"
+      "id": "graphify_wiki_scorenode",
+      "label": "scoreNode()",
+      "norm_label": "scorenode()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L163"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "pre_push_validation_proof_collectvalidationfingerprintpaths",
-      "label": "collectValidationFingerprintPaths()",
-      "norm_label": "collectvalidationfingerprintpaths()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L257"
+      "id": "graphify_wiki_tomarkdownlink",
+      "label": "toMarkdownLink()",
+      "norm_label": "tomarkdownlink()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L131"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "pre_push_validation_proof_evaluateprepushvalidationproof",
-      "label": "evaluatePrePushValidationProof()",
-      "norm_label": "evaluateprepushvalidationproof()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L410"
+      "id": "graphify_wiki_tosourcelink",
+      "label": "toSourceLink()",
+      "norm_label": "tosourcelink()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L139"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "pre_push_validation_proof_formatpathlist",
-      "label": "formatPathList()",
-      "norm_label": "formatpathlist()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L118"
+      "id": "graphify_wiki_writegraphifywikipages",
+      "label": "writeGraphifyWikiPages()",
+      "norm_label": "writegraphifywikipages()",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L371"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "pre_push_validation_proof_hashvalidationwiring",
-      "label": "hashValidationWiring()",
-      "norm_label": "hashvalidationwiring()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L286"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "pre_push_validation_proof_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "pre_push_validation_proof_parseporcelainpaths",
-      "label": "parsePorcelainPaths()",
-      "norm_label": "parseporcelainpaths()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L109"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "pre_push_validation_proof_readprathenascript",
-      "label": "readPrAthenaScript()",
-      "norm_label": "readprathenascript()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L310"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "pre_push_validation_proof_recordprepushvalidationproof",
-      "label": "recordPrePushValidationProof()",
-      "norm_label": "recordprepushvalidationproof()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L497"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "pre_push_validation_proof_runcommand",
-      "label": "runCommand()",
-      "norm_label": "runcommand()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L84"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "pre_push_validation_proof_sortuniquepaths",
-      "label": "sortUniquePaths()",
-      "norm_label": "sortuniquepaths()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "pre_push_validation_proof_validateproofshape",
-      "label": "validateProofShape()",
-      "norm_label": "validateproofshape()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L377"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "scripts_pre_push_validation_proof_ts",
-      "label": "pre-push-validation-proof.ts",
-      "norm_label": "pre-push-validation-proof.ts",
-      "source_file": "scripts/pre-push-validation-proof.ts",
+      "id": "scripts_graphify_wiki_ts",
+      "label": "graphify-wiki.ts",
+      "norm_label": "graphify-wiki.ts",
+      "source_file": "scripts/graphify-wiki.ts",
       "source_location": "L1"
     },
     {
@@ -247900,7 +247957,7 @@
       "label": "createSpawn()",
       "norm_label": "createspawn()",
       "source_file": "scripts/harness-review-identity.test.ts",
-      "source_location": "L23"
+      "source_location": "L24"
     },
     {
       "community": 372,
@@ -247909,7 +247966,7 @@
       "label": "entryFor()",
       "norm_label": "entryfor()",
       "source_file": "scripts/harness-review-identity.test.ts",
-      "source_location": "L247"
+      "source_location": "L263"
     },
     {
       "community": 372,
@@ -247918,7 +247975,7 @@
       "label": "git()",
       "norm_label": "git()",
       "source_file": "scripts/harness-review-identity.test.ts",
-      "source_location": "L288"
+      "source_location": "L304"
     },
     {
       "community": 372,
@@ -247927,7 +247984,7 @@
       "label": "gitFixture()",
       "norm_label": "gitfixture()",
       "source_file": "scripts/harness-review-identity.test.ts",
-      "source_location": "L304"
+      "source_location": "L320"
     },
     {
       "community": 372,
@@ -247936,7 +247993,7 @@
       "label": "headTreeIdentity()",
       "norm_label": "headtreeidentity()",
       "source_file": "scripts/harness-review-identity.test.ts",
-      "source_location": "L327"
+      "source_location": "L343"
     },
     {
       "community": 372,
@@ -247945,7 +248002,7 @@
       "label": "identityFor()",
       "norm_label": "identityfor()",
       "source_file": "scripts/harness-review-identity.test.ts",
-      "source_location": "L41"
+      "source_location": "L42"
     },
     {
       "community": 372,
@@ -247954,7 +248011,7 @@
       "label": "lsTreeOutput()",
       "norm_label": "lstreeoutput()",
       "source_file": "scripts/harness-review-identity.test.ts",
-      "source_location": "L16"
+      "source_location": "L17"
     },
     {
       "community": 372,
@@ -254403,6 +254460,69 @@
     {
       "community": 437,
       "file_type": "code",
+      "id": "harness_review_identity_computedeliverabletreeidentity",
+      "label": "computeDeliverableTreeIdentity()",
+      "norm_label": "computedeliverabletreeidentity()",
+      "source_file": "scripts/harness-review-identity.ts",
+      "source_location": "L149"
+    },
+    {
+      "community": 437,
+      "file_type": "code",
+      "id": "harness_review_identity_digestdeliverableentries",
+      "label": "digestDeliverableEntries()",
+      "norm_label": "digestdeliverableentries()",
+      "source_file": "scripts/harness-review-identity.ts",
+      "source_location": "L125"
+    },
+    {
+      "community": 437,
+      "file_type": "code",
+      "id": "harness_review_identity_ispostgatevalidationneutralpath",
+      "label": "isPostGateValidationNeutralPath()",
+      "norm_label": "ispostgatevalidationneutralpath()",
+      "source_file": "scripts/harness-review-identity.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 437,
+      "file_type": "code",
+      "id": "harness_review_identity_isreviewneutralpath",
+      "label": "isReviewNeutralPath()",
+      "norm_label": "isreviewneutralpath()",
+      "source_file": "scripts/harness-review-identity.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 437,
+      "file_type": "code",
+      "id": "harness_review_identity_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/harness-review-identity.ts",
+      "source_location": "L72"
+    },
+    {
+      "community": 437,
+      "file_type": "code",
+      "id": "harness_review_identity_parsetreeentries",
+      "label": "parseTreeEntries()",
+      "norm_label": "parsetreeentries()",
+      "source_file": "scripts/harness-review-identity.ts",
+      "source_location": "L110"
+    },
+    {
+      "community": 437,
+      "file_type": "code",
+      "id": "scripts_harness_review_identity_ts",
+      "label": "harness-review-identity.ts",
+      "norm_label": "harness-review-identity.ts",
+      "source_file": "scripts/harness-review-identity.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 438,
+      "file_type": "code",
       "id": "harness_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
       "norm_label": "createfixturerepo()",
@@ -254410,7 +254530,7 @@
       "source_location": "L25"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "harness_review_test_error",
       "label": "error()",
@@ -254419,7 +254539,7 @@
       "source_location": "L293"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "harness_review_test_initializegithistory",
       "label": "initializeGitHistory()",
@@ -254428,7 +254548,7 @@
       "source_location": "L262"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "harness_review_test_log",
       "label": "log()",
@@ -254437,7 +254557,7 @@
       "source_location": "L292"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "harness_review_test_rungit",
       "label": "runGit()",
@@ -254446,7 +254566,7 @@
       "source_location": "L248"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "harness_review_test_write",
       "label": "write()",
@@ -254455,7 +254575,7 @@
       "source_location": "L19"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "scripts_harness_review_test_ts",
       "label": "harness-review.test.ts",
@@ -254464,7 +254584,7 @@
       "source_location": "L1"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "landed_change_report_check_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -254473,7 +254593,7 @@
       "source_location": "L16"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "landed_change_report_check_test_gitenv",
       "label": "gitEnv()",
@@ -254482,7 +254602,7 @@
       "source_location": "L51"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "landed_change_report_check_test_linechanges",
       "label": "lineChanges()",
@@ -254491,7 +254611,7 @@
       "source_location": "L67"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "landed_change_report_check_test_rungit",
       "label": "runGit()",
@@ -254500,7 +254620,7 @@
       "source_location": "L36"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "landed_change_report_check_test_validreport",
       "label": "validReport()",
@@ -254509,7 +254629,7 @@
       "source_location": "L76"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "landed_change_report_check_test_write",
       "label": "write()",
@@ -254518,67 +254638,13 @@
       "source_location": "L30"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "scripts_landed_change_report_check_test_ts",
       "label": "landed-change-report-check.test.ts",
       "norm_label": "landed-change-report-check.test.ts",
       "source_file": "scripts/landed-change-report-check.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_automation_scheduledrunledger_ts",
-      "label": "scheduledRunLedger.ts",
-      "norm_label": "scheduledrunledger.ts",
-      "source_file": "packages/athena-webapp/convex/automation/scheduledRunLedger.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "scheduledrunledger_besteffortrecordscheduledrunevidence",
-      "label": "bestEffortRecordScheduledRunEvidence()",
-      "norm_label": "besteffortrecordscheduledrunevidence()",
-      "source_file": "packages/athena-webapp/convex/automation/scheduledRunLedger.ts",
-      "source_location": "L152"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "scheduledrunledger_buildscheduledrunkey",
-      "label": "buildScheduledRunKey()",
-      "norm_label": "buildscheduledrunkey()",
-      "source_file": "packages/athena-webapp/convex/automation/scheduledRunLedger.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "scheduledrunledger_derivescheduledrunoutcome",
-      "label": "deriveScheduledRunOutcome()",
-      "norm_label": "derivescheduledrunoutcome()",
-      "source_file": "packages/athena-webapp/convex/automation/scheduledRunLedger.ts",
-      "source_location": "L82"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "scheduledrunledger_recordscheduledrunevidencewithctx",
-      "label": "recordScheduledRunEvidenceWithCtx()",
-      "norm_label": "recordscheduledrunevidencewithctx()",
-      "source_file": "packages/athena-webapp/convex/automation/scheduledRunLedger.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "scheduledrunledger_resolvescheduledwindow",
-      "label": "resolveScheduledWindow()",
-      "norm_label": "resolvescheduledwindow()",
-      "source_file": "packages/athena-webapp/convex/automation/scheduledRunLedger.ts",
-      "source_location": "L51"
     },
     {
       "community": 44,
@@ -254862,6 +254928,60 @@
     {
       "community": 440,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_automation_scheduledrunledger_ts",
+      "label": "scheduledRunLedger.ts",
+      "norm_label": "scheduledrunledger.ts",
+      "source_file": "packages/athena-webapp/convex/automation/scheduledRunLedger.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "scheduledrunledger_besteffortrecordscheduledrunevidence",
+      "label": "bestEffortRecordScheduledRunEvidence()",
+      "norm_label": "besteffortrecordscheduledrunevidence()",
+      "source_file": "packages/athena-webapp/convex/automation/scheduledRunLedger.ts",
+      "source_location": "L152"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "scheduledrunledger_buildscheduledrunkey",
+      "label": "buildScheduledRunKey()",
+      "norm_label": "buildscheduledrunkey()",
+      "source_file": "packages/athena-webapp/convex/automation/scheduledRunLedger.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "scheduledrunledger_derivescheduledrunoutcome",
+      "label": "deriveScheduledRunOutcome()",
+      "norm_label": "derivescheduledrunoutcome()",
+      "source_file": "packages/athena-webapp/convex/automation/scheduledRunLedger.ts",
+      "source_location": "L82"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "scheduledrunledger_recordscheduledrunevidencewithctx",
+      "label": "recordScheduledRunEvidenceWithCtx()",
+      "norm_label": "recordscheduledrunevidencewithctx()",
+      "source_file": "packages/athena-webapp/convex/automation/scheduledRunLedger.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "scheduledrunledger_resolvescheduledwindow",
+      "label": "resolveScheduledWindow()",
+      "norm_label": "resolvescheduledwindow()",
+      "source_file": "packages/athena-webapp/convex/automation/scheduledRunLedger.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
       "id": "index_valkeyclient",
       "label": "ValkeyClient",
       "norm_label": "valkeyclient",
@@ -254869,7 +254989,7 @@
       "source_location": "L4"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "index_valkeyclient_constructor",
       "label": ".constructor()",
@@ -254878,7 +254998,7 @@
       "source_location": "L11"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "index_valkeyclient_get",
       "label": ".get()",
@@ -254887,7 +255007,7 @@
       "source_location": "L20"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "index_valkeyclient_invalidate",
       "label": ".invalidate()",
@@ -254896,7 +255016,7 @@
       "source_location": "L75"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "index_valkeyclient_set",
       "label": ".set()",
@@ -254905,7 +255025,7 @@
       "source_location": "L48"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cache_index_ts",
       "label": "index.ts",
@@ -254914,7 +255034,7 @@
       "source_location": "L1"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "contextevents_appendcontexteventwithctx",
       "label": "appendContextEventWithCtx()",
@@ -254923,7 +255043,7 @@
       "source_location": "L65"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "contextevents_buildcontexteventsemanticenvelopehash",
       "label": "buildContextEventSemanticEnvelopeHash()",
@@ -254932,7 +255052,7 @@
       "source_location": "L33"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "contextevents_isallowedglobalcontextevent",
       "label": "isAllowedGlobalContextEvent()",
@@ -254941,7 +255061,7 @@
       "source_location": "L204"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "contextevents_iscontexteventwritequotaexceeded",
       "label": "isContextEventWriteQuotaExceeded()",
@@ -254950,7 +255070,7 @@
       "source_location": "L19"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "contextevents_selectcontexteventappendquotadecision",
       "label": "selectContextEventAppendQuotaDecision()",
@@ -254959,7 +255079,7 @@
       "source_location": "L23"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_contexttracking_contextevents_ts",
       "label": "contextEvents.ts",
@@ -254968,7 +255088,7 @@
       "source_location": "L1"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_registercloseoutvariancealert_tsx",
       "label": "RegisterCloseoutVarianceAlert.tsx",
@@ -254977,7 +255097,7 @@
       "source_location": "L1"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "registercloseoutvariancealert_registercloseoutvariancealert",
       "label": "RegisterCloseoutVarianceAlert()",
@@ -254986,7 +255106,7 @@
       "source_location": "L60"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "registercloseoutvariancealert_registercloseoutvariancealertemailpreview",
       "label": "RegisterCloseoutVarianceAlertEmailPreview()",
@@ -254995,7 +255115,7 @@
       "source_location": "L186"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "registercloseoutvariancealert_sectionheading",
       "label": "SectionHeading()",
@@ -255004,7 +255124,7 @@
       "source_location": "L194"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "registercloseoutvariancealert_statusbadge",
       "label": "StatusBadge()",
@@ -255013,7 +255133,7 @@
       "source_location": "L204"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "registercloseoutvariancealert_summaryvaluestylefor",
       "label": "summaryValueStyleFor()",
@@ -255022,7 +255142,7 @@
       "source_location": "L232"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_walkthroughrequests_ts",
       "label": "walkthroughRequests.ts",
@@ -255031,7 +255151,7 @@
       "source_location": "L1"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "walkthroughrequests_canonical",
       "label": "canonical()",
@@ -255040,7 +255160,7 @@
       "source_location": "L24"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "walkthroughrequests_evaluatewalkthroughingress",
       "label": "evaluateWalkthroughIngress()",
@@ -255049,7 +255169,7 @@
       "source_location": "L16"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "walkthroughrequests_isvalidbody",
       "label": "isValidBody()",
@@ -255058,7 +255178,7 @@
       "source_location": "L26"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "walkthroughrequests_sha256",
       "label": "sha256()",
@@ -255067,7 +255187,7 @@
       "source_location": "L25"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "walkthroughrequests_text",
       "label": "text()",
@@ -255076,7 +255196,7 @@
       "source_location": "L23"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_security_ts",
       "label": "security.ts",
@@ -255085,7 +255205,7 @@
       "source_location": "L1"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "security_buildcanonicalcheckoutproducts",
       "label": "buildCanonicalCheckoutProducts()",
@@ -255094,7 +255214,7 @@
       "source_location": "L42"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "security_hasvalidpositivequantity",
       "label": "hasValidPositiveQuantity()",
@@ -255103,7 +255223,7 @@
       "source_location": "L27"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "security_isamounttampered",
       "label": "isAmountTampered()",
@@ -255112,7 +255232,7 @@
       "source_location": "L65"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "security_isauthorizedresourceowner",
       "label": "isAuthorizedResourceOwner()",
@@ -255121,7 +255241,7 @@
       "source_location": "L31"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "security_isduplicatechargesuccess",
       "label": "isDuplicateChargeSuccess()",
@@ -255130,7 +255250,7 @@
       "source_location": "L76"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "catalogimport_test_buildtrustedconversionargs",
       "label": "buildTrustedConversionArgs()",
@@ -255139,7 +255259,7 @@
       "source_location": "L397"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "catalogimport_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -255148,7 +255268,7 @@
       "source_location": "L144"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "catalogimport_test_gethandler",
       "label": "getHandler()",
@@ -255157,7 +255277,7 @@
       "source_location": "L140"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "catalogimport_test_readtrustedconversionbinding",
       "label": "readTrustedConversionBinding()",
@@ -255166,7 +255286,7 @@
       "source_location": "L383"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "catalogimport_test_seedtrustedconversiondata",
       "label": "seedTrustedConversionData()",
@@ -255175,7 +255295,7 @@
       "source_location": "L289"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_catalogimport_test_ts",
       "label": "catalogImport.test.ts",
@@ -255184,7 +255304,7 @@
       "source_location": "L1"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "expensesessions_expensesessionerror",
       "label": "expenseSessionError()",
@@ -255193,7 +255313,7 @@
       "source_location": "L47"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "expensesessions_loadexpensesessionitems",
       "label": "loadExpenseSessionItems()",
@@ -255202,7 +255322,7 @@
       "source_location": "L114"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "expensesessions_mapexpensesessionvalidationerror",
       "label": "mapExpenseSessionValidationError()",
@@ -255211,7 +255331,7 @@
       "source_location": "L95"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "expensesessions_recordexpensesessionlifecycletrace",
       "label": "recordExpenseSessionLifecycleTrace()",
@@ -255220,7 +255340,7 @@
       "source_location": "L139"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "expensesessions_usererrorfromexpensesessioncommandfailure",
       "label": "userErrorFromExpenseSessionCommandFailure()",
@@ -255229,7 +255349,7 @@
       "source_location": "L61"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessions_ts",
       "label": "expenseSessions.ts",
@@ -255238,7 +255358,7 @@
       "source_location": "L1"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "backfillreportfactobservedat_test_createctx",
       "label": "createCtx()",
@@ -255247,7 +255367,7 @@
       "source_location": "L20"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "backfillreportfactobservedat_test_createstoreverificationctx",
       "label": "createStoreVerificationCtx()",
@@ -255256,7 +255376,7 @@
       "source_location": "L58"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "backfillreportfactobservedat_test_finishbackfill",
       "label": "finishBackfill()",
@@ -255265,7 +255385,7 @@
       "source_location": "L96"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "backfillreportfactobservedat_test_finishverification",
       "label": "finishVerification()",
@@ -255274,7 +255394,7 @@
       "source_location": "L116"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "backfillreportfactobservedat_test_observedatfield",
       "label": "observedAtField()",
@@ -255283,7 +255403,7 @@
       "source_location": "L264"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_backfillreportfactobservedat_test_ts",
       "label": "backfillReportFactObservedAt.test.ts",
@@ -255292,7 +255412,7 @@
       "source_location": "L1"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "backfillstorecurrencycase_backfillstorecurrencycasewithctx",
       "label": "backfillStoreCurrencyCaseWithCtx()",
@@ -255301,7 +255421,7 @@
       "source_location": "L70"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "backfillstorecurrencycase_boundedlimit",
       "label": "boundedLimit()",
@@ -255310,7 +255430,7 @@
       "source_location": "L43"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "backfillstorecurrencycase_needsnormalization",
       "label": "needsNormalization()",
@@ -255319,7 +255439,7 @@
       "source_location": "L66"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "backfillstorecurrencycase_storepage",
       "label": "storePage()",
@@ -255328,7 +255448,7 @@
       "source_location": "L50"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "backfillstorecurrencycase_verifystorecurrencycasewithctx",
       "label": "verifyStoreCurrencyCaseWithCtx()",
@@ -255337,66 +255457,12 @@
       "source_location": "L133"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_backfillstorecurrencycase_ts",
       "label": "backfillStoreCurrencyCase.ts",
       "norm_label": "backfillstorecurrencycase.ts",
       "source_file": "packages/athena-webapp/convex/migrations/backfillStoreCurrencyCase.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "actors_getoperationactorathenauserid",
-      "label": "getOperationActorAthenaUserId()",
-      "norm_label": "getoperationactorathenauserid()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/actors.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "actors_isnormaluseroperationactor",
-      "label": "isNormalUserOperationActor()",
-      "norm_label": "isnormaluseroperationactor()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/actors.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "actors_ispublicoperationactor",
-      "label": "isPublicOperationActor()",
-      "norm_label": "ispublicoperationactor()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/actors.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "actors_isshareddemooperationactor",
-      "label": "isSharedDemoOperationActor()",
-      "norm_label": "isshareddemooperationactor()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/actors.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "actors_requireoperationactorathenauserid",
-      "label": "requireOperationActorAthenaUserId()",
-      "norm_label": "requireoperationactorathenauserid()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/actors.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operationadmission_actors_ts",
-      "label": "actors.ts",
-      "norm_label": "actors.ts",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/actors.ts",
       "source_location": "L1"
     },
     {
@@ -255672,6 +255738,60 @@
     {
       "community": 450,
       "file_type": "code",
+      "id": "actors_getoperationactorathenauserid",
+      "label": "getOperationActorAthenaUserId()",
+      "norm_label": "getoperationactorathenauserid()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/actors.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "actors_isnormaluseroperationactor",
+      "label": "isNormalUserOperationActor()",
+      "norm_label": "isnormaluseroperationactor()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/actors.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "actors_ispublicoperationactor",
+      "label": "isPublicOperationActor()",
+      "norm_label": "ispublicoperationactor()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/actors.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "actors_isshareddemooperationactor",
+      "label": "isSharedDemoOperationActor()",
+      "norm_label": "isshareddemooperationactor()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/actors.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "actors_requireoperationactorathenauserid",
+      "label": "requireOperationActorAthenaUserId()",
+      "norm_label": "requireoperationactorathenauserid()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/actors.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operationadmission_actors_ts",
+      "label": "actors.ts",
+      "norm_label": "actors.ts",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/actors.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
       "id": "approval_builddailycloseapprovalsubject",
       "label": "buildDailyCloseApprovalSubject()",
       "norm_label": "builddailycloseapprovalsubject()",
@@ -255679,7 +255799,7 @@
       "source_location": "L15"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "approval_builddailyclosecarryforwardapprovalrequirement",
       "label": "buildDailyCloseCarryForwardApprovalRequirement()",
@@ -255688,7 +255808,7 @@
       "source_location": "L101"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "approval_builddailyclosecarryforwardapprovalsubject",
       "label": "buildDailyCloseCarryForwardApprovalSubject()",
@@ -255697,7 +255817,7 @@
       "source_location": "L88"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "approval_builddailyclosecompletionapprovalrequirement",
       "label": "buildDailyCloseCompletionApprovalRequirement()",
@@ -255706,7 +255826,7 @@
       "source_location": "L26"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "approval_builddailyclosereopenapprovalrequirement",
       "label": "buildDailyCloseReopenApprovalRequirement()",
@@ -255715,7 +255835,7 @@
       "source_location": "L54"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_dailyclose_approval_ts",
       "label": "approval.ts",
@@ -255724,7 +255844,7 @@
       "source_location": "L1"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "eventbuilders_buildonlineorderoperationaleventmessage",
       "label": "buildOnlineOrderOperationalEventMessage()",
@@ -255733,7 +255853,7 @@
       "source_location": "L68"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "eventbuilders_buildoperationaleventmessage",
       "label": "buildOperationalEventMessage()",
@@ -255742,7 +255862,7 @@
       "source_location": "L1"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "eventbuilders_buildstockadjustmentoperationaleventmessage",
       "label": "buildStockAdjustmentOperationalEventMessage()",
@@ -255751,7 +255871,7 @@
       "source_location": "L93"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "eventbuilders_formatonlineorderlabel",
       "label": "formatOnlineOrderLabel()",
@@ -255760,7 +255880,7 @@
       "source_location": "L112"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "eventbuilders_formatstockadjustmentsubjectdetail",
       "label": "formatStockAdjustmentSubjectDetail()",
@@ -255769,7 +255889,7 @@
       "source_location": "L106"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_helpers_eventbuilders_ts",
       "label": "eventBuilders.ts",
@@ -255778,7 +255898,7 @@
       "source_location": "L1"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_serviceintake_test_ts",
       "label": "serviceIntake.test.ts",
@@ -255787,7 +255907,7 @@
       "source_location": "L1"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "serviceintake_test_buildcreateserviceintakeargs",
       "label": "buildCreateServiceIntakeArgs()",
@@ -255796,7 +255916,7 @@
       "source_location": "L38"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "serviceintake_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -255805,7 +255925,7 @@
       "source_location": "L52"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "serviceintake_test_createserviceintakebehaviorctx",
       "label": "createServiceIntakeBehaviorCtx()",
@@ -255814,7 +255934,7 @@
       "source_location": "L96"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "serviceintake_test_gethandler",
       "label": "getHandler()",
@@ -255823,7 +255943,7 @@
       "source_location": "L34"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "serviceintake_test_getsource",
       "label": "getSource()",
@@ -255832,7 +255952,7 @@
       "source_location": "L30"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_weeklymanagerreportemail_test_ts",
       "label": "weeklyManagerReportEmail.test.ts",
@@ -255841,7 +255961,7 @@
       "source_location": "L1"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "weeklymanagerreportemail_test_buildpayload",
       "label": "buildPayload()",
@@ -255850,7 +255970,7 @@
       "source_location": "L128"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "weeklymanagerreportemail_test_countedcashsection",
       "label": "countedCashSection()",
@@ -255859,7 +255979,7 @@
       "source_location": "L234"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "weeklymanagerreportemail_test_evidencecoverage",
       "label": "evidenceCoverage()",
@@ -255868,7 +255988,7 @@
       "source_location": "L61"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "weeklymanagerreportemail_test_lineageday",
       "label": "lineageDay()",
@@ -255877,7 +255997,7 @@
       "source_location": "L117"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "weeklymanagerreportemail_test_makecloseevidence",
       "label": "makeCloseEvidence()",
@@ -255886,7 +256006,7 @@
       "source_location": "L69"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "completetransaction_test_createvoidctx",
       "label": "createVoidCtx()",
@@ -255895,7 +256015,7 @@
       "source_location": "L219"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "completetransaction_test_expectnocompletionsideeffects",
       "label": "expectNoCompletionSideEffects()",
@@ -255904,7 +256024,7 @@
       "source_location": "L197"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "completetransaction_test_expectnovoidbusinesssideeffects",
       "label": "expectNoVoidBusinessSideEffects()",
@@ -255913,7 +256033,7 @@
       "source_location": "L211"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "completetransaction_test_seeddirect",
       "label": "seedDirect()",
@@ -255922,7 +256042,7 @@
       "source_location": "L4778"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "completetransaction_test_seeddirecthappypath",
       "label": "seedDirectHappyPath()",
@@ -255931,7 +256051,7 @@
       "source_location": "L4625"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_completetransaction_test_ts",
       "label": "completeTransaction.test.ts",
@@ -255940,7 +256060,7 @@
       "source_location": "L1"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_registerlifecycleauthority_test_ts",
       "label": "registerLifecycleAuthority.test.ts",
@@ -255949,7 +256069,7 @@
       "source_location": "L1"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "registerlifecycleauthority_test_createrepository",
       "label": "createRepository()",
@@ -255958,7 +256078,7 @@
       "source_location": "L675"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "registerlifecycleauthority_test_mapping",
       "label": "mapping()",
@@ -255967,7 +256087,7 @@
       "source_location": "L741"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "registerlifecycleauthority_test_mappingauthority",
       "label": "mappingAuthority()",
@@ -255976,7 +256096,7 @@
       "source_location": "L708"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "registerlifecycleauthority_test_registersession",
       "label": "registerSession()",
@@ -255985,7 +256105,7 @@
       "source_location": "L760"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "registerlifecycleauthority_test_terminal",
       "label": "terminal()",
@@ -255994,7 +256114,7 @@
       "source_location": "L726"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "localsyncrepository_areconflictdetailsequivalent",
       "label": "areConflictDetailsEquivalent()",
@@ -256003,7 +256123,7 @@
       "source_location": "L62"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "localsyncrepository_createconvexlocalsyncrepository",
       "label": "createConvexLocalSyncRepository()",
@@ -256012,7 +256132,7 @@
       "source_location": "L152"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "localsyncrepository_omitundefined",
       "label": "omitUndefined()",
@@ -256021,7 +256141,7 @@
       "source_location": "L56"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "localsyncrepository_reportfactsfromlocalsyncingressargs",
       "label": "reportFactsFromLocalSyncIngressArgs()",
@@ -256030,7 +256150,7 @@
       "source_location": "L107"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "localsyncrepository_trimoptional",
       "label": "trimOptional()",
@@ -256039,7 +256159,7 @@
       "source_location": "L92"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_localsyncrepository_ts",
       "label": "localSyncRepository.ts",
@@ -256048,7 +256168,7 @@
       "source_location": "L1"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_sync_ts",
       "label": "sync.ts",
@@ -256057,7 +256177,7 @@
       "source_location": "L1"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "sync_isvariancereviewforcloseout",
       "label": "isVarianceReviewForCloseout()",
@@ -256066,7 +256186,7 @@
       "source_location": "L455"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "sync_readapprovalrequeststatuses",
       "label": "readApprovalRequestStatuses()",
@@ -256075,7 +256195,7 @@
       "source_location": "L436"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "sync_scheduleregistercloseoutnotifications",
       "label": "scheduleRegisterCloseoutNotifications()",
@@ -256084,7 +256204,7 @@
       "source_location": "L281"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "sync_shareddemocapabilityforsyncevent",
       "label": "sharedDemoCapabilityForSyncEvent()",
@@ -256093,7 +256213,7 @@
       "source_location": "L112"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "sync_wasvariancenotifiedbeforerail",
       "label": "wasVarianceNotifiedBeforeRail()",
@@ -256102,7 +256222,7 @@
       "source_location": "L471"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_telemetry_ts",
       "label": "telemetry.ts",
@@ -256111,7 +256231,7 @@
       "source_location": "L1"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "telemetry_cleaneventtext",
       "label": "cleanEventText()",
@@ -256120,7 +256240,7 @@
       "source_location": "L66"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "telemetry_cleanoptionaleventtext",
       "label": "cleanOptionalEventText()",
@@ -256129,7 +256249,7 @@
       "source_location": "L70"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "telemetry_requirepostelemetryaccess",
       "label": "requirePosTelemetryAccess()",
@@ -256138,7 +256258,7 @@
       "source_location": "L96"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "telemetry_sanitizeclienteventmetadata",
       "label": "sanitizeClientEventMetadata()",
@@ -256147,67 +256267,13 @@
       "source_location": "L77"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "telemetry_truncate",
       "label": "truncate()",
       "norm_label": "truncate()",
       "source_file": "packages/athena-webapp/convex/pos/public/telemetry.ts",
       "source_location": "L59"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_remoteassist_transportinternal_test_ts",
-      "label": "transportInternal.test.ts",
-      "norm_label": "transportinternal.test.ts",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/transportInternal.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "transportinternal_test_buildclient",
-      "label": "buildClient()",
-      "norm_label": "buildclient()",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/transportInternal.test.ts",
-      "source_location": "L342"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "transportinternal_test_buildruntimectx",
-      "label": "buildRuntimeCtx()",
-      "norm_label": "buildruntimectx()",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/transportInternal.test.ts",
-      "source_location": "L318"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "transportinternal_test_buildsession",
-      "label": "buildSession()",
-      "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/transportInternal.test.ts",
-      "source_location": "L352"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "transportinternal_test_buildterminal",
-      "label": "buildTerminal()",
-      "norm_label": "buildterminal()",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/transportInternal.test.ts",
-      "source_location": "L365"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "transportinternal_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/transportInternal.test.ts",
-      "source_location": "L34"
     },
     {
       "community": 46,
@@ -256482,6 +256548,60 @@
     {
       "community": 460,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_remoteassist_transportinternal_test_ts",
+      "label": "transportInternal.test.ts",
+      "norm_label": "transportinternal.test.ts",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/transportInternal.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "transportinternal_test_buildclient",
+      "label": "buildClient()",
+      "norm_label": "buildclient()",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/transportInternal.test.ts",
+      "source_location": "L342"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "transportinternal_test_buildruntimectx",
+      "label": "buildRuntimeCtx()",
+      "norm_label": "buildruntimectx()",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/transportInternal.test.ts",
+      "source_location": "L318"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "transportinternal_test_buildsession",
+      "label": "buildSession()",
+      "norm_label": "buildsession()",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/transportInternal.test.ts",
+      "source_location": "L352"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "transportinternal_test_buildterminal",
+      "label": "buildTerminal()",
+      "norm_label": "buildterminal()",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/transportInternal.test.ts",
+      "source_location": "L365"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "transportinternal_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/transportInternal.test.ts",
+      "source_location": "L34"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
       "id": "foldday_comparefacts",
       "label": "compareFacts()",
       "norm_label": "comparefacts()",
@@ -256489,7 +256609,7 @@
       "source_location": "L95"
     },
     {
-      "community": 460,
+      "community": 461,
       "file_type": "code",
       "id": "foldday_foldday",
       "label": "foldDay()",
@@ -256498,7 +256618,7 @@
       "source_location": "L126"
     },
     {
-      "community": 460,
+      "community": 461,
       "file_type": "code",
       "id": "foldday_revenuecontribution",
       "label": "revenueContribution()",
@@ -256507,7 +256627,7 @@
       "source_location": "L108"
     },
     {
-      "community": 460,
+      "community": 461,
       "file_type": "code",
       "id": "foldday_zerodaymetrics",
       "label": "zeroDayMetrics()",
@@ -256516,7 +256636,7 @@
       "source_location": "L51"
     },
     {
-      "community": 460,
+      "community": 461,
       "file_type": "code",
       "id": "foldday_zeroskuaccumulator",
       "label": "zeroSkuAccumulator()",
@@ -256525,7 +256645,7 @@
       "source_location": "L77"
     },
     {
-      "community": 460,
+      "community": 461,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_foldday_ts",
       "label": "foldDay.ts",
@@ -256534,7 +256654,7 @@
       "source_location": "L1"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "operatingday_configuredtimezone",
       "label": "configuredTimezone()",
@@ -256543,7 +256663,7 @@
       "source_location": "L52"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "operatingday_isvalidtimezone",
       "label": "isValidTimezone()",
@@ -256552,7 +256672,7 @@
       "source_location": "L27"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "operatingday_localdatelabel",
       "label": "localDateLabel()",
@@ -256561,7 +256681,7 @@
       "source_location": "L38"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "operatingday_resolveoperatingdate",
       "label": "resolveOperatingDate()",
@@ -256570,7 +256690,7 @@
       "source_location": "L98"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "operatingday_resolvestoretimezone",
       "label": "resolveStoreTimezone()",
@@ -256579,7 +256699,7 @@
       "source_location": "L68"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_operatingday_ts",
       "label": "operatingDay.ts",
@@ -256588,7 +256708,7 @@
       "source_location": "L1"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_reseed_test_ts",
       "label": "reseed.test.ts",
@@ -256597,7 +256717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "reseed_test_at",
       "label": "at()",
@@ -256606,7 +256726,7 @@
       "source_location": "L48"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "reseed_test_factsignature",
       "label": "factSignature()",
@@ -256615,7 +256735,7 @@
       "source_location": "L116"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "reseed_test_resumereseed",
       "label": "resumeReseed()",
@@ -256624,7 +256744,7 @@
       "source_location": "L99"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "reseed_test_runreseed",
       "label": "runReseed()",
@@ -256633,7 +256753,7 @@
       "source_location": "L75"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "reseed_test_seedfullday",
       "label": "seedFullDay()",
@@ -256642,7 +256762,7 @@
       "source_location": "L140"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_weeklyinventory_ts",
       "label": "weeklyInventory.ts",
@@ -256651,7 +256771,7 @@
       "source_location": "L1"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "weeklyinventory_classifyweeklyinventorygroup",
       "label": "classifyWeeklyInventoryGroup()",
@@ -256660,7 +256780,7 @@
       "source_location": "L56"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "weeklyinventory_issyncedsaleinventoryreviewgroup",
       "label": "isSyncedSaleInventoryReviewGroup()",
@@ -256669,7 +256789,7 @@
       "source_location": "L101"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "weeklyinventory_projectfrozenweeklyinventoryattention",
       "label": "projectFrozenWeeklyInventoryAttention()",
@@ -256678,7 +256798,7 @@
       "source_location": "L144"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "weeklyinventory_projectliveweeklyinventoryattention",
       "label": "projectLiveWeeklyInventoryAttention()",
@@ -256687,7 +256807,7 @@
       "source_location": "L110"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "weeklyinventory_summarizeweeklyinventoryattention",
       "label": "summarizeWeeklyInventoryAttention()",
@@ -256696,7 +256816,7 @@
       "source_location": "L82"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "orderemailservice_buildorderstatusmessage",
       "label": "buildOrderStatusMessage()",
@@ -256705,7 +256825,7 @@
       "source_location": "L49"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "orderemailservice_buildpickupdetails",
       "label": "buildPickupDetails()",
@@ -256714,7 +256834,7 @@
       "source_location": "L77"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "orderemailservice_sendpaymentverificationemails",
       "label": "sendPaymentVerificationEmails()",
@@ -256723,7 +256843,7 @@
       "source_location": "L217"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "orderemailservice_sendpodorderemails",
       "label": "sendPODOrderEmails()",
@@ -256732,7 +256852,7 @@
       "source_location": "L96"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "orderemailservice_shouldsendtoadmins",
       "label": "shouldSendToAdmins()",
@@ -256741,7 +256861,7 @@
       "source_location": "L42"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
       "label": "orderEmailService.ts",
@@ -256750,7 +256870,7 @@
       "source_location": "L1"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "actor_getshareddemoactorwithctx",
       "label": "getSharedDemoActorWithCtx()",
@@ -256759,7 +256879,7 @@
       "source_location": "L14"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "actor_requirereadyshareddemostorecapabilityifapplicable",
       "label": "requireReadySharedDemoStoreCapabilityIfApplicable()",
@@ -256768,7 +256888,7 @@
       "source_location": "L92"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "actor_requireshareddemoactorwithctx",
       "label": "requireSharedDemoActorWithCtx()",
@@ -256777,7 +256897,7 @@
       "source_location": "L57"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "actor_requireshareddemocapabilityifapplicable",
       "label": "requireSharedDemoCapabilityIfApplicable()",
@@ -256786,7 +256906,7 @@
       "source_location": "L66"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "actor_requireshareddemostorecapabilityifapplicable",
       "label": "requireSharedDemoStoreCapabilityIfApplicable()",
@@ -256795,7 +256915,7 @@
       "source_location": "L78"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_actor_ts",
       "label": "actor.ts",
@@ -256804,7 +256924,7 @@
       "source_location": "L1"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_scheduledrestore_ts",
       "label": "scheduledRestore.ts",
@@ -256813,7 +256933,7 @@
       "source_location": "L1"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "scheduledrestore_continuerestorewithctx",
       "label": "continueRestoreWithCtx()",
@@ -256822,7 +256942,7 @@
       "source_location": "L20"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "scheduledrestore_provisionforscheduledworkwithctx",
       "label": "provisionForScheduledWorkWithCtx()",
@@ -256831,7 +256951,7 @@
       "source_location": "L76"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "scheduledrestore_rundailyrestorewithctx",
       "label": "runDailyRestoreWithCtx()",
@@ -256840,7 +256960,7 @@
       "source_location": "L117"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "scheduledrestore_runhourlyprovisionhealwithctx",
       "label": "runHourlyProvisionHealWithCtx()",
@@ -256849,7 +256969,7 @@
       "source_location": "L108"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "scheduledrestore_shareddemorestoreenabled",
       "label": "sharedDemoRestoreEnabled()",
@@ -256858,7 +256978,7 @@
       "source_location": "L7"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "adjustments_test_createapprovaldecisionmutationctx",
       "label": "createApprovalDecisionMutationCtx()",
@@ -256867,7 +256987,7 @@
       "source_location": "L305"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "adjustments_test_createinventorysnapshotqueryctx",
       "label": "createInventorySnapshotQueryCtx()",
@@ -256876,7 +256996,7 @@
       "source_location": "L57"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "adjustments_test_createsubmissionmutationctx",
       "label": "createSubmissionMutationCtx()",
@@ -256885,7 +257005,7 @@
       "source_location": "L506"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "adjustments_test_gethandler",
       "label": "getHandler()",
@@ -256894,7 +257014,7 @@
       "source_location": "L53"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "adjustments_test_getsource",
       "label": "getSource()",
@@ -256903,7 +257023,7 @@
       "source_location": "L49"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
       "label": "adjustments.test.ts",
@@ -256912,7 +257032,7 @@
       "source_location": "L1"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_ts",
       "label": "vendors.ts",
@@ -256921,7 +257041,7 @@
       "source_location": "L1"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "vendors_createvendorcommandwithctx",
       "label": "createVendorCommandWithCtx()",
@@ -256930,7 +257050,7 @@
       "source_location": "L124"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "vendors_createvendorwithctx",
       "label": "createVendorWithCtx()",
@@ -256939,7 +257059,7 @@
       "source_location": "L75"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "vendors_mapcreatevendorerror",
       "label": "mapCreateVendorError()",
@@ -256948,7 +257068,7 @@
       "source_location": "L46"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "vendors_normalizevendorlookupkey",
       "label": "normalizeVendorLookupKey()",
@@ -256957,67 +257077,13 @@
       "source_location": "L38"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "vendors_trimoptional",
       "label": "trimOptional()",
       "norm_label": "trimoptional()",
       "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
       "source_location": "L33"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_returnexchangeoperations_ts",
-      "label": "returnExchangeOperations.ts",
-      "norm_label": "returnexchangeoperations.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "returnexchangeoperations_buildonlineorderreportedreturns",
-      "label": "buildOnlineOrderReportedReturns()",
-      "norm_label": "buildonlineorderreportedreturns()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "returnexchangeoperations_buildonlineorderreturnexchangeplan",
-      "label": "buildOnlineOrderReturnExchangePlan()",
-      "norm_label": "buildonlineorderreturnexchangeplan()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
-      "source_location": "L137"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "returnexchangeoperations_getapprovalreason",
-      "label": "getApprovalReason()",
-      "norm_label": "getapprovalreason()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
-      "source_location": "L112"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "returnexchangeoperations_getkind",
-      "label": "getKind()",
-      "norm_label": "getkind()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "returnexchangeoperations_getlinerefundamount",
-      "label": "getLineRefundAmount()",
-      "norm_label": "getlinerefundamount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
-      "source_location": "L92"
     },
     {
       "community": 47,
@@ -257292,6 +257358,60 @@
     {
       "community": 470,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_helpers_returnexchangeoperations_ts",
+      "label": "returnExchangeOperations.ts",
+      "norm_label": "returnexchangeoperations.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "returnexchangeoperations_buildonlineorderreportedreturns",
+      "label": "buildOnlineOrderReportedReturns()",
+      "norm_label": "buildonlineorderreportedreturns()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "returnexchangeoperations_buildonlineorderreturnexchangeplan",
+      "label": "buildOnlineOrderReturnExchangePlan()",
+      "norm_label": "buildonlineorderreturnexchangeplan()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
+      "source_location": "L137"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "returnexchangeoperations_getapprovalreason",
+      "label": "getApprovalReason()",
+      "norm_label": "getapprovalreason()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
+      "source_location": "L112"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "returnexchangeoperations_getkind",
+      "label": "getKind()",
+      "norm_label": "getkind()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "returnexchangeoperations_getlinerefundamount",
+      "label": "getLineRefundAmount()",
+      "norm_label": "getlinerefundamount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/returnExchangeOperations.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
       "id": "onlineorder_test_createunauthorizednormalorderctx",
       "label": "createUnauthorizedNormalOrderCtx()",
       "norm_label": "createunauthorizednormalorderctx()",
@@ -257299,7 +257419,7 @@
       "source_location": "L164"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "onlineorder_test_gethandler",
       "label": "getHandler()",
@@ -257308,7 +257428,7 @@
       "source_location": "L160"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "onlineorder_test_getsource",
       "label": "getSource()",
@@ -257317,7 +257437,7 @@
       "source_location": "L156"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "onlineorder_test_readstorefrontfacts",
       "label": "readStorefrontFacts()",
@@ -257326,7 +257446,7 @@
       "source_location": "L150"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "onlineorder_test_seedfulfillableorder",
       "label": "seedFulfillableOrder()",
@@ -257335,7 +257455,7 @@
       "source_location": "L29"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorder_test_ts",
       "label": "onlineOrder.test.ts",
@@ -257344,7 +257464,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storetime_storetimeauthority_ts",
       "label": "storeTimeAuthority.ts",
@@ -257353,7 +257473,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "storetimeauthority_assertstoretimezoneversioncanbeinserted",
       "label": "assertStoreTimezoneVersionCanBeInserted()",
@@ -257362,7 +257482,7 @@
       "source_location": "L50"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "storetimeauthority_includesoccurrence",
       "label": "includesOccurrence()",
@@ -257371,7 +257491,7 @@
       "source_location": "L18"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "storetimeauthority_intervalsoverlap",
       "label": "intervalsOverlap()",
@@ -257380,7 +257500,7 @@
       "source_location": "L41"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "storetimeauthority_localdate",
       "label": "localDate()",
@@ -257389,7 +257509,7 @@
       "source_location": "L28"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "storetimeauthority_resolvestoretimeauthority",
       "label": "resolveStoreTimeAuthority()",
@@ -257398,7 +257518,7 @@
       "source_location": "L84"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_purchaseorder_ts",
       "label": "purchaseOrder.ts",
@@ -257407,7 +257527,7 @@
       "source_location": "L1"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "purchaseorder_buildpurchaseorderreceivinglookup",
       "label": "buildPurchaseOrderReceivingLookup()",
@@ -257416,7 +257536,7 @@
       "source_location": "L162"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "purchaseorder_buildpurchaseordertraceseed",
       "label": "buildPurchaseOrderTraceSeed()",
@@ -257425,7 +257545,7 @@
       "source_location": "L82"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "purchaseorder_compactdetails",
       "label": "compactDetails()",
@@ -257434,7 +257554,7 @@
       "source_location": "L74"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "purchaseorder_formatpurchaseorderlabel",
       "label": "formatPurchaseOrderLabel()",
@@ -257443,7 +257563,7 @@
       "source_location": "L45"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "purchaseorder_normalizelookup",
       "label": "normalizeLookup()",
@@ -257452,7 +257572,7 @@
       "source_location": "L53"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_find_block_end",
       "label": "find_block_end()",
@@ -257461,7 +257581,7 @@
       "source_location": "L123"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_list_convex_files",
       "label": "list_convex_files()",
@@ -257470,7 +257590,7 @@
       "source_location": "L187"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_main",
       "label": "main()",
@@ -257479,7 +257599,7 @@
       "source_location": "L207"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_scan_file",
       "label": "scan_file()",
@@ -257488,7 +257608,7 @@
       "source_location": "L137"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_strip_code",
       "label": "strip_code()",
@@ -257497,7 +257617,7 @@
       "source_location": "L9"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "packages_athena_webapp_scripts_convexpaginationantipatterncheck_py",
       "label": "convexPaginationAntiPatternCheck.py",
@@ -257506,7 +257626,7 @@
       "source_location": "L1"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "commandresult_approvalrequired",
       "label": "approvalRequired()",
@@ -257515,7 +257635,7 @@
       "source_location": "L62"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "commandresult_isapprovalrequiredresult",
       "label": "isApprovalRequiredResult()",
@@ -257524,7 +257644,7 @@
       "source_location": "L77"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "commandresult_isusererrorresult",
       "label": "isUserErrorResult()",
@@ -257533,7 +257653,7 @@
       "source_location": "L71"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "commandresult_ok",
       "label": "ok()",
@@ -257542,7 +257662,7 @@
       "source_location": "L48"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "commandresult_usererror",
       "label": "userError()",
@@ -257551,7 +257671,7 @@
       "source_location": "L55"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_commandresult_ts",
       "label": "commandResult.ts",
@@ -257560,7 +257680,7 @@
       "source_location": "L1"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "homepageranking_comparehomepagerankeditems",
       "label": "compareHomepageRankedItems()",
@@ -257569,7 +257689,7 @@
       "source_location": "L22"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "homepageranking_gethomepagesortrank",
       "label": "getHomepageSortRank()",
@@ -257578,7 +257698,7 @@
       "source_location": "L9"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "homepageranking_getnexthomepagerank",
       "label": "getNextHomepageRank()",
@@ -257587,7 +257707,7 @@
       "source_location": "L40"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "homepageranking_getpresentedhomepagerank",
       "label": "getPresentedHomepageRank()",
@@ -257596,7 +257716,7 @@
       "source_location": "L15"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "homepageranking_sorthomepagerankeditems",
       "label": "sortHomepageRankedItems()",
@@ -257605,7 +257725,7 @@
       "source_location": "L36"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_homepageranking_ts",
       "label": "homepageRanking.ts",
@@ -257614,7 +257734,7 @@
       "source_location": "L1"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_poslocalsynccontract_ts",
       "label": "posLocalSyncContract.ts",
@@ -257623,7 +257743,7 @@
       "source_location": "L1"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "poslocalsynccontract_canuploadposlocalsynclocaleventtype",
       "label": "canUploadPosLocalSyncLocalEventType()",
@@ -257632,7 +257752,7 @@
       "source_location": "L143"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "poslocalsynccontract_eventtypesfromcontract",
       "label": "eventTypesFromContract()",
@@ -257641,7 +257761,7 @@
       "source_location": "L60"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "poslocalsynccontract_getposlocalsynceventcontractforlocaleventtype",
       "label": "getPosLocalSyncEventContractForLocalEventType()",
@@ -257650,7 +257770,7 @@
       "source_location": "L123"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "poslocalsynccontract_getposlocalsynceventtypeforlocaleventtype",
       "label": "getPosLocalSyncEventTypeForLocalEventType()",
@@ -257659,7 +257779,7 @@
       "source_location": "L136"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "poslocalsynccontract_isposlocalsynceventtype",
       "label": "isPosLocalSyncEventType()",
@@ -257668,7 +257788,7 @@
       "source_location": "L117"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_registersessionstatus_ts",
       "label": "registerSessionStatus.ts",
@@ -257677,7 +257797,7 @@
       "source_location": "L1"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "registersessionstatus_includesregistersessionstatus",
       "label": "includesRegisterSessionStatus()",
@@ -257686,7 +257806,7 @@
       "source_location": "L38"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "registersessionstatus_iscashcontrolvisibleregistersessionstatus",
       "label": "isCashControlVisibleRegisterSessionStatus()",
@@ -257695,7 +257815,7 @@
       "source_location": "L62"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "registersessionstatus_isposusableregistersessionstatus",
       "label": "isPosUsableRegisterSessionStatus()",
@@ -257704,7 +257824,7 @@
       "source_location": "L48"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "registersessionstatus_isregistersessionconflictblockingstatus",
       "label": "isRegisterSessionConflictBlockingStatus()",
@@ -257713,7 +257833,7 @@
       "source_location": "L55"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "registersessionstatus_isregistersessionstatus",
       "label": "isRegisterSessionStatus()",
@@ -257722,7 +257842,7 @@
       "source_location": "L29"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_workflowtrace_ts",
       "label": "workflowTrace.ts",
@@ -257731,7 +257851,7 @@
       "source_location": "L1"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "workflowtrace_assertobjectkeysareminimized",
       "label": "assertObjectKeysAreMinimized()",
@@ -257740,7 +257860,7 @@
       "source_location": "L44"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "workflowtrace_assertworkflowtracedetailsareminimized",
       "label": "assertWorkflowTraceDetailsAreMinimized()",
@@ -257749,7 +257869,7 @@
       "source_location": "L67"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "workflowtrace_createworkflowtraceid",
       "label": "createWorkflowTraceId()",
@@ -257758,7 +257878,7 @@
       "source_location": "L93"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "workflowtrace_normalizeworkflowtraceeventkey",
       "label": "normalizeWorkflowTraceEventKey()",
@@ -257767,67 +257887,13 @@
       "source_location": "L83"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "workflowtrace_normalizeworkflowtracelookupvalue",
       "label": "normalizeWorkflowTraceLookupValue()",
       "norm_label": "normalizeworkflowtracelookupvalue()",
       "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
       "source_location": "L73"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productcategorization_tsx",
-      "label": "ProductCategorization.tsx",
-      "norm_label": "productcategorization.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "productcategorization_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
-      "source_location": "L327"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "productcategorization_handleclose",
-      "label": "handleClose()",
-      "norm_label": "handleclose()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
-      "source_location": "L234"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "productcategorization_handleproductposvisibility",
-      "label": "handleProductPosVisibility()",
-      "norm_label": "handleproductposvisibility()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
-      "source_location": "L284"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "productcategorization_handleproductvisibility",
-      "label": "handleProductVisibility()",
-      "norm_label": "handleproductvisibility()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
-      "source_location": "L274"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "productcategorization_setinitialselectedoption",
-      "label": "setInitialSelectedOption()",
-      "norm_label": "setinitialselectedoption()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
-      "source_location": "L261"
     },
     {
       "community": 48,
@@ -258093,6 +258159,60 @@
     {
       "community": 480,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_productcategorization_tsx",
+      "label": "ProductCategorization.tsx",
+      "norm_label": "productcategorization.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "productcategorization_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
+      "source_location": "L327"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "productcategorization_handleclose",
+      "label": "handleClose()",
+      "norm_label": "handleclose()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
+      "source_location": "L234"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "productcategorization_handleproductposvisibility",
+      "label": "handleProductPosVisibility()",
+      "norm_label": "handleproductposvisibility()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
+      "source_location": "L284"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "productcategorization_handleproductvisibility",
+      "label": "handleProductVisibility()",
+      "norm_label": "handleproductvisibility()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
+      "source_location": "L274"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "productcategorization_setinitialselectedoption",
+      "label": "setInitialSelectedOption()",
+      "norm_label": "setinitialselectedoption()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
+      "source_location": "L261"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
       "id": "data_table_toolbar_datatabletoolbar",
       "label": "DataTableToolbar()",
       "norm_label": "datatabletoolbar()",
@@ -258100,7 +258220,7 @@
       "source_location": "L23"
     },
     {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -258109,7 +258229,7 @@
       "source_location": "L1"
     },
     {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -258118,7 +258238,7 @@
       "source_location": "L1"
     },
     {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -258127,7 +258247,7 @@
       "source_location": "L1"
     },
     {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -258136,7 +258256,7 @@
       "source_location": "L1"
     },
     {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -258145,7 +258265,7 @@
       "source_location": "L1"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
       "label": "selectable-data-provider.tsx",
@@ -258154,7 +258274,7 @@
       "source_location": "L1"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
       "label": "selectable-data-provider.tsx",
@@ -258163,7 +258283,7 @@
       "source_location": "L1"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
       "label": "selectable-data-provider.tsx",
@@ -258172,7 +258292,7 @@
       "source_location": "L1"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
       "label": "selectable-data-provider.tsx",
@@ -258181,7 +258301,7 @@
       "source_location": "L1"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "selectable_data_provider_selectedproductsprovider",
       "label": "SelectedProductsProvider()",
@@ -258190,7 +258310,7 @@
       "source_location": "L16"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "selectable_data_provider_useselectedproducts",
       "label": "useSelectedProducts()",
@@ -258199,7 +258319,7 @@
       "source_location": "L37"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "flipnumber_defaultformatvalue",
       "label": "defaultFormatValue()",
@@ -258208,7 +258328,7 @@
       "source_location": "L20"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "flipnumber_flipnumber",
       "label": "FlipNumber()",
@@ -258217,7 +258337,7 @@
       "source_location": "L202"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "flipnumber_fliptext",
       "label": "FlipText()",
@@ -258226,7 +258346,7 @@
       "source_location": "L47"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "flipnumber_renderflipglyphs",
       "label": "renderFlipGlyphs()",
@@ -258235,7 +258355,7 @@
       "source_location": "L24"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "flipnumber_renderfliptext",
       "label": "renderFlipText()",
@@ -258244,7 +258364,7 @@
       "source_location": "L37"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_flipnumber_tsx",
       "label": "FlipNumber.tsx",
@@ -258253,7 +258373,7 @@
       "source_location": "L1"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "bannermessageeditor_getcountdownstatus",
       "label": "getCountdownStatus()",
@@ -258262,7 +258382,7 @@
       "source_location": "L130"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "bannermessageeditor_handleactivetoggle",
       "label": "handleActiveToggle()",
@@ -258271,7 +258391,7 @@
       "source_location": "L90"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "bannermessageeditor_handleclear",
       "label": "handleClear()",
@@ -258280,7 +258400,7 @@
       "source_location": "L65"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "bannermessageeditor_handlecountdownchange",
       "label": "handleCountdownChange()",
@@ -258289,7 +258409,7 @@
       "source_location": "L120"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "bannermessageeditor_handlesave",
       "label": "handleSave()",
@@ -258298,7 +258418,7 @@
       "source_location": "L45"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bannermessageeditor_tsx",
       "label": "BannerMessageEditor.tsx",
@@ -258307,7 +258427,7 @@
       "source_location": "L1"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "bestsellers_bestsellers",
       "label": "bestSellers()",
@@ -258316,7 +258436,7 @@
       "source_location": "L157"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "bestsellers_handleremovebestseller",
       "label": "handleRemoveBestSeller()",
@@ -258325,7 +258445,7 @@
       "source_location": "L66"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "bestsellers_movebestseller",
       "label": "moveBestSeller()",
@@ -258334,7 +258454,7 @@
       "source_location": "L126"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "bestsellers_ondragend",
       "label": "onDragEnd()",
@@ -258343,7 +258463,7 @@
       "source_location": "L76"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "bestsellers_saveorder",
       "label": "saveOrder()",
@@ -258352,7 +258472,7 @@
       "source_location": "L104"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
       "label": "BestSellers.tsx",
@@ -258361,7 +258481,7 @@
       "source_location": "L1"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "featuredsection_formatstoredcurrencyamount",
       "label": "formatStoredCurrencyAmount()",
@@ -258370,7 +258490,7 @@
       "source_location": "L215"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "featuredsection_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -258379,7 +258499,7 @@
       "source_location": "L66"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "featuredsection_movefeatureditem",
       "label": "moveFeaturedItem()",
@@ -258388,7 +258508,7 @@
       "source_location": "L128"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "featuredsection_ondragend",
       "label": "onDragEnd()",
@@ -258397,7 +258517,7 @@
       "source_location": "L78"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "featuredsection_saveorder",
       "label": "saveOrder()",
@@ -258406,7 +258526,7 @@
       "source_location": "L106"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
       "label": "FeaturedSection.tsx",
@@ -258415,7 +258535,7 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_landing_story_scenechrome_tsx",
       "label": "SceneChrome.tsx",
@@ -258424,7 +258544,7 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "scenechrome_appshellexhibit",
       "label": "AppShellExhibit()",
@@ -258433,7 +258553,7 @@
       "source_location": "L131"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "scenechrome_automationbeat",
       "label": "AutomationBeat()",
@@ -258442,7 +258562,7 @@
       "source_location": "L272"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "scenechrome_possyncbadge",
       "label": "PosSyncBadge()",
@@ -258451,7 +258571,7 @@
       "source_location": "L248"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "scenechrome_workspaceexhibit",
       "label": "WorkspaceExhibit()",
@@ -258460,7 +258580,7 @@
       "source_location": "L80"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "scenechrome_workspaceframe",
       "label": "WorkspaceFrame()",
@@ -258469,7 +258589,7 @@
       "source_location": "L39"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "dailyclosehistoryview_test_historyrecord",
       "label": "historyRecord()",
@@ -258478,7 +258598,7 @@
       "source_location": "L190"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "dailyclosehistoryview_test_mockprotectedstate",
       "label": "mockProtectedState()",
@@ -258487,7 +258607,7 @@
       "source_location": "L241"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "dailyclosehistoryview_test_mockqueries",
       "label": "mockQueries()",
@@ -258496,7 +258616,7 @@
       "source_location": "L255"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "dailyclosehistoryview_test_snapshot",
       "label": "snapshot()",
@@ -258505,7 +258625,7 @@
       "source_location": "L104"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "dailyclosehistoryview_test_storedreportsnapshot",
       "label": "storedReportSnapshot()",
@@ -258514,7 +258634,7 @@
       "source_location": "L171"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_dailyclosehistoryview_test_tsx",
       "label": "DailyCloseHistoryView.test.tsx",
@@ -258523,7 +258643,7 @@
       "source_location": "L1"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "dailyopeningview_test_async",
       "label": "async()",
@@ -258532,7 +258652,7 @@
       "source_location": "L124"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "dailyopeningview_test_disconnect",
       "label": "disconnect()",
@@ -258541,7 +258661,7 @@
       "source_location": "L359"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "dailyopeningview_test_formatexpectedtimestamp",
       "label": "formatExpectedTimestamp()",
@@ -258550,7 +258670,7 @@
       "source_location": "L258"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "dailyopeningview_test_observe",
       "label": "observe()",
@@ -258559,7 +258679,7 @@
       "source_location": "L360"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "dailyopeningview_test_unobserve",
       "label": "unobserve()",
@@ -258568,67 +258688,13 @@
       "source_location": "L361"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_dailyopeningview_test_tsx",
       "label": "DailyOpeningView.test.tsx",
       "norm_label": "dailyopeningview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_skuactivityuntrustedsales_tsx",
-      "label": "SkuActivityUntrustedSales.tsx",
-      "norm_label": "skuactivityuntrustedsales.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/SkuActivityUntrustedSales.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "skuactivityuntrustedsales_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/operations/SkuActivityUntrustedSales.tsx",
-      "source_location": "L207"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "skuactivityuntrustedsales_formatcountlabel",
-      "label": "formatCountLabel()",
-      "norm_label": "formatcountlabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/SkuActivityUntrustedSales.tsx",
-      "source_location": "L139"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "skuactivityuntrustedsales_handlesourcepagechange",
-      "label": "handleSourcePageChange()",
-      "norm_label": "handlesourcepagechange()",
-      "source_file": "packages/athena-webapp/src/components/operations/SkuActivityUntrustedSales.tsx",
-      "source_location": "L932"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "skuactivityuntrustedsales_sourcematchesevidencequery",
-      "label": "sourceMatchesEvidenceQuery()",
-      "norm_label": "sourcematchesevidencequery()",
-      "source_file": "packages/athena-webapp/src/components/operations/SkuActivityUntrustedSales.tsx",
-      "source_location": "L147"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "skuactivityuntrustedsales_usedetailstickyposition",
-      "label": "useDetailStickyPosition()",
-      "norm_label": "usedetailstickyposition()",
-      "source_file": "packages/athena-webapp/src/components/operations/SkuActivityUntrustedSales.tsx",
-      "source_location": "L83"
     },
     {
       "community": 49,
@@ -258894,6 +258960,60 @@
     {
       "community": 490,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_operations_skuactivityuntrustedsales_tsx",
+      "label": "SkuActivityUntrustedSales.tsx",
+      "norm_label": "skuactivityuntrustedsales.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/SkuActivityUntrustedSales.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "skuactivityuntrustedsales_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/operations/SkuActivityUntrustedSales.tsx",
+      "source_location": "L207"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "skuactivityuntrustedsales_formatcountlabel",
+      "label": "formatCountLabel()",
+      "norm_label": "formatcountlabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/SkuActivityUntrustedSales.tsx",
+      "source_location": "L139"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "skuactivityuntrustedsales_handlesourcepagechange",
+      "label": "handleSourcePageChange()",
+      "norm_label": "handlesourcepagechange()",
+      "source_file": "packages/athena-webapp/src/components/operations/SkuActivityUntrustedSales.tsx",
+      "source_location": "L932"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "skuactivityuntrustedsales_sourcematchesevidencequery",
+      "label": "sourceMatchesEvidenceQuery()",
+      "norm_label": "sourcematchesevidencequery()",
+      "source_file": "packages/athena-webapp/src/components/operations/SkuActivityUntrustedSales.tsx",
+      "source_location": "L147"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "skuactivityuntrustedsales_usedetailstickyposition",
+      "label": "useDetailStickyPosition()",
+      "norm_label": "usedetailstickyposition()",
+      "source_file": "packages/athena-webapp/src/components/operations/SkuActivityUntrustedSales.tsx",
+      "source_location": "L83"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_useapprovedcommand_tsx",
       "label": "useApprovedCommand.tsx",
       "norm_label": "useapprovedcommand.tsx",
@@ -258901,7 +259021,7 @@
       "source_location": "L1"
     },
     {
-      "community": 490,
+      "community": 491,
       "file_type": "code",
       "id": "useapprovedcommand_buildapprovalretryargs",
       "label": "buildApprovalRetryArgs()",
@@ -258910,7 +259030,7 @@
       "source_location": "L90"
     },
     {
-      "community": 490,
+      "community": 491,
       "file_type": "code",
       "id": "useapprovedcommand_getasyncapprovalrequestid",
       "label": "getAsyncApprovalRequestId()",
@@ -258919,7 +259039,7 @@
       "source_location": "L78"
     },
     {
-      "community": 490,
+      "community": 491,
       "file_type": "code",
       "id": "useapprovedcommand_hasasyncapprovalrequest",
       "label": "hasAsyncApprovalRequest()",
@@ -258928,7 +259048,7 @@
       "source_location": "L72"
     },
     {
-      "community": 490,
+      "community": 491,
       "file_type": "code",
       "id": "useapprovedcommand_hasinlinemanagerproof",
       "label": "hasInlineManagerProof()",
@@ -258937,7 +259057,7 @@
       "source_location": "L66"
     },
     {
-      "community": 490,
+      "community": 491,
       "file_type": "code",
       "id": "useapprovedcommand_useapprovedcommand",
       "label": "useApprovedCommand()",
@@ -258946,7 +259066,7 @@
       "source_location": "L102"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_test_tsx",
       "label": "PaymentsAddedList.test.tsx",
@@ -258955,7 +259075,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "paymentsaddedlist_test_deferred",
       "label": "deferred()",
@@ -258964,7 +259084,7 @@
       "source_location": "L46"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "paymentsaddedlist_test_getsummaryamount",
       "label": "getSummaryAmount()",
@@ -258973,7 +259093,7 @@
       "source_location": "L28"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "paymentsaddedlist_test_getsummarylabel",
       "label": "getSummaryLabel()",
@@ -258982,7 +259102,7 @@
       "source_location": "L19"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "paymentsaddedlist_test_getsummarypanel",
       "label": "getSummaryPanel()",
@@ -258991,7 +259111,7 @@
       "source_location": "L41"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "paymentsaddedlist_test_stripwhitespace",
       "label": "stripWhitespace()",
@@ -259000,7 +259120,7 @@
       "source_location": "L15"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
       "label": "PointOfSaleView.tsx",
@@ -259009,7 +259129,7 @@
       "source_location": "L1"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "pointofsaleview_formatnextopeninglabel",
       "label": "formatNextOpeningLabel()",
@@ -259018,7 +259138,7 @@
       "source_location": "L132"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "pointofsaleview_formatstorehourstimelabel",
       "label": "formatStoreHoursTimeLabel()",
@@ -259027,7 +259147,7 @@
       "source_location": "L101"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "pointofsaleview_formatstorelocaldatelabel",
       "label": "formatStoreLocalDateLabel()",
@@ -259036,7 +259156,7 @@
       "source_location": "L117"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "pointofsaleview_formatstorelocaldatetime",
       "label": "formatStoreLocalDateTime()",
@@ -259045,7 +259165,7 @@
       "source_location": "L80"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "pointofsaleview_useminutenow",
       "label": "useMinuteNow()",
@@ -259054,7 +259174,7 @@
       "source_location": "L145"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_posregisteropeningguard_tsx",
       "label": "POSRegisterOpeningGuard.tsx",
@@ -259063,7 +259183,7 @@
       "source_location": "L1"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "posregisteropeningguard_getlocaloperatingdate",
       "label": "getLocalOperatingDate()",
@@ -259072,7 +259192,7 @@
       "source_location": "L65"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "posregisteropeningguard_getlocaloperatingdaterange",
       "label": "getLocalOperatingDateRange()",
@@ -259081,7 +259201,7 @@
       "source_location": "L73"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "posregisteropeningguard_if",
       "label": "if()",
@@ -259090,7 +259210,7 @@
       "source_location": "L689"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "posregisteropeningguard_isbrowseroffline",
       "label": "isBrowserOffline()",
@@ -259099,7 +259219,7 @@
       "source_location": "L92"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "posregisteropeningguard_posregisteropeningguard",
       "label": "POSRegisterOpeningGuard()",
@@ -259108,7 +259228,7 @@
       "source_location": "L96"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
       "label": "TransactionView.test.tsx",
@@ -259117,7 +259237,7 @@
       "source_location": "L1"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "transactionview_test_async",
       "label": "async()",
@@ -259126,7 +259246,7 @@
       "source_location": "L199"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "transactionview_test_deferred",
       "label": "deferred()",
@@ -259135,7 +259255,7 @@
       "source_location": "L15"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "transactionview_test_mocktransactionmutations",
       "label": "mockTransactionMutations()",
@@ -259144,7 +259264,7 @@
       "source_location": "L554"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "transactionview_test_paymentapprovalrequirement",
       "label": "paymentApprovalRequirement()",
@@ -259153,7 +259273,7 @@
       "source_location": "L473"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "transactionview_test_voidapprovalrequirement",
       "label": "voidApprovalRequirement()",
@@ -259162,7 +259282,7 @@
       "source_location": "L506"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_test_tsx",
       "label": "ProcurementView.test.tsx",
@@ -259171,7 +259291,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "procurementview_test_choosedraftvendor",
       "label": "chooseDraftVendor()",
@@ -259180,7 +259300,7 @@
       "source_location": "L367"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "procurementview_test_chooseprocurementmode",
       "label": "chooseProcurementMode()",
@@ -259189,7 +259309,7 @@
       "source_location": "L357"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "procurementview_test_installmutationmocks",
       "label": "installMutationMocks()",
@@ -259198,7 +259318,7 @@
       "source_location": "L323"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "procurementview_test_makeproductskusearchresult",
       "label": "makeProductSkuSearchResult()",
@@ -259207,7 +259327,7 @@
       "source_location": "L294"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "procurementview_test_makerecommendation",
       "label": "makeRecommendation()",
@@ -259216,7 +259336,7 @@
       "source_location": "L285"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_weeklyreportpresentation_ts",
       "label": "weeklyReportPresentation.ts",
@@ -259225,7 +259345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "weeklyreportpresentation_weeklyamendmentlabel",
       "label": "weeklyAmendmentLabel()",
@@ -259234,7 +259354,7 @@
       "source_location": "L74"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "weeklyreportpresentation_weeklylifecyclelabel",
       "label": "weeklyLifecycleLabel()",
@@ -259243,7 +259363,7 @@
       "source_location": "L16"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "weeklyreportpresentation_weeklytotalswithheld",
       "label": "weeklyTotalsWithheld()",
@@ -259252,7 +259372,7 @@
       "source_location": "L50"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "weeklyreportpresentation_weeklyupdatedat",
       "label": "weeklyUpdatedAt()",
@@ -259261,7 +259381,7 @@
       "source_location": "L3"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "weeklyreportpresentation_weeklyvaluelabelprefix",
       "label": "weeklyValueLabelPrefix()",
@@ -259270,7 +259390,7 @@
       "source_location": "L63"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewsview_tsx",
       "label": "ReviewsView.tsx",
@@ -259279,7 +259399,7 @@
       "source_location": "L1"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "reviewsview_handleapprove",
       "label": "handleApprove()",
@@ -259288,7 +259408,7 @@
       "source_location": "L44"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "reviewsview_handlepublish",
       "label": "handlePublish()",
@@ -259297,7 +259417,7 @@
       "source_location": "L80"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "reviewsview_handlereject",
       "label": "handleReject()",
@@ -259306,7 +259426,7 @@
       "source_location": "L62"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "reviewsview_handleunpublish",
       "label": "handleUnpublish()",
@@ -259315,7 +259435,7 @@
       "source_location": "L98"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "reviewsview_header",
       "label": "Header()",
@@ -259324,7 +259444,7 @@
       "source_location": "L15"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecatalogform_ts",
       "label": "serviceCatalogForm.ts",
@@ -259333,7 +259453,7 @@
       "source_location": "L1"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "servicecatalogform_formatservicecatalogname",
       "label": "formatServiceCatalogName()",
@@ -259342,7 +259462,7 @@
       "source_location": "L92"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "servicecatalogform_itemtoservicecatalogformstate",
       "label": "itemToServiceCatalogFormState()",
@@ -259351,7 +259471,7 @@
       "source_location": "L154"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "servicecatalogform_parseservicecatalogcreateform",
       "label": "parseServiceCatalogCreateForm()",
@@ -259360,7 +259480,7 @@
       "source_location": "L178"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "servicecatalogform_parseservicecatalogupdateform",
       "label": "parseServiceCatalogUpdateForm()",
@@ -259369,67 +259489,13 @@
       "source_location": "L203"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "servicecatalogform_validateservicecatalogform",
       "label": "validateServiceCatalogForm()",
       "norm_label": "validateservicecatalogform()",
       "source_file": "packages/athena-webapp/src/components/services/serviceCatalogForm.ts",
       "source_location": "L102"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_shared_demo_shareddemolivereportsday_test_ts",
-      "label": "sharedDemoLiveReportsDay.test.ts",
-      "norm_label": "shareddemolivereportsday.test.ts",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLiveReportsDay.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "shareddemolivereportsday_test_identity",
-      "label": "identity()",
-      "norm_label": "identity()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLiveReportsDay.test.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "shareddemolivereportsday_test_liveresult",
-      "label": "liveResult()",
-      "norm_label": "liveresult()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLiveReportsDay.test.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "shareddemolivereportsday_test_metrics",
-      "label": "metrics()",
-      "norm_label": "metrics()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLiveReportsDay.test.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "shareddemolivereportsday_test_quickaddidentity",
-      "label": "quickAddIdentity()",
-      "norm_label": "quickaddidentity()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLiveReportsDay.test.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "shareddemolivereportsday_test_skumetrics",
-      "label": "skuMetrics()",
-      "norm_label": "skumetrics()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLiveReportsDay.test.ts",
-      "source_location": "L64"
     },
     {
       "community": 5,
@@ -260379,6 +260445,60 @@
     {
       "community": 500,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_shared_demo_shareddemolivereportsday_test_ts",
+      "label": "sharedDemoLiveReportsDay.test.ts",
+      "norm_label": "shareddemolivereportsday.test.ts",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLiveReportsDay.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "shareddemolivereportsday_test_identity",
+      "label": "identity()",
+      "norm_label": "identity()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLiveReportsDay.test.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "shareddemolivereportsday_test_liveresult",
+      "label": "liveResult()",
+      "norm_label": "liveresult()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLiveReportsDay.test.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "shareddemolivereportsday_test_metrics",
+      "label": "metrics()",
+      "norm_label": "metrics()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLiveReportsDay.test.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "shareddemolivereportsday_test_quickaddidentity",
+      "label": "quickAddIdentity()",
+      "norm_label": "quickaddidentity()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLiveReportsDay.test.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "shareddemolivereportsday_test_skumetrics",
+      "label": "skuMetrics()",
+      "norm_label": "skumetrics()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLiveReportsDay.test.ts",
+      "source_location": "L64"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemolivereportsday_ts",
       "label": "sharedDemoLiveReportsDay.ts",
       "norm_label": "shareddemolivereportsday.ts",
@@ -260386,7 +260506,7 @@
       "source_location": "L1"
     },
     {
-      "community": 500,
+      "community": 501,
       "file_type": "code",
       "id": "shareddemolivereportsday_addskumetrics",
       "label": "addSkuMetrics()",
@@ -260395,7 +260515,7 @@
       "source_location": "L142"
     },
     {
-      "community": 500,
+      "community": 501,
       "file_type": "code",
       "id": "shareddemolivereportsday_shareddemofixtureskuid",
       "label": "sharedDemoFixtureSkuId()",
@@ -260404,7 +260524,7 @@
       "source_location": "L117"
     },
     {
-      "community": 500,
+      "community": 501,
       "file_type": "code",
       "id": "shareddemolivereportsday_toshareddemolivereportsday",
       "label": "toSharedDemoLiveReportsDay()",
@@ -260413,7 +260533,7 @@
       "source_location": "L169"
     },
     {
-      "community": 500,
+      "community": 501,
       "file_type": "code",
       "id": "shareddemolivereportsday_toshareddemoliveskustock",
       "label": "toSharedDemoLiveSkuStock()",
@@ -260422,7 +260542,7 @@
       "source_location": "L240"
     },
     {
-      "community": 500,
+      "community": 501,
       "file_type": "code",
       "id": "shareddemolivereportsday_zerodaymetrics",
       "label": "zeroDayMetrics()",
@@ -260431,7 +260551,7 @@
       "source_location": "L127"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemosurfacecatalog_ts",
       "label": "sharedDemoSurfaceCatalog.ts",
@@ -260440,7 +260560,7 @@
       "source_location": "L1"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "shareddemosurfacecatalog_classifyathenaviewsurface",
       "label": "classifyAthenaViewSurface()",
@@ -260449,7 +260569,7 @@
       "source_location": "L395"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "shareddemosurfacecatalog_isshareddemosurfacevisible",
       "label": "isSharedDemoSurfaceVisible()",
@@ -260458,7 +260578,7 @@
       "source_location": "L401"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "shareddemosurfacecatalog_normalizepathname",
       "label": "normalizePathname()",
@@ -260467,7 +260587,7 @@
       "source_location": "L332"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "shareddemosurfacecatalog_resolveathenaviewroute",
       "label": "resolveAthenaViewRoute()",
@@ -260476,7 +260596,7 @@
       "source_location": "L364"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "shareddemosurfacecatalog_routetemplatematches",
       "label": "routeTemplateMatches()",
@@ -260485,7 +260605,7 @@
       "source_location": "L340"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "feesview_formatdeliveryfeeinput",
       "label": "formatDeliveryFeeInput()",
@@ -260494,7 +260614,7 @@
       "source_location": "L31"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "feesview_handletoggleallfees",
       "label": "handleToggleAllFees()",
@@ -260503,7 +260623,7 @@
       "source_location": "L162"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "feesview_handleupdatefees",
       "label": "handleUpdateFees()",
@@ -260512,7 +260632,7 @@
       "source_location": "L88"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "feesview_parsedeliveryfeeinputs",
       "label": "parseDeliveryFeeInputs()",
@@ -260521,7 +260641,7 @@
       "source_location": "L45"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "feesview_parseoptionaldeliveryfeeinput",
       "label": "parseOptionalDeliveryFeeInput()",
@@ -260530,7 +260650,7 @@
       "source_location": "L35"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_tsx",
       "label": "FeesView.tsx",
@@ -260539,7 +260659,7 @@
       "source_location": "L1"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usenotificationsubscriptions_ts",
       "label": "useNotificationSubscriptions.ts",
@@ -260548,7 +260668,7 @@
       "source_location": "L1"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "usenotificationsubscriptions_derivecategorystate",
       "label": "deriveCategoryState()",
@@ -260557,7 +260677,7 @@
       "source_location": "L113"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "usenotificationsubscriptions_isvalidrecipientemail",
       "label": "isValidRecipientEmail()",
@@ -260566,7 +260686,7 @@
       "source_location": "L104"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "usenotificationsubscriptions_normalizerecipientemailinput",
       "label": "normalizeRecipientEmailInput()",
@@ -260575,7 +260695,7 @@
       "source_location": "L100"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "usenotificationsubscriptions_sortrecipientcandidates",
       "label": "sortRecipientCandidates()",
@@ -260584,7 +260704,7 @@
       "source_location": "L127"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "usenotificationsubscriptions_usenotificationsubscriptions",
       "label": "useNotificationSubscriptions()",
@@ -260593,7 +260713,7 @@
       "source_location": "L138"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "image_uploader_ondragend",
       "label": "onDragEnd()",
@@ -260602,7 +260722,7 @@
       "source_location": "L101"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "image_uploader_ondrop",
       "label": "onDrop()",
@@ -260611,7 +260731,7 @@
       "source_location": "L20"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "image_uploader_removeimage",
       "label": "removeImage()",
@@ -260620,7 +260740,7 @@
       "source_location": "L31"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "image_uploader_unmarkfordeletion",
       "label": "unmarkForDeletion()",
@@ -260629,7 +260749,7 @@
       "source_location": "L46"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
       "label": "image-uploader.tsx",
@@ -260638,7 +260758,7 @@
       "source_location": "L1"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
       "label": "image-uploader.tsx",
@@ -260647,7 +260767,7 @@
       "source_location": "L1"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "config_derivestorefrontfromadminhost",
       "label": "deriveStoreFrontFromAdminHost()",
@@ -260656,7 +260776,7 @@
       "source_location": "L29"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "config_getruntimeorigin",
       "label": "getRuntimeOrigin()",
@@ -260665,7 +260785,7 @@
       "source_location": "L12"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "config_islocalhost",
       "label": "isLocalHost()",
@@ -260674,7 +260794,7 @@
       "source_location": "L20"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "config_resolvestorefronturl",
       "label": "resolveStoreFrontUrl()",
@@ -260683,7 +260803,7 @@
       "source_location": "L51"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "config_trimtrailingslash",
       "label": "trimTrailingSlash()",
@@ -260692,7 +260812,7 @@
       "source_location": "L8"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "packages_athena_webapp_src_config_ts",
       "label": "config.ts",
@@ -260701,7 +260821,7 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "managerelevationcontext_getstaffdisplayname",
       "label": "getStaffDisplayName()",
@@ -260710,7 +260830,7 @@
       "source_location": "L64"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "managerelevationcontext_managerelevationprovider",
       "label": "ManagerElevationProvider()",
@@ -260719,7 +260839,7 @@
       "source_location": "L87"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "managerelevationcontext_tostaffauthenticationresult",
       "label": "toStaffAuthenticationResult()",
@@ -260728,7 +260848,7 @@
       "source_location": "L74"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "managerelevationcontext_usemanagerelevation",
       "label": "useManagerElevation()",
@@ -260737,7 +260857,7 @@
       "source_location": "L242"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "managerelevationcontext_useoptionalmanagerelevation",
       "label": "useOptionalManagerElevation()",
@@ -260746,7 +260866,7 @@
       "source_location": "L251"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_managerelevationcontext_tsx",
       "label": "ManagerElevationContext.tsx",
@@ -260755,7 +260875,7 @@
       "source_location": "L1"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
       "label": "useExpenseSessions.ts",
@@ -260764,7 +260884,7 @@
       "source_location": "L1"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "useexpensesessions_useexpenseactivesession",
       "label": "useExpenseActiveSession()",
@@ -260773,7 +260893,7 @@
       "source_location": "L42"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesession",
       "label": "useExpenseSession()",
@@ -260782,7 +260902,7 @@
       "source_location": "L32"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessioncreate",
       "label": "useExpenseSessionCreate()",
@@ -260791,7 +260911,7 @@
       "source_location": "L62"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessionupdate",
       "label": "useExpenseSessionUpdate()",
@@ -260800,7 +260920,7 @@
       "source_location": "L101"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "useexpensesessions_useexpensestoresessions",
       "label": "useExpenseStoreSessions()",
@@ -260809,7 +260929,7 @@
       "source_location": "L10"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "capabilities_canaccesscashcontrolssurface",
       "label": "canAccessCashControlsSurface()",
@@ -260818,7 +260938,7 @@
       "source_location": "L54"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "capabilities_canaccessfulladminsurface",
       "label": "canAccessFullAdminSurface()",
@@ -260827,7 +260947,7 @@
       "source_location": "L41"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "capabilities_canaccessstoredaysurface",
       "label": "canAccessStoreDaySurface()",
@@ -260836,7 +260956,7 @@
       "source_location": "L47"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "capabilities_canviewfinancialdetails",
       "label": "canViewFinancialDetails()",
@@ -260845,7 +260965,7 @@
       "source_location": "L61"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "capabilities_getsurfaceaccess",
       "label": "getSurfaceAccess()",
@@ -260854,66 +260974,12 @@
       "source_location": "L68"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_access_capabilities_ts",
       "label": "capabilities.ts",
       "norm_label": "capabilities.ts",
       "source_file": "packages/athena-webapp/src/lib/access/capabilities.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "behaviorutils_calculateengagementmetrics",
-      "label": "calculateEngagementMetrics()",
-      "norm_label": "calculateengagementmetrics()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L173"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "behaviorutils_calculateriskindicators",
-      "label": "calculateRiskIndicators()",
-      "norm_label": "calculateriskindicators()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "behaviorutils_getactivitypriority",
-      "label": "getActivityPriority()",
-      "norm_label": "getactivitypriority()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L251"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "behaviorutils_getcustomerjourneystage",
-      "label": "getCustomerJourneyStage()",
-      "norm_label": "getcustomerjourneystage()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "behaviorutils_getjourneystageinfo",
-      "label": "getJourneyStageInfo()",
-      "norm_label": "getjourneystageinfo()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L277"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
-      "label": "behaviorUtils.ts",
-      "norm_label": "behaviorutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L1"
     },
     {
@@ -261180,6 +261246,60 @@
     {
       "community": 510,
       "file_type": "code",
+      "id": "behaviorutils_calculateengagementmetrics",
+      "label": "calculateEngagementMetrics()",
+      "norm_label": "calculateengagementmetrics()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L173"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "behaviorutils_calculateriskindicators",
+      "label": "calculateRiskIndicators()",
+      "norm_label": "calculateriskindicators()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "behaviorutils_getactivitypriority",
+      "label": "getActivityPriority()",
+      "norm_label": "getactivitypriority()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L251"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "behaviorutils_getcustomerjourneystage",
+      "label": "getCustomerJourneyStage()",
+      "norm_label": "getcustomerjourneystage()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "behaviorutils_getjourneystageinfo",
+      "label": "getJourneyStageInfo()",
+      "norm_label": "getjourneystageinfo()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L277"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
+      "label": "behaviorUtils.ts",
+      "norm_label": "behaviorutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
       "label": "results.ts",
       "norm_label": "results.ts",
@@ -261187,7 +261307,7 @@
       "source_location": "L1"
     },
     {
-      "community": 510,
+      "community": 511,
       "file_type": "code",
       "id": "results_isposusecasesuccess",
       "label": "isPosUseCaseSuccess()",
@@ -261196,7 +261316,7 @@
       "source_location": "L134"
     },
     {
-      "community": 510,
+      "community": 511,
       "file_type": "code",
       "id": "results_mapcommandoutcome",
       "label": "mapCommandOutcome()",
@@ -261205,7 +261325,7 @@
       "source_location": "L69"
     },
     {
-      "community": 510,
+      "community": 511,
       "file_type": "code",
       "id": "results_mapcommandresult",
       "label": "mapCommandResult()",
@@ -261214,7 +261334,7 @@
       "source_location": "L86"
     },
     {
-      "community": 510,
+      "community": 511,
       "file_type": "code",
       "id": "results_maplegacymutationresult",
       "label": "mapLegacyMutationResult()",
@@ -261223,7 +261343,7 @@
       "source_location": "L52"
     },
     {
-      "community": 510,
+      "community": 511,
       "file_type": "code",
       "id": "results_mapthrownerror",
       "label": "mapThrownError()",
@@ -261232,7 +261352,7 @@
       "source_location": "L103"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registerlifecycleauthoritycandidates_ts",
       "label": "registerLifecycleAuthorityCandidates.ts",
@@ -261241,7 +261361,7 @@
       "source_location": "L1"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_deriveregisterlifecycleauthoritycandidates",
       "label": "deriveRegisterLifecycleAuthorityCandidates()",
@@ -261250,7 +261370,7 @@
       "source_location": "L45"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_isboundedidentifier",
       "label": "isBoundedIdentifier()",
@@ -261259,7 +261379,7 @@
       "source_location": "L220"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_iseligibleregistermapping",
       "label": "isEligibleRegisterMapping()",
@@ -261268,7 +261388,7 @@
       "source_location": "L167"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_legacymappingmatchesactivesession",
       "label": "legacyMappingMatchesActiveSession()",
@@ -261277,7 +261397,7 @@
       "source_location": "L182"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_mappingcandidate",
       "label": "mappingCandidate()",
@@ -261286,7 +261406,7 @@
       "source_location": "L194"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_useposlocalsyncruntime_test_ts",
       "label": "usePosLocalSyncRuntime.test.ts",
@@ -261295,7 +261415,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_buildlocalevent",
       "label": "buildLocalEvent()",
@@ -261304,7 +261424,7 @@
       "source_location": "L7449"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_buildrecoverycommand",
       "label": "buildRecoveryCommand()",
@@ -261313,7 +261433,7 @@
       "source_location": "L7472"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_buildrecoverycommandstore",
       "label": "buildRecoveryCommandStore()",
@@ -261322,7 +261442,7 @@
       "source_location": "L7491"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_deferred",
       "label": "deferred()",
@@ -261331,7 +261451,7 @@
       "source_location": "L108"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_storefactory",
       "label": "storeFactory()",
@@ -261340,7 +261460,7 @@
       "source_location": "L352"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
       "label": "selectors.ts",
@@ -261349,7 +261469,7 @@
       "source_location": "L1"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "selectors_buildregisterheaderstate",
       "label": "buildRegisterHeaderState()",
@@ -261358,7 +261478,7 @@
       "source_location": "L28"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "selectors_buildregisterinfostate",
       "label": "buildRegisterInfoState()",
@@ -261367,7 +261487,7 @@
       "source_location": "L37"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "selectors_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -261376,7 +261496,7 @@
       "source_location": "L12"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "selectors_getregistercustomerinfo",
       "label": "getRegisterCustomerInfo()",
@@ -261385,7 +261505,7 @@
       "source_location": "L6"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "selectors_isregistersessionactive",
       "label": "isRegisterSessionActive()",
@@ -261394,7 +261514,7 @@
       "source_location": "L49"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
       "label": "toastService.ts",
@@ -261403,7 +261523,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "toastservice_handleposoperation",
       "label": "handlePOSOperation()",
@@ -261412,7 +261532,7 @@
       "source_location": "L171"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "toastservice_showinventoryerror",
       "label": "showInventoryError()",
@@ -261421,7 +261541,7 @@
       "source_location": "L302"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "toastservice_shownoactivesessionerror",
       "label": "showNoActiveSessionError()",
@@ -261430,7 +261550,7 @@
       "source_location": "L319"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "toastservice_showsessionexpirederror",
       "label": "showSessionExpiredError()",
@@ -261439,7 +261559,7 @@
       "source_location": "L312"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "toastservice_showvalidationerror",
       "label": "showValidationError()",
@@ -261448,7 +261568,7 @@
       "source_location": "L293"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_sheetreturn_ts",
       "label": "sheetReturn.ts",
@@ -261457,7 +261577,7 @@
       "source_location": "L1"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "sheetreturn_decodesheetreturn",
       "label": "decodeSheetReturn()",
@@ -261466,7 +261586,7 @@
       "source_location": "L85"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "sheetreturn_encodefocuskey",
       "label": "encodeFocusKey()",
@@ -261475,7 +261595,7 @@
       "source_location": "L74"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "sheetreturn_encodesheetreturn",
       "label": "encodeSheetReturn()",
@@ -261484,7 +261604,7 @@
       "source_location": "L55"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "sheetreturn_sheetreturnfocusselector",
       "label": "sheetReturnFocusSelector()",
@@ -261493,7 +261613,7 @@
       "source_location": "L126"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "sheetreturn_sheetreturntargetprops",
       "label": "sheetReturnTargetProps()",
@@ -261502,7 +261622,7 @@
       "source_location": "L131"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_skusearch_productskusearchadapters_ts",
       "label": "productSkuSearchAdapters.ts",
@@ -261511,7 +261631,7 @@
       "source_location": "L1"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "productskusearchadapters_buildadminskusearchoption",
       "label": "buildAdminSkuSearchOption()",
@@ -261520,7 +261640,7 @@
       "source_location": "L80"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "productskusearchadapters_buildadminskusearchoptions",
       "label": "buildAdminSkuSearchOptions()",
@@ -261529,7 +261649,7 @@
       "source_location": "L132"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "productskusearchadapters_compactjoin",
       "label": "compactJoin()",
@@ -261538,7 +261658,7 @@
       "source_location": "L73"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "productskusearchadapters_groupadminskusearchoptionsbyproduct",
       "label": "groupAdminSkuSearchOptionsByProduct()",
@@ -261547,7 +261667,7 @@
       "source_location": "L138"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "productskusearchadapters_presentationtext",
       "label": "presentationText()",
@@ -261556,7 +261676,7 @@
       "source_location": "L66"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_stockops_skusearch_ts",
       "label": "skuSearch.ts",
@@ -261565,7 +261685,7 @@
       "source_location": "L1"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "skusearch_isbarcodeshapedsearchquery",
       "label": "isBarcodeShapedSearchQuery()",
@@ -261574,7 +261694,7 @@
       "source_location": "L49"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "skusearch_matchesskusearchterms",
       "label": "matchesSkuSearchTerms()",
@@ -261583,7 +261703,7 @@
       "source_location": "L11"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "skusearch_normalizeidentifier",
       "label": "normalizeIdentifier()",
@@ -261592,7 +261712,7 @@
       "source_location": "L53"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "skusearch_normalizeskusearchquery",
       "label": "normalizeSkuSearchQuery()",
@@ -261601,7 +261721,7 @@
       "source_location": "L7"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "skusearch_scoreskusearchterms",
       "label": "scoreSkuSearchTerms()",
@@ -261610,7 +261730,7 @@
       "source_location": "L18"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "packages_athena_webapp_src_offline_posappshellroutes_ts",
       "label": "posAppShellRoutes.ts",
@@ -261619,7 +261739,7 @@
       "source_location": "L1"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "posappshellroutes_isexcludedfromposappshellcache",
       "label": "isExcludedFromPosAppShellCache()",
@@ -261628,7 +261748,7 @@
       "source_location": "L53"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "posappshellroutes_isposappshellnavigationrequest",
       "label": "isPosAppShellNavigationRequest()",
@@ -261637,7 +261757,7 @@
       "source_location": "L71"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "posappshellroutes_isposappshellroutepath",
       "label": "isPosAppShellRoutePath()",
@@ -261646,7 +261766,7 @@
       "source_location": "L48"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "posappshellroutes_isposappshellstaticassetrequest",
       "label": "isPosAppShellStaticAssetRequest()",
@@ -261655,67 +261775,13 @@
       "source_location": "L88"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "posappshellroutes_readheader",
       "label": "readHeader()",
       "norm_label": "readheader()",
       "source_file": "packages/athena-webapp/src/offline/posAppShellRoutes.ts",
       "source_location": "L107"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_offline_posappshellserviceworkerstaging_test_ts",
-      "label": "posAppShellServiceWorkerStaging.test.ts",
-      "norm_label": "posappshellserviceworkerstaging.test.ts",
-      "source_file": "packages/athena-webapp/src/offline/posAppShellServiceWorkerStaging.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "posappshellserviceworkerstaging_test_createserviceworkerfixture",
-      "label": "createServiceWorkerFixture()",
-      "norm_label": "createserviceworkerfixture()",
-      "source_file": "packages/athena-webapp/src/offline/posAppShellServiceWorkerStaging.test.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "posappshellserviceworkerstaging_test_memorycache",
-      "label": "MemoryCache",
-      "norm_label": "memorycache",
-      "source_file": "packages/athena-webapp/src/offline/posAppShellServiceWorkerStaging.test.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "posappshellserviceworkerstaging_test_memorycache_keys",
-      "label": ".keys()",
-      "norm_label": ".keys()",
-      "source_file": "packages/athena-webapp/src/offline/posAppShellServiceWorkerStaging.test.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "posappshellserviceworkerstaging_test_memorycache_match",
-      "label": ".match()",
-      "norm_label": ".match()",
-      "source_file": "packages/athena-webapp/src/offline/posAppShellServiceWorkerStaging.test.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "posappshellserviceworkerstaging_test_memorycache_put",
-      "label": ".put()",
-      "norm_label": ".put()",
-      "source_file": "packages/athena-webapp/src/offline/posAppShellServiceWorkerStaging.test.ts",
-      "source_location": "L22"
     },
     {
       "community": 52,
@@ -261981,6 +262047,60 @@
     {
       "community": 520,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_offline_posappshellserviceworkerstaging_test_ts",
+      "label": "posAppShellServiceWorkerStaging.test.ts",
+      "norm_label": "posappshellserviceworkerstaging.test.ts",
+      "source_file": "packages/athena-webapp/src/offline/posAppShellServiceWorkerStaging.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "posappshellserviceworkerstaging_test_createserviceworkerfixture",
+      "label": "createServiceWorkerFixture()",
+      "norm_label": "createserviceworkerfixture()",
+      "source_file": "packages/athena-webapp/src/offline/posAppShellServiceWorkerStaging.test.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "posappshellserviceworkerstaging_test_memorycache",
+      "label": "MemoryCache",
+      "norm_label": "memorycache",
+      "source_file": "packages/athena-webapp/src/offline/posAppShellServiceWorkerStaging.test.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "posappshellserviceworkerstaging_test_memorycache_keys",
+      "label": ".keys()",
+      "norm_label": ".keys()",
+      "source_file": "packages/athena-webapp/src/offline/posAppShellServiceWorkerStaging.test.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "posappshellserviceworkerstaging_test_memorycache_match",
+      "label": ".match()",
+      "norm_label": ".match()",
+      "source_file": "packages/athena-webapp/src/offline/posAppShellServiceWorkerStaging.test.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "posappshellserviceworkerstaging_test_memorycache_put",
+      "label": ".put()",
+      "norm_label": ".put()",
+      "source_file": "packages/athena-webapp/src/offline/posAppShellServiceWorkerStaging.test.ts",
+      "source_location": "L22"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
       "id": "docs_shared_companionsection",
       "label": "CompanionSection()",
       "norm_label": "companionsection()",
@@ -261988,7 +262108,7 @@
       "source_location": "L81"
     },
     {
-      "community": 520,
+      "community": 521,
       "file_type": "code",
       "id": "docs_shared_formatcategorylabel",
       "label": "formatCategoryLabel()",
@@ -261997,7 +262117,7 @@
       "source_location": "L7"
     },
     {
-      "community": 520,
+      "community": 521,
       "file_type": "code",
       "id": "docs_shared_formatdocdate",
       "label": "formatDocDate()",
@@ -262006,7 +262126,7 @@
       "source_location": "L11"
     },
     {
-      "community": 520,
+      "community": 521,
       "file_type": "code",
       "id": "docs_shared_severityindicator",
       "label": "SeverityIndicator()",
@@ -262015,7 +262135,7 @@
       "source_location": "L32"
     },
     {
-      "community": 520,
+      "community": 521,
       "file_type": "code",
       "id": "docs_shared_solutiondoccard",
       "label": "SolutionDocCard()",
@@ -262024,7 +262144,7 @@
       "source_location": "L48"
     },
     {
-      "community": 520,
+      "community": 521,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_docs_shared_tsx",
       "label": "-docs-shared.tsx",
@@ -262033,7 +262153,7 @@
       "source_location": "L1"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "index_route_view_democtabutton",
       "label": "DemoCtaButton()",
@@ -262042,7 +262162,7 @@
       "source_location": "L192"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "index_route_view_herogrid",
       "label": "HeroGrid()",
@@ -262051,7 +262171,7 @@
       "source_location": "L178"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "index_route_view_rest",
       "label": "rest()",
@@ -262060,7 +262180,7 @@
       "source_location": "L246"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "index_route_view_useheroshotrevealref",
       "label": "useHeroShotRevealRef()",
@@ -262069,7 +262189,7 @@
       "source_location": "L54"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "index_route_view_useheroshottiltref",
       "label": "useHeroShotTiltRef()",
@@ -262078,7 +262198,7 @@
       "source_location": "L107"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_route_view_tsx",
       "label": "-index-route-view.tsx",
@@ -262087,7 +262207,7 @@
       "source_location": "L1"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
       "label": "procurement.index.tsx",
@@ -262096,7 +262216,7 @@
       "source_location": "L1"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementmodesearch",
       "label": "getNextProcurementModeSearch()",
@@ -262105,7 +262225,7 @@
       "source_location": "L19"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementpagesearch",
       "label": "getNextProcurementPageSearch()",
@@ -262114,7 +262234,7 @@
       "source_location": "L37"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementquerysearch",
       "label": "getNextProcurementQuerySearch()",
@@ -262123,7 +262243,7 @@
       "source_location": "L47"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementselectedskusearch",
       "label": "getNextProcurementSelectedSkuSearch()",
@@ -262132,7 +262252,7 @@
       "source_location": "L62"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "procurement_index_procurementroute",
       "label": "ProcurementRoute()",
@@ -262141,7 +262261,7 @@
       "source_location": "L88"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_weekly_lifecycle_test_tsx",
       "label": "weekly.lifecycle.test.tsx",
@@ -262150,7 +262270,7 @@
       "source_location": "L1"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "weekly_lifecycle_test_installcompletedmovement",
       "label": "installCompletedMovement()",
@@ -262159,7 +262279,7 @@
       "source_location": "L283"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "weekly_lifecycle_test_isshareddemostandingread",
       "label": "isSharedDemoStandingRead()",
@@ -262168,7 +262288,7 @@
       "source_location": "L102"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "weekly_lifecycle_test_movementrow",
       "label": "movementRow()",
@@ -262177,7 +262297,7 @@
       "source_location": "L268"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "weekly_lifecycle_test_params",
       "label": "params()",
@@ -262186,7 +262306,7 @@
       "source_location": "L40"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "weekly_lifecycle_test_stubensuremutation",
       "label": "stubEnsureMutation()",
@@ -262195,7 +262315,7 @@
       "source_location": "L81"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "login_layout_completependingauthsync",
       "label": "completePendingAuthSync()",
@@ -262204,7 +262324,7 @@
       "source_location": "L145"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "login_layout_handlependingauthsync",
       "label": "handlePendingAuthSync()",
@@ -262213,7 +262333,7 @@
       "source_location": "L95"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "login_layout_navigationtargetforredirect",
       "label": "navigationTargetForRedirect()",
@@ -262222,7 +262342,7 @@
       "source_location": "L33"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "login_layout_sleep",
       "label": "sleep()",
@@ -262231,7 +262351,7 @@
       "source_location": "L29"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "login_layout_usedocumentscrolllock",
       "label": "useDocumentScrollLock()",
@@ -262240,7 +262360,7 @@
       "source_location": "L45"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_login_layout_tsx",
       "label": "-login-layout.tsx",
@@ -262249,7 +262369,7 @@
       "source_location": "L1"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "organizationsettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -262258,7 +262378,7 @@
       "source_location": "L155"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "organizationsettingsview_navigation",
       "label": "Navigation()",
@@ -262267,7 +262387,7 @@
       "source_location": "L197"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "organizationsettingsview_onsubmit",
       "label": "onSubmit()",
@@ -262276,7 +262396,7 @@
       "source_location": "L104"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "organizationsettingsview_organizationsettings",
       "label": "OrganizationSettings()",
@@ -262285,7 +262405,7 @@
       "source_location": "L25"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "organizationsettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -262294,7 +262414,7 @@
       "source_location": "L72"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
       "label": "OrganizationSettingsView.tsx",
@@ -262303,7 +262423,7 @@
       "source_location": "L1"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
       "label": "StoreSettingsView.tsx",
@@ -262312,7 +262432,7 @@
       "source_location": "L1"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "storesettingsview_handledeleteallproductsinstore",
       "label": "handleDeleteAllProductsInStore()",
@@ -262321,7 +262441,7 @@
       "source_location": "L231"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "storesettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -262330,7 +262450,7 @@
       "source_location": "L167"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "storesettingsview_onsubmit",
       "label": "onSubmit()",
@@ -262339,7 +262459,7 @@
       "source_location": "L116"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "storesettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -262348,7 +262468,7 @@
       "source_location": "L83"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "storesettingsview_storesettings",
       "label": "StoreSettings()",
@@ -262357,7 +262477,7 @@
       "source_location": "L29"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "devfixtureactivation_usedailyclosefixture",
       "label": "useDailyCloseFixture()",
@@ -262366,7 +262486,7 @@
       "source_location": "L102"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "devfixtureactivation_usedailyopeningfixture",
       "label": "useDailyOpeningFixture()",
@@ -262375,7 +262495,7 @@
       "source_location": "L96"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "devfixtureactivation_usedailyoperationsfixture",
       "label": "useDailyOperationsFixture()",
@@ -262384,7 +262504,7 @@
       "source_location": "L90"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "devfixtureactivation_useposhubfixture",
       "label": "usePosHubFixture()",
@@ -262393,7 +262513,7 @@
       "source_location": "L108"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "devfixtureactivation_useworkspacefixture",
       "label": "useWorkspaceFixture()",
@@ -262402,7 +262522,7 @@
       "source_location": "L46"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_operations_devfixtureactivation_ts",
       "label": "devFixtureActivation.ts",
@@ -262411,7 +262531,7 @@
       "source_location": "L1"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
       "label": "storybook-shell.tsx",
@@ -262420,7 +262540,7 @@
       "source_location": "L1"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "storybook_shell_storybookcallout",
       "label": "StorybookCallout()",
@@ -262429,7 +262549,7 @@
       "source_location": "L76"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "storybook_shell_storybooklist",
       "label": "StorybookList()",
@@ -262438,7 +262558,7 @@
       "source_location": "L55"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "storybook_shell_storybookpillrow",
       "label": "StorybookPillRow()",
@@ -262447,7 +262567,7 @@
       "source_location": "L88"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "storybook_shell_storybooksection",
       "label": "StorybookSection()",
@@ -262456,67 +262576,13 @@
       "source_location": "L34"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "storybook_shell_storybookshell",
       "label": "StorybookShell()",
       "norm_label": "storybookshell()",
       "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
       "source_location": "L13"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_postransaction_ts",
-      "label": "posTransaction.ts",
-      "norm_label": "postransaction.ts",
-      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "postransaction_fetchpostransaction",
-      "label": "fetchPosTransaction()",
-      "norm_label": "fetchpostransaction()",
-      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
-      "source_location": "L69"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "postransaction_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "postransaction_getpostransactionbyreceipttoken",
-      "label": "getPosTransactionByReceiptToken()",
-      "norm_label": "getpostransactionbyreceipttoken()",
-      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "postransaction_postransactionreceipterror",
-      "label": "PosTransactionReceiptError",
-      "norm_label": "postransactionreceipterror",
-      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "postransaction_postransactionreceipterror_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
-      "source_location": "L62"
     },
     {
       "community": 53,
@@ -262782,6 +262848,60 @@
     {
       "community": 530,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_postransaction_ts",
+      "label": "posTransaction.ts",
+      "norm_label": "postransaction.ts",
+      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "postransaction_fetchpostransaction",
+      "label": "fetchPosTransaction()",
+      "norm_label": "fetchpostransaction()",
+      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
+      "source_location": "L69"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "postransaction_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "postransaction_getpostransactionbyreceipttoken",
+      "label": "getPosTransactionByReceiptToken()",
+      "norm_label": "getpostransactionbyreceipttoken()",
+      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "postransaction_postransactionreceipterror",
+      "label": "PosTransactionReceiptError",
+      "norm_label": "postransactionreceipterror",
+      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "postransaction_postransactionreceipterror_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_promocodes_ts",
       "label": "promoCodes.ts",
       "norm_label": "promocodes.ts",
@@ -262789,7 +262909,7 @@
       "source_location": "L1"
     },
     {
-      "community": 530,
+      "community": 531,
       "file_type": "code",
       "id": "promocodes_getbaseurl",
       "label": "getBaseUrl()",
@@ -262798,7 +262918,7 @@
       "source_location": "L4"
     },
     {
-      "community": 530,
+      "community": 531,
       "file_type": "code",
       "id": "promocodes_getpromocodeitems",
       "label": "getPromoCodeItems()",
@@ -262807,7 +262927,7 @@
       "source_location": "L49"
     },
     {
-      "community": 530,
+      "community": 531,
       "file_type": "code",
       "id": "promocodes_getpromocodes",
       "label": "getPromoCodes()",
@@ -262816,7 +262936,7 @@
       "source_location": "L34"
     },
     {
-      "community": 530,
+      "community": 531,
       "file_type": "code",
       "id": "promocodes_getredeemedpromocodes",
       "label": "getRedeemedPromoCodes()",
@@ -262825,7 +262945,7 @@
       "source_location": "L74"
     },
     {
-      "community": 530,
+      "community": 531,
       "file_type": "code",
       "id": "promocodes_redeempromocode",
       "label": "redeemPromoCode()",
@@ -262834,7 +262954,7 @@
       "source_location": "L6"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "billingdetails_clearform",
       "label": "clearForm()",
@@ -262843,7 +262963,7 @@
       "source_location": "L173"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "billingdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -262852,7 +262972,7 @@
       "source_location": "L102"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "billingdetails_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -262861,7 +262981,7 @@
       "source_location": "L201"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "billingdetails_onsubmit",
       "label": "onSubmit()",
@@ -262870,7 +262990,7 @@
       "source_location": "L150"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "billingdetails_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -262879,7 +262999,7 @@
       "source_location": "L155"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
       "label": "BillingDetails.tsx",
@@ -262888,7 +263008,7 @@
       "source_location": "L1"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "homehero_test_attachmedia",
       "label": "attachMedia()",
@@ -262897,7 +263017,7 @@
       "source_location": "L22"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "homehero_test_destroy",
       "label": "destroy()",
@@ -262906,7 +263026,7 @@
       "source_location": "L24"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "homehero_test_issupported",
       "label": "isSupported()",
@@ -262915,7 +263035,7 @@
       "source_location": "L18"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "homehero_test_loadsource",
       "label": "loadSource()",
@@ -262924,7 +263044,7 @@
       "source_location": "L21"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "homehero_test_on",
       "label": "on()",
@@ -262933,7 +263053,7 @@
       "source_location": "L23"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homehero_test_tsx",
       "label": "HomeHero.test.tsx",
@@ -262942,7 +263062,7 @@
       "source_location": "L1"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "mobileproductactions_collapseonpageclick",
       "label": "collapseOnPageClick()",
@@ -262951,7 +263071,7 @@
       "source_location": "L76"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "mobileproductactions_handleconfirm",
       "label": "handleConfirm()",
@@ -262960,7 +263080,7 @@
       "source_location": "L120"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "mobileproductactions_handleprimaryaction",
       "label": "handlePrimaryAction()",
@@ -262969,7 +263089,7 @@
       "source_location": "L129"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "mobileproductactions_handlesecondaryaction",
       "label": "handleSecondaryAction()",
@@ -262978,7 +263098,7 @@
       "source_location": "L133"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "mobileproductactions_updateposition",
       "label": "updatePosition()",
@@ -262987,7 +263107,7 @@
       "source_location": "L44"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
       "label": "MobileProductActions.tsx",
@@ -262996,7 +263116,7 @@
       "source_location": "L1"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "checkoutexpired_checkoutexpired",
       "label": "CheckoutExpired()",
@@ -263005,7 +263125,7 @@
       "source_location": "L9"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessiongeneric",
       "label": "CheckoutSessionGeneric()",
@@ -263014,7 +263134,7 @@
       "source_location": "L73"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessionnotfound",
       "label": "CheckoutSessionNotFound()",
@@ -263023,7 +263143,7 @@
       "source_location": "L54"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "checkoutexpired_handlesendemail",
       "label": "handleSendEmail()",
@@ -263032,7 +263152,7 @@
       "source_location": "L98"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "checkoutexpired_nocheckoutsession",
       "label": "NoCheckoutSession()",
@@ -263041,7 +263161,7 @@
       "source_location": "L33"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
       "label": "CheckoutExpired.tsx",
@@ -263050,7 +263170,7 @@
       "source_location": "L1"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "feeutils_getremainingforfreedelivery",
       "label": "getRemainingForFreeDelivery()",
@@ -263059,7 +263179,7 @@
       "source_location": "L138"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "feeutils_haswaiverconfigured",
       "label": "hasWaiverConfigured()",
@@ -263068,7 +263188,7 @@
       "source_location": "L100"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "feeutils_isanyfeewaived",
       "label": "isAnyFeeWaived()",
@@ -263077,7 +263197,7 @@
       "source_location": "L74"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "feeutils_isfeewaived",
       "label": "isFeeWaived()",
@@ -263086,7 +263206,7 @@
       "source_location": "L34"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "feeutils_meetsthreshold",
       "label": "meetsThreshold()",
@@ -263095,7 +263215,7 @@
       "source_location": "L17"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_feeutils_ts",
       "label": "feeUtils.ts",
@@ -263104,7 +263224,7 @@
       "source_location": "L1"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "auth_verify_formattime",
       "label": "formatTime()",
@@ -263113,7 +263233,7 @@
       "source_location": "L149"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "auth_verify_handlecodechange",
       "label": "handleCodeChange()",
@@ -263122,7 +263242,7 @@
       "source_location": "L156"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "auth_verify_onsubmit",
       "label": "onSubmit()",
@@ -263131,7 +263251,7 @@
       "source_location": "L201"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "auth_verify_reportauthfailure",
       "label": "reportAuthFailure()",
@@ -263140,7 +263260,7 @@
       "source_location": "L93"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "auth_verify_resendverificationcode",
       "label": "resendVerificationCode()",
@@ -263149,7 +263269,7 @@
       "source_location": "L282"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_auth_verify_tsx",
       "label": "auth.verify.tsx",
@@ -263158,7 +263278,7 @@
       "source_location": "L1"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "coverage_summary_test_coveragesummary",
       "label": "coverageSummary()",
@@ -263167,7 +263287,7 @@
       "source_location": "L27"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "coverage_summary_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -263176,7 +263296,7 @@
       "source_location": "L15"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "coverage_summary_test_write",
       "label": "write()",
@@ -263185,7 +263305,7 @@
       "source_location": "L21"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "coverage_summary_test_writepackagesummaries",
       "label": "writePackageSummaries()",
@@ -263194,7 +263314,7 @@
       "source_location": "L38"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "coverage_summary_test_writerealbaselinesummaries",
       "label": "writeRealBaselineSummaries()",
@@ -263203,7 +263323,7 @@
       "source_location": "L54"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "scripts_coverage_summary_test_ts",
       "label": "coverage-summary.test.ts",
@@ -263212,7 +263332,7 @@
       "source_location": "L1"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "docs_solution_link_check_assertdocslinks",
       "label": "assertDocsLinks()",
@@ -263221,7 +263341,7 @@
       "source_location": "L148"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "docs_solution_link_check_classifylink",
       "label": "classifyLink()",
@@ -263230,7 +263350,7 @@
       "source_location": "L49"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "docs_solution_link_check_collectdocslinkfindings",
       "label": "collectDocsLinkFindings()",
@@ -263239,7 +263359,7 @@
       "source_location": "L85"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "docs_solution_link_check_collectsolutionslugs",
       "label": "collectSolutionSlugs()",
@@ -263248,7 +263368,7 @@
       "source_location": "L36"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "docs_solution_link_check_solutionsroot",
       "label": "solutionsRoot()",
@@ -263257,66 +263377,12 @@
       "source_location": "L31"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "scripts_docs_solution_link_check_ts",
       "label": "docs-solution-link-check.ts",
       "norm_label": "docs-solution-link-check.ts",
       "source_file": "scripts/docs-solution-link-check.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "graphify_check_collectrepocodefiles",
-      "label": "collectRepoCodeFiles()",
-      "norm_label": "collectrepocodefiles()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "graphify_check_collectstalegraphifyartifacts",
-      "label": "collectStaleGraphifyArtifacts()",
-      "norm_label": "collectstalegraphifyartifacts()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L125"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "graphify_check_copygraphifycheckinputs",
-      "label": "copyGraphifyCheckInputs()",
-      "norm_label": "copygraphifycheckinputs()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "graphify_check_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L64"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "graphify_check_rungraphifycheck",
-      "label": "runGraphifyCheck()",
-      "norm_label": "rungraphifycheck()",
-      "source_file": "scripts/graphify-check.ts",
-      "source_location": "L152"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "scripts_graphify_check_ts",
-      "label": "graphify-check.ts",
-      "norm_label": "graphify-check.ts",
-      "source_file": "scripts/graphify-check.ts",
       "source_location": "L1"
     },
     {
@@ -263574,6 +263640,60 @@
     {
       "community": 540,
       "file_type": "code",
+      "id": "graphify_check_collectrepocodefiles",
+      "label": "collectRepoCodeFiles()",
+      "norm_label": "collectrepocodefiles()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "graphify_check_collectstalegraphifyartifacts",
+      "label": "collectStaleGraphifyArtifacts()",
+      "norm_label": "collectstalegraphifyartifacts()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L125"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "graphify_check_copygraphifycheckinputs",
+      "label": "copyGraphifyCheckInputs()",
+      "norm_label": "copygraphifycheckinputs()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "graphify_check_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L64"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "graphify_check_rungraphifycheck",
+      "label": "runGraphifyCheck()",
+      "norm_label": "rungraphifycheck()",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L152"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "scripts_graphify_check_ts",
+      "label": "graphify-check.ts",
+      "norm_label": "graphify-check.ts",
+      "source_file": "scripts/graphify-check.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
       "id": "harness_inferential_review_test_commitfixturerepo",
       "label": "commitFixtureRepo()",
       "norm_label": "commitfixturerepo()",
@@ -263581,7 +263701,7 @@
       "source_location": "L169"
     },
     {
-      "community": 540,
+      "community": 541,
       "file_type": "code",
       "id": "harness_inferential_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -263590,7 +263710,7 @@
       "source_location": "L66"
     },
     {
-      "community": 540,
+      "community": 541,
       "file_type": "code",
       "id": "harness_inferential_review_test_gitfixtureenv",
       "label": "gitFixtureEnv()",
@@ -263599,7 +263719,7 @@
       "source_location": "L60"
     },
     {
-      "community": 540,
+      "community": 541,
       "file_type": "code",
       "id": "harness_inferential_review_test_runfixturecommand",
       "label": "runFixtureCommand()",
@@ -263608,7 +263728,7 @@
       "source_location": "L22"
     },
     {
-      "community": 540,
+      "community": 541,
       "file_type": "code",
       "id": "harness_inferential_review_test_write",
       "label": "write()",
@@ -263617,7 +263737,7 @@
       "source_location": "L16"
     },
     {
-      "community": 540,
+      "community": 541,
       "file_type": "code",
       "id": "scripts_harness_inferential_review_test_ts",
       "label": "harness-inferential-review.test.ts",
@@ -263626,7 +263746,7 @@
       "source_location": "L1"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "harness_repo_validation_collectharnessrepovalidationcapabilities",
       "label": "collectHarnessRepoValidationCapabilities()",
@@ -263635,7 +263755,7 @@
       "source_location": "L73"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "harness_repo_validation_collectharnessrepovalidationselection",
       "label": "collectHarnessRepoValidationSelection()",
@@ -263644,7 +263764,7 @@
       "source_location": "L50"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "harness_repo_validation_matchesharnessrepovalidationpath",
       "label": "matchesHarnessRepoValidationPath()",
@@ -263653,7 +263773,7 @@
       "source_location": "L42"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "harness_repo_validation_normalizerepopath",
       "label": "normalizeRepoPath()",
@@ -263662,7 +263782,7 @@
       "source_location": "L32"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "harness_repo_validation_sortuniquepaths",
       "label": "sortUniquePaths()",
@@ -263671,66 +263791,12 @@
       "source_location": "L36"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_ts",
       "label": "harness-repo-validation.ts",
       "norm_label": "harness-repo-validation.ts",
       "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 542,
-      "file_type": "code",
-      "id": "harness_review_identity_computedeliverabletreeidentity",
-      "label": "computeDeliverableTreeIdentity()",
-      "norm_label": "computedeliverabletreeidentity()",
-      "source_file": "scripts/harness-review-identity.ts",
-      "source_location": "L132"
-    },
-    {
-      "community": 542,
-      "file_type": "code",
-      "id": "harness_review_identity_digestdeliverableentries",
-      "label": "digestDeliverableEntries()",
-      "norm_label": "digestdeliverableentries()",
-      "source_file": "scripts/harness-review-identity.ts",
-      "source_location": "L108"
-    },
-    {
-      "community": 542,
-      "file_type": "code",
-      "id": "harness_review_identity_isreviewneutralpath",
-      "label": "isReviewNeutralPath()",
-      "norm_label": "isreviewneutralpath()",
-      "source_file": "scripts/harness-review-identity.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 542,
-      "file_type": "code",
-      "id": "harness_review_identity_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/harness-review-identity.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 542,
-      "file_type": "code",
-      "id": "harness_review_identity_parsetreeentries",
-      "label": "parseTreeEntries()",
-      "norm_label": "parsetreeentries()",
-      "source_file": "scripts/harness-review-identity.ts",
-      "source_location": "L93"
-    },
-    {
-      "community": 542,
-      "file_type": "code",
-      "id": "scripts_harness_review_identity_ts",
-      "label": "harness-review-identity.ts",
-      "norm_label": "harness-review-identity.ts",
-      "source_file": "scripts/harness-review-identity.ts",
       "source_location": "L1"
     },
     {
@@ -263758,7 +263824,7 @@
       "label": "log()",
       "norm_label": "log()",
       "source_file": "scripts/pre-push-validation-proof.test.ts",
-      "source_location": "L153"
+      "source_location": "L171"
     },
     {
       "community": 543,
@@ -263767,7 +263833,7 @@
       "label": "warn()",
       "norm_label": "warn()",
       "source_file": "scripts/pre-push-validation-proof.test.ts",
-      "source_location": "L293"
+      "source_location": "L309"
     },
     {
       "community": 543,
@@ -264582,6 +264648,51 @@
     {
       "community": 556,
       "file_type": "code",
+      "id": "currency_formatstoredamount",
+      "label": "formatStoredAmount()",
+      "norm_label": "formatstoredamount()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 556,
+      "file_type": "code",
+      "id": "currency_todisplayamount",
+      "label": "toDisplayAmount()",
+      "norm_label": "todisplayamount()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 556,
+      "file_type": "code",
+      "id": "currency_topesewas",
+      "label": "toPesewas()",
+      "norm_label": "topesewas()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 556,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 556,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 557,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_marketing_walkthroughrequestnotifications_ts",
       "label": "walkthroughRequestNotifications.ts",
       "norm_label": "walkthroughrequestnotifications.ts",
@@ -264589,7 +264700,7 @@
       "source_location": "L1"
     },
     {
-      "community": 556,
+      "community": 557,
       "file_type": "code",
       "id": "walkthroughrequestnotifications_boundedauditvalue",
       "label": "boundedAuditValue()",
@@ -264598,7 +264709,7 @@
       "source_location": "L27"
     },
     {
-      "community": 556,
+      "community": 557,
       "file_type": "code",
       "id": "walkthroughrequestnotifications_classifydeliveryresult",
       "label": "classifyDeliveryResult()",
@@ -264607,7 +264718,7 @@
       "source_location": "L13"
     },
     {
-      "community": 556,
+      "community": 557,
       "file_type": "code",
       "id": "walkthroughrequestnotifications_isdeliberateretryeligible",
       "label": "isDeliberateRetryEligible()",
@@ -264616,7 +264727,7 @@
       "source_location": "L20"
     },
     {
-      "community": 556,
+      "community": 557,
       "file_type": "code",
       "id": "walkthroughrequestnotifications_nextbackoffms",
       "label": "nextBackoffMs()",
@@ -264625,7 +264736,7 @@
       "source_location": "L12"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "backfillreportingcyclestart_test_createctx",
       "label": "createCtx()",
@@ -264634,7 +264745,7 @@
       "source_location": "L80"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "backfillreportingcyclestart_test_createstoreverificationctx",
       "label": "createStoreVerificationCtx()",
@@ -264643,7 +264754,7 @@
       "source_location": "L29"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "backfillreportingcyclestart_test_finishbackfill",
       "label": "finishBackfill()",
@@ -264652,7 +264763,7 @@
       "source_location": "L118"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "backfillreportingcyclestart_test_finishverification",
       "label": "finishVerification()",
@@ -264661,7 +264772,7 @@
       "source_location": "L139"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_backfillreportingcyclestart_test_ts",
       "label": "backfillReportingCycleStart.test.ts",
@@ -264670,7 +264781,7 @@
       "source_location": "L1"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "backfillstoretimezoneauthority_backfillstoretimezoneauthoritywithctx",
       "label": "backfillStoreTimezoneAuthorityWithCtx()",
@@ -264679,7 +264790,7 @@
       "source_location": "L127"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "backfillstoretimezoneauthority_buildrow",
       "label": "buildRow()",
@@ -264688,7 +264799,7 @@
       "source_location": "L47"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "backfillstoretimezoneauthority_listschedulesforstore",
       "label": "listSchedulesForStore()",
@@ -264697,7 +264808,7 @@
       "source_location": "L35"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "backfillstoretimezoneauthority_normalizelimit",
       "label": "normalizeLimit()",
@@ -264706,57 +264817,12 @@
       "source_location": "L28"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_backfillstoretimezoneauthority_ts",
       "label": "backfillStoreTimezoneAuthority.ts",
       "norm_label": "backfillstoretimezoneauthority.ts",
       "source_file": "packages/athena-webapp/convex/migrations/backfillStoreTimezoneAuthority.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "dispatch_recordnotificationfailureeventwithctx",
-      "label": "recordNotificationFailureEventWithCtx()",
-      "norm_label": "recordnotificationfailureeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/notifications/dispatch.ts",
-      "source_location": "L400"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "dispatch_recordterminaldeliveryfailureevent",
-      "label": "recordTerminalDeliveryFailureEvent()",
-      "norm_label": "recordterminaldeliveryfailureevent()",
-      "source_file": "packages/athena-webapp/convex/notifications/dispatch.ts",
-      "source_location": "L427"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "dispatch_resolverecipients",
-      "label": "resolveRecipients()",
-      "norm_label": "resolverecipients()",
-      "source_file": "packages/athena-webapp/convex/notifications/dispatch.ts",
-      "source_location": "L53"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "dispatch_suppressintentwithctx",
-      "label": "suppressIntentWithCtx()",
-      "norm_label": "suppressintentwithctx()",
-      "source_file": "packages/athena-webapp/convex/notifications/dispatch.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_notifications_dispatch_ts",
-      "label": "dispatch.ts",
-      "norm_label": "dispatch.ts",
-      "source_file": "packages/athena-webapp/convex/notifications/dispatch.ts",
       "source_location": "L1"
     },
     {
@@ -265005,6 +265071,51 @@
     {
       "community": 560,
       "file_type": "code",
+      "id": "dispatch_recordnotificationfailureeventwithctx",
+      "label": "recordNotificationFailureEventWithCtx()",
+      "norm_label": "recordnotificationfailureeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/notifications/dispatch.ts",
+      "source_location": "L400"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "dispatch_recordterminaldeliveryfailureevent",
+      "label": "recordTerminalDeliveryFailureEvent()",
+      "norm_label": "recordterminaldeliveryfailureevent()",
+      "source_file": "packages/athena-webapp/convex/notifications/dispatch.ts",
+      "source_location": "L427"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "dispatch_resolverecipients",
+      "label": "resolveRecipients()",
+      "norm_label": "resolverecipients()",
+      "source_file": "packages/athena-webapp/convex/notifications/dispatch.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "dispatch_suppressintentwithctx",
+      "label": "suppressIntentWithCtx()",
+      "norm_label": "suppressintentwithctx()",
+      "source_file": "packages/athena-webapp/convex/notifications/dispatch.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_notifications_dispatch_ts",
+      "label": "dispatch.ts",
+      "norm_label": "dispatch.ts",
+      "source_file": "packages/athena-webapp/convex/notifications/dispatch.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_notifications_registry_test_ts",
       "label": "registry.test.ts",
       "norm_label": "registry.test.ts",
@@ -265012,7 +265123,7 @@
       "source_location": "L1"
     },
     {
-      "community": 560,
+      "community": 561,
       "file_type": "code",
       "id": "registry_test_dedupekey",
       "label": "dedupeKey()",
@@ -265021,7 +265132,7 @@
       "source_location": "L558"
     },
     {
-      "community": 560,
+      "community": 561,
       "file_type": "code",
       "id": "registry_test_keyfor",
       "label": "keyFor()",
@@ -265030,7 +265141,7 @@
       "source_location": "L733"
     },
     {
-      "community": 560,
+      "community": 561,
       "file_type": "code",
       "id": "registry_test_prepare",
       "label": "prepare()",
@@ -265039,7 +265150,7 @@
       "source_location": "L48"
     },
     {
-      "community": 560,
+      "community": 561,
       "file_type": "code",
       "id": "registry_test_stubctx",
       "label": "stubCtx()",
@@ -265048,7 +265159,7 @@
       "source_location": "L29"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "adapters_createnormaluseroperationadapter",
       "label": "createNormalUserOperationAdapter()",
@@ -265057,7 +265168,7 @@
       "source_location": "L13"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "adapters_createpublicoperationadapter",
       "label": "createPublicOperationAdapter()",
@@ -265066,7 +265177,7 @@
       "source_location": "L41"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "adapters_isadmitted",
       "label": "isAdmitted()",
@@ -265075,7 +265186,7 @@
       "source_location": "L115"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "adapters_resolveoperationadmission",
       "label": "resolveOperationAdmission()",
@@ -265084,7 +265195,7 @@
       "source_location": "L59"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_adapters_ts",
       "label": "adapters.ts",
@@ -265093,7 +265204,7 @@
       "source_location": "L1"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "approvalrequesterchallenges_consumeapprovalrequesterchallengewithctx",
       "label": "consumeApprovalRequesterChallengeWithCtx()",
@@ -265102,7 +265213,7 @@
       "source_location": "L97"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "approvalrequesterchallenges_createapprovalrequesterchallengewithctx",
       "label": "createApprovalRequesterChallengeWithCtx()",
@@ -265111,7 +265222,7 @@
       "source_location": "L55"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "approvalrequesterchallenges_invalidapprovalrequesterchallengeresult",
       "label": "invalidApprovalRequesterChallengeResult()",
@@ -265120,7 +265231,7 @@
       "source_location": "L37"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "approvalrequesterchallenges_torequesterbinding",
       "label": "toRequesterBinding()",
@@ -265129,7 +265240,7 @@
       "source_location": "L44"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequesterchallenges_ts",
       "label": "approvalRequesterChallenges.ts",
@@ -265138,7 +265249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "customerprofiles_compactrecord",
       "label": "compactRecord()",
@@ -265147,7 +265258,7 @@
       "source_location": "L24"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "customerprofiles_ensurecustomerprofilefromsourceswithctx",
       "label": "ensureCustomerProfileFromSourcesWithCtx()",
@@ -265156,7 +265267,7 @@
       "source_location": "L207"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "customerprofiles_findexistingprofile",
       "label": "findExistingProfile()",
@@ -265165,7 +265276,7 @@
       "source_location": "L45"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "customerprofiles_loadcustomersources",
       "label": "loadCustomerSources()",
@@ -265174,7 +265285,7 @@
       "source_location": "L30"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_customerprofiles_ts",
       "label": "customerProfiles.ts",
@@ -265183,7 +265294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "operationalworkitems_test_approvalrequest",
       "label": "approvalRequest()",
@@ -265192,7 +265303,7 @@
       "source_location": "L46"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "operationalworkitems_test_createqueuecontext",
       "label": "createQueueContext()",
@@ -265201,7 +265312,7 @@
       "source_location": "L59"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "operationalworkitems_test_gethandler",
       "label": "getHandler()",
@@ -265210,7 +265321,7 @@
       "source_location": "L25"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "operationalworkitems_test_workitem",
       "label": "workItem()",
@@ -265219,7 +265330,7 @@
       "source_location": "L31"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalworkitems_test_ts",
       "label": "operationalWorkItems.test.ts",
@@ -265228,7 +265339,7 @@
       "source_location": "L1"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "oweddailyclosesweep_completedoperatingdatesforstore",
       "label": "completedOperatingDatesForStore()",
@@ -265237,7 +265348,7 @@
       "source_location": "L149"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "oweddailyclosesweep_daysbetweenoperatingdates",
       "label": "daysBetweenOperatingDates()",
@@ -265246,7 +265357,7 @@
       "source_location": "L354"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "oweddailyclosesweep_listenabledeodpolicies",
       "label": "listEnabledEodPolicies()",
@@ -265255,7 +265366,7 @@
       "source_location": "L135"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "oweddailyclosesweep_selectoweddailyclosedates",
       "label": "selectOwedDailyCloseDates()",
@@ -265264,7 +265375,7 @@
       "source_location": "L84"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "label": "owedDailyCloseSweep.ts",
@@ -265273,7 +265384,7 @@
       "source_location": "L1"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_paymenttotals_ts",
       "label": "paymentTotals.ts",
@@ -265282,7 +265393,7 @@
       "source_location": "L1"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "paymenttotals_buildpaymenttotals",
       "label": "buildPaymentTotals()",
@@ -265291,7 +265402,7 @@
       "source_location": "L50"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "paymenttotals_listtransactionpayments",
       "label": "listTransactionPayments()",
@@ -265300,7 +265411,7 @@
       "source_location": "L11"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "paymenttotals_transactioncashdelta",
       "label": "transactionCashDelta()",
@@ -265309,7 +265420,7 @@
       "source_location": "L81"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "paymenttotals_transactionpaymenttotals",
       "label": "transactionPaymentTotals()",
@@ -265318,7 +265429,7 @@
       "source_location": "L25"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffcredentials_test_ts",
       "label": "staffCredentials.test.ts",
@@ -265327,7 +265438,7 @@
       "source_location": "L1"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "staffcredentials_test_admissionawareauth",
       "label": "admissionAwareAuth()",
@@ -265336,7 +265447,7 @@
       "source_location": "L256"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "staffcredentials_test_createrestoredproofvalidationctx",
       "label": "createRestoredProofValidationCtx()",
@@ -265345,7 +265456,7 @@
       "source_location": "L271"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "staffcredentials_test_createstaffcredentialsmutationctx",
       "label": "createStaffCredentialsMutationCtx()",
@@ -265354,7 +265465,7 @@
       "source_location": "L81"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "staffcredentials_test_gethandler",
       "label": "getHandler()",
@@ -265363,7 +265474,7 @@
       "source_location": "L267"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "assigncustomer_test_customerprofile",
       "label": "customerProfile()",
@@ -265372,7 +265483,7 @@
       "source_location": "L319"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "assigncustomer_test_guest",
       "label": "guest()",
@@ -265381,7 +265492,7 @@
       "source_location": "L346"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "assigncustomer_test_poscustomer",
       "label": "posCustomer()",
@@ -265390,7 +265501,7 @@
       "source_location": "L303"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "assigncustomer_test_storefrontuser",
       "label": "storeFrontUser()",
@@ -265399,58 +265510,13 @@
       "source_location": "L333"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_test_ts",
       "label": "assignCustomer.test.ts",
       "norm_label": "assigncustomer.test.ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_registerlifecycleauthority_ts",
-      "label": "registerLifecycleAuthority.ts",
-      "norm_label": "registerlifecycleauthority.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/registerLifecycleAuthority.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "registerlifecycleauthority_acknowledgeregisterlifecycleauthority",
-      "label": "acknowledgeRegisterLifecycleAuthority()",
-      "norm_label": "acknowledgeregisterlifecycleauthority()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/registerLifecycleAuthority.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "registerlifecycleauthority_equivalentacknowledgement",
-      "label": "equivalentAcknowledgement()",
-      "norm_label": "equivalentacknowledgement()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/registerLifecycleAuthority.ts",
-      "source_location": "L124"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "registerlifecycleauthority_isrevision",
-      "label": "isRevision()",
-      "norm_label": "isrevision()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/registerLifecycleAuthority.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "registerlifecycleauthority_normalizesafemetadata",
-      "label": "normalizeSafeMetadata()",
-      "norm_label": "normalizesafemetadata()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/registerLifecycleAuthority.ts",
-      "source_location": "L145"
     },
     {
       "community": 57,
@@ -265698,6 +265764,51 @@
     {
       "community": 570,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_registerlifecycleauthority_ts",
+      "label": "registerLifecycleAuthority.ts",
+      "norm_label": "registerlifecycleauthority.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/registerLifecycleAuthority.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "registerlifecycleauthority_acknowledgeregisterlifecycleauthority",
+      "label": "acknowledgeRegisterLifecycleAuthority()",
+      "norm_label": "acknowledgeregisterlifecycleauthority()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/registerLifecycleAuthority.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "registerlifecycleauthority_equivalentacknowledgement",
+      "label": "equivalentAcknowledgement()",
+      "norm_label": "equivalentacknowledgement()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/registerLifecycleAuthority.ts",
+      "source_location": "L124"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "registerlifecycleauthority_isrevision",
+      "label": "isRevision()",
+      "norm_label": "isrevision()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/registerLifecycleAuthority.ts",
+      "source_location": "L153"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "registerlifecycleauthority_normalizesafemetadata",
+      "label": "normalizeSafeMetadata()",
+      "norm_label": "normalizesafemetadata()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/registerLifecycleAuthority.ts",
+      "source_location": "L145"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
       "id": "correctionpolicy_builddecision",
       "label": "buildDecision()",
       "norm_label": "builddecision()",
@@ -265705,7 +265816,7 @@
       "source_location": "L107"
     },
     {
-      "community": 570,
+      "community": 571,
       "file_type": "code",
       "id": "correctionpolicy_classifycorrectionintent",
       "label": "classifyCorrectionIntent()",
@@ -265714,7 +265825,7 @@
       "source_location": "L117"
     },
     {
-      "community": 570,
+      "community": 571,
       "file_type": "code",
       "id": "correctionpolicy_issupportedcorrectionintent",
       "label": "isSupportedCorrectionIntent()",
@@ -265723,7 +265834,7 @@
       "source_location": "L91"
     },
     {
-      "community": 570,
+      "community": 571,
       "file_type": "code",
       "id": "correctionpolicy_isunsupportedhighriskcorrectionintent",
       "label": "isUnsupportedHighRiskCorrectionIntent()",
@@ -265732,7 +265843,7 @@
       "source_location": "L99"
     },
     {
-      "community": 570,
+      "community": 571,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_corrections_correctionpolicy_ts",
       "label": "correctionPolicy.ts",
@@ -265741,7 +265852,7 @@
       "source_location": "L1"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_reconcilesequencegaps_ts",
       "label": "reconcileSequenceGaps.ts",
@@ -265750,7 +265861,7 @@
       "source_location": "L1"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "reconcilesequencegaps_collectterminalevidence",
       "label": "collectTerminalEvidence()",
@@ -265759,7 +265870,7 @@
       "source_location": "L185"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "reconcilesequencegaps_issuegapprobe",
       "label": "issueGapProbe()",
@@ -265768,7 +265879,7 @@
       "source_location": "L249"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "reconcilesequencegaps_listheldeventsforcursor",
       "label": "listHeldEventsForCursor()",
@@ -265777,7 +265888,7 @@
       "source_location": "L156"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "reconcilesequencegaps_skipsequencegap",
       "label": "skipSequenceGap()",
@@ -265786,7 +265897,7 @@
       "source_location": "L295"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminaloperationalstate_policy_test_ts",
       "label": "policy.test.ts",
@@ -265795,7 +265906,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "policy_test_baseinput",
       "label": "baseInput()",
@@ -265804,7 +265915,7 @@
       "source_location": "L1225"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "policy_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -265813,7 +265924,7 @@
       "source_location": "L1329"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "policy_test_buildruntimestatus",
       "label": "buildRuntimeStatus()",
@@ -265822,7 +265933,7 @@
       "source_location": "L1287"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "policy_test_emptysyncevidence",
       "label": "emptySyncEvidence()",
@@ -265831,7 +265942,7 @@
       "source_location": "L1267"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_terminalrecoveryrepository_test_ts",
       "label": "terminalRecoveryRepository.test.ts",
@@ -265840,7 +265951,7 @@
       "source_location": "L1"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "terminalrecoveryrepository_test_buildctx",
       "label": "buildCtx()",
@@ -265849,7 +265960,7 @@
       "source_location": "L381"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "terminalrecoveryrepository_test_buildqueryctx",
       "label": "buildQueryCtx()",
@@ -265858,7 +265969,7 @@
       "source_location": "L469"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "terminalrecoveryrepository_test_filterrows",
       "label": "filterRows()",
@@ -265867,7 +265978,7 @@
       "source_location": "L483"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "terminalrecoveryrepository_test_orderedrows",
       "label": "orderedRows()",
@@ -265876,7 +265987,7 @@
       "source_location": "L492"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "customers_requireposcustomeraccessbyid",
       "label": "requirePosCustomerAccessById()",
@@ -265885,7 +265996,7 @@
       "source_location": "L76"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "customers_requireposcustomerreadaccessbyid",
       "label": "requirePosCustomerReadAccessById()",
@@ -265894,7 +266005,7 @@
       "source_location": "L123"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "customers_requireposcustomerstoreaccess",
       "label": "requirePosCustomerStoreAccess()",
@@ -265903,7 +266014,7 @@
       "source_location": "L53"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "customers_requireposcustomerstorereadaccess",
       "label": "requirePosCustomerStoreReadAccess()",
@@ -265912,7 +266023,7 @@
       "source_location": "L99"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_customers_ts",
       "label": "customers.ts",
@@ -265921,7 +266032,7 @@
       "source_location": "L1"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_posrecoverycodes_test_ts",
       "label": "posRecoveryCodes.test.ts",
@@ -265930,7 +266041,7 @@
       "source_location": "L1"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "posrecoverycodes_test_buildctx",
       "label": "buildCtx()",
@@ -265939,7 +266050,7 @@
       "source_location": "L565"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "posrecoverycodes_test_createfilter",
       "label": "createFilter()",
@@ -265948,7 +266059,7 @@
       "source_location": "L669"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "posrecoverycodes_test_createquery",
       "label": "createQuery()",
@@ -265957,7 +266068,7 @@
       "source_location": "L642"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "posrecoverycodes_test_gethandler",
       "label": "getHandler()",
@@ -265966,7 +266077,7 @@
       "source_location": "L25"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_telemetry_test_ts",
       "label": "telemetry.test.ts",
@@ -265975,7 +266086,7 @@
       "source_location": "L1"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "telemetry_test_baseevent",
       "label": "baseEvent()",
@@ -265984,7 +266095,7 @@
       "source_location": "L106"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "telemetry_test_createctx",
       "label": "createCtx()",
@@ -265993,7 +266104,7 @@
       "source_location": "L34"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "telemetry_test_gethandler",
       "label": "getHandler()",
@@ -266002,7 +266113,7 @@
       "source_location": "L24"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "telemetry_test_storedevent",
       "label": "storedEvent()",
@@ -266011,7 +266122,7 @@
       "source_location": "L371"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_ts",
       "label": "transactions.ts",
@@ -266020,7 +266131,7 @@
       "source_location": "L1"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "transactions_mapcorrectionerror",
       "label": "mapCorrectionError()",
@@ -266029,7 +266140,7 @@
       "source_location": "L339"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "transactions_redactpospulsesummary",
       "label": "redactPosPulseSummary()",
@@ -266038,7 +266149,7 @@
       "source_location": "L307"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "transactions_requirepostransactionaccess",
       "label": "requirePosTransactionAccess()",
@@ -266047,7 +266158,7 @@
       "source_location": "L93"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "transactions_requirepostransactionstoreaccess",
       "label": "requirePosTransactionStoreAccess()",
@@ -266056,7 +266167,7 @@
       "source_location": "L64"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_application_policy_ts",
       "label": "policy.ts",
@@ -266065,7 +266176,7 @@
       "source_location": "L1"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "policy_denied",
       "label": "denied()",
@@ -266074,7 +266185,7 @@
       "source_location": "L96"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "policy_evaluateremoteassistpolicy",
       "label": "evaluateRemoteAssistPolicy()",
@@ -266083,7 +266194,7 @@
       "source_location": "L31"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "policy_isclientfresh",
       "label": "isClientFresh()",
@@ -266092,58 +266203,13 @@
       "source_location": "L88"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "policy_policydecisiontocommandresult",
       "label": "policyDecisionToCommandResult()",
       "norm_label": "policydecisiontocommandresult()",
       "source_file": "packages/athena-webapp/convex/remoteAssist/application/policy.ts",
       "source_location": "L76"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_remoteassist_infrastructure_remoteassistreadrepository_ts",
-      "label": "remoteAssistReadRepository.ts",
-      "norm_label": "remoteassistreadrepository.ts",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/infrastructure/remoteAssistReadRepository.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "remoteassistreadrepository_compareremoteassistsessionforsupportview",
-      "label": "compareRemoteAssistSessionForSupportView()",
-      "norm_label": "compareremoteassistsessionforsupportview()",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/infrastructure/remoteAssistReadRepository.ts",
-      "source_location": "L88"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "remoteassistreadrepository_createremoteassistreadrepository",
-      "label": "createRemoteAssistReadRepository()",
-      "norm_label": "createremoteassistreadrepository()",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/infrastructure/remoteAssistReadRepository.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "remoteassistreadrepository_toremoteassistclient",
-      "label": "toRemoteAssistClient()",
-      "norm_label": "toremoteassistclient()",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/infrastructure/remoteAssistReadRepository.ts",
-      "source_location": "L108"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "remoteassistreadrepository_toremoteassistsession",
-      "label": "toRemoteAssistSession()",
-      "norm_label": "toremoteassistsession()",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/infrastructure/remoteAssistReadRepository.ts",
-      "source_location": "L121"
     },
     {
       "community": 58,
@@ -266391,6 +266457,51 @@
     {
       "community": 580,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_remoteassist_infrastructure_remoteassistreadrepository_ts",
+      "label": "remoteAssistReadRepository.ts",
+      "norm_label": "remoteassistreadrepository.ts",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/infrastructure/remoteAssistReadRepository.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "remoteassistreadrepository_compareremoteassistsessionforsupportview",
+      "label": "compareRemoteAssistSessionForSupportView()",
+      "norm_label": "compareremoteassistsessionforsupportview()",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/infrastructure/remoteAssistReadRepository.ts",
+      "source_location": "L88"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "remoteassistreadrepository_createremoteassistreadrepository",
+      "label": "createRemoteAssistReadRepository()",
+      "norm_label": "createremoteassistreadrepository()",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/infrastructure/remoteAssistReadRepository.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "remoteassistreadrepository_toremoteassistclient",
+      "label": "toRemoteAssistClient()",
+      "norm_label": "toremoteassistclient()",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/infrastructure/remoteAssistReadRepository.ts",
+      "source_location": "L108"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "remoteassistreadrepository_toremoteassistsession",
+      "label": "toRemoteAssistSession()",
+      "norm_label": "toremoteassistsession()",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/infrastructure/remoteAssistReadRepository.ts",
+      "source_location": "L121"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
       "id": "fingerprint_factfingerprint",
       "label": "factFingerprint()",
       "norm_label": "factfingerprint()",
@@ -266398,7 +266509,7 @@
       "source_location": "L86"
     },
     {
-      "community": 580,
+      "community": 581,
       "file_type": "code",
       "id": "fingerprint_fingerprintpayload",
       "label": "fingerprintPayload()",
@@ -266407,7 +266518,7 @@
       "source_location": "L33"
     },
     {
-      "community": 580,
+      "community": 581,
       "file_type": "code",
       "id": "fingerprint_matchesstoredfingerprint",
       "label": "matchesStoredFingerprint()",
@@ -266416,7 +266527,7 @@
       "source_location": "L103"
     },
     {
-      "community": 580,
+      "community": 581,
       "file_type": "code",
       "id": "fingerprint_stablestringhash",
       "label": "stableStringHash()",
@@ -266425,7 +266536,7 @@
       "source_location": "L72"
     },
     {
-      "community": 580,
+      "community": 581,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_fingerprint_ts",
       "label": "fingerprint.ts",
@@ -266434,7 +266545,7 @@
       "source_location": "L1"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "foldday_test_fact",
       "label": "fact()",
@@ -266443,7 +266554,7 @@
       "source_location": "L78"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "foldday_test_receipt",
       "label": "receipt()",
@@ -266452,7 +266563,7 @@
       "source_location": "L757"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "foldday_test_sale",
       "label": "sale()",
@@ -266461,7 +266572,7 @@
       "source_location": "L97"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "foldday_test_shuffle",
       "label": "shuffle()",
@@ -266470,7 +266581,7 @@
       "source_location": "L108"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_foldday_test_ts",
       "label": "foldDay.test.ts",
@@ -266479,7 +266590,7 @@
       "source_location": "L1"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_servicecases_test_ts",
       "label": "serviceCases.test.ts",
@@ -266488,7 +266599,7 @@
       "source_location": "L1"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "servicecases_test_createinventoryusagectx",
       "label": "createInventoryUsageCtx()",
@@ -266497,7 +266608,7 @@
       "source_location": "L77"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "servicecases_test_expectindex",
       "label": "expectIndex()",
@@ -266506,7 +266617,7 @@
       "source_location": "L66"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "servicecases_test_gethandler",
       "label": "getHandler()",
@@ -266515,7 +266626,7 @@
       "source_location": "L73"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "servicecases_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -266524,7 +266635,7 @@
       "source_location": "L59"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_services_paystackservice_ts",
       "label": "paystackService.ts",
@@ -266533,7 +266644,7 @@
       "source_location": "L1"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "paystackservice_getpaystackheaders",
       "label": "getPaystackHeaders()",
@@ -266542,7 +266653,7 @@
       "source_location": "L11"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "paystackservice_initializetransaction",
       "label": "initializeTransaction()",
@@ -266551,7 +266662,7 @@
       "source_location": "L21"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "paystackservice_initiaterefund",
       "label": "initiateRefund()",
@@ -266560,7 +266671,7 @@
       "source_location": "L87"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "paystackservice_verifytransaction",
       "label": "verifyTransaction()",
@@ -266569,7 +266680,7 @@
       "source_location": "L65"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "admission_test_admissioncontext",
       "label": "admissionContext()",
@@ -266578,7 +266689,7 @@
       "source_location": "L17"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "admission_test_configureadmissionenvironment",
       "label": "configureAdmissionEnvironment()",
@@ -266587,7 +266698,7 @@
       "source_location": "L60"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "admission_test_contextwith",
       "label": "contextWith()",
@@ -266596,7 +266707,7 @@
       "source_location": "L120"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "admission_test_invoke",
       "label": "invoke()",
@@ -266605,7 +266716,7 @@
       "source_location": "L14"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_admission_test_ts",
       "label": "admission.test.ts",
@@ -266614,7 +266725,7 @@
       "source_location": "L1"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "config_calculateshareddemoexpectedcash",
       "label": "calculateSharedDemoExpectedCash()",
@@ -266623,7 +266734,7 @@
       "source_location": "L23"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "config_isshareddemoenabled",
       "label": "isSharedDemoEnabled()",
@@ -266632,7 +266743,7 @@
       "source_location": "L33"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "config_readruntimeshareddemoconfig",
       "label": "readRuntimeSharedDemoConfig()",
@@ -266641,7 +266752,7 @@
       "source_location": "L59"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "config_readshareddemoconfig",
       "label": "readSharedDemoConfig()",
@@ -266650,7 +266761,7 @@
       "source_location": "L40"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_config_ts",
       "label": "config.ts",
@@ -266659,7 +266770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "openingbaseline_buildshareddemoopeningbaseline",
       "label": "buildSharedDemoOpeningBaseline()",
@@ -266668,7 +266779,7 @@
       "source_location": "L63"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "openingbaseline_buildshareddemostoredayevent",
       "label": "buildSharedDemoStoreDayEvent()",
@@ -266677,7 +266788,7 @@
       "source_location": "L105"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "openingbaseline_rollshareddemoopeningbaselinewithctx",
       "label": "rollSharedDemoOpeningBaselineWithCtx()",
@@ -266686,7 +266797,7 @@
       "source_location": "L132"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "openingbaseline_shareddemooperatingdaterange",
       "label": "sharedDemoOperatingDateRange()",
@@ -266695,7 +266806,7 @@
       "source_location": "L21"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_openingbaseline_ts",
       "label": "openingBaseline.ts",
@@ -266704,7 +266815,7 @@
       "source_location": "L1"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "operationadapter_createshareddemooperationadapter",
       "label": "createSharedDemoOperationAdapter()",
@@ -266713,7 +266824,7 @@
       "source_location": "L18"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "operationadapter_isrecognizedshareddemoactorerror",
       "label": "isRecognizedSharedDemoActorError()",
@@ -266722,7 +266833,7 @@
       "source_location": "L100"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "operationadapter_shareddemodenialerror",
       "label": "sharedDemoDenialError()",
@@ -266731,7 +266842,7 @@
       "source_location": "L124"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "operationadapter_shareddemodenied",
       "label": "sharedDemoDenied()",
@@ -266740,7 +266851,7 @@
       "source_location": "L108"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_operationadapter_ts",
       "label": "operationAdapter.ts",
@@ -266749,7 +266860,7 @@
       "source_location": "L1"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_ts",
       "label": "storefrontObservabilityReport.ts",
@@ -266758,7 +266869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "storefrontobservabilityreport_buildstorefrontobservabilityreport",
       "label": "buildStorefrontObservabilityReport()",
@@ -266767,7 +266878,7 @@
       "source_location": "L124"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "storefrontobservabilityreport_getnonemptystring",
       "label": "getNonEmptyString()",
@@ -266776,7 +266887,7 @@
       "source_location": "L67"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "storefrontobservabilityreport_gettrafficsource",
       "label": "getTrafficSource()",
@@ -266785,58 +266896,13 @@
       "source_location": "L106"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "storefrontobservabilityreport_normalizestorefrontobservabilityevent",
       "label": "normalizeStorefrontObservabilityEvent()",
       "norm_label": "normalizestorefrontobservabilityevent()",
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
       "source_location": "L73"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "onlineorder_buildlookup",
-      "label": "buildLookup()",
-      "norm_label": "buildlookup()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/onlineOrder.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "onlineorder_buildonlineordertraceseed",
-      "label": "buildOnlineOrderTraceSeed()",
-      "norm_label": "buildonlineordertraceseed()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/onlineOrder.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "onlineorder_buildsafeexternalreferenceref",
-      "label": "buildSafeExternalReferenceRef()",
-      "norm_label": "buildsafeexternalreferenceref()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/onlineOrder.ts",
-      "source_location": "L53"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "onlineorder_stablefingerprint",
-      "label": "stableFingerprint()",
-      "norm_label": "stablefingerprint()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/onlineOrder.ts",
-      "source_location": "L43"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_adapters_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/onlineOrder.ts",
-      "source_location": "L1"
     },
     {
       "community": 59,
@@ -267075,6 +267141,51 @@
     {
       "community": 590,
       "file_type": "code",
+      "id": "onlineorder_buildlookup",
+      "label": "buildLookup()",
+      "norm_label": "buildlookup()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/onlineOrder.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "onlineorder_buildonlineordertraceseed",
+      "label": "buildOnlineOrderTraceSeed()",
+      "norm_label": "buildonlineordertraceseed()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/onlineOrder.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "onlineorder_buildsafeexternalreferenceref",
+      "label": "buildSafeExternalReferenceRef()",
+      "norm_label": "buildsafeexternalreferenceref()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/onlineOrder.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "onlineorder_stablefingerprint",
+      "label": "stableFingerprint()",
+      "norm_label": "stablefingerprint()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/onlineOrder.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_adapters_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/onlineOrder.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_queryusage_test_ts",
       "label": "queryUsage.test.ts",
       "norm_label": "queryusage.test.ts",
@@ -267082,7 +267193,7 @@
       "source_location": "L1"
     },
     {
-      "community": 590,
+      "community": 591,
       "file_type": "code",
       "id": "queryusage_test_comparebyfields",
       "label": "compareByFields()",
@@ -267091,7 +267202,7 @@
       "source_location": "L102"
     },
     {
-      "community": 590,
+      "community": 591,
       "file_type": "code",
       "id": "queryusage_test_createadmintracereadctx",
       "label": "createAdminTraceReadCtx()",
@@ -267100,7 +267211,7 @@
       "source_location": "L220"
     },
     {
-      "community": 590,
+      "community": 591,
       "file_type": "code",
       "id": "queryusage_test_createtestctx",
       "label": "createTestCtx()",
@@ -267109,7 +267220,7 @@
       "source_location": "L118"
     },
     {
-      "community": 590,
+      "community": 591,
       "file_type": "code",
       "id": "queryusage_test_deniedauthorizer",
       "label": "deniedAuthorizer()",
@@ -267118,7 +267229,7 @@
       "source_location": "L1071"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "appsettingsview_appearancelabel",
       "label": "appearanceLabel()",
@@ -267127,7 +267238,7 @@
       "source_location": "L38"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "appsettingsview_cn",
       "label": "cn()",
@@ -267136,7 +267247,7 @@
       "source_location": "L154"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "appsettingsview_selectthememode",
       "label": "selectThemeMode()",
@@ -267145,7 +267256,7 @@
       "source_location": "L85"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "appsettingsview_transitiontimelabel",
       "label": "transitionTimeLabel()",
@@ -267154,7 +267265,7 @@
       "source_location": "L42"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_settings_appsettingsview_tsx",
       "label": "AppSettingsView.tsx",
@@ -267163,7 +267274,7 @@
       "source_location": "L1"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "dashboard_getperiodrange",
       "label": "getPeriodRange()",
@@ -267172,7 +267283,7 @@
       "source_location": "L19"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "dashboard_loadingsection",
       "label": "LoadingSection()",
@@ -267181,7 +267292,7 @@
       "source_location": "L49"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "dashboard_renderproductssection",
       "label": "renderProductsSection()",
@@ -267190,7 +267301,7 @@
       "source_location": "L341"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "dashboard_rendersalessection",
       "label": "renderSalesSection()",
@@ -267199,7 +267310,7 @@
       "source_location": "L321"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
       "label": "Dashboard.tsx",
@@ -267208,7 +267319,7 @@
       "source_location": "L1"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "docsscrolltotop_cancel",
       "label": "cancel()",
@@ -267217,7 +267328,7 @@
       "source_location": "L87"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "docsscrolltotop_handleclick",
       "label": "handleClick()",
@@ -267226,7 +267337,7 @@
       "source_location": "L103"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "docsscrolltotop_read",
       "label": "read()",
@@ -267235,7 +267346,7 @@
       "source_location": "L37"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "docsscrolltotop_schedule",
       "label": "schedule()",
@@ -267244,7 +267355,7 @@
       "source_location": "L59"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_docs_docsscrolltotop_tsx",
       "label": "DocsScrollToTop.tsx",
@@ -267253,7 +267364,7 @@
       "source_location": "L1"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "herosectiontabs_handledisplaytypechange",
       "label": "handleDisplayTypeChange()",
@@ -267262,7 +267373,7 @@
       "source_location": "L61"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "herosectiontabs_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -267271,7 +267382,7 @@
       "source_location": "L57"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "herosectiontabs_handleoverlaytoggle",
       "label": "handleOverlayToggle()",
@@ -267280,7 +267391,7 @@
       "source_location": "L98"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "herosectiontabs_handletexttoggle",
       "label": "handleTextToggle()",
@@ -267289,7 +267400,7 @@
       "source_location": "L134"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
       "label": "HeroSectionTabs.tsx",
@@ -267298,7 +267409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
       "label": "ReelUploader.tsx",
@@ -267307,7 +267418,7 @@
       "source_location": "L1"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "reeluploader_formatfilesize",
       "label": "formatFileSize()",
@@ -267316,7 +267427,7 @@
       "source_location": "L38"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "reeluploader_handlefileselect",
       "label": "handleFileSelect()",
@@ -267325,7 +267436,7 @@
       "source_location": "L64"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "reeluploader_handleupload",
       "label": "handleUpload()",
@@ -267334,7 +267445,7 @@
       "source_location": "L135"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "reeluploader_validatefile",
       "label": "validateFile()",
@@ -267343,7 +267454,7 @@
       "source_location": "L43"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "activityview_iscreatedaction",
       "label": "isCreatedAction()",
@@ -267352,7 +267463,7 @@
       "source_location": "L90"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "activityview_isfeedbackrequestaction",
       "label": "isFeedbackRequestAction()",
@@ -267361,7 +267472,7 @@
       "source_location": "L95"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "activityview_isrefundaction",
       "label": "isRefundAction()",
@@ -267370,7 +267481,7 @@
       "source_location": "L82"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "activityview_istransitionaction",
       "label": "isTransitionAction()",
@@ -267379,7 +267490,7 @@
       "source_location": "L85"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
       "label": "ActivityView.tsx",
@@ -267388,7 +267499,7 @@
       "source_location": "L1"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "orderitemsview_handlerequestfeedback",
       "label": "handleRequestFeedback()",
@@ -267397,7 +267508,7 @@
       "source_location": "L113"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "orderitemsview_handlerestockall",
       "label": "handleRestockAll()",
@@ -267406,7 +267517,7 @@
       "source_location": "L349"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "orderitemsview_handlereturnitemtostock",
       "label": "handleReturnItemToStock()",
@@ -267415,7 +267526,7 @@
       "source_location": "L86"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "orderitemsview_handleupdateorderitem",
       "label": "handleUpdateOrderItem()",
@@ -267424,7 +267535,7 @@
       "source_location": "L62"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
       "label": "OrderItemsView.tsx",
@@ -267433,7 +267544,7 @@
       "source_location": "L1"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "cashierauthdialog_test_buildlocalauthorityrecord",
       "label": "buildLocalAuthorityRecord()",
@@ -267442,7 +267553,7 @@
       "source_location": "L121"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "cashierauthdialog_test_renderdialog",
       "label": "renderDialog()",
@@ -267451,7 +267562,7 @@
       "source_location": "L152"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "cashierauthdialog_test_submitcredentials",
       "label": "submitCredentials()",
@@ -267460,7 +267571,7 @@
       "source_location": "L216"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "cashierauthdialog_test_submitlockedcashierpin",
       "label": "submitLockedCashierPin()",
@@ -267469,57 +267580,12 @@
       "source_location": "L208"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_test_tsx",
       "label": "CashierAuthDialog.test.tsx",
       "norm_label": "cashierauthdialog.test.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "ordersummary_test_getbalancedueamount",
-      "label": "getBalanceDueAmount()",
-      "norm_label": "getbalancedueamount()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
-      "source_location": "L49"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "ordersummary_test_getbalanceduelabel",
-      "label": "getBalanceDueLabel()",
-      "norm_label": "getbalanceduelabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "ordersummary_test_getbalanceduepanel",
-      "label": "getBalanceDuePanel()",
-      "norm_label": "getbalanceduepanel()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
-      "source_location": "L75"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "ordersummary_test_stripwhitespace",
-      "label": "stripWhitespace()",
-      "norm_label": "stripwhitespace()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_ordersummary_test_tsx",
-      "label": "OrderSummary.test.tsx",
-      "norm_label": "ordersummary.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
       "source_location": "L1"
     },
     {
@@ -268407,6 +268473,51 @@
     {
       "community": 600,
       "file_type": "code",
+      "id": "ordersummary_test_getbalancedueamount",
+      "label": "getBalanceDueAmount()",
+      "norm_label": "getbalancedueamount()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
+      "source_location": "L49"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "ordersummary_test_getbalanceduelabel",
+      "label": "getBalanceDueLabel()",
+      "norm_label": "getbalanceduelabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "ordersummary_test_getbalanceduepanel",
+      "label": "getBalanceDuePanel()",
+      "norm_label": "getbalanceduepanel()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
+      "source_location": "L75"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "ordersummary_test_stripwhitespace",
+      "label": "stripWhitespace()",
+      "norm_label": "stripwhitespace()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_ordersummary_test_tsx",
+      "label": "OrderSummary.test.tsx",
+      "norm_label": "ordersummary.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_test_tsx",
       "label": "POSSettingsView.test.tsx",
       "norm_label": "possettingsview.test.tsx",
@@ -268414,7 +268525,7 @@
       "source_location": "L1"
     },
     {
-      "community": 600,
+      "community": 601,
       "file_type": "code",
       "id": "possettingsview_test_findtrigger",
       "label": "findTrigger()",
@@ -268423,7 +268534,7 @@
       "source_location": "L185"
     },
     {
-      "community": 600,
+      "community": 601,
       "file_type": "code",
       "id": "possettingsview_test_selectcontent",
       "label": "SelectContent()",
@@ -268432,7 +268543,7 @@
       "source_location": "L160"
     },
     {
-      "community": 600,
+      "community": 601,
       "file_type": "code",
       "id": "possettingsview_test_selectitem",
       "label": "SelectItem()",
@@ -268441,7 +268552,7 @@
       "source_location": "L163"
     },
     {
-      "community": 600,
+      "community": 601,
       "file_type": "code",
       "id": "possettingsview_test_selecttrigger",
       "label": "SelectTrigger()",
@@ -268450,7 +268561,7 @@
       "source_location": "L165"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productslistview_tsx",
       "label": "ProductsListView.tsx",
@@ -268459,7 +268570,7 @@
       "source_location": "L1"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "productslistview_handlecategorypageindexchange",
       "label": "handleCategoryPageIndexChange()",
@@ -268468,7 +268579,7 @@
       "source_location": "L220"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "productslistview_handleclearcache",
       "label": "handleClearCache()",
@@ -268477,7 +268588,7 @@
       "source_location": "L108"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "productslistview_handlestorefrontvisibilitychange",
       "label": "handleStorefrontVisibilityChange()",
@@ -268486,7 +268597,7 @@
       "source_location": "L87"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "productslistview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -268495,7 +268606,7 @@
       "source_location": "L33"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeview_tsx",
       "label": "PromoCodeView.tsx",
@@ -268504,7 +268615,7 @@
       "source_location": "L1"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "promocodeview_handleaddpromocode",
       "label": "handleAddPromoCode()",
@@ -268513,7 +268624,7 @@
       "source_location": "L158"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "promocodeview_handleupdatepromocode",
       "label": "handleUpdatePromoCode()",
@@ -268522,7 +268633,7 @@
       "source_location": "L231"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "promocodeview_updatehomepagediscountcode",
       "label": "updateHomepageDiscountCode()",
@@ -268531,7 +268642,7 @@
       "source_location": "L324"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "promocodeview_updateleaveareviewdiscountcode",
       "label": "updateLeaveAReviewDiscountCode()",
@@ -268540,7 +268651,7 @@
       "source_location": "L379"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportsoverviewview_test_tsx",
       "label": "ReportsOverviewView.test.tsx",
@@ -268549,7 +268660,7 @@
       "source_location": "L1"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "reportsoverviewview_test_expectanimatedmetrics",
       "label": "expectAnimatedMetrics()",
@@ -268558,7 +268669,7 @@
       "source_location": "L450"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "reportsoverviewview_test_harness",
       "label": "Harness()",
@@ -268567,7 +268678,7 @@
       "source_location": "L173"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "reportsoverviewview_test_linkedrange",
       "label": "linkedRange()",
@@ -268576,7 +268687,7 @@
       "source_location": "L584"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "reportsoverviewview_test_snapshot",
       "label": "snapshot()",
@@ -268585,7 +268696,7 @@
       "source_location": "L87"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportroutesearch_ts",
       "label": "reportRouteSearch.ts",
@@ -268594,7 +268705,7 @@
       "source_location": "L1"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "reportroutesearch_overviewsearchfromweeklyreturn",
       "label": "overviewSearchFromWeeklyReturn()",
@@ -268603,7 +268714,7 @@
       "source_location": "L148"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "reportroutesearch_parseunitssheetfocussearch",
       "label": "parseUnitsSheetFocusSearch()",
@@ -268612,7 +268723,7 @@
       "source_location": "L81"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "reportroutesearch_unitssheetfocussearchvalue",
       "label": "unitsSheetFocusSearchValue()",
@@ -268621,7 +268732,7 @@
       "source_location": "L72"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "reportroutesearch_weeklyreturnsearchfromoverview",
       "label": "weeklyReturnSearchFromOverview()",
@@ -268630,7 +268741,7 @@
       "source_location": "L125"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_pulse_storepulsesummaryview_tsx",
       "label": "StorePulseSummaryView.tsx",
@@ -268639,7 +268750,7 @@
       "source_location": "L1"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "storepulsesummaryview_formatcomparisonhelper",
       "label": "formatComparisonHelper()",
@@ -268648,7 +268759,7 @@
       "source_location": "L165"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "storepulsesummaryview_formatxaxistick",
       "label": "formatXAxisTick()",
@@ -268657,7 +268768,7 @@
       "source_location": "L379"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "storepulsesummaryview_gettrendvalue",
       "label": "getTrendValue()",
@@ -268666,7 +268777,7 @@
       "source_location": "L312"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "storepulsesummaryview_helper",
       "label": "helper()",
@@ -268675,7 +268786,7 @@
       "source_location": "L202"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "date_time_picker_handleclear",
       "label": "handleClear()",
@@ -268684,7 +268795,7 @@
       "source_location": "L101"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "date_time_picker_handledateselect",
       "label": "handleDateSelect()",
@@ -268693,7 +268804,7 @@
       "source_location": "L55"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "date_time_picker_handletimeblur",
       "label": "handleTimeBlur()",
@@ -268702,7 +268813,7 @@
       "source_location": "L77"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "date_time_picker_handletimechange",
       "label": "handleTimeChange()",
@@ -268711,7 +268822,7 @@
       "source_location": "L65"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
       "label": "date-time-picker.tsx",
@@ -268720,7 +268831,7 @@
       "source_location": "L1"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "custom_modal_example_basicmodalexample",
       "label": "BasicModalExample()",
@@ -268729,7 +268840,7 @@
       "source_location": "L7"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "custom_modal_example_customclosebuttonexample",
       "label": "CustomCloseButtonExample()",
@@ -268738,7 +268849,7 @@
       "source_location": "L69"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "custom_modal_example_custompositionmodalexample",
       "label": "CustomPositionModalExample()",
@@ -268747,7 +268858,7 @@
       "source_location": "L44"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "custom_modal_example_fullscreenmodalexample",
       "label": "FullScreenModalExample()",
@@ -268756,7 +268867,7 @@
       "source_location": "L103"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_example_tsx",
       "label": "custom-modal-example.tsx",
@@ -268765,7 +268876,7 @@
       "source_location": "L1"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpenselocalruntime_ts",
       "label": "useExpenseLocalRuntime.ts",
@@ -268774,7 +268885,7 @@
       "source_location": "L1"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "useexpenselocalruntime_createlocalid",
       "label": "createLocalId()",
@@ -268783,7 +268894,7 @@
       "source_location": "L23"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "useexpenselocalruntime_getexpenselocalstore",
       "label": "getExpenseLocalStore()",
@@ -268792,7 +268903,7 @@
       "source_location": "L12"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "useexpenselocalruntime_notifyexpenselocaleventappended",
       "label": "notifyExpenseLocalEventAppended()",
@@ -268801,58 +268912,13 @@
       "source_location": "L17"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "useexpenselocalruntime_useexpenselocalruntime",
       "label": "useExpenseLocalRuntime()",
       "norm_label": "useexpenselocalruntime()",
       "source_file": "packages/athena-webapp/src/hooks/useExpenseLocalRuntime.ts",
       "source_location": "L31"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "appmessagesprovider_appmessagesprovider",
-      "label": "AppMessagesProvider()",
-      "norm_label": "appmessagesprovider()",
-      "source_file": "packages/athena-webapp/src/lib/app-messages/AppMessagesProvider.tsx",
-      "source_location": "L28"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "appmessagesprovider_areblockersequal",
-      "label": "areBlockersEqual()",
-      "norm_label": "areblockersequal()",
-      "source_file": "packages/athena-webapp/src/lib/app-messages/AppMessagesProvider.tsx",
-      "source_location": "L215"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "appmessagesprovider_aremessagesequal",
-      "label": "areMessagesEqual()",
-      "norm_label": "aremessagesequal()",
-      "source_file": "packages/athena-webapp/src/lib/app-messages/AppMessagesProvider.tsx",
-      "source_location": "L185"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "appmessagesprovider_getpreferredvariant",
-      "label": "getPreferredVariant()",
-      "norm_label": "getpreferredvariant()",
-      "source_file": "packages/athena-webapp/src/lib/app-messages/AppMessagesProvider.tsx",
-      "source_location": "L203"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_app_messages_appmessagesprovider_tsx",
-      "label": "AppMessagesProvider.tsx",
-      "norm_label": "appmessagesprovider.tsx",
-      "source_file": "packages/athena-webapp/src/lib/app-messages/AppMessagesProvider.tsx",
-      "source_location": "L1"
     },
     {
       "community": 61,
@@ -269082,6 +269148,51 @@
     {
       "community": 610,
       "file_type": "code",
+      "id": "appmessagesprovider_appmessagesprovider",
+      "label": "AppMessagesProvider()",
+      "norm_label": "appmessagesprovider()",
+      "source_file": "packages/athena-webapp/src/lib/app-messages/AppMessagesProvider.tsx",
+      "source_location": "L28"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "appmessagesprovider_areblockersequal",
+      "label": "areBlockersEqual()",
+      "norm_label": "areblockersequal()",
+      "source_file": "packages/athena-webapp/src/lib/app-messages/AppMessagesProvider.tsx",
+      "source_location": "L215"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "appmessagesprovider_aremessagesequal",
+      "label": "areMessagesEqual()",
+      "norm_label": "aremessagesequal()",
+      "source_file": "packages/athena-webapp/src/lib/app-messages/AppMessagesProvider.tsx",
+      "source_location": "L185"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "appmessagesprovider_getpreferredvariant",
+      "label": "getPreferredVariant()",
+      "norm_label": "getpreferredvariant()",
+      "source_file": "packages/athena-webapp/src/lib/app-messages/AppMessagesProvider.tsx",
+      "source_location": "L203"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_app_messages_appmessagesprovider_tsx",
+      "label": "AppMessagesProvider.tsx",
+      "norm_label": "appmessagesprovider.tsx",
+      "source_file": "packages/athena-webapp/src/lib/app-messages/AppMessagesProvider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
       "id": "appactionblockers_compareappactionblockers",
       "label": "compareAppActionBlockers()",
       "norm_label": "compareappactionblockers()",
@@ -269089,7 +269200,7 @@
       "source_location": "L41"
     },
     {
-      "community": 610,
+      "community": 611,
       "file_type": "code",
       "id": "appactionblockers_getselectedappactionblocker",
       "label": "getSelectedAppActionBlocker()",
@@ -269098,7 +269209,7 @@
       "source_location": "L26"
     },
     {
-      "community": 610,
+      "community": 611,
       "file_type": "code",
       "id": "appactionblockers_isvalidappactionblockerinput",
       "label": "isValidAppActionBlockerInput()",
@@ -269107,7 +269218,7 @@
       "source_location": "L30"
     },
     {
-      "community": 610,
+      "community": 611,
       "file_type": "code",
       "id": "appactionblockers_sortappactionblockers",
       "label": "sortAppActionBlockers()",
@@ -269116,7 +269227,7 @@
       "source_location": "L22"
     },
     {
-      "community": 610,
+      "community": 611,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_messages_appactionblockers_ts",
       "label": "appActionBlockers.ts",
@@ -269125,7 +269236,7 @@
       "source_location": "L1"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "appmessages_compareappmessages",
       "label": "compareAppMessages()",
@@ -269134,7 +269245,7 @@
       "source_location": "L39"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "appmessages_getselectedappmessage",
       "label": "getSelectedAppMessage()",
@@ -269143,7 +269254,7 @@
       "source_location": "L27"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "appmessages_isvalidappmessageinput",
       "label": "isValidAppMessageInput()",
@@ -269152,7 +269263,7 @@
       "source_location": "L31"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "appmessages_sortappmessages",
       "label": "sortAppMessages()",
@@ -269161,7 +269272,7 @@
       "source_location": "L23"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_messages_appmessages_ts",
       "label": "appMessages.ts",
@@ -269170,7 +269281,7 @@
       "source_location": "L1"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "appupdatereload_cleartrackedbeforeunloadhandlers",
       "label": "clearTrackedBeforeUnloadHandlers()",
@@ -269179,7 +269290,7 @@
       "source_location": "L85"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "appupdatereload_getcapture",
       "label": "getCapture()",
@@ -269188,7 +269299,7 @@
       "source_location": "L102"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "appupdatereload_installappupdateunloadpromptbypass",
       "label": "installAppUpdateUnloadPromptBypass()",
@@ -269197,7 +269308,7 @@
       "source_location": "L13"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "appupdatereload_reloadbrowserforappupdate",
       "label": "reloadBrowserForAppUpdate()",
@@ -269206,7 +269317,7 @@
       "source_location": "L74"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_update_appupdatereload_ts",
       "label": "appUpdateReload.ts",
@@ -269215,7 +269326,7 @@
       "source_location": "L1"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "browserfingerprint_buffertohex",
       "label": "bufferToHex()",
@@ -269224,7 +269335,7 @@
       "source_location": "L18"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "browserfingerprint_collectbrowserinfo",
       "label": "collectBrowserInfo()",
@@ -269233,7 +269344,7 @@
       "source_location": "L23"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "browserfingerprint_generatebrowserfingerprint",
       "label": "generateBrowserFingerprint()",
@@ -269242,7 +269353,7 @@
       "source_location": "L65"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "browserfingerprint_hashfingerprintsource",
       "label": "hashFingerprintSource()",
@@ -269251,7 +269362,7 @@
       "source_location": "L45"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_browserfingerprint_ts",
       "label": "browserFingerprint.ts",
@@ -269260,7 +269371,7 @@
       "source_location": "L1"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_ts",
       "label": "runCommand.ts",
@@ -269269,7 +269380,7 @@
       "source_location": "L1"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "runcommand_extracttraceid",
       "label": "extractTraceId()",
@@ -269278,7 +269389,7 @@
       "source_location": "L40"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "runcommand_getshareddemodenial",
       "label": "getSharedDemoDenial()",
@@ -269287,7 +269398,7 @@
       "source_location": "L48"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "runcommand_isapprovalrequiredresult",
       "label": "isApprovalRequiredResult()",
@@ -269296,7 +269407,7 @@
       "source_location": "L34"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "runcommand_runcommand",
       "label": "runCommand()",
@@ -269305,7 +269416,7 @@
       "source_location": "L68"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "imageutils_test_arraybuffer",
       "label": "arrayBuffer()",
@@ -269314,7 +269425,7 @@
       "source_location": "L78"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "imageutils_test_constructor",
       "label": "constructor()",
@@ -269323,7 +269434,7 @@
       "source_location": "L74"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "imageutils_test_mockimage",
       "label": "MockImage",
@@ -269332,7 +269443,7 @@
       "source_location": "L103"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "imageutils_test_mockimage_src",
       "label": ".src()",
@@ -269341,7 +269452,7 @@
       "source_location": "L109"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_test_ts",
       "label": "imageUtils.test.ts",
@@ -269350,7 +269461,7 @@
       "source_location": "L1"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "imageutils_convertimagestojpg",
       "label": "convertImagesToJpg()",
@@ -269359,7 +269470,7 @@
       "source_location": "L75"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "imageutils_convertimagestowebp",
       "label": "convertImagesToWebp()",
@@ -269368,7 +269479,7 @@
       "source_location": "L26"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "imageutils_converttojpg",
       "label": "convertToJpg()",
@@ -269377,7 +269488,7 @@
       "source_location": "L38"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "imageutils_getuploadimagesdata",
       "label": "getUploadImagesData()",
@@ -269386,7 +269497,7 @@
       "source_location": "L4"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_ts",
       "label": "imageUtils.ts",
@@ -269395,7 +269506,7 @@
       "source_location": "L1"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_ts",
       "label": "registerGateway.ts",
@@ -269404,7 +269515,7 @@
       "source_location": "L1"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "registergateway_mapregisterstatedto",
       "label": "mapRegisterStateDto()",
@@ -269413,7 +269524,7 @@
       "source_location": "L13"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "registergateway_mapterminaldto",
       "label": "mapTerminalDto()",
@@ -269422,7 +269533,7 @@
       "source_location": "L31"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "registergateway_useconvexregisterstate",
       "label": "useConvexRegisterState()",
@@ -269431,7 +269542,7 @@
       "source_location": "L37"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "registergateway_useconvexterminalbyfingerprint",
       "label": "useConvexTerminalByFingerprint()",
@@ -269440,7 +269551,7 @@
       "source_location": "L59"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "expenselocalcommandgateway_createexpenselocalcommandgateway",
       "label": "createExpenseLocalCommandGateway()",
@@ -269449,7 +269560,7 @@
       "source_location": "L55"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "expenselocalcommandgateway_itempayload",
       "label": "itemPayload()",
@@ -269458,7 +269569,7 @@
       "source_location": "L282"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "expenselocalcommandgateway_reasonpayload",
       "label": "reasonPayload()",
@@ -269467,7 +269578,7 @@
       "source_location": "L303"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "expenselocalcommandgateway_resolvestaffprooftoken",
       "label": "resolveStaffProofToken()",
@@ -269476,57 +269587,12 @@
       "source_location": "L310"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_expenselocalcommandgateway_ts",
       "label": "expenseLocalCommandGateway.ts",
       "norm_label": "expenselocalcommandgateway.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/expenseLocalCommandGateway.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "localcommandgateway_test_appendopendrawer",
-      "label": "appendOpenDrawer()",
-      "norm_label": "appendopendrawer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts",
-      "source_location": "L22"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "localcommandgateway_test_blockdrawerauthority",
-      "label": "blockDrawerAuthority()",
-      "norm_label": "blockdrawerauthority()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts",
-      "source_location": "L34"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "localcommandgateway_test_createblockedsalegateway",
-      "label": "createBlockedSaleGateway()",
-      "norm_label": "createblockedsalegateway()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "localcommandgateway_test_salecommandinput",
-      "label": "saleCommandInput()",
-      "norm_label": "salecommandinput()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localcommandgateway_test_ts",
-      "label": "localCommandGateway.test.ts",
-      "norm_label": "localcommandgateway.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts",
       "source_location": "L1"
     },
     {
@@ -269757,6 +269823,51 @@
     {
       "community": 620,
       "file_type": "code",
+      "id": "localcommandgateway_test_appendopendrawer",
+      "label": "appendOpenDrawer()",
+      "norm_label": "appendopendrawer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts",
+      "source_location": "L22"
+    },
+    {
+      "community": 620,
+      "file_type": "code",
+      "id": "localcommandgateway_test_blockdrawerauthority",
+      "label": "blockDrawerAuthority()",
+      "norm_label": "blockdrawerauthority()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts",
+      "source_location": "L34"
+    },
+    {
+      "community": 620,
+      "file_type": "code",
+      "id": "localcommandgateway_test_createblockedsalegateway",
+      "label": "createBlockedSaleGateway()",
+      "norm_label": "createblockedsalegateway()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 620,
+      "file_type": "code",
+      "id": "localcommandgateway_test_salecommandinput",
+      "label": "saleCommandInput()",
+      "norm_label": "salecommandinput()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 620,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localcommandgateway_test_ts",
+      "label": "localCommandGateway.test.ts",
+      "norm_label": "localcommandgateway.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
       "id": "localregisterreader_readlatestdrawerauthoritystate",
       "label": "readLatestDrawerAuthorityState()",
       "norm_label": "readlatestdrawerauthoritystate()",
@@ -269764,7 +269875,7 @@
       "source_location": "L325"
     },
     {
-      "community": 620,
+      "community": 621,
       "file_type": "code",
       "id": "localregisterreader_readprojectedlocalregistermodel",
       "label": "readProjectedLocalRegisterModel()",
@@ -269773,7 +269884,7 @@
       "source_location": "L129"
     },
     {
-      "community": 620,
+      "community": 621,
       "file_type": "code",
       "id": "localregisterreader_readscopedpagesorfallback",
       "label": "readScopedPagesOrFallback()",
@@ -269782,7 +269893,7 @@
       "source_location": "L266"
     },
     {
-      "community": 620,
+      "community": 621,
       "file_type": "code",
       "id": "localregisterreader_readscopedposlocalevents",
       "label": "readScopedPosLocalEvents()",
@@ -269791,7 +269902,7 @@
       "source_location": "L86"
     },
     {
-      "community": 620,
+      "community": 621,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localregisterreader_ts",
       "label": "localRegisterReader.ts",
@@ -269800,7 +269911,7 @@
       "source_location": "L1"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registerreadmodel_test_ts",
       "label": "registerReadModel.test.ts",
@@ -269809,7 +269920,7 @@
       "source_location": "L1"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "registerreadmodel_test_errorcodes",
       "label": "errorCodes()",
@@ -269818,7 +269929,7 @@
       "source_location": "L1565"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "registerreadmodel_test_event",
       "label": "event()",
@@ -269827,7 +269938,7 @@
       "source_location": "L1569"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "registerreadmodel_test_servicedraftevent",
       "label": "serviceDraftEvent()",
@@ -269836,7 +269947,7 @@
       "source_location": "L1611"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "registerreadmodel_test_servicedraftprelude",
       "label": "serviceDraftPrelude()",
@@ -269845,7 +269956,7 @@
       "source_location": "L1593"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_runtimereadiness_ts",
       "label": "runtimeReadiness.ts",
@@ -269854,7 +269965,7 @@
       "source_location": "L1"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "runtimereadiness_emptyposterminalruntimereadiness",
       "label": "emptyPosTerminalRuntimeReadiness()",
@@ -269863,7 +269974,7 @@
       "source_location": "L39"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "runtimereadiness_getruntimevisibleactiveregistersession",
       "label": "getRuntimeVisibleActiveRegisterSession()",
@@ -269872,7 +269983,7 @@
       "source_location": "L165"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "runtimereadiness_refreshterminalruntimereadiness",
       "label": "refreshTerminalRuntimeReadiness()",
@@ -269881,7 +269992,7 @@
       "source_location": "L51"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "runtimereadiness_toruntimeactiveregistersession",
       "label": "toRuntimeActiveRegisterSession()",
@@ -269890,7 +270001,7 @@
       "source_location": "L179"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_useregisterlifecycleauthorityruntime_ts",
       "label": "useRegisterLifecycleAuthorityRuntime.ts",
@@ -269899,7 +270010,7 @@
       "source_location": "L1"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_applysnapshot",
       "label": "applySnapshot()",
@@ -269908,7 +270019,7 @@
       "source_location": "L389"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_isregisterlifecyclerepairclassification",
       "label": "isRegisterLifecycleRepairClassification()",
@@ -269917,7 +270028,7 @@
       "source_location": "L554"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_toobservation",
       "label": "toObservation()",
@@ -269926,7 +270037,7 @@
       "source_location": "L523"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_useregisterlifecycleauthorityruntime",
       "label": "useRegisterLifecycleAuthorityRuntime()",
@@ -269935,7 +270046,7 @@
       "source_location": "L53"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_transactionutils_ts",
       "label": "transactionUtils.ts",
@@ -269944,7 +270055,7 @@
       "source_location": "L1"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "transactionutils_calculatechange",
       "label": "calculateChange()",
@@ -269953,7 +270064,7 @@
       "source_location": "L42"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "transactionutils_formatcurrency",
       "label": "formatCurrency()",
@@ -269962,7 +270073,7 @@
       "source_location": "L29"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "transactionutils_formattimestamp",
       "label": "formatTimestamp()",
@@ -269971,7 +270082,7 @@
       "source_location": "L49"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "transactionutils_generatetransactionnumber",
       "label": "generateTransactionNumber()",
@@ -269980,7 +270091,7 @@
       "source_location": "L14"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_runtimebuildmetadata_ts",
       "label": "runtimeBuildMetadata.ts",
@@ -269989,7 +270100,7 @@
       "source_location": "L1"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "runtimebuildmetadata_getinitialruntimebuildmetadata",
       "label": "getInitialRuntimeBuildMetadata()",
@@ -269998,7 +270109,7 @@
       "source_location": "L16"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "runtimebuildmetadata_normalizedeploymetadata",
       "label": "normalizeDeployMetadata()",
@@ -270007,7 +270118,7 @@
       "source_location": "L49"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "runtimebuildmetadata_normalizemetadatavalue",
       "label": "normalizeMetadataValue()",
@@ -270016,7 +270127,7 @@
       "source_location": "L63"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "runtimebuildmetadata_readruntimebuildmetadata",
       "label": "readRuntimeBuildMetadata()",
@@ -270025,7 +270136,7 @@
       "source_location": "L32"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_timelineutils_ts",
       "label": "timelineUtils.ts",
@@ -270034,7 +270145,7 @@
       "source_location": "L1"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevent",
       "label": "enrichTimelineEvent()",
@@ -270043,7 +270154,7 @@
       "source_location": "L184"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevents",
       "label": "enrichTimelineEvents()",
@@ -270052,7 +270163,7 @@
       "source_location": "L200"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "timelineutils_gettimerangelabel",
       "label": "getTimeRangeLabel()",
@@ -270061,7 +270172,7 @@
       "source_location": "L244"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "timelineutils_groupeventsbytimeframe",
       "label": "groupEventsByTimeframe()",
@@ -270070,7 +270181,7 @@
       "source_location": "L206"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "packages_athena_webapp_src_offline_registerposappshellserviceworker_ts",
       "label": "registerPosAppShellServiceWorker.ts",
@@ -270079,7 +270190,7 @@
       "source_location": "L1"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "registerposappshellserviceworker_isposappshellserviceworkerregistration",
       "label": "isPosAppShellServiceWorkerRegistration()",
@@ -270088,7 +270199,7 @@
       "source_location": "L52"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "registerposappshellserviceworker_registerposappshellserviceworker",
       "label": "registerPosAppShellServiceWorker()",
@@ -270097,7 +270208,7 @@
       "source_location": "L6"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "registerposappshellserviceworker_resetposappshellserviceworkerregistrationfortest",
       "label": "resetPosAppShellServiceWorkerRegistrationForTest()",
@@ -270106,7 +270217,7 @@
       "source_location": "L20"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "registerposappshellserviceworker_unregisterposappshellserviceworkerfordev",
       "label": "unregisterPosAppShellServiceWorkerForDev()",
@@ -270115,7 +270226,7 @@
       "source_location": "L24"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -270124,7 +270235,7 @@
       "source_location": "L1"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "root_getathenadocumenttitle",
       "label": "getAthenaDocumentTitle()",
@@ -270133,7 +270244,7 @@
       "source_location": "L89"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "root_rootcomponent",
       "label": "RootComponent()",
@@ -270142,7 +270253,7 @@
       "source_location": "L62"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "root_rootdocument",
       "label": "RootDocument()",
@@ -270151,58 +270262,13 @@
       "source_location": "L72"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "root_rootnotfound",
       "label": "RootNotFound()",
       "norm_label": "rootnotfound()",
       "source_file": "packages/athena-webapp/src/routes/__root.tsx",
       "source_location": "L48"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
-      "label": "$traceId.tsx",
-      "norm_label": "$traceid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "traceid_hasorgnotfoundpayload",
-      "label": "hasOrgNotFoundPayload()",
-      "norm_label": "hasorgnotfoundpayload()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "traceid_workflowtraceroute",
-      "label": "WorkflowTraceRoute()",
-      "norm_label": "workflowtraceroute()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L85"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "traceid_workflowtraceroutecontent",
-      "label": "WorkflowTraceRouteContent()",
-      "norm_label": "workflowtraceroutecontent()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "traceid_workflowtracerouteshell",
-      "label": "WorkflowTraceRouteShell()",
-      "norm_label": "workflowtracerouteshell()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
-      "source_location": "L50"
     },
     {
       "community": 63,
@@ -270432,6 +270498,51 @@
     {
       "community": 630,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
+      "label": "$traceId.tsx",
+      "norm_label": "$traceid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 630,
+      "file_type": "code",
+      "id": "traceid_hasorgnotfoundpayload",
+      "label": "hasOrgNotFoundPayload()",
+      "norm_label": "hasorgnotfoundpayload()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 630,
+      "file_type": "code",
+      "id": "traceid_workflowtraceroute",
+      "label": "WorkflowTraceRoute()",
+      "norm_label": "workflowtraceroute()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L85"
+    },
+    {
+      "community": 630,
+      "file_type": "code",
+      "id": "traceid_workflowtraceroutecontent",
+      "label": "WorkflowTraceRouteContent()",
+      "norm_label": "workflowtraceroutecontent()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 630,
+      "file_type": "code",
+      "id": "traceid_workflowtracerouteshell",
+      "label": "WorkflowTraceRouteShell()",
+      "norm_label": "workflowtracerouteshell()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 631,
+      "file_type": "code",
       "id": "expensestore_expensecartitemsourcekey",
       "label": "expenseCartItemSourceKey()",
       "norm_label": "expensecartitemsourcekey()",
@@ -270439,7 +270550,7 @@
       "source_location": "L179"
     },
     {
-      "community": 630,
+      "community": 631,
       "file_type": "code",
       "id": "expensestore_ispendingoptimisticexpensecartitem",
       "label": "isPendingOptimisticExpenseCartItem()",
@@ -270448,7 +270559,7 @@
       "source_location": "L197"
     },
     {
-      "community": 630,
+      "community": 631,
       "file_type": "code",
       "id": "expensestore_mapexpensesessioncartitemtocartitem",
       "label": "mapExpenseSessionCartItemToCartItem()",
@@ -270457,7 +270568,7 @@
       "source_location": "L213"
     },
     {
-      "community": 630,
+      "community": 631,
       "file_type": "code",
       "id": "expensestore_sessionitemrepresentscartitem",
       "label": "sessionItemRepresentsCartItem()",
@@ -270466,7 +270577,7 @@
       "source_location": "L201"
     },
     {
-      "community": 630,
+      "community": 631,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stores_expensestore_ts",
       "label": "expenseStore.ts",
@@ -270475,7 +270586,7 @@
       "source_location": "L1"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "analytics_getproductviewcount",
       "label": "getProductViewCount()",
@@ -270484,7 +270595,7 @@
       "source_location": "L93"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "analytics_logout",
       "label": "logout()",
@@ -270493,7 +270604,7 @@
       "source_location": "L75"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "analytics_postanalytics",
       "label": "postAnalytics()",
@@ -270502,7 +270613,7 @@
       "source_location": "L4"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "analytics_updateanalyticsowner",
       "label": "updateAnalyticsOwner()",
@@ -270511,7 +270622,7 @@
       "source_location": "L47"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_ts",
       "label": "analytics.ts",
@@ -270520,7 +270631,7 @@
       "source_location": "L1"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "category_getallcategories",
       "label": "getAllCategories()",
@@ -270529,7 +270640,7 @@
       "source_location": "L11"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "category_getallcategorieswithsubcategories",
       "label": "getAllCategoriesWithSubcategories()",
@@ -270538,7 +270649,7 @@
       "source_location": "L25"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "category_getbaseurl",
       "label": "getBaseUrl()",
@@ -270547,7 +270658,7 @@
       "source_location": "L9"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "category_getcategory",
       "label": "getCategory()",
@@ -270556,7 +270667,7 @@
       "source_location": "L39"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_category_ts",
       "label": "category.ts",
@@ -270565,7 +270676,7 @@
       "source_location": "L1"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "onlineorder_getbaseurl",
       "label": "getBaseUrl()",
@@ -270574,7 +270685,7 @@
       "source_location": "L4"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "onlineorder_getorder",
       "label": "getOrder()",
@@ -270583,7 +270694,7 @@
       "source_location": "L24"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "onlineorder_getorders",
       "label": "getOrders()",
@@ -270592,7 +270703,7 @@
       "source_location": "L6"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "onlineorder_updateordersowner",
       "label": "updateOrdersOwner()",
@@ -270601,7 +270712,7 @@
       "source_location": "L42"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -270610,7 +270721,7 @@
       "source_location": "L1"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefrontuser_ts",
       "label": "storeFrontUser.ts",
@@ -270619,7 +270730,7 @@
       "source_location": "L1"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "storefrontuser_getactiveuser",
       "label": "getActiveUser()",
@@ -270628,7 +270739,7 @@
       "source_location": "L28"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "storefrontuser_getbaseurl",
       "label": "getBaseUrl()",
@@ -270637,7 +270748,7 @@
       "source_location": "L5"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "storefrontuser_getguest",
       "label": "getGuest()",
@@ -270646,7 +270757,7 @@
       "source_location": "L7"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "storefrontuser_updateuser",
       "label": "updateUser()",
@@ -270655,7 +270766,7 @@
       "source_location": "L46"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "homepage_enableprompts",
       "label": "enablePrompts()",
@@ -270664,7 +270775,7 @@
       "source_location": "L137"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "homepage_handleclickonleavereviewbutton",
       "label": "handleClickOnLeaveReviewButton()",
@@ -270673,7 +270784,7 @@
       "source_location": "L176"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "homepage_handlescroll",
       "label": "handleScroll()",
@@ -270682,7 +270793,7 @@
       "source_location": "L105"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "homepage_homepagereadyshell",
       "label": "HomePageReadyShell()",
@@ -270691,7 +270802,7 @@
       "source_location": "L31"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_tsx",
       "label": "HomePage.tsx",
@@ -270700,7 +270811,7 @@
       "source_location": "L1"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "homepagecontent_resolvehomepagecontent",
       "label": "resolveHomepageContent()",
@@ -270709,7 +270820,7 @@
       "source_location": "L102"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "homepagecontent_todisplayproduct",
       "label": "toDisplayProduct()",
@@ -270718,7 +270829,7 @@
       "source_location": "L70"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "homepagecontent_todisplaysku",
       "label": "toDisplaySku()",
@@ -270727,7 +270838,7 @@
       "source_location": "L54"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "homepagecontent_tofeatureditem",
       "label": "toFeaturedItem()",
@@ -270736,7 +270847,7 @@
       "source_location": "L78"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
       "label": "homePageContent.ts",
@@ -270745,7 +270856,7 @@
       "source_location": "L1"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "inventorylevelbadge_lowstockbadge",
       "label": "LowStockBadge()",
@@ -270754,7 +270865,7 @@
       "source_location": "L14"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastbadge",
       "label": "SellingFastBadge()",
@@ -270763,7 +270874,7 @@
       "source_location": "L22"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastsignal",
       "label": "SellingFastSignal()",
@@ -270772,7 +270883,7 @@
       "source_location": "L30"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "inventorylevelbadge_soldoutbadge",
       "label": "SoldOutBadge()",
@@ -270781,57 +270892,12 @@
       "source_location": "L3"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_inventorylevelbadge_tsx",
       "label": "InventoryLevelBadge.tsx",
       "norm_label": "inventorylevelbadge.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 638,
-      "file_type": "code",
-      "id": "currency_formatstoredamount",
-      "label": "formatStoredAmount()",
-      "norm_label": "formatstoredamount()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 638,
-      "file_type": "code",
-      "id": "currency_todisplayamount",
-      "label": "toDisplayAmount()",
-      "norm_label": "todisplayamount()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 638,
-      "file_type": "code",
-      "id": "currency_topesewas",
-      "label": "toPesewas()",
-      "norm_label": "topesewas()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 638,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 638,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
       "source_location": "L1"
     },
     {

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -20795,7 +20795,7 @@
       "relation": "calls",
       "source": "harness_gate_admission_test_greenoptions",
       "source_file": "scripts/harness-gate-admission.test.ts",
-      "source_location": "L78",
+      "source_location": "L79",
       "target": "harness_gate_admission_test_humanwaiveroptions",
       "weight": 1
     },
@@ -155351,7 +155351,7 @@
       "relation": "contains",
       "source": "scripts_harness_gate_admission_test_ts",
       "source_file": "scripts/harness-gate-admission.test.ts",
-      "source_location": "L40",
+      "source_location": "L41",
       "target": "harness_gate_admission_test_greenoptions",
       "weight": 1
     },
@@ -155363,7 +155363,7 @@
       "relation": "contains",
       "source": "scripts_harness_gate_admission_test_ts",
       "source_file": "scripts/harness-gate-admission.test.ts",
-      "source_location": "L77",
+      "source_location": "L78",
       "target": "harness_gate_admission_test_humanwaiveroptions",
       "weight": 1
     },
@@ -155375,7 +155375,7 @@
       "relation": "contains",
       "source": "scripts_harness_gate_admission_test_ts",
       "source_file": "scripts/harness-gate-admission.test.ts",
-      "source_location": "L251",
+      "source_location": "L252",
       "target": "harness_gate_admission_test_missingtelemetry",
       "weight": 1
     },
@@ -159743,7 +159743,7 @@
       "relation": "contains",
       "source": "scripts_harness_test_test_ts",
       "source_file": "scripts/harness-test.test.ts",
-      "source_location": "L21",
+      "source_location": "L22",
       "target": "harness_test_test_createfixtureroot",
       "weight": 1
     },
@@ -159755,7 +159755,7 @@
       "relation": "contains",
       "source": "scripts_harness_test_test_ts",
       "source_file": "scripts/harness-test.test.ts",
-      "source_location": "L27",
+      "source_location": "L28",
       "target": "harness_test_test_rungit",
       "weight": 1
     },
@@ -159767,7 +159767,7 @@
       "relation": "contains",
       "source": "scripts_harness_test_test_ts",
       "source_file": "scripts/harness-test.test.ts",
-      "source_location": "L15",
+      "source_location": "L16",
       "target": "harness_test_test_write",
       "weight": 1
     },
@@ -160907,7 +160907,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_hook_test_ts",
       "source_file": "scripts/pre-push-hook.test.ts",
-      "source_location": "L18",
+      "source_location": "L20",
       "target": "pre_push_hook_test_createhookfixture",
       "weight": 1
     },
@@ -160919,7 +160919,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_hook_test_ts",
       "source_file": "scripts/pre-push-hook.test.ts",
-      "source_location": "L80",
+      "source_location": "L93",
       "target": "pre_push_hook_test_isprocessalive",
       "weight": 1
     },
@@ -160931,7 +160931,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_hook_test_ts",
       "source_file": "scripts/pre-push-hook.test.ts",
-      "source_location": "L72",
+      "source_location": "L85",
       "target": "pre_push_hook_test_retainedlogpath",
       "weight": 1
     },
@@ -160943,7 +160943,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_hook_test_ts",
       "source_file": "scripts/pre-push-hook.test.ts",
-      "source_location": "L59",
+      "source_location": "L72",
       "target": "pre_push_hook_test_waitforfile",
       "weight": 1
     },
@@ -160955,7 +160955,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_test_ts",
       "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L35",
+      "source_location": "L36",
       "target": "pre_push_review_test_createblockedpublicgatefixture",
       "weight": 1
     },
@@ -160967,7 +160967,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_test_ts",
       "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L920",
+      "source_location": "L921",
       "target": "pre_push_review_test_error",
       "weight": 1
     },
@@ -160979,7 +160979,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_test_ts",
       "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L918",
+      "source_location": "L919",
       "target": "pre_push_review_test_log",
       "weight": 1
     },
@@ -160991,7 +160991,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_test_ts",
       "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L919",
+      "source_location": "L920",
       "target": "pre_push_review_test_warn",
       "weight": 1
     },
@@ -161951,7 +161951,7 @@
       "relation": "contains",
       "source": "scripts_worktree_bootstrap_check_test_ts",
       "source_file": "scripts/worktree-bootstrap-check.test.ts",
-      "source_location": "L27",
+      "source_location": "L29",
       "target": "worktree_bootstrap_check_test_createfixturerepo",
       "weight": 1
     },
@@ -161963,7 +161963,7 @@
       "relation": "contains",
       "source": "scripts_worktree_bootstrap_check_test_ts",
       "source_file": "scripts/worktree-bootstrap-check.test.ts",
-      "source_location": "L13",
+      "source_location": "L14",
       "target": "worktree_bootstrap_check_test_rungit",
       "weight": 1
     },
@@ -181127,7 +181127,7 @@
       "relation": "calls",
       "source": "worktree_bootstrap_check_test_rungit",
       "source_file": "scripts/worktree-bootstrap-check.test.ts",
-      "source_location": "L32",
+      "source_location": "L34",
       "target": "worktree_bootstrap_check_test_createfixturerepo",
       "weight": 1
     },
@@ -189382,7 +189382,7 @@
       "label": "createFixtureRepo()",
       "norm_label": "createfixturerepo()",
       "source_file": "scripts/worktree-bootstrap-check.test.ts",
-      "source_location": "L27"
+      "source_location": "L29"
     },
     {
       "community": 1122,
@@ -189391,7 +189391,7 @@
       "label": "runGit()",
       "norm_label": "rungit()",
       "source_file": "scripts/worktree-bootstrap-check.test.ts",
-      "source_location": "L13"
+      "source_location": "L14"
     },
     {
       "community": 1123,
@@ -271426,7 +271426,7 @@
       "label": "createHookFixture()",
       "norm_label": "createhookfixture()",
       "source_file": "scripts/pre-push-hook.test.ts",
-      "source_location": "L18"
+      "source_location": "L20"
     },
     {
       "community": 647,
@@ -271435,7 +271435,7 @@
       "label": "isProcessAlive()",
       "norm_label": "isprocessalive()",
       "source_file": "scripts/pre-push-hook.test.ts",
-      "source_location": "L80"
+      "source_location": "L93"
     },
     {
       "community": 647,
@@ -271444,7 +271444,7 @@
       "label": "retainedLogPath()",
       "norm_label": "retainedlogpath()",
       "source_file": "scripts/pre-push-hook.test.ts",
-      "source_location": "L72"
+      "source_location": "L85"
     },
     {
       "community": 647,
@@ -271453,7 +271453,7 @@
       "label": "waitForFile()",
       "norm_label": "waitforfile()",
       "source_file": "scripts/pre-push-hook.test.ts",
-      "source_location": "L59"
+      "source_location": "L72"
     },
     {
       "community": 647,
@@ -271471,7 +271471,7 @@
       "label": "createBlockedPublicGateFixture()",
       "norm_label": "createblockedpublicgatefixture()",
       "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L35"
+      "source_location": "L36"
     },
     {
       "community": 648,
@@ -271480,7 +271480,7 @@
       "label": "error()",
       "norm_label": "error()",
       "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L208"
+      "source_location": "L209"
     },
     {
       "community": 648,
@@ -271489,7 +271489,7 @@
       "label": "log()",
       "norm_label": "log()",
       "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L206"
+      "source_location": "L207"
     },
     {
       "community": 648,
@@ -271498,7 +271498,7 @@
       "label": "warn()",
       "norm_label": "warn()",
       "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L207"
+      "source_location": "L208"
     },
     {
       "community": 648,
@@ -283495,7 +283495,7 @@
       "label": "greenOptions()",
       "norm_label": "greenoptions()",
       "source_file": "scripts/harness-gate-admission.test.ts",
-      "source_location": "L40"
+      "source_location": "L41"
     },
     {
       "community": 836,
@@ -283504,7 +283504,7 @@
       "label": "humanWaiverOptions()",
       "norm_label": "humanwaiveroptions()",
       "source_file": "scripts/harness-gate-admission.test.ts",
-      "source_location": "L77"
+      "source_location": "L78"
     },
     {
       "community": 836,
@@ -283513,7 +283513,7 @@
       "label": "missingTelemetry()",
       "norm_label": "missingtelemetry()",
       "source_file": "scripts/harness-gate-admission.test.ts",
-      "source_location": "L251"
+      "source_location": "L252"
     },
     {
       "community": 836,
@@ -283603,7 +283603,7 @@
       "label": "createFixtureRoot()",
       "norm_label": "createfixtureroot()",
       "source_file": "scripts/harness-test.test.ts",
-      "source_location": "L21"
+      "source_location": "L22"
     },
     {
       "community": 839,
@@ -283612,7 +283612,7 @@
       "label": "runGit()",
       "norm_label": "rungit()",
       "source_file": "scripts/harness-test.test.ts",
-      "source_location": "L27"
+      "source_location": "L28"
     },
     {
       "community": 839,
@@ -283621,7 +283621,7 @@
       "label": "write()",
       "norm_label": "write()",
       "source_file": "scripts/harness-test.test.ts",
-      "source_location": "L15"
+      "source_location": "L16"
     },
     {
       "community": 839,

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -139379,7 +139379,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_collectunstagedfiles",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L218",
+      "source_location": "L231",
       "target": "pre_push_validation_proof_assertprathenaproofready",
       "weight": 1
     },
@@ -139391,7 +139391,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_collectuntrackedfiles",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L219",
+      "source_location": "L232",
       "target": "pre_push_validation_proof_assertprathenaproofready",
       "weight": 1
     },
@@ -139403,7 +139403,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_formatpathlist",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L229",
+      "source_location": "L242",
       "target": "pre_push_validation_proof_assertprathenaproofready",
       "weight": 1
     },
@@ -139415,7 +139415,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_parseporcelainpaths",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L250",
+      "source_location": "L263",
       "target": "pre_push_validation_proof_assertprathenaproofready",
       "weight": 1
     },
@@ -139427,7 +139427,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_runcommand",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L213",
+      "source_location": "L226",
       "target": "pre_push_validation_proof_assertprathenaproofready",
       "weight": 1
     },
@@ -139439,7 +139439,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_normalizerepopath",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L284",
+      "source_location": "L297",
       "target": "pre_push_validation_proof_collectfilesunder",
       "weight": 1
     },
@@ -139451,7 +139451,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_hashvalidationwiring",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L384",
+      "source_location": "L397",
       "target": "pre_push_validation_proof_collectproofsnapshot",
       "weight": 1
     },
@@ -139463,7 +139463,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_readprathenascript",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L383",
+      "source_location": "L396",
       "target": "pre_push_validation_proof_collectproofsnapshot",
       "weight": 1
     },
@@ -139475,7 +139475,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_runcommand",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L377",
+      "source_location": "L390",
       "target": "pre_push_validation_proof_collectproofsnapshot",
       "weight": 1
     },
@@ -139487,7 +139487,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_runcommand",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L195",
+      "source_location": "L208",
       "target": "pre_push_validation_proof_collectuntrackedfiles",
       "weight": 1
     },
@@ -139499,7 +139499,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_collectfilesunder",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L319",
+      "source_location": "L332",
       "target": "pre_push_validation_proof_collectvalidationfingerprintpaths",
       "weight": 1
     },
@@ -139511,7 +139511,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_sortuniquepaths",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L303",
+      "source_location": "L316",
       "target": "pre_push_validation_proof_collectvalidationfingerprintpaths",
       "weight": 1
     },
@@ -139523,7 +139523,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_classifysnapshoterror",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L461",
+      "source_location": "L474",
       "target": "pre_push_validation_proof_evaluateprepushvalidationproof",
       "weight": 1
     },
@@ -139535,7 +139535,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_collectproofsnapshot",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L458",
+      "source_location": "L471",
       "target": "pre_push_validation_proof_evaluateprepushvalidationproof",
       "weight": 1
     },
@@ -139547,7 +139547,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_collecttreechangedpaths",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L489",
+      "source_location": "L502",
       "target": "pre_push_validation_proof_evaluateprepushvalidationproof",
       "weight": 1
     },
@@ -139559,7 +139559,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_validateproofshape",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L477",
+      "source_location": "L490",
       "target": "pre_push_validation_proof_evaluateprepushvalidationproof",
       "weight": 1
     },
@@ -139571,7 +139571,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_collectvalidationfingerprintpaths",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L335",
+      "source_location": "L348",
       "target": "pre_push_validation_proof_hashvalidationwiring",
       "weight": 1
     },
@@ -139583,7 +139583,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_collectproofsnapshot",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L591",
+      "source_location": "L603",
       "target": "pre_push_validation_proof_recordprepushvalidationproof",
       "weight": 1
     },
@@ -139595,7 +139595,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_runcommand",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L608",
+      "source_location": "L620",
       "target": "pre_push_validation_proof_recordprepushvalidationproof",
       "weight": 1
     },
@@ -139607,7 +139607,7 @@
       "relation": "calls",
       "source": "pre_push_validation_proof_test_write",
       "source_file": "scripts/pre-push-validation-proof.test.ts",
-      "source_location": "L24",
+      "source_location": "L25",
       "target": "pre_push_validation_proof_test_createfixtureroot",
       "weight": 1
     },
@@ -161183,7 +161183,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_test_ts",
       "source_file": "scripts/pre-push-validation-proof.test.ts",
-      "source_location": "L20",
+      "source_location": "L21",
       "target": "pre_push_validation_proof_test_createfixtureroot",
       "weight": 1
     },
@@ -161195,7 +161195,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_test_ts",
       "source_file": "scripts/pre-push-validation-proof.test.ts",
-      "source_location": "L63",
+      "source_location": "L64",
       "target": "pre_push_validation_proof_test_createspawn",
       "weight": 1
     },
@@ -161207,7 +161207,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_test_ts",
       "source_file": "scripts/pre-push-validation-proof.test.ts",
-      "source_location": "L582",
+      "source_location": "L596",
       "target": "pre_push_validation_proof_test_log",
       "weight": 1
     },
@@ -161219,7 +161219,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_test_ts",
       "source_file": "scripts/pre-push-validation-proof.test.ts",
-      "source_location": "L582",
+      "source_location": "L596",
       "target": "pre_push_validation_proof_test_warn",
       "weight": 1
     },
@@ -161231,8 +161231,20 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_test_ts",
       "source_file": "scripts/pre-push-validation-proof.test.ts",
-      "source_location": "L14",
+      "source_location": "L15",
       "target": "pre_push_validation_proof_test_write",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_pre_push_validation_proof_ts",
+      "_tgt": "pre_push_validation_proof_assertpostgatetelemetrychanges",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_pre_push_validation_proof_ts",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L83",
+      "target": "pre_push_validation_proof_assertpostgatetelemetrychanges",
       "weight": 1
     },
     {
@@ -161243,7 +161255,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L207",
+      "source_location": "L220",
       "target": "pre_push_validation_proof_assertprathenaproofready",
       "weight": 1
     },
@@ -161255,7 +161267,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L439",
+      "source_location": "L452",
       "target": "pre_push_validation_proof_classifysnapshoterror",
       "weight": 1
     },
@@ -161267,7 +161279,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L263",
+      "source_location": "L276",
       "target": "pre_push_validation_proof_collectfilesunder",
       "weight": 1
     },
@@ -161279,7 +161291,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L369",
+      "source_location": "L382",
       "target": "pre_push_validation_proof_collectproofsnapshot",
       "weight": 1
     },
@@ -161291,7 +161303,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L125",
+      "source_location": "L138",
       "target": "pre_push_validation_proof_collecttreechangedpaths",
       "weight": 1
     },
@@ -161303,7 +161315,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L164",
+      "source_location": "L177",
       "target": "pre_push_validation_proof_collectunstagedfiles",
       "weight": 1
     },
@@ -161315,7 +161327,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L191",
+      "source_location": "L204",
       "target": "pre_push_validation_proof_collectuntrackedfiles",
       "weight": 1
     },
@@ -161327,7 +161339,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L299",
+      "source_location": "L312",
       "target": "pre_push_validation_proof_collectvalidationfingerprintpaths",
       "weight": 1
     },
@@ -161339,7 +161351,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L452",
+      "source_location": "L465",
       "target": "pre_push_validation_proof_evaluateprepushvalidationproof",
       "weight": 1
     },
@@ -161351,7 +161363,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L121",
+      "source_location": "L134",
       "target": "pre_push_validation_proof_formatpathlist",
       "weight": 1
     },
@@ -161363,7 +161375,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L328",
+      "source_location": "L341",
       "target": "pre_push_validation_proof_hashvalidationwiring",
       "weight": 1
     },
@@ -161375,7 +161387,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L77",
+      "source_location": "L90",
       "target": "pre_push_validation_proof_normalizerepopath",
       "weight": 1
     },
@@ -161387,7 +161399,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L112",
+      "source_location": "L125",
       "target": "pre_push_validation_proof_parseporcelainpaths",
       "weight": 1
     },
@@ -161399,7 +161411,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L352",
+      "source_location": "L365",
       "target": "pre_push_validation_proof_readprathenascript",
       "weight": 1
     },
@@ -161411,7 +161423,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L584",
+      "source_location": "L596",
       "target": "pre_push_validation_proof_recordprepushvalidationproof",
       "weight": 1
     },
@@ -161423,7 +161435,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L87",
+      "source_location": "L100",
       "target": "pre_push_validation_proof_runcommand",
       "weight": 1
     },
@@ -161435,7 +161447,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L81",
+      "source_location": "L94",
       "target": "pre_push_validation_proof_sortuniquepaths",
       "weight": 1
     },
@@ -161447,7 +161459,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_validation_proof_ts",
       "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L419",
+      "source_location": "L432",
       "target": "pre_push_validation_proof_validateproofshape",
       "weight": 1
     },
@@ -186123,181 +186135,181 @@
     {
       "community": 106,
       "file_type": "code",
-      "id": "preview_worktree_commandforport",
-      "label": "commandForPort()",
-      "norm_label": "commandforport()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L188"
+      "id": "pre_push_validation_proof_assertpostgatetelemetrychanges",
+      "label": "assertPostGateTelemetryChanges()",
+      "norm_label": "assertpostgatetelemetrychanges()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L83"
     },
     {
       "community": 106,
       "file_type": "code",
-      "id": "preview_worktree_defaultcommand",
-      "label": "defaultCommand()",
-      "norm_label": "defaultcommand()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L48"
+      "id": "pre_push_validation_proof_assertprathenaproofready",
+      "label": "assertPrAthenaProofReady()",
+      "norm_label": "assertprathenaproofready()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L220"
     },
     {
       "community": 106,
       "file_type": "code",
-      "id": "preview_worktree_findport",
-      "label": "findPort()",
-      "norm_label": "findport()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L166"
+      "id": "pre_push_validation_proof_classifysnapshoterror",
+      "label": "classifySnapshotError()",
+      "norm_label": "classifysnapshoterror()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L452"
     },
     {
       "community": 106,
       "file_type": "code",
-      "id": "preview_worktree_isprocessalive",
-      "label": "isProcessAlive()",
-      "norm_label": "isprocessalive()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L92"
+      "id": "pre_push_validation_proof_collectfilesunder",
+      "label": "collectFilesUnder()",
+      "norm_label": "collectfilesunder()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L276"
     },
     {
       "community": 106,
       "file_type": "code",
-      "id": "preview_worktree_isreachable",
-      "label": "isReachable()",
-      "norm_label": "isreachable()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L101"
+      "id": "pre_push_validation_proof_collectproofsnapshot",
+      "label": "collectProofSnapshot()",
+      "norm_label": "collectproofsnapshot()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L382"
     },
     {
       "community": 106,
       "file_type": "code",
-      "id": "preview_worktree_listpreviews",
-      "label": "listPreviews()",
-      "norm_label": "listpreviews()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L267"
+      "id": "pre_push_validation_proof_collecttreechangedpaths",
+      "label": "collectTreeChangedPaths()",
+      "norm_label": "collecttreechangedpaths()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L138"
     },
     {
       "community": 106,
       "file_type": "code",
-      "id": "preview_worktree_logpathfor",
-      "label": "logPathFor()",
-      "norm_label": "logpathfor()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L193"
+      "id": "pre_push_validation_proof_collectunstagedfiles",
+      "label": "collectUnstagedFiles()",
+      "norm_label": "collectunstagedfiles()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L177"
     },
     {
       "community": 106,
       "file_type": "code",
-      "id": "preview_worktree_optionsfromenv",
-      "label": "optionsFromEnv()",
-      "norm_label": "optionsfromenv()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L301"
+      "id": "pre_push_validation_proof_collectuntrackedfiles",
+      "label": "collectUntrackedFiles()",
+      "norm_label": "collectuntrackedfiles()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L204"
     },
     {
       "community": 106,
       "file_type": "code",
-      "id": "preview_worktree_prunestate",
-      "label": "pruneState()",
-      "norm_label": "prunestate()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L128"
+      "id": "pre_push_validation_proof_collectvalidationfingerprintpaths",
+      "label": "collectValidationFingerprintPaths()",
+      "norm_label": "collectvalidationfingerprintpaths()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L312"
     },
     {
       "community": 106,
       "file_type": "code",
-      "id": "preview_worktree_readstate",
-      "label": "readState()",
-      "norm_label": "readstate()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L79"
+      "id": "pre_push_validation_proof_evaluateprepushvalidationproof",
+      "label": "evaluatePrePushValidationProof()",
+      "norm_label": "evaluateprepushvalidationproof()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L465"
     },
     {
       "community": 106,
       "file_type": "code",
-      "id": "preview_worktree_resolvestatedir",
-      "label": "resolveStateDir()",
-      "norm_label": "resolvestatedir()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L67"
+      "id": "pre_push_validation_proof_formatpathlist",
+      "label": "formatPathList()",
+      "norm_label": "formatpathlist()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L134"
     },
     {
       "community": 106,
       "file_type": "code",
-      "id": "preview_worktree_resolveworktreeroot",
-      "label": "resolveWorktreeRoot()",
-      "norm_label": "resolveworktreeroot()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L63"
+      "id": "pre_push_validation_proof_hashvalidationwiring",
+      "label": "hashValidationWiring()",
+      "norm_label": "hashvalidationwiring()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L341"
     },
     {
       "community": 106,
       "file_type": "code",
-      "id": "preview_worktree_runpreviewcli",
-      "label": "runPreviewCli()",
-      "norm_label": "runpreviewcli()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L325"
+      "id": "pre_push_validation_proof_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L90"
     },
     {
       "community": 106,
       "file_type": "code",
-      "id": "preview_worktree_startpreview",
-      "label": "startPreview()",
-      "norm_label": "startpreview()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L198"
+      "id": "pre_push_validation_proof_parseporcelainpaths",
+      "label": "parsePorcelainPaths()",
+      "norm_label": "parseporcelainpaths()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L125"
     },
     {
       "community": 106,
       "file_type": "code",
-      "id": "preview_worktree_statepath",
-      "label": "statePath()",
-      "norm_label": "statepath()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L75"
+      "id": "pre_push_validation_proof_readprathenascript",
+      "label": "readPrAthenaScript()",
+      "norm_label": "readprathenascript()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L365"
     },
     {
       "community": 106,
       "file_type": "code",
-      "id": "preview_worktree_stoppreview",
-      "label": "stopPreview()",
-      "norm_label": "stoppreview()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L274"
+      "id": "pre_push_validation_proof_recordprepushvalidationproof",
+      "label": "recordPrePushValidationProof()",
+      "norm_label": "recordprepushvalidationproof()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L596"
     },
     {
       "community": 106,
       "file_type": "code",
-      "id": "preview_worktree_waitforreachable",
-      "label": "waitForReachable()",
-      "norm_label": "waitforreachable()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L110"
+      "id": "pre_push_validation_proof_runcommand",
+      "label": "runCommand()",
+      "norm_label": "runcommand()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L100"
     },
     {
       "community": 106,
       "file_type": "code",
-      "id": "preview_worktree_withlock",
-      "label": "withLock()",
-      "norm_label": "withlock()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L144"
+      "id": "pre_push_validation_proof_sortuniquepaths",
+      "label": "sortUniquePaths()",
+      "norm_label": "sortuniquepaths()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L94"
     },
     {
       "community": 106,
       "file_type": "code",
-      "id": "preview_worktree_writestate",
-      "label": "writeState()",
-      "norm_label": "writestate()",
-      "source_file": "scripts/preview-worktree.ts",
-      "source_location": "L87"
+      "id": "pre_push_validation_proof_validateproofshape",
+      "label": "validateProofShape()",
+      "norm_label": "validateproofshape()",
+      "source_file": "scripts/pre-push-validation-proof.ts",
+      "source_location": "L432"
     },
     {
       "community": 106,
       "file_type": "code",
-      "id": "scripts_preview_worktree_ts",
-      "label": "preview-worktree.ts",
-      "norm_label": "preview-worktree.ts",
-      "source_file": "scripts/preview-worktree.ts",
+      "id": "scripts_pre_push_validation_proof_ts",
+      "label": "pre-push-validation-proof.ts",
+      "norm_label": "pre-push-validation-proof.ts",
+      "source_file": "scripts/pre-push-validation-proof.ts",
       "source_location": "L1"
     },
     {
@@ -186573,173 +186585,182 @@
     {
       "community": 107,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_lib_returnvalidatorcontract_ts",
-      "label": "returnValidatorContract.ts",
-      "norm_label": "returnvalidatorcontract.ts",
-      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
+      "id": "preview_worktree_commandforport",
+      "label": "commandForPort()",
+      "norm_label": "commandforport()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L188"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "preview_worktree_defaultcommand",
+      "label": "defaultCommand()",
+      "norm_label": "defaultcommand()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "preview_worktree_findport",
+      "label": "findPort()",
+      "norm_label": "findport()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L166"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "preview_worktree_isprocessalive",
+      "label": "isProcessAlive()",
+      "norm_label": "isprocessalive()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "preview_worktree_isreachable",
+      "label": "isReachable()",
+      "norm_label": "isreachable()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "preview_worktree_listpreviews",
+      "label": "listPreviews()",
+      "norm_label": "listpreviews()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L267"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "preview_worktree_logpathfor",
+      "label": "logPathFor()",
+      "norm_label": "logpathfor()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L193"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "preview_worktree_optionsfromenv",
+      "label": "optionsFromEnv()",
+      "norm_label": "optionsfromenv()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L301"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "preview_worktree_prunestate",
+      "label": "pruneState()",
+      "norm_label": "prunestate()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "preview_worktree_readstate",
+      "label": "readState()",
+      "norm_label": "readstate()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L79"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "preview_worktree_resolvestatedir",
+      "label": "resolveStateDir()",
+      "norm_label": "resolvestatedir()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "preview_worktree_resolveworktreeroot",
+      "label": "resolveWorktreeRoot()",
+      "norm_label": "resolveworktreeroot()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "preview_worktree_runpreviewcli",
+      "label": "runPreviewCli()",
+      "norm_label": "runpreviewcli()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L325"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "preview_worktree_startpreview",
+      "label": "startPreview()",
+      "norm_label": "startpreview()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L198"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "preview_worktree_statepath",
+      "label": "statePath()",
+      "norm_label": "statepath()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "preview_worktree_stoppreview",
+      "label": "stopPreview()",
+      "norm_label": "stoppreview()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L274"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "preview_worktree_waitforreachable",
+      "label": "waitForReachable()",
+      "norm_label": "waitforreachable()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L110"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "preview_worktree_withlock",
+      "label": "withLock()",
+      "norm_label": "withlock()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L144"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "preview_worktree_writestate",
+      "label": "writeState()",
+      "norm_label": "writestate()",
+      "source_file": "scripts/preview-worktree.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "scripts_preview_worktree_ts",
+      "label": "preview-worktree.ts",
+      "norm_label": "preview-worktree.ts",
+      "source_file": "scripts/preview-worktree.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "returnvalidatorcontract_assertconformstoexportedreturns",
-      "label": "assertConformsToExportedReturns()",
-      "norm_label": "assertconformstoexportedreturns()",
-      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "returnvalidatorcontract_collectreturnvalidatorissues",
-      "label": "collectReturnValidatorIssues()",
-      "norm_label": "collectreturnvalidatorissues()",
-      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "returnvalidatorcontract_decodeserializedfloat64",
-      "label": "decodeSerializedFloat64()",
-      "norm_label": "decodeserializedfloat64()",
-      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
-      "source_location": "L334"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "returnvalidatorcontract_decodeserializedint64",
-      "label": "decodeSerializedInt64()",
-      "norm_label": "decodeserializedint64()",
-      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
-      "source_location": "L324"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "returnvalidatorcontract_decodeserializedliteralvalue",
-      "label": "decodeSerializedLiteralValue()",
-      "norm_label": "decodeserializedliteralvalue()",
-      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
-      "source_location": "L306"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "returnvalidatorcontract_describevalue",
-      "label": "describeValue()",
-      "norm_label": "describevalue()",
-      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
-      "source_location": "L354"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "returnvalidatorcontract_formatreturnvalidatorissues",
-      "label": "formatReturnValidatorIssues()",
-      "norm_label": "formatreturnvalidatorissues()",
-      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
-      "source_location": "L367"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "returnvalidatorcontract_isconvexvalue",
-      "label": "isConvexValue()",
-      "norm_label": "isconvexvalue()",
-      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
-      "source_location": "L268"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "returnvalidatorcontract_isint64",
-      "label": "isInt64()",
-      "norm_label": "isint64()",
-      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
-      "source_location": "L302"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "returnvalidatorcontract_isplainobject",
-      "label": "isPlainObject()",
-      "norm_label": "isplainobject()",
-      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
-      "source_location": "L258"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "returnvalidatorcontract_issue",
-      "label": "issue()",
-      "norm_label": "issue()",
-      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
-      "source_location": "L344"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "returnvalidatorcontract_joinpath",
-      "label": "joinPath()",
-      "norm_label": "joinpath()",
-      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
-      "source_location": "L348"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "returnvalidatorcontract_parseexportedreturnvalidator",
-      "label": "parseExportedReturnValidator()",
-      "norm_label": "parseexportedreturnvalidator()",
-      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
-      "source_location": "L80"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "returnvalidatorcontract_validatearray",
-      "label": "validateArray()",
-      "norm_label": "validatearray()",
-      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
-      "source_location": "L163"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "returnvalidatorcontract_validateobject",
-      "label": "validateObject()",
-      "norm_label": "validateobject()",
-      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
-      "source_location": "L177"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "returnvalidatorcontract_validaterecord",
-      "label": "validateRecord()",
-      "norm_label": "validaterecord()",
-      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
-      "source_location": "L212"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "returnvalidatorcontract_validateunion",
-      "label": "validateUnion()",
-      "norm_label": "validateunion()",
-      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
-      "source_location": "L236"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "returnvalidatorcontract_validatevalue",
-      "label": "validateValue()",
-      "norm_label": "validatevalue()",
-      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
-      "source_location": "L84"
     },
     {
       "community": 1070,
@@ -187014,173 +187035,173 @@
     {
       "community": 108,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_verificationsweep_ts",
-      "label": "verificationSweep.ts",
-      "norm_label": "verificationsweep.ts",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
+      "id": "packages_athena_webapp_convex_lib_returnvalidatorcontract_ts",
+      "label": "returnValidatorContract.ts",
+      "norm_label": "returnvalidatorcontract.ts",
+      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
       "source_location": "L1"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "verificationsweep_cycleframeof",
-      "label": "cycleFrameOf()",
-      "norm_label": "cycleframeof()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
-      "source_location": "L1023"
+      "id": "returnvalidatorcontract_assertconformstoexportedreturns",
+      "label": "assertConformsToExportedReturns()",
+      "norm_label": "assertconformstoexportedreturns()",
+      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
+      "source_location": "L59"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "verificationsweep_haspendingdirtymark",
-      "label": "hasPendingDirtyMark()",
-      "norm_label": "haspendingdirtymark()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
-      "source_location": "L609"
+      "id": "returnvalidatorcontract_collectreturnvalidatorissues",
+      "label": "collectReturnValidatorIssues()",
+      "norm_label": "collectreturnvalidatorissues()",
+      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
+      "source_location": "L73"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "verificationsweep_haspendingweeklydirtymarks",
-      "label": "hasPendingWeeklyDirtyMarks()",
-      "norm_label": "haspendingweeklydirtymarks()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
-      "source_location": "L995"
+      "id": "returnvalidatorcontract_decodeserializedfloat64",
+      "label": "decodeSerializedFloat64()",
+      "norm_label": "decodeserializedfloat64()",
+      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
+      "source_location": "L334"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "verificationsweep_isreverifytick",
-      "label": "isReverifyTick()",
-      "norm_label": "isreverifytick()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
-      "source_location": "L397"
+      "id": "returnvalidatorcontract_decodeserializedint64",
+      "label": "decodeSerializedInt64()",
+      "norm_label": "decodeserializedint64()",
+      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
+      "source_location": "L324"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "verificationsweep_isverificationalertemailenabled",
-      "label": "isVerificationAlertEmailEnabled()",
-      "norm_label": "isverificationalertemailenabled()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
-      "source_location": "L359"
+      "id": "returnvalidatorcontract_decodeserializedliteralvalue",
+      "label": "decodeSerializedLiteralValue()",
+      "norm_label": "decodeserializedliteralvalue()",
+      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
+      "source_location": "L306"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "verificationsweep_loadrunrow",
-      "label": "loadRunRow()",
-      "norm_label": "loadrunrow()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
-      "source_location": "L592"
+      "id": "returnvalidatorcontract_describevalue",
+      "label": "describeValue()",
+      "norm_label": "describevalue()",
+      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
+      "source_location": "L354"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "verificationsweep_logswallowed",
-      "label": "logSwallowed()",
-      "norm_label": "logswallowed()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
-      "source_location": "L1543"
+      "id": "returnvalidatorcontract_formatreturnvalidatorissues",
+      "label": "formatReturnValidatorIssues()",
+      "norm_label": "formatreturnvalidatorissues()",
+      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
+      "source_location": "L367"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "verificationsweep_maybeemitverificationalert",
-      "label": "maybeEmitVerificationAlert()",
-      "norm_label": "maybeemitverificationalert()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
-      "source_location": "L1201"
+      "id": "returnvalidatorcontract_isconvexvalue",
+      "label": "isConvexValue()",
+      "norm_label": "isconvexvalue()",
+      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
+      "source_location": "L268"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "verificationsweep_normalizemissingdayresult",
-      "label": "normalizeMissingDayResult()",
-      "norm_label": "normalizemissingdayresult()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
-      "source_location": "L919"
+      "id": "returnvalidatorcontract_isint64",
+      "label": "isInt64()",
+      "norm_label": "isint64()",
+      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
+      "source_location": "L302"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "verificationsweep_recorderroroutcome",
-      "label": "recordErrorOutcome()",
-      "norm_label": "recorderroroutcome()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
-      "source_location": "L1555"
+      "id": "returnvalidatorcontract_isplainobject",
+      "label": "isPlainObject()",
+      "norm_label": "isplainobject()",
+      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
+      "source_location": "L258"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "verificationsweep_runverificationsweepwithctx",
-      "label": "runVerificationSweepWithCtx()",
-      "norm_label": "runverificationsweepwithctx()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
-      "source_location": "L1578"
+      "id": "returnvalidatorcontract_issue",
+      "label": "issue()",
+      "norm_label": "issue()",
+      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
+      "source_location": "L344"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "verificationsweep_shouldescalatewedge",
-      "label": "shouldEscalateWedge()",
-      "norm_label": "shouldescalatewedge()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
-      "source_location": "L262"
+      "id": "returnvalidatorcontract_joinpath",
+      "label": "joinPath()",
+      "norm_label": "joinpath()",
+      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
+      "source_location": "L348"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "verificationsweep_streakstatefromrow",
-      "label": "streakStateFromRow()",
-      "norm_label": "streakstatefromrow()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
-      "source_location": "L1236"
+      "id": "returnvalidatorcontract_parseexportedreturnvalidator",
+      "label": "parseExportedReturnValidator()",
+      "norm_label": "parseexportedreturnvalidator()",
+      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
+      "source_location": "L80"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "verificationsweep_summarizeclassification",
-      "label": "summarizeClassification()",
-      "norm_label": "summarizeclassification()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
-      "source_location": "L464"
+      "id": "returnvalidatorcontract_validatearray",
+      "label": "validateArray()",
+      "norm_label": "validatearray()",
+      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
+      "source_location": "L163"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "verificationsweep_tosummary",
-      "label": "toSummary()",
-      "norm_label": "tosummary()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
-      "source_location": "L448"
+      "id": "returnvalidatorcontract_validateobject",
+      "label": "validateObject()",
+      "norm_label": "validateobject()",
+      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
+      "source_location": "L177"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "verificationsweep_verificationtickindex",
-      "label": "verificationTickIndex()",
-      "norm_label": "verificationtickindex()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
-      "source_location": "L115"
+      "id": "returnvalidatorcontract_validaterecord",
+      "label": "validateRecord()",
+      "norm_label": "validaterecord()",
+      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
+      "source_location": "L212"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "verificationsweep_verificationtickintervalms",
-      "label": "verificationTickIntervalMs()",
-      "norm_label": "verificationtickintervalms()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
-      "source_location": "L99"
+      "id": "returnvalidatorcontract_validateunion",
+      "label": "validateUnion()",
+      "norm_label": "validateunion()",
+      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
+      "source_location": "L236"
     },
     {
       "community": 108,
       "file_type": "code",
-      "id": "verificationsweep_weekmarkblockscycle",
-      "label": "weekMarkBlocksCycle()",
-      "norm_label": "weekmarkblockscycle()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
-      "source_location": "L976"
+      "id": "returnvalidatorcontract_validatevalue",
+      "label": "validateValue()",
+      "norm_label": "validatevalue()",
+      "source_file": "packages/athena-webapp/convex/lib/returnValidatorContract.ts",
+      "source_location": "L84"
     },
     {
       "community": 1080,
@@ -187455,173 +187476,173 @@
     {
       "community": 109,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_replenishment_ts",
-      "label": "replenishment.ts",
-      "norm_label": "replenishment.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "id": "packages_athena_webapp_convex_reports_verificationsweep_ts",
+      "label": "verificationSweep.ts",
+      "norm_label": "verificationsweep.ts",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
       "source_location": "L1"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "replenishment_buildguidance",
-      "label": "buildGuidance()",
-      "norm_label": "buildguidance()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L101"
+      "id": "verificationsweep_cycleframeof",
+      "label": "cycleFrameOf()",
+      "norm_label": "cycleframeof()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
+      "source_location": "L1023"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "replenishment_buildskucontinuitycontextbyid",
-      "label": "buildSkuContinuityContextById()",
-      "norm_label": "buildskucontinuitycontextbyid()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L292"
+      "id": "verificationsweep_haspendingdirtymark",
+      "label": "hasPendingDirtyMark()",
+      "norm_label": "haspendingdirtymark()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
+      "source_location": "L609"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "replenishment_derivecontinuitystatus",
-      "label": "deriveContinuityStatus()",
-      "norm_label": "derivecontinuitystatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L416"
+      "id": "verificationsweep_haspendingweeklydirtymarks",
+      "label": "hasPendingWeeklyDirtyMarks()",
+      "norm_label": "haspendingweeklydirtymarks()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
+      "source_location": "L995"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "replenishment_deriverecommendationstatus",
-      "label": "deriveRecommendationStatus()",
-      "norm_label": "deriverecommendationstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L405"
+      "id": "verificationsweep_isreverifytick",
+      "label": "isReverifyTick()",
+      "norm_label": "isreverifytick()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
+      "source_location": "L397"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "replenishment_getcontinuitystatusrank",
-      "label": "getContinuityStatusRank()",
-      "norm_label": "getcontinuitystatusrank()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L76"
+      "id": "verificationsweep_isverificationalertemailenabled",
+      "label": "isVerificationAlertEmailEnabled()",
+      "norm_label": "isverificationalertemailenabled()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
+      "source_location": "L359"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "replenishment_getplannedactionat",
-      "label": "getPlannedActionAt()",
-      "norm_label": "getplannedactionat()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L224"
+      "id": "verificationsweep_loadrunrow",
+      "label": "loadRunRow()",
+      "norm_label": "loadrunrow()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
+      "source_location": "L592"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "replenishment_getstartofcurrentday",
-      "label": "getStartOfCurrentDay()",
-      "norm_label": "getstartofcurrentday()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L236"
+      "id": "verificationsweep_logswallowed",
+      "label": "logSwallowed()",
+      "norm_label": "logswallowed()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
+      "source_location": "L1543"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "replenishment_haslateinbound",
-      "label": "hasLateInbound()",
-      "norm_label": "haslateinbound()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L254"
+      "id": "verificationsweep_maybeemitverificationalert",
+      "label": "maybeEmitVerificationAlert()",
+      "norm_label": "maybeemitverificationalert()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
+      "source_location": "L1201"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "replenishment_hasrelatedpurchaseordercontext",
-      "label": "hasRelatedPurchaseOrderContext()",
-      "norm_label": "hasrelatedpurchaseordercontext()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L396"
+      "id": "verificationsweep_normalizemissingdayresult",
+      "label": "normalizeMissingDayResult()",
+      "norm_label": "normalizemissingdayresult()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
+      "source_location": "L919"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "replenishment_hasstaleplannedaction",
-      "label": "hasStalePlannedAction()",
-      "norm_label": "hasstaleplannedaction()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L246"
+      "id": "verificationsweep_recorderroroutcome",
+      "label": "recordErrorOutcome()",
+      "norm_label": "recorderroroutcome()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
+      "source_location": "L1555"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "replenishment_isinboundstatus",
-      "label": "isInboundStatus()",
-      "norm_label": "isinboundstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L218"
+      "id": "verificationsweep_runverificationsweepwithctx",
+      "label": "runVerificationSweepWithCtx()",
+      "norm_label": "runverificationsweepwithctx()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
+      "source_location": "L1578"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "replenishment_isplannedstatus",
-      "label": "isPlannedStatus()",
-      "norm_label": "isplannedstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L212"
+      "id": "verificationsweep_shouldescalatewedge",
+      "label": "shouldEscalateWedge()",
+      "norm_label": "shouldescalatewedge()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
+      "source_location": "L262"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "replenishment_listactivestorevendors",
-      "label": "listActiveStoreVendors()",
-      "norm_label": "listactivestorevendors()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L177"
+      "id": "verificationsweep_streakstatefromrow",
+      "label": "streakStateFromRow()",
+      "norm_label": "streakstatefromrow()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
+      "source_location": "L1236"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "replenishment_listpurchaseorderlineitems",
-      "label": "listPurchaseOrderLineItems()",
-      "norm_label": "listpurchaseorderlineitems()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L195"
+      "id": "verificationsweep_summarizeclassification",
+      "label": "summarizeClassification()",
+      "norm_label": "summarizeclassification()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
+      "source_location": "L464"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "replenishment_listreplenishmentrecommendationswithctx",
-      "label": "listReplenishmentRecommendationsWithCtx()",
-      "norm_label": "listreplenishmentrecommendationswithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L473"
+      "id": "verificationsweep_tosummary",
+      "label": "toSummary()",
+      "norm_label": "tosummary()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
+      "source_location": "L448"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "replenishment_liststoreproductskus",
-      "label": "listStoreProductSkus()",
-      "norm_label": "liststoreproductskus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L145"
+      "id": "verificationsweep_verificationtickindex",
+      "label": "verificationTickIndex()",
+      "norm_label": "verificationtickindex()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
+      "source_location": "L115"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "replenishment_liststorepurchaseordersbystatus",
-      "label": "listStorePurchaseOrdersByStatus()",
-      "norm_label": "liststorepurchaseordersbystatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L157"
+      "id": "verificationsweep_verificationtickintervalms",
+      "label": "verificationTickIntervalMs()",
+      "norm_label": "verificationtickintervalms()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
+      "source_location": "L99"
     },
     {
       "community": 109,
       "file_type": "code",
-      "id": "replenishment_sortpurchaseordercontexts",
-      "label": "sortPurchaseOrderContexts()",
-      "norm_label": "sortpurchaseordercontexts()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L265"
+      "id": "verificationsweep_weekmarkblockscycle",
+      "label": "weekMarkBlocksCycle()",
+      "norm_label": "weekmarkblockscycle()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.ts",
+      "source_location": "L976"
     },
     {
       "community": 1090,
@@ -188337,173 +188358,173 @@
     {
       "community": 110,
       "file_type": "code",
-      "id": "pre_push_validation_proof_assertprathenaproofready",
-      "label": "assertPrAthenaProofReady()",
-      "norm_label": "assertprathenaproofready()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L207"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "pre_push_validation_proof_classifysnapshoterror",
-      "label": "classifySnapshotError()",
-      "norm_label": "classifysnapshoterror()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L439"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "pre_push_validation_proof_collectfilesunder",
-      "label": "collectFilesUnder()",
-      "norm_label": "collectfilesunder()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L263"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "pre_push_validation_proof_collectproofsnapshot",
-      "label": "collectProofSnapshot()",
-      "norm_label": "collectproofsnapshot()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L369"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "pre_push_validation_proof_collecttreechangedpaths",
-      "label": "collectTreeChangedPaths()",
-      "norm_label": "collecttreechangedpaths()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L125"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "pre_push_validation_proof_collectunstagedfiles",
-      "label": "collectUnstagedFiles()",
-      "norm_label": "collectunstagedfiles()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L164"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "pre_push_validation_proof_collectuntrackedfiles",
-      "label": "collectUntrackedFiles()",
-      "norm_label": "collectuntrackedfiles()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L191"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "pre_push_validation_proof_collectvalidationfingerprintpaths",
-      "label": "collectValidationFingerprintPaths()",
-      "norm_label": "collectvalidationfingerprintpaths()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L299"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "pre_push_validation_proof_evaluateprepushvalidationproof",
-      "label": "evaluatePrePushValidationProof()",
-      "norm_label": "evaluateprepushvalidationproof()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L452"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "pre_push_validation_proof_formatpathlist",
-      "label": "formatPathList()",
-      "norm_label": "formatpathlist()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L121"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "pre_push_validation_proof_hashvalidationwiring",
-      "label": "hashValidationWiring()",
-      "norm_label": "hashvalidationwiring()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L328"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "pre_push_validation_proof_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "pre_push_validation_proof_parseporcelainpaths",
-      "label": "parsePorcelainPaths()",
-      "norm_label": "parseporcelainpaths()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L112"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "pre_push_validation_proof_readprathenascript",
-      "label": "readPrAthenaScript()",
-      "norm_label": "readprathenascript()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L352"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "pre_push_validation_proof_recordprepushvalidationproof",
-      "label": "recordPrePushValidationProof()",
-      "norm_label": "recordprepushvalidationproof()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L584"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "pre_push_validation_proof_runcommand",
-      "label": "runCommand()",
-      "norm_label": "runcommand()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L87"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "pre_push_validation_proof_sortuniquepaths",
-      "label": "sortUniquePaths()",
-      "norm_label": "sortuniquepaths()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L81"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "pre_push_validation_proof_validateproofshape",
-      "label": "validateProofShape()",
-      "norm_label": "validateproofshape()",
-      "source_file": "scripts/pre-push-validation-proof.ts",
-      "source_location": "L419"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "scripts_pre_push_validation_proof_ts",
-      "label": "pre-push-validation-proof.ts",
-      "norm_label": "pre-push-validation-proof.ts",
-      "source_file": "scripts/pre-push-validation-proof.ts",
+      "id": "packages_athena_webapp_convex_stockops_replenishment_ts",
+      "label": "replenishment.ts",
+      "norm_label": "replenishment.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "replenishment_buildguidance",
+      "label": "buildGuidance()",
+      "norm_label": "buildguidance()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "replenishment_buildskucontinuitycontextbyid",
+      "label": "buildSkuContinuityContextById()",
+      "norm_label": "buildskucontinuitycontextbyid()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L292"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "replenishment_derivecontinuitystatus",
+      "label": "deriveContinuityStatus()",
+      "norm_label": "derivecontinuitystatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L416"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "replenishment_deriverecommendationstatus",
+      "label": "deriveRecommendationStatus()",
+      "norm_label": "deriverecommendationstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L405"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "replenishment_getcontinuitystatusrank",
+      "label": "getContinuityStatusRank()",
+      "norm_label": "getcontinuitystatusrank()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "replenishment_getplannedactionat",
+      "label": "getPlannedActionAt()",
+      "norm_label": "getplannedactionat()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L224"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "replenishment_getstartofcurrentday",
+      "label": "getStartOfCurrentDay()",
+      "norm_label": "getstartofcurrentday()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L236"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "replenishment_haslateinbound",
+      "label": "hasLateInbound()",
+      "norm_label": "haslateinbound()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L254"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "replenishment_hasrelatedpurchaseordercontext",
+      "label": "hasRelatedPurchaseOrderContext()",
+      "norm_label": "hasrelatedpurchaseordercontext()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L396"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "replenishment_hasstaleplannedaction",
+      "label": "hasStalePlannedAction()",
+      "norm_label": "hasstaleplannedaction()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L246"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "replenishment_isinboundstatus",
+      "label": "isInboundStatus()",
+      "norm_label": "isinboundstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L218"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "replenishment_isplannedstatus",
+      "label": "isPlannedStatus()",
+      "norm_label": "isplannedstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L212"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "replenishment_listactivestorevendors",
+      "label": "listActiveStoreVendors()",
+      "norm_label": "listactivestorevendors()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L177"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "replenishment_listpurchaseorderlineitems",
+      "label": "listPurchaseOrderLineItems()",
+      "norm_label": "listpurchaseorderlineitems()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L195"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "replenishment_listreplenishmentrecommendationswithctx",
+      "label": "listReplenishmentRecommendationsWithCtx()",
+      "norm_label": "listreplenishmentrecommendationswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L473"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "replenishment_liststoreproductskus",
+      "label": "listStoreProductSkus()",
+      "norm_label": "liststoreproductskus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L145"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "replenishment_liststorepurchaseordersbystatus",
+      "label": "listStorePurchaseOrdersByStatus()",
+      "norm_label": "liststorepurchaseordersbystatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L157"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "replenishment_sortpurchaseordercontexts",
+      "label": "sortPurchaseOrderContexts()",
+      "norm_label": "sortpurchaseordercontexts()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L265"
     },
     {
       "community": 1100,
@@ -229980,92 +230001,92 @@
     {
       "community": 247,
       "file_type": "code",
-      "id": "index_resolveverificationcoderecipient",
-      "label": "resolveVerificationCodeRecipient()",
-      "norm_label": "resolveverificationcoderecipient()",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "index_senddailymanagerreportemail",
-      "label": "sendDailyManagerReportEmail()",
-      "norm_label": "senddailymanagerreportemail()",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
-      "source_location": "L373"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "index_senddiscountcodeemail",
-      "label": "sendDiscountCodeEmail()",
-      "norm_label": "senddiscountcodeemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L255"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "index_senddiscountreminderemail",
-      "label": "sendDiscountReminderEmail()",
-      "norm_label": "senddiscountreminderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L334"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "index_sendfeedbackrequestemail",
-      "label": "sendFeedbackRequestEmail()",
-      "norm_label": "sendfeedbackrequestemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L167"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "index_sendneworderemail",
-      "label": "sendNewOrderEmail()",
-      "norm_label": "sendneworderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L117"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "index_sendorderemail",
-      "label": "sendOrderEmail()",
-      "norm_label": "sendorderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "index_sendverificationcode",
-      "label": "sendVerificationCode()",
-      "norm_label": "sendverificationcode()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "id": "packages_athena_webapp_convex_marketing_walkthroughconfig_ts",
+      "label": "walkthroughConfig.ts",
+      "norm_label": "walkthroughconfig.ts",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
       "source_location": "L1"
     },
     {
       "community": 247,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L1"
+      "id": "walkthroughconfig_landingfunnelhourlylimit",
+      "label": "landingFunnelHourlyLimit()",
+      "norm_label": "landingfunnelhourlylimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "walkthroughconfig_parseboundedpositiveinteger",
+      "label": "parseBoundedPositiveInteger()",
+      "norm_label": "parseboundedpositiveinteger()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "walkthroughconfig_resolvewalkthroughallowedorigins",
+      "label": "resolveWalkthroughAllowedOrigins()",
+      "norm_label": "resolvewalkthroughallowedorigins()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughallowedorigins",
+      "label": "walkthroughAllowedOrigins()",
+      "norm_label": "walkthroughallowedorigins()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughdailyperemaillimit",
+      "label": "walkthroughDailyPerEmailLimit()",
+      "norm_label": "walkthroughdailyperemaillimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughhourlygloballimit",
+      "label": "walkthroughHourlyGlobalLimit()",
+      "norm_label": "walkthroughhourlygloballimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughhourlynotificationlimit",
+      "label": "walkthroughHourlyNotificationLimit()",
+      "norm_label": "walkthroughhourlynotificationlimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughmaxbodybytes",
+      "label": "walkthroughMaxBodyBytes()",
+      "norm_label": "walkthroughmaxbodybytes()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughprivacycontact",
+      "label": "walkthroughPrivacyContact()",
+      "norm_label": "walkthroughprivacycontact()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L95"
     },
     {
       "community": 2470,
@@ -230160,92 +230181,92 @@
     {
       "community": 248,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_marketing_walkthroughconfig_ts",
-      "label": "walkthroughConfig.ts",
-      "norm_label": "walkthroughconfig.ts",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "id": "definitions_costoverlaystorewriteoperation",
+      "label": "costOverlayStoreWriteOperation()",
+      "norm_label": "costoverlaystorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L569"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "definitions_cyclecountdraftstorewriteoperation",
+      "label": "cycleCountDraftStoreWriteOperation()",
+      "norm_label": "cyclecountdraftstorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L383"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "definitions_defineoperation",
+      "label": "defineOperation()",
+      "norm_label": "defineoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "definitions_inventoryimportreviewpayloadwriteoperation",
+      "label": "inventoryImportReviewPayloadWriteOperation()",
+      "norm_label": "inventoryimportreviewpayloadwriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L544"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "definitions_notificationsubscriptionrowwriteoperation",
+      "label": "notificationSubscriptionRowWriteOperation()",
+      "norm_label": "notificationsubscriptionrowwriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L629"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "definitions_orderstorewriteoperation",
+      "label": "orderStoreWriteOperation()",
+      "norm_label": "orderstorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L155"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "definitions_storewriteoperation",
+      "label": "storeWriteOperation()",
+      "norm_label": "storewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L108"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "definitions_transactionstorewriteoperation",
+      "label": "transactionStoreWriteOperation()",
+      "norm_label": "transactionstorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "definitions_validateoperationdefinition",
+      "label": "validateOperationDefinition()",
+      "norm_label": "validateoperationdefinition()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L724"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operationadmission_definitions_ts",
+      "label": "definitions.ts",
+      "norm_label": "definitions.ts",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "walkthroughconfig_landingfunnelhourlylimit",
-      "label": "landingFunnelHourlyLimit()",
-      "norm_label": "landingfunnelhourlylimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "walkthroughconfig_parseboundedpositiveinteger",
-      "label": "parseBoundedPositiveInteger()",
-      "norm_label": "parseboundedpositiveinteger()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "walkthroughconfig_resolvewalkthroughallowedorigins",
-      "label": "resolveWalkthroughAllowedOrigins()",
-      "norm_label": "resolvewalkthroughallowedorigins()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughallowedorigins",
-      "label": "walkthroughAllowedOrigins()",
-      "norm_label": "walkthroughallowedorigins()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughdailyperemaillimit",
-      "label": "walkthroughDailyPerEmailLimit()",
-      "norm_label": "walkthroughdailyperemaillimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L55"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughhourlygloballimit",
-      "label": "walkthroughHourlyGlobalLimit()",
-      "norm_label": "walkthroughhourlygloballimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughhourlynotificationlimit",
-      "label": "walkthroughHourlyNotificationLimit()",
-      "norm_label": "walkthroughhourlynotificationlimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughmaxbodybytes",
-      "label": "walkthroughMaxBodyBytes()",
-      "norm_label": "walkthroughmaxbodybytes()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughprivacycontact",
-      "label": "walkthroughPrivacyContact()",
-      "norm_label": "walkthroughprivacycontact()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L95"
     },
     {
       "community": 2480,
@@ -230340,91 +230361,91 @@
     {
       "community": 249,
       "file_type": "code",
-      "id": "definitions_costoverlaystorewriteoperation",
-      "label": "costOverlayStoreWriteOperation()",
-      "norm_label": "costoverlaystorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L569"
+      "id": "adjustmentreports_adjustmentappliedat",
+      "label": "adjustmentAppliedAt()",
+      "norm_label": "adjustmentappliedat()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L101"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "definitions_cyclecountdraftstorewriteoperation",
-      "label": "cycleCountDraftStoreWriteOperation()",
-      "norm_label": "cyclecountdraftstorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L383"
+      "id": "adjustmentreports_adjustmentsalesdelta",
+      "label": "adjustmentSalesDelta()",
+      "norm_label": "adjustmentsalesdelta()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L116"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "definitions_defineoperation",
-      "label": "defineOperation()",
-      "norm_label": "defineoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L11"
+      "id": "adjustmentreports_adjustmentsettlementamount",
+      "label": "adjustmentSettlementAmount()",
+      "norm_label": "adjustmentsettlementamount()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L143"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "definitions_inventoryimportreviewpayloadwriteoperation",
-      "label": "inventoryImportReviewPayloadWriteOperation()",
-      "norm_label": "inventoryimportreviewpayloadwriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L544"
+      "id": "adjustmentreports_adjustmenttransactionid",
+      "label": "adjustmentTransactionId()",
+      "norm_label": "adjustmenttransactionid()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L110"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "definitions_notificationsubscriptionrowwriteoperation",
-      "label": "notificationSubscriptionRowWriteOperation()",
-      "norm_label": "notificationsubscriptionrowwriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L629"
+      "id": "adjustmentreports_buildadjustmentpaymenttotals",
+      "label": "buildAdjustmentPaymentTotals()",
+      "norm_label": "buildadjustmentpaymenttotals()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L242"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "definitions_orderstorewriteoperation",
-      "label": "orderStoreWriteOperation()",
-      "norm_label": "orderstorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L155"
+      "id": "adjustmentreports_buildadjustmentreporttotals",
+      "label": "buildAdjustmentReportTotals()",
+      "norm_label": "buildadjustmentreporttotals()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L275"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "definitions_storewriteoperation",
-      "label": "storeWriteOperation()",
-      "norm_label": "storewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L108"
+      "id": "adjustmentreports_listappliedtransactionadjustmentsforday",
+      "label": "listAppliedTransactionAdjustmentsForDay()",
+      "norm_label": "listappliedtransactionadjustmentsforday()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L229"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "definitions_transactionstorewriteoperation",
-      "label": "transactionStoreWriteOperation()",
-      "norm_label": "transactionstorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L128"
+      "id": "adjustmentreports_readappliedtransactionadjustmentsforday",
+      "label": "readAppliedTransactionAdjustmentsForDay()",
+      "norm_label": "readappliedtransactionadjustmentsforday()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L173"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "definitions_validateoperationdefinition",
-      "label": "validateOperationDefinition()",
-      "norm_label": "validateoperationdefinition()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L724"
+      "id": "adjustmentreports_sourcecompletenessentry",
+      "label": "sourceCompletenessEntry()",
+      "norm_label": "sourcecompletenessentry()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L76"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operationadmission_definitions_ts",
-      "label": "definitions.ts",
-      "norm_label": "definitions.ts",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "id": "packages_athena_webapp_convex_operations_dailyclose_adjustmentreports_ts",
+      "label": "adjustmentReports.ts",
+      "norm_label": "adjustmentreports.ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
       "source_location": "L1"
     },
     {
@@ -230871,91 +230892,91 @@
     {
       "community": 250,
       "file_type": "code",
-      "id": "adjustmentreports_adjustmentappliedat",
-      "label": "adjustmentAppliedAt()",
-      "norm_label": "adjustmentappliedat()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L101"
+      "id": "inventorymovements_assertnobusinesseventconflict",
+      "label": "assertNoBusinessEventConflict()",
+      "norm_label": "assertnobusinesseventconflict()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L178"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "adjustmentreports_adjustmentsalesdelta",
-      "label": "adjustmentSalesDelta()",
-      "norm_label": "adjustmentsalesdelta()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L116"
+      "id": "inventorymovements_buildinventorymovement",
+      "label": "buildInventoryMovement()",
+      "norm_label": "buildinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L124"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "adjustmentreports_adjustmentsettlementamount",
-      "label": "adjustmentSettlementAmount()",
-      "norm_label": "adjustmentsettlementamount()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L143"
+      "id": "inventorymovements_buildskuactivityforinventorymovement",
+      "label": "buildSkuActivityForInventoryMovement()",
+      "norm_label": "buildskuactivityforinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L66"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "adjustmentreports_adjustmenttransactionid",
-      "label": "adjustmentTransactionId()",
-      "norm_label": "adjustmenttransactionid()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L110"
+      "id": "inventorymovements_getskuactivitytypeformovement",
+      "label": "getSkuActivityTypeForMovement()",
+      "norm_label": "getskuactivitytypeformovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L49"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "adjustmentreports_buildadjustmentpaymenttotals",
-      "label": "buildAdjustmentPaymentTotals()",
-      "norm_label": "buildadjustmentpaymenttotals()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L242"
+      "id": "inventorymovements_matchesexistingmovement",
+      "label": "matchesExistingMovement()",
+      "norm_label": "matchesexistingmovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L150"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "adjustmentreports_buildadjustmentreporttotals",
-      "label": "buildAdjustmentReportTotals()",
-      "norm_label": "buildadjustmentreporttotals()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L275"
+      "id": "inventorymovements_recordinventorymovementwithctx",
+      "label": "recordInventoryMovementWithCtx()",
+      "norm_label": "recordinventorymovementwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L200"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "adjustmentreports_listappliedtransactionadjustmentsforday",
-      "label": "listAppliedTransactionAdjustmentsForDay()",
-      "norm_label": "listappliedtransactionadjustmentsforday()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L229"
+      "id": "inventorymovements_recordinventorymovementwithdispositionwithctx",
+      "label": "recordInventoryMovementWithDispositionWithCtx()",
+      "norm_label": "recordinventorymovementwithdispositionwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L245"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "adjustmentreports_readappliedtransactionadjustmentsforday",
-      "label": "readAppliedTransactionAdjustmentsForDay()",
-      "norm_label": "readappliedtransactionadjustmentsforday()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L173"
+      "id": "inventorymovements_recordskuactivityforinventorymovementwithctx",
+      "label": "recordSkuActivityForInventoryMovementWithCtx()",
+      "norm_label": "recordskuactivityforinventorymovementwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L111"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "adjustmentreports_sourcecompletenessentry",
-      "label": "sourceCompletenessEntry()",
-      "norm_label": "sourcecompletenessentry()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L76"
+      "id": "inventorymovements_summarizeinventorymovements",
+      "label": "summarizeInventoryMovements()",
+      "norm_label": "summarizeinventorymovements()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L135"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_dailyclose_adjustmentreports_ts",
-      "label": "adjustmentReports.ts",
-      "norm_label": "adjustmentreports.ts",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
+      "label": "inventoryMovements.ts",
+      "norm_label": "inventorymovements.ts",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
       "source_location": "L1"
     },
     {
@@ -231051,91 +231072,91 @@
     {
       "community": 251,
       "file_type": "code",
-      "id": "inventorymovements_assertnobusinesseventconflict",
-      "label": "assertNoBusinessEventConflict()",
-      "norm_label": "assertnobusinesseventconflict()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L178"
+      "id": "operationalevents_buildoperationalevent",
+      "label": "buildOperationalEvent()",
+      "norm_label": "buildoperationalevent()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L43"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "inventorymovements_buildinventorymovement",
-      "label": "buildInventoryMovement()",
-      "norm_label": "buildinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L124"
+      "id": "operationalevents_buildtracemetadata",
+      "label": "buildTraceMetadata()",
+      "norm_label": "buildtracemetadata()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L96"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "inventorymovements_buildskuactivityforinventorymovement",
-      "label": "buildSkuActivityForInventoryMovement()",
-      "norm_label": "buildskuactivityforinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L66"
+      "id": "operationalevents_isrecord",
+      "label": "isRecord()",
+      "norm_label": "isrecord()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L145"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "inventorymovements_getskuactivitytypeformovement",
-      "label": "getSkuActivityTypeForMovement()",
-      "norm_label": "getskuactivitytypeformovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L49"
+      "id": "operationalevents_listproductoperationaltimelinewithctx",
+      "label": "listProductOperationalTimelineWithCtx()",
+      "norm_label": "listproductoperationaltimelinewithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L246"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "inventorymovements_matchesexistingmovement",
-      "label": "matchesExistingMovement()",
-      "norm_label": "matchesexistingmovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L150"
+      "id": "operationalevents_matchesexistingevent",
+      "label": "matchesExistingEvent()",
+      "norm_label": "matchesexistingevent()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L149"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "inventorymovements_recordinventorymovementwithctx",
-      "label": "recordInventoryMovementWithCtx()",
-      "norm_label": "recordinventorymovementwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L200"
+      "id": "operationalevents_metadatadedupekeysmatch",
+      "label": "metadataDedupeKeysMatch()",
+      "norm_label": "metadatadedupekeysmatch()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L205"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "inventorymovements_recordinventorymovementwithdispositionwithctx",
-      "label": "recordInventoryMovementWithDispositionWithCtx()",
-      "norm_label": "recordinventorymovementwithdispositionwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L245"
+      "id": "operationalevents_normalizeoperationaleventtracefields",
+      "label": "normalizeOperationalEventTraceFields()",
+      "norm_label": "normalizeoperationaleventtracefields()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L60"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "inventorymovements_recordskuactivityforinventorymovementwithctx",
-      "label": "recordSkuActivityForInventoryMovementWithCtx()",
-      "norm_label": "recordskuactivityforinventorymovementwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L111"
+      "id": "operationalevents_recordoperationaleventwithctx",
+      "label": "recordOperationalEventWithCtx()",
+      "norm_label": "recordoperationaleventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L215"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "inventorymovements_summarizeinventorymovements",
-      "label": "summarizeInventoryMovements()",
-      "norm_label": "summarizeinventorymovements()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L135"
+      "id": "operationalevents_shouldnormalizepostrace",
+      "label": "shouldNormalizePosTrace()",
+      "norm_label": "shouldnormalizepostrace()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L118"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
-      "label": "inventoryMovements.ts",
-      "norm_label": "inventorymovements.ts",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
+      "label": "operationalEvents.ts",
+      "norm_label": "operationalevents.ts",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
       "source_location": "L1"
     },
     {
@@ -231231,91 +231252,91 @@
     {
       "community": 252,
       "file_type": "code",
-      "id": "operationalevents_buildoperationalevent",
-      "label": "buildOperationalEvent()",
-      "norm_label": "buildoperationalevent()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L43"
+      "id": "oversizedoperationalworkrepair_amendrepairwithctx",
+      "label": "amendRepairWithCtx()",
+      "norm_label": "amendrepairwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L430"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "operationalevents_buildtracemetadata",
-      "label": "buildTraceMetadata()",
-      "norm_label": "buildtracemetadata()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L96"
+      "id": "oversizedoperationalworkrepair_createrepairwithctx",
+      "label": "createRepairWithCtx()",
+      "norm_label": "createrepairwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L160"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "operationalevents_isrecord",
-      "label": "isRecord()",
-      "norm_label": "isrecord()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L145"
+      "id": "oversizedoperationalworkrepair_pauserepair",
+      "label": "pauseRepair()",
+      "norm_label": "pauserepair()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L231"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "operationalevents_listproductoperationaltimelinewithctx",
-      "label": "listProductOperationalTimelineWithCtx()",
-      "norm_label": "listproductoperationaltimelinewithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L246"
+      "id": "oversizedoperationalworkrepair_processrepairbatchwithctx",
+      "label": "processRepairBatchWithCtx()",
+      "norm_label": "processrepairbatchwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L249"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "operationalevents_matchesexistingevent",
-      "label": "matchesExistingEvent()",
-      "norm_label": "matchesexistingevent()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L149"
+      "id": "oversizedoperationalworkrepair_readcurrentgroup",
+      "label": "readCurrentGroup()",
+      "norm_label": "readcurrentgroup()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L49"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "operationalevents_metadatadedupekeysmatch",
-      "label": "metadataDedupeKeysMatch()",
-      "norm_label": "metadatadedupekeysmatch()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L205"
+      "id": "oversizedoperationalworkrepair_recordrepairauditevent",
+      "label": "recordRepairAuditEvent()",
+      "norm_label": "recordrepairauditevent()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L85"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "operationalevents_normalizeoperationaleventtracefields",
-      "label": "normalizeOperationalEventTraceFields()",
-      "norm_label": "normalizeoperationaleventtracefields()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L60"
+      "id": "oversizedoperationalworkrepair_requireevidence",
+      "label": "requireEvidence()",
+      "norm_label": "requireevidence()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L37"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "operationalevents_recordoperationaleventwithctx",
-      "label": "recordOperationalEventWithCtx()",
-      "norm_label": "recordoperationaleventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L215"
+      "id": "oversizedoperationalworkrepair_resumerepairwithctx",
+      "label": "resumeRepairWithCtx()",
+      "norm_label": "resumerepairwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L472"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "operationalevents_shouldnormalizepostrace",
-      "label": "shouldNormalizePosTrace()",
-      "norm_label": "shouldnormalizepostrace()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L118"
+      "id": "oversizedoperationalworkrepair_schedulenextbatch",
+      "label": "scheduleNextBatch()",
+      "norm_label": "schedulenextbatch()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L153"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
-      "label": "operationalEvents.ts",
-      "norm_label": "operationalevents.ts",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "id": "packages_athena_webapp_convex_operations_oversizedoperationalworkrepair_ts",
+      "label": "oversizedOperationalWorkRepair.ts",
+      "norm_label": "oversizedoperationalworkrepair.ts",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
       "source_location": "L1"
     },
     {
@@ -231411,92 +231432,92 @@
     {
       "community": 253,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_amendrepairwithctx",
-      "label": "amendRepairWithCtx()",
-      "norm_label": "amendrepairwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L430"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_createrepairwithctx",
-      "label": "createRepairWithCtx()",
-      "norm_label": "createrepairwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L160"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_pauserepair",
-      "label": "pauseRepair()",
-      "norm_label": "pauserepair()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L231"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_processrepairbatchwithctx",
-      "label": "processRepairBatchWithCtx()",
-      "norm_label": "processrepairbatchwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L249"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_readcurrentgroup",
-      "label": "readCurrentGroup()",
-      "norm_label": "readcurrentgroup()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_recordrepairauditevent",
-      "label": "recordRepairAuditEvent()",
-      "norm_label": "recordrepairauditevent()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_requireevidence",
-      "label": "requireEvidence()",
-      "norm_label": "requireevidence()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_resumerepairwithctx",
-      "label": "resumeRepairWithCtx()",
-      "norm_label": "resumerepairwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L472"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_schedulenextbatch",
-      "label": "scheduleNextBatch()",
-      "norm_label": "schedulenextbatch()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_oversizedoperationalworkrepair_ts",
-      "label": "oversizedOperationalWorkRepair.ts",
-      "norm_label": "oversizedoperationalworkrepair.ts",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "id": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
+      "label": "registerSessionTracing.ts",
+      "norm_label": "registersessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registersessiontracing_buildactorrefs",
+      "label": "buildActorRefs()",
+      "norm_label": "buildactorrefs()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registersessiontracing_buildtraceevent",
+      "label": "buildTraceEvent()",
+      "norm_label": "buildtraceevent()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L196"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registersessiontracing_buildtracerecord",
+      "label": "buildTraceRecord()",
+      "norm_label": "buildtracerecord()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L161"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registersessiontracing_displaytraceamount",
+      "label": "displayTraceAmount()",
+      "norm_label": "displaytraceamount()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L114"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registersessiontracing_formattransactionlabel",
+      "label": "formatTransactionLabel()",
+      "norm_label": "formattransactionlabel()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L132"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registersessiontracing_recordregistersessiontracebesteffort",
+      "label": "recordRegisterSessionTraceBestEffort()",
+      "norm_label": "recordregistersessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L407"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registersessiontracing_resolveoccurredat",
+      "label": "resolveOccurredAt()",
+      "norm_label": "resolveoccurredat()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registersessiontracing_resolvestorecurrency",
+      "label": "resolveStoreCurrency()",
+      "norm_label": "resolvestorecurrency()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L146"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registersessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L92"
     },
     {
       "community": 2530,
@@ -231591,92 +231612,92 @@
     {
       "community": 254,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
-      "label": "registerSessionTracing.ts",
-      "norm_label": "registersessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "id": "finalizedlineageremediation_classifyfinalizedlineagerepairconflicts",
+      "label": "classifyFinalizedLineageRepairConflicts()",
+      "norm_label": "classifyfinalizedlineagerepairconflicts()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L222"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_classifyrepaircandidate",
+      "label": "classifyRepairCandidate()",
+      "norm_label": "classifyrepaircandidate()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L164"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_countrepairablefinalizedlineagelines",
+      "label": "countRepairableFinalizedLineageLines()",
+      "norm_label": "countrepairablefinalizedlineagelines()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L284"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_getprovisionalimportsku",
+      "label": "getProvisionalImportSku()",
+      "norm_label": "getprovisionalimportsku()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L318"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_isclosedregisterrepairreplayconflict",
+      "label": "isClosedRegisterRepairReplayConflict()",
+      "norm_label": "isclosedregisterrepairreplayconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L273"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_isfinalizedlineagerepairconflict",
+      "label": "isFinalizedLineageRepairConflict()",
+      "norm_label": "isfinalizedlineagerepairconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L258"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_isprovisionalrowchangedconflict",
+      "label": "isProvisionalRowChangedConflict()",
+      "norm_label": "isprovisionalrowchangedconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L265"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_recordfinalizedlineagerepairevent",
+      "label": "recordFinalizedLineageRepairEvent()",
+      "norm_label": "recordfinalizedlineagerepairevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L358"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_skipped",
+      "label": "skipped()",
+      "norm_label": "skipped()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L346"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_sync_finalizedlineageremediation_ts",
+      "label": "finalizedLineageRemediation.ts",
+      "norm_label": "finalizedlineageremediation.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "registersessiontracing_buildactorrefs",
-      "label": "buildActorRefs()",
-      "norm_label": "buildactorrefs()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "registersessiontracing_buildtraceevent",
-      "label": "buildTraceEvent()",
-      "norm_label": "buildtraceevent()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L196"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "registersessiontracing_buildtracerecord",
-      "label": "buildTraceRecord()",
-      "norm_label": "buildtracerecord()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L161"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "registersessiontracing_displaytraceamount",
-      "label": "displayTraceAmount()",
-      "norm_label": "displaytraceamount()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L114"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "registersessiontracing_formattransactionlabel",
-      "label": "formatTransactionLabel()",
-      "norm_label": "formattransactionlabel()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L132"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "registersessiontracing_recordregistersessiontracebesteffort",
-      "label": "recordRegisterSessionTraceBestEffort()",
-      "norm_label": "recordregistersessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L407"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "registersessiontracing_resolveoccurredat",
-      "label": "resolveOccurredAt()",
-      "norm_label": "resolveoccurredat()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L76"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "registersessiontracing_resolvestorecurrency",
-      "label": "resolveStoreCurrency()",
-      "norm_label": "resolvestorecurrency()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L146"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "registersessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L92"
     },
     {
       "community": 2540,
@@ -231771,92 +231792,92 @@
     {
       "community": 255,
       "file_type": "code",
-      "id": "finalizedlineageremediation_classifyfinalizedlineagerepairconflicts",
-      "label": "classifyFinalizedLineageRepairConflicts()",
-      "norm_label": "classifyfinalizedlineagerepairconflicts()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_terminalrecoveryrepository_ts",
+      "label": "terminalRecoveryRepository.ts",
+      "norm_label": "terminalrecoveryrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_createterminalrecoverycommandreadrepository",
+      "label": "createTerminalRecoveryCommandReadRepository()",
+      "norm_label": "createterminalrecoverycommandreadrepository()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_createterminalrecoverycommandrepository",
+      "label": "createTerminalRecoveryCommandRepository()",
+      "norm_label": "createterminalrecoverycommandrepository()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L127"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_deduperecoverycommandsbyid",
+      "label": "dedupeRecoveryCommandsById()",
+      "norm_label": "deduperecoverycommandsbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L116"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_deduperecoveryconflictsbyid",
+      "label": "dedupeRecoveryConflictsById()",
+      "norm_label": "deduperecoveryconflictsbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L193"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_getterminalrecoverysourceevent",
+      "label": "getTerminalRecoverySourceEvent()",
+      "norm_label": "getterminalrecoverysourceevent()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
       "source_location": "L222"
     },
     {
       "community": 255,
       "file_type": "code",
-      "id": "finalizedlineageremediation_classifyrepaircandidate",
-      "label": "classifyRepairCandidate()",
-      "norm_label": "classifyrepaircandidate()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L164"
+      "id": "terminalrecoveryrepository_iscurrentterminalrecoveryconflict",
+      "label": "isCurrentTerminalRecoveryConflict()",
+      "norm_label": "iscurrentterminalrecoveryconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L206"
     },
     {
       "community": 255,
       "file_type": "code",
-      "id": "finalizedlineageremediation_countrepairablefinalizedlineagelines",
-      "label": "countRepairableFinalizedLineageLines()",
-      "norm_label": "countrepairablefinalizedlineagelines()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L284"
+      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsforrepair",
+      "label": "listTerminalRecoveryConflictsForRepair()",
+      "norm_label": "listterminalrecoveryconflictsforrepair()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L141"
     },
     {
       "community": 255,
       "file_type": "code",
-      "id": "finalizedlineageremediation_getprovisionalimportsku",
-      "label": "getProvisionalImportSku()",
-      "norm_label": "getprovisionalimportsku()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L318"
+      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsources",
+      "label": "listTerminalRecoveryConflictSources()",
+      "norm_label": "listterminalrecoveryconflictsources()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L162"
     },
     {
       "community": 255,
       "file_type": "code",
-      "id": "finalizedlineageremediation_isclosedregisterrepairreplayconflict",
-      "label": "isClosedRegisterRepairReplayConflict()",
-      "norm_label": "isclosedregisterrepairreplayconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L273"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_isfinalizedlineagerepairconflict",
-      "label": "isFinalizedLineageRepairConflict()",
-      "norm_label": "isfinalizedlineagerepairconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L258"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_isprovisionalrowchangedconflict",
-      "label": "isProvisionalRowChangedConflict()",
-      "norm_label": "isprovisionalrowchangedconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L265"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_recordfinalizedlineagerepairevent",
-      "label": "recordFinalizedLineageRepairEvent()",
-      "norm_label": "recordfinalizedlineagerepairevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L358"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_skipped",
-      "label": "skipped()",
-      "norm_label": "skipped()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L346"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sync_finalizedlineageremediation_ts",
-      "label": "finalizedLineageRemediation.ts",
-      "norm_label": "finalizedlineageremediation.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L1"
+      "id": "terminalrecoveryrepository_patchterminalrecoveryconflict",
+      "label": "patchTerminalRecoveryConflict()",
+      "norm_label": "patchterminalrecoveryconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L241"
     },
     {
       "community": 2550,
@@ -231951,92 +231972,92 @@
     {
       "community": 256,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_terminalrecoveryrepository_ts",
-      "label": "terminalRecoveryRepository.ts",
-      "norm_label": "terminalrecoveryrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "id": "contract_test_day",
+      "label": "day()",
+      "norm_label": "day()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L1308"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "contract_test_fieldsof",
+      "label": "fieldsOf()",
+      "norm_label": "fieldsof()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L86"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "contract_test_headerfor",
+      "label": "headerFor()",
+      "norm_label": "headerfor()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L972"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "contract_test_inclusivedays",
+      "label": "inclusiveDays()",
+      "norm_label": "inclusivedays()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L1216"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "contract_test_movementidentityargs",
+      "label": "movementIdentityArgs()",
+      "norm_label": "movementidentityargs()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L602"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "contract_test_probe",
+      "label": "probe()",
+      "norm_label": "probe()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L1312"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "contract_test_seedproductsku",
+      "label": "seedProductSku()",
+      "norm_label": "seedproductsku()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L561"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "contract_test_seedstore",
+      "label": "seedStore()",
+      "norm_label": "seedstore()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L542"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "contract_test_unionliterals",
+      "label": "unionLiterals()",
+      "norm_label": "unionliterals()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_reports_contract_test_ts",
+      "label": "contract.test.ts",
+      "norm_label": "contract.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_createterminalrecoverycommandreadrepository",
-      "label": "createTerminalRecoveryCommandReadRepository()",
-      "norm_label": "createterminalrecoverycommandreadrepository()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_createterminalrecoverycommandrepository",
-      "label": "createTerminalRecoveryCommandRepository()",
-      "norm_label": "createterminalrecoverycommandrepository()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L127"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_deduperecoverycommandsbyid",
-      "label": "dedupeRecoveryCommandsById()",
-      "norm_label": "deduperecoverycommandsbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_deduperecoveryconflictsbyid",
-      "label": "dedupeRecoveryConflictsById()",
-      "norm_label": "deduperecoveryconflictsbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L193"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_getterminalrecoverysourceevent",
-      "label": "getTerminalRecoverySourceEvent()",
-      "norm_label": "getterminalrecoverysourceevent()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L222"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_iscurrentterminalrecoveryconflict",
-      "label": "isCurrentTerminalRecoveryConflict()",
-      "norm_label": "iscurrentterminalrecoveryconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L206"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsforrepair",
-      "label": "listTerminalRecoveryConflictsForRepair()",
-      "norm_label": "listterminalrecoveryconflictsforrepair()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L141"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsources",
-      "label": "listTerminalRecoveryConflictSources()",
-      "norm_label": "listterminalrecoveryconflictsources()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L162"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_patchterminalrecoveryconflict",
-      "label": "patchTerminalRecoveryConflict()",
-      "norm_label": "patchterminalrecoveryconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L241"
     },
     {
       "community": 2560,
@@ -232131,91 +232152,91 @@
     {
       "community": 257,
       "file_type": "code",
-      "id": "contract_test_day",
-      "label": "day()",
-      "norm_label": "day()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L1308"
+      "id": "customrange_aggregateskudays",
+      "label": "aggregateSkuDays()",
+      "norm_label": "aggregateskudays()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L217"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "contract_test_fieldsof",
-      "label": "fieldsOf()",
-      "norm_label": "fieldsof()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L86"
+      "id": "customrange_computerange",
+      "label": "computeRange()",
+      "norm_label": "computerange()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L253"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "contract_test_headerfor",
-      "label": "headerFor()",
-      "norm_label": "headerfor()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L972"
+      "id": "customrange_computerequestkey",
+      "label": "computeRequestKey()",
+      "norm_label": "computerequestkey()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L84"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "contract_test_inclusivedays",
-      "label": "inclusiveDays()",
-      "norm_label": "inclusivedays()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L1216"
+      "id": "customrange_inclusivedayspan",
+      "label": "inclusiveDaySpan()",
+      "norm_label": "inclusivedayspan()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L52"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "contract_test_movementidentityargs",
-      "label": "movementIdentityArgs()",
-      "norm_label": "movementidentityargs()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L602"
+      "id": "customrange_isvalidoperatingdate",
+      "label": "isValidOperatingDate()",
+      "norm_label": "isvalidoperatingdate()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L35"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "contract_test_probe",
-      "label": "probe()",
-      "norm_label": "probe()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L1312"
+      "id": "customrange_requestrangecore",
+      "label": "requestRangeCore()",
+      "norm_label": "requestrangecore()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L112"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "contract_test_seedproductsku",
-      "label": "seedProductSku()",
-      "norm_label": "seedproductsku()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L561"
+      "id": "customrange_sumdays",
+      "label": "sumDays()",
+      "norm_label": "sumdays()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L189"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "contract_test_seedstore",
-      "label": "seedStore()",
-      "norm_label": "seedstore()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L542"
+      "id": "customrange_utcmillisforlabel",
+      "label": "utcMillisForLabel()",
+      "norm_label": "utcmillisforlabel()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L46"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "contract_test_unionliterals",
-      "label": "unionLiterals()",
-      "norm_label": "unionliterals()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L92"
+      "id": "customrange_validaterangeargs",
+      "label": "validateRangeArgs()",
+      "norm_label": "validaterangeargs()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L58"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_contract_test_ts",
-      "label": "contract.test.ts",
-      "norm_label": "contract.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "id": "packages_athena_webapp_convex_reports_customrange_ts",
+      "label": "customRange.ts",
+      "norm_label": "customrange.ts",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
       "source_location": "L1"
     },
     {
@@ -232311,92 +232332,92 @@
     {
       "community": 258,
       "file_type": "code",
-      "id": "customrange_aggregateskudays",
-      "label": "aggregateSkuDays()",
-      "norm_label": "aggregateskudays()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L217"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "customrange_computerange",
-      "label": "computeRange()",
-      "norm_label": "computerange()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L253"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "customrange_computerequestkey",
-      "label": "computeRequestKey()",
-      "norm_label": "computerequestkey()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L84"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "customrange_inclusivedayspan",
-      "label": "inclusiveDaySpan()",
-      "norm_label": "inclusivedayspan()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "customrange_isvalidoperatingdate",
-      "label": "isValidOperatingDate()",
-      "norm_label": "isvalidoperatingdate()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "customrange_requestrangecore",
-      "label": "requestRangeCore()",
-      "norm_label": "requestrangecore()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L112"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "customrange_sumdays",
-      "label": "sumDays()",
-      "norm_label": "sumdays()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L189"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "customrange_utcmillisforlabel",
-      "label": "utcMillisForLabel()",
-      "norm_label": "utcmillisforlabel()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "customrange_validaterangeargs",
-      "label": "validateRangeArgs()",
-      "norm_label": "validaterangeargs()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_customrange_ts",
-      "label": "customRange.ts",
-      "norm_label": "customrange.ts",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "id": "packages_athena_webapp_convex_reports_rangesnapshotlifecycle_test_ts",
+      "label": "rangeSnapshotLifecycle.test.ts",
+      "norm_label": "rangesnapshotlifecycle.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_allow",
+      "label": "allow()",
+      "norm_label": "allow()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_certifyday",
+      "label": "certifyDay()",
+      "norm_label": "certifyday()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L109"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_consume",
+      "label": "consume()",
+      "norm_label": "consume()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L296"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_drive",
+      "label": "drive()",
+      "norm_label": "drive()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L247"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_ensuresynthetic",
+      "label": "ensureSynthetic()",
+      "norm_label": "ensuresynthetic()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L208"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_headerbykey",
+      "label": "headerByKey()",
+      "norm_label": "headerbykey()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L230"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_insertkindedheader",
+      "label": "insertKindedHeader()",
+      "norm_label": "insertkindedheader()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L612"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_seedstore",
+      "label": "seedStore()",
+      "norm_label": "seedstore()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_synthetickind",
+      "label": "syntheticKind()",
+      "norm_label": "synthetickind()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L150"
     },
     {
       "community": 2580,
@@ -232491,92 +232512,92 @@
     {
       "community": 259,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_rangesnapshotlifecycle_test_ts",
-      "label": "rangeSnapshotLifecycle.test.ts",
-      "norm_label": "rangesnapshotlifecycle.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "id": "packages_athena_webapp_convex_reports_verificationclassify_ts",
+      "label": "verificationClassify.ts",
+      "norm_label": "verificationclassify.ts",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
       "source_location": "L1"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_allow",
-      "label": "allow()",
-      "norm_label": "allow()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L53"
+      "id": "verificationclassify_buildclassification",
+      "label": "buildClassification()",
+      "norm_label": "buildclassification()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L448"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_certifyday",
-      "label": "certifyDay()",
-      "norm_label": "certifyday()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L109"
+      "id": "verificationclassify_classifydayresult",
+      "label": "classifyDayResult()",
+      "norm_label": "classifydayresult()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L481"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_consume",
-      "label": "consume()",
-      "norm_label": "consume()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L296"
+      "id": "verificationclassify_classifyweekresult",
+      "label": "classifyWeekResult()",
+      "norm_label": "classifyweekresult()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L562"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_drive",
-      "label": "drive()",
-      "norm_label": "drive()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L247"
+      "id": "verificationclassify_confirmsclean",
+      "label": "confirmsClean()",
+      "norm_label": "confirmsclean()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L681"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_ensuresynthetic",
-      "label": "ensureSynthetic()",
-      "norm_label": "ensuresynthetic()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L208"
+      "id": "verificationclassify_explainmetricdifference",
+      "label": "explainMetricDifference()",
+      "norm_label": "explainmetricdifference()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L378"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_headerbykey",
-      "label": "headerByKey()",
-      "norm_label": "headerbykey()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L230"
+      "id": "verificationclassify_fingerprintdifferences",
+      "label": "fingerprintDifferences()",
+      "norm_label": "fingerprintdifferences()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L354"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_insertkindedheader",
-      "label": "insertKindedHeader()",
-      "norm_label": "insertkindedheader()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L612"
+      "id": "verificationclassify_initialstreakstate",
+      "label": "initialStreakState()",
+      "norm_label": "initialstreakstate()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L658"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_seedstore",
-      "label": "seedStore()",
-      "norm_label": "seedstore()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L73"
+      "id": "verificationclassify_nextstreakstate",
+      "label": "nextStreakState()",
+      "norm_label": "nextstreakstate()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L707"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_synthetickind",
-      "label": "syntheticKind()",
-      "norm_label": "synthetickind()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L150"
+      "id": "verificationclassify_partitiondifferences",
+      "label": "partitionDifferences()",
+      "norm_label": "partitiondifferences()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L434"
     },
     {
       "community": 2590,
@@ -233013,92 +233034,92 @@
     {
       "community": 260,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_verificationclassify_ts",
-      "label": "verificationClassify.ts",
-      "norm_label": "verificationclassify.ts",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "id": "index_resolveverificationcoderecipient",
+      "label": "resolveVerificationCodeRecipient()",
+      "norm_label": "resolveverificationcoderecipient()",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "index_senddailymanagerreportemail",
+      "label": "sendDailyManagerReportEmail()",
+      "norm_label": "senddailymanagerreportemail()",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "source_location": "L373"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "index_senddiscountcodeemail",
+      "label": "sendDiscountCodeEmail()",
+      "norm_label": "senddiscountcodeemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L255"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "index_senddiscountreminderemail",
+      "label": "sendDiscountReminderEmail()",
+      "norm_label": "senddiscountreminderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L334"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "index_sendfeedbackrequestemail",
+      "label": "sendFeedbackRequestEmail()",
+      "norm_label": "sendfeedbackrequestemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "index_sendneworderemail",
+      "label": "sendNewOrderEmail()",
+      "norm_label": "sendneworderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L117"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "index_sendorderemail",
+      "label": "sendOrderEmail()",
+      "norm_label": "sendorderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "index_sendverificationcode",
+      "label": "sendVerificationCode()",
+      "norm_label": "sendverificationcode()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
       "source_location": "L1"
     },
     {
       "community": 260,
       "file_type": "code",
-      "id": "verificationclassify_buildclassification",
-      "label": "buildClassification()",
-      "norm_label": "buildclassification()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L448"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "verificationclassify_classifydayresult",
-      "label": "classifyDayResult()",
-      "norm_label": "classifydayresult()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L481"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "verificationclassify_classifyweekresult",
-      "label": "classifyWeekResult()",
-      "norm_label": "classifyweekresult()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L562"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "verificationclassify_confirmsclean",
-      "label": "confirmsClean()",
-      "norm_label": "confirmsclean()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L681"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "verificationclassify_explainmetricdifference",
-      "label": "explainMetricDifference()",
-      "norm_label": "explainmetricdifference()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L378"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "verificationclassify_fingerprintdifferences",
-      "label": "fingerprintDifferences()",
-      "norm_label": "fingerprintdifferences()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L354"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "verificationclassify_initialstreakstate",
-      "label": "initialStreakState()",
-      "norm_label": "initialstreakstate()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L658"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "verificationclassify_nextstreakstate",
-      "label": "nextStreakState()",
-      "norm_label": "nextstreakstate()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L707"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "verificationclassify_partitiondifferences",
-      "label": "partitionDifferences()",
-      "norm_label": "partitiondifferences()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L434"
+      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L1"
     },
     {
       "community": 2600,
@@ -263806,7 +263827,7 @@
       "label": "createFixtureRoot()",
       "norm_label": "createfixtureroot()",
       "source_file": "scripts/pre-push-validation-proof.test.ts",
-      "source_location": "L20"
+      "source_location": "L21"
     },
     {
       "community": 543,
@@ -263815,7 +263836,7 @@
       "label": "createSpawn()",
       "norm_label": "createspawn()",
       "source_file": "scripts/pre-push-validation-proof.test.ts",
-      "source_location": "L63"
+      "source_location": "L64"
     },
     {
       "community": 543,
@@ -263824,7 +263845,7 @@
       "label": "log()",
       "norm_label": "log()",
       "source_file": "scripts/pre-push-validation-proof.test.ts",
-      "source_location": "L171"
+      "source_location": "L185"
     },
     {
       "community": 543,
@@ -263833,7 +263854,7 @@
       "label": "warn()",
       "norm_label": "warn()",
       "source_file": "scripts/pre-push-validation-proof.test.ts",
-      "source_location": "L309"
+      "source_location": "L323"
     },
     {
       "community": 543,
@@ -263842,7 +263863,7 @@
       "label": "write()",
       "norm_label": "write()",
       "source_file": "scripts/pre-push-validation-proof.test.ts",
-      "source_location": "L14"
+      "source_location": "L15"
     },
     {
       "community": 543,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2883
-- Graph nodes: 12263
-- Graph edges: 15099
+- Graph nodes: 12265
+- Graph edges: 15103
 - Communities: 2808
 
 ## Graph Hotspots

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 2882
-- Graph nodes: 12260
-- Graph edges: 15097
-- Communities: 2807
+- Code files discovered: 2883
+- Graph nodes: 12263
+- Graph edges: 15099
+- Communities: 2808
 
 ## Graph Hotspots
 - `dailyClose.ts` (98 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2883
-- Graph nodes: 12265
-- Graph edges: 15103
+- Graph nodes: 12266
+- Graph edges: 15104
 - Communities: 2808
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -20,7 +20,7 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 - `storefrontJourneyEvents.ts` (45 edges, Community 14) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 14) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `getStoreConfigV2()` (17 edges, Community 86) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
-- `storefrontContextEvents.ts` (17 edges, Community 117) - [`packages/storefront-webapp/src/lib/storefrontContextEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontContextEvents.ts)
+- `storefrontContextEvents.ts` (17 edges, Community 118) - [`packages/storefront-webapp/src/lib/storefrontContextEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontContextEvents.ts)
 - `checkoutSession.ts` (14 edges, Community 152) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 
 ## Navigation

--- a/scripts/git-environment.ts
+++ b/scripts/git-environment.ts
@@ -1,0 +1,7 @@
+export function withoutGitRepositoryContext(
+  environment: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  return Object.fromEntries(
+    Object.entries(environment).filter(([key]) => !key.startsWith("GIT_")),
+  );
+}

--- a/scripts/harness-gate-admission.test.ts
+++ b/scripts/harness-gate-admission.test.ts
@@ -17,6 +17,7 @@ import {
   ATHENA_PR_VALIDATION_GATE_ID,
   HARNESS_GATE_REGISTRY,
 } from "./harness-gate-registry";
+import { withoutGitRepositoryContext } from "./git-environment";
 import { HARNESS_REVIEW_IDENTITY_VERSION } from "./harness-review-identity";
 
 const HEAVY_PROVIDER_COMMANDS =
@@ -585,7 +586,10 @@ describe("harness gate admission", () => {
   it("writes events inside the Git-private directory without overwriting", async () => {
     const rootDir = await mkdtemp(path.join(tmpdir(), "athena-admission-"));
     temporaryDirectories.push(rootDir);
-    await execFileAsync("git", ["init", "--quiet"], { cwd: rootDir });
+    await execFileAsync("git", ["init", "--quiet"], {
+      cwd: rootDir,
+      env: withoutGitRepositoryContext(),
+    });
     const options = greenOptions();
     await runHarnessGateAdmission("/repo", options as never);
     const event = options._spies.writeDecisionEvent.mock.calls[0][1];

--- a/scripts/harness-review-identity.test.ts
+++ b/scripts/harness-review-identity.test.ts
@@ -7,6 +7,7 @@ import {
   HARNESS_REVIEW_IDENTITY_VERSION,
   computeDeliverableTreeIdentity,
   digestDeliverableEntries,
+  isPostGateValidationNeutralPath,
   isReviewNeutralPath,
   parseTreeEntries,
 } from "./harness-review-identity";
@@ -68,6 +69,21 @@ describe("review-neutral path policy", () => {
     // deliverable.
     expect(isReviewNeutralPath("telemetry/some-future-record.json")).toBe(false);
     expect(isReviewNeutralPath("telemetry/scripts/run.ts")).toBe(false);
+  });
+
+  it("keeps post-gate validation neutrality narrower than review neutrality", () => {
+    expect(
+      isPostGateValidationNeutralPath("telemetry/delivery-runs/run.json"),
+    ).toBe(true);
+    expect(isPostGateValidationNeutralPath("telemetry/delivery-runs/README.md")).toBe(
+      false,
+    );
+    expect(isPostGateValidationNeutralPath("docs/reports/changed.html")).toBe(
+      false,
+    );
+    expect(isPostGateValidationNeutralPath("docs/solutions/changed.md")).toBe(
+      false,
+    );
   });
 
   it.each([

--- a/scripts/harness-review-identity.ts
+++ b/scripts/harness-review-identity.ts
@@ -36,6 +36,8 @@ export const REVIEW_NEUTRAL_PATH_PREFIXES = [
   "telemetry/delivery-runs/",
 ] as const;
 
+const POST_GATE_VALIDATION_NEUTRAL_PATH_PREFIX = "telemetry/delivery-runs/";
+
 export const HARNESS_REVIEW_IDENTITY_VERSION = "deliverable-tree/v1" as const;
 
 export type HarnessReviewIdentityVersion =
@@ -75,6 +77,21 @@ export function isReviewNeutralPath(repoPath: string) {
   const normalizedPath = normalizeRepoPath(repoPath);
   return REVIEW_NEUTRAL_PATH_PREFIXES.some((prefix) =>
     normalizedPath.startsWith(prefix),
+  );
+}
+
+/**
+ * Paths that may be written after a successful merge-grade gate without
+ * invalidating its reusable pre-push proof. This is intentionally narrower
+ * than review neutrality: reports and solution notes still need their own
+ * validation, while the canonical telemetry record describes the gate that
+ * just completed and is checked by delivery:telemetry-check.
+ */
+export function isPostGateValidationNeutralPath(repoPath: string) {
+  const normalizedPath = normalizeRepoPath(repoPath);
+  return (
+    normalizedPath.startsWith(POST_GATE_VALIDATION_NEUTRAL_PATH_PREFIX) &&
+    normalizedPath.endsWith(".json")
   );
 }
 

--- a/scripts/harness-test.test.ts
+++ b/scripts/harness-test.test.ts
@@ -8,6 +8,7 @@ import {
   parseHarnessTestCliArgs,
   runHarnessTest,
 } from "./harness-test";
+import { withoutGitRepositoryContext } from "./git-environment";
 import { collectRootScriptTestFiles } from "./root-scripts-coverage";
 
 const tempRoots: string[] = [];
@@ -27,6 +28,7 @@ async function createFixtureRoot() {
 function runGit(rootDir: string, ...args: string[]) {
   const result = Bun.spawnSync(["git", ...args], {
     cwd: rootDir,
+    env: withoutGitRepositoryContext(),
     stdout: "pipe",
     stderr: "pipe",
   });

--- a/scripts/harness-test.test.ts
+++ b/scripts/harness-test.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -22,6 +22,18 @@ async function createFixtureRoot() {
   const rootDir = await mkdtemp(path.join(tmpdir(), "athena-harness-test-"));
   tempRoots.push(rootDir);
   return rootDir;
+}
+
+function runGit(rootDir: string, ...args: string[]) {
+  const result = Bun.spawnSync(["git", ...args], {
+    cwd: rootDir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(result.stderr.toString().trim());
+  }
+  return result.stdout.toString().trim();
 }
 
 afterEach(async () => {
@@ -83,6 +95,128 @@ describe("collectHarnessTestTargets", () => {
 });
 
 describe("runHarnessTest", () => {
+  it("keeps parent Git state unchanged while real fixture tests run under hook context", async () => {
+    const parentRoot = await createFixtureRoot();
+    runGit(parentRoot, "init", "--initial-branch=main");
+    runGit(parentRoot, "config", "user.email", "parent@example.com");
+    runGit(parentRoot, "config", "user.name", "Parent Fixture");
+    runGit(parentRoot, "config", "core.bare", "false");
+    runGit(parentRoot, "config", "extensions.worktreeConfig", "true");
+    await write("seed.txt", "parent seed\n", parentRoot);
+    runGit(parentRoot, "add", "seed.txt");
+    runGit(parentRoot, "commit", "-m", "parent seed");
+
+    const testRoot = await createFixtureRoot();
+    await write(
+      "scripts/real-repository.test.ts",
+      `
+        import { mkdir, writeFile } from "node:fs/promises";
+        import path from "node:path";
+        import { expect, test } from "bun:test";
+
+        test("nested Git commands stay inside the fixture", async () => {
+          expect(Object.keys(process.env).filter((key) => key.startsWith("GIT_"))).toEqual([]);
+          const fixtureRoot = path.join(import.meta.dir, "nested-repo");
+          await mkdir(fixtureRoot, { recursive: true });
+          const git = (...args: string[]) => {
+            const result = Bun.spawnSync(["git", ...args], {
+              cwd: fixtureRoot,
+              stdout: "pipe",
+              stderr: "pipe",
+            });
+            expect(result.exitCode, result.stderr.toString()).toBe(0);
+          };
+          git("init", "--initial-branch=fixture");
+          git("config", "user.email", "nested@example.com");
+          git("config", "user.name", "Nested Fixture");
+          git("config", "core.bare", "true");
+          await writeFile(path.join(fixtureRoot, "marker.txt"), "fixture only\\n");
+          expect(await Bun.file(path.join(fixtureRoot, ".git", "config")).text()).toContain("bare = true");
+        });
+      `,
+      testRoot,
+    );
+
+    const gitDir = path.join(parentRoot, ".git");
+    const indexPath = path.join(gitDir, "index");
+    const configPath = path.join(gitDir, "config");
+    const configBefore = await readFile(configPath);
+    const indexBefore = await readFile(indexPath);
+    const refsBefore = runGit(parentRoot, "show-ref");
+    const hookEnvironment = {
+      GIT_DIR: gitDir,
+      GIT_WORK_TREE: parentRoot,
+      GIT_INDEX_FILE: indexPath,
+      GIT_PREFIX: "scripts/",
+      GIT_OBJECT_DIRECTORY: path.join(gitDir, "objects"),
+    };
+    const originals = Object.fromEntries(
+      Object.keys(hookEnvironment).map((key) => [key, process.env[key]]),
+    );
+
+    try {
+      Object.assign(process.env, hookEnvironment);
+      await runHarnessTest(testRoot);
+    } finally {
+      for (const [key, value] of Object.entries(originals)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
+
+    expect(await readFile(configPath)).toEqual(configBefore);
+    expect(await readFile(indexPath)).toEqual(indexBefore);
+    expect(runGit(parentRoot, "show-ref")).toBe(refsBefore);
+    expect(runGit(parentRoot, "config", "--get", "core.bare")).toBe("false");
+    expect(
+      runGit(parentRoot, "config", "--get", "extensions.worktreeConfig"),
+    ).toBe("true");
+    expect(
+      await readFile(
+        path.join(testRoot, "scripts", "nested-repo", ".git", "config"),
+        "utf8",
+      ),
+    ).toContain("bare = true");
+  });
+
+  it("removes inherited Git repository context from the bun test process", async () => {
+    const rootDir = await createFixtureRoot();
+    await write("scripts/harness-audit.test.ts", "test('root', () => {});\n", rootDir);
+
+    const originalGitDir = process.env.GIT_DIR;
+    const originalGitWorkTree = process.env.GIT_WORK_TREE;
+    const originalGitIndexFile = process.env.GIT_INDEX_FILE;
+    process.env.GIT_DIR = "/parent/repo/.git";
+    process.env.GIT_WORK_TREE = "/parent/repo";
+    process.env.GIT_INDEX_FILE = "/parent/repo/.git/index.locked";
+
+    let spawnedEnv: Record<string, string | undefined> | undefined;
+    try {
+      await runHarnessTest(rootDir, {
+        spawn: (_command, options) => {
+          spawnedEnv = options.env;
+          return { exited: Promise.resolve(0) };
+        },
+      });
+    } finally {
+      if (originalGitDir === undefined) delete process.env.GIT_DIR;
+      else process.env.GIT_DIR = originalGitDir;
+      if (originalGitWorkTree === undefined) delete process.env.GIT_WORK_TREE;
+      else process.env.GIT_WORK_TREE = originalGitWorkTree;
+      if (originalGitIndexFile === undefined) delete process.env.GIT_INDEX_FILE;
+      else process.env.GIT_INDEX_FILE = originalGitIndexFile;
+    }
+
+    expect(spawnedEnv).toBeDefined();
+    expect(spawnedEnv?.PATH).toBe(process.env.PATH);
+    expect(spawnedEnv?.GIT_DIR).toBeUndefined();
+    expect(spawnedEnv?.GIT_WORK_TREE).toBeUndefined();
+    expect(spawnedEnv?.GIT_INDEX_FILE).toBeUndefined();
+    expect(process.env.GIT_DIR).toBe(originalGitDir);
+    expect(process.env.GIT_WORK_TREE).toBe(originalGitWorkTree);
+    expect(process.env.GIT_INDEX_FILE).toBe(originalGitIndexFile);
+  });
+
   it("supports --dry-run selection checks without invoking bun test", async () => {
     const rootDir = await createFixtureRoot();
     await write("scripts/harness-audit.test.ts", "test('root', () => {});\n", rootDir);

--- a/scripts/harness-test.ts
+++ b/scripts/harness-test.ts
@@ -1,6 +1,8 @@
 import { readdir } from "node:fs/promises";
 import path from "node:path";
 
+import { withoutGitRepositoryContext } from "./git-environment";
+
 const ROOT_TEST_DIRECTORY = "scripts";
 const TEST_FILE_SUFFIX = ".test.ts";
 
@@ -11,7 +13,12 @@ type SpawnedProcess = {
 type HarnessTestOptions = {
   spawn?: (
     command: string[],
-    options: { cwd: string; stdout: "inherit"; stderr: "inherit" }
+    options: {
+      cwd: string;
+      env: NodeJS.ProcessEnv;
+      stdout: "inherit";
+      stderr: "inherit";
+    }
   ) => SpawnedProcess;
   passthroughArgs?: string[];
   dryRun?: boolean;
@@ -59,6 +66,7 @@ export async function runHarnessTest(
 
   const proc = spawn(["bun", "test", ...targets, ...passthroughArgs], {
     cwd: rootDir,
+    env: withoutGitRepositoryContext(),
     stdout: "inherit",
     stderr: "inherit",
   });

--- a/scripts/pre-push-hook.test.ts
+++ b/scripts/pre-push-hook.test.ts
@@ -11,6 +11,8 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
+import { withoutGitRepositoryContext } from "./git-environment";
+
 const ROOT_DIR = path.resolve(import.meta.dirname, "..");
 const decoder = new TextDecoder();
 const fixtureRoots: string[] = [];
@@ -31,6 +33,14 @@ async function createHookFixture(fakeBunSource: string) {
     await readFile(path.join(ROOT_DIR, ".husky/pre-push"), "utf8"),
   );
   await writeFile(
+    path.join(fixtureRoot, ".husky/pre-commit"),
+    await readFile(path.join(ROOT_DIR, ".husky/pre-commit"), "utf8"),
+  );
+  await writeFile(
+    path.join(fixtureRoot, ".husky/scrub-git-env.sh"),
+    await readFile(path.join(ROOT_DIR, ".husky/scrub-git-env.sh"), "utf8"),
+  );
+  await writeFile(
     path.join(fixtureBin, "bun"),
     [
       "#!/bin/sh",
@@ -41,7 +51,10 @@ async function createHookFixture(fakeBunSource: string) {
   await chmod(path.join(fixtureBin, "bun"), 0o755);
 
   expect(
-    Bun.spawnSync(["git", "init", "-q"], { cwd: fixtureRoot }).exitCode,
+    Bun.spawnSync(["git", "init", "-q"], {
+      cwd: fixtureRoot,
+      env: withoutGitRepositoryContext(),
+    }).exitCode,
   ).toBe(0);
 
   return {
@@ -93,6 +106,50 @@ afterEach(async () => {
 });
 
 describe("bounded pre-push hook", () => {
+  it.each(["pre-push", "pre-commit"])(
+    "scrubs inherited Git context before %s validation commands",
+    async (hookName) => {
+      const fixture = await createHookFixture(
+        [
+          "#!/bin/sh",
+          'env > "$ATHENA_TEST_VALIDATOR_ENV_FILE"',
+          "exit 0",
+        ].join("\n"),
+      );
+      const validatorEnvFile = path.join(
+        fixture.fixtureRoot,
+        `${hookName}-validator.env`,
+      );
+
+      const result = Bun.spawnSync(["sh", `.husky/${hookName}`], {
+        cwd: fixture.fixtureRoot,
+        env: {
+          ...fixture.env,
+          ATHENA_TEST_VALIDATOR_ENV_FILE: validatorEnvFile,
+          GIT_COMMON_DIR: path.join(fixture.fixtureRoot, ".git"),
+          GIT_DIR: path.join(fixture.fixtureRoot, ".git"),
+          GIT_INDEX_FILE: path.join(fixture.fixtureRoot, ".git", "index"),
+          GIT_OBJECT_DIRECTORY: path.join(fixture.fixtureRoot, ".git", "objects"),
+          GIT_PREFIX: "scripts/",
+          GIT_WORK_TREE: fixture.fixtureRoot,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      expect(result.exitCode, decoder.decode(result.stderr)).toBe(0);
+      const validatorEnvironment = await readFile(validatorEnvFile, "utf8");
+      expect(
+        validatorEnvironment
+          .split("\n")
+          .filter((line) => line.startsWith("GIT_")),
+      ).toEqual([]);
+      expect(validatorEnvironment).toContain(
+        `ATHENA_TEST_VALIDATOR_ENV_FILE=${validatorEnvFile}`,
+      );
+    },
+  );
+
   it("propagates failure status while byte-bounding diagnostics and retaining the full log", async () => {
     const fixture = await createHookFixture(
       [

--- a/scripts/pre-push-review.test.ts
+++ b/scripts/pre-push-review.test.ts
@@ -15,6 +15,7 @@ import {
   ATHENA_PR_VALIDATION_GATE_ID,
   HARNESS_GATE_REGISTRY,
 } from "./harness-gate-registry";
+import { withoutGitRepositoryContext } from "./git-environment";
 import * as prePushReview from "./pre-push-review";
 
 const ROOT_DIR = path.resolve(import.meta.dirname, "..");
@@ -950,6 +951,10 @@ describe("pre-push review wiring", () => {
       await mkdir(fixtureTmp, { recursive: true });
       await writeFile(path.join(fixtureRoot, ".husky/pre-push"), hookContents);
       await writeFile(
+        path.join(fixtureRoot, ".husky/scrub-git-env.sh"),
+        await readFile(path.join(ROOT_DIR, ".husky/scrub-git-env.sh"), "utf8"),
+      );
+      await writeFile(
         path.join(fixtureBin, "bun"),
         [
           "#!/bin/sh",
@@ -967,7 +972,10 @@ describe("pre-push review wiring", () => {
       await chmod(path.join(fixtureBin, "bun"), 0o755);
 
       expect(
-        Bun.spawnSync(["git", "init", "-q"], { cwd: fixtureRoot }).exitCode,
+        Bun.spawnSync(["git", "init", "-q"], {
+          cwd: fixtureRoot,
+          env: withoutGitRepositoryContext(),
+        }).exitCode,
       ).toBe(0);
 
       const startedAt = Date.now();

--- a/scripts/pre-push-validation-proof.test.ts
+++ b/scripts/pre-push-validation-proof.test.ts
@@ -70,6 +70,9 @@ function createSpawn(outputs: {
   unstagedDiffExitCode?: number;
   unstagedFiles?: string;
   bunVersion?: string;
+  changedTreeFiles?: string[];
+  changedTreeEntries?: Array<{ status: string; path: string }>;
+  treeContents?: Record<string, string>;
 }) {
   const next = {
     headSha: "head-a",
@@ -81,6 +84,9 @@ function createSpawn(outputs: {
     unstagedDiffExitCode: 0,
     unstagedFiles: "",
     bunVersion: "1.1.29",
+    changedTreeFiles: [],
+    changedTreeEntries: undefined,
+    treeContents: {},
     ...outputs,
   };
 
@@ -120,16 +126,28 @@ function createSpawn(outputs: {
     } else if (command.join(" ") === "bun --version") {
       output = next.bunVersion;
     } else if (command[0] === "git" && command[1] === "ls-tree") {
-      // The candidate identity reads the prepared tree; contents are irrelevant
-      // to proof reuse, which still binds to the raw tree SHA.
-      output = `100644 blob blob-a\tsrc/app.ts`;
+      const treeSha = command.at(-1) ?? "";
+      output =
+        next.treeContents[treeSha] ?? `100644 blob blob-a\tsrc/app.ts`;
+    } else if (
+      command[0] === "git" &&
+      command[1] === "diff" &&
+      command.includes("--name-status") &&
+      command.includes("-z")
+    ) {
+      const entries =
+        next.changedTreeEntries ??
+        next.changedTreeFiles.map((path) => ({ status: "A", path }));
+      output = entries.map((entry) => `${entry.status}\0${entry.path}\0`).join("");
     } else {
       throw new Error(`unexpected command: ${command.join(" ")}`);
     }
 
     return {
       exited: Promise.resolve(0),
-      stdout: new Response(`${output}\n`).body,
+      stdout: new Response(
+        command.includes("-z") ? output : `${output}\n`,
+      ).body,
       stderr: new Response("").body,
     };
   };
@@ -279,6 +297,109 @@ describe("pre-push validation proof", () => {
     });
   });
 
+  it("reuses proof after the canonical post-gate telemetry record is committed", async () => {
+    const rootDir = await createFixtureRoot();
+    await recordPrePushValidationProof(rootDir, {
+      spawn: createSpawn({
+        headSha: "head-before",
+        headTreeSha: "tree-before",
+        indexTreeSha: "tree-validated",
+        status: "A  telemetry/delivery-runs/run.json",
+      }),
+      logger: { log() {}, warn() {} },
+    });
+    let telemetryChecked = false;
+
+    await expect(
+      evaluatePrePushValidationProof(rootDir, {
+        spawn: createSpawn({
+          headSha: "head-after",
+          headTreeSha: "tree-with-telemetry",
+          indexTreeSha: "tree-with-telemetry",
+          changedTreeFiles: ["telemetry/delivery-runs/run.json"],
+        }),
+        validatePostGateNeutralChanges: async () => {
+          telemetryChecked = true;
+        },
+      }),
+    ).resolves.toMatchObject({ reusable: true, status: "reusable" });
+    expect(telemetryChecked).toBe(true);
+  });
+
+  it("does not reuse proof for other review-neutral documentation changes", async () => {
+    const rootDir = await createFixtureRoot();
+    await recordPrePushValidationProof(rootDir, {
+      spawn: createSpawn({}),
+      logger: { log() {}, warn() {} },
+    });
+
+    await expect(
+      evaluatePrePushValidationProof(rootDir, {
+        spawn: createSpawn({
+          headTreeSha: "tree-with-report",
+          indexTreeSha: "tree-with-report",
+          changedTreeFiles: ["docs/reports/changed.html"],
+        }),
+      }),
+    ).resolves.toMatchObject({
+      reusable: false,
+      status: "stale",
+      reason: "HEAD tree changed outside post-gate validation-neutral paths",
+    });
+  });
+
+  it("fails closed when committed post-gate telemetry is invalid", async () => {
+    const rootDir = await createFixtureRoot();
+    await recordPrePushValidationProof(rootDir, {
+      spawn: createSpawn({}),
+      logger: { log() {}, warn() {} },
+    });
+
+    await expect(
+      evaluatePrePushValidationProof(rootDir, {
+        spawn: createSpawn({
+          headTreeSha: "tree-with-telemetry",
+          indexTreeSha: "tree-with-telemetry",
+          changedTreeFiles: ["telemetry/delivery-runs/run.json"],
+        }),
+        validatePostGateNeutralChanges: async () => {
+          throw new Error("telemetry record is stale");
+        },
+      }),
+    ).resolves.toMatchObject({
+      reusable: false,
+      status: "stale",
+      reason: "post-gate telemetry validation failed: telemetry record is stale",
+    });
+  });
+
+  it("does not reuse proof for telemetry edits or path-prefix lookalikes", async () => {
+    const rootDir = await createFixtureRoot();
+    await recordPrePushValidationProof(rootDir, {
+      spawn: createSpawn({}),
+      logger: { log() {}, warn() {} },
+    });
+
+    for (const changedTreeEntries of [
+      [{ status: "M", path: "telemetry/delivery-runs/run.json" }],
+      [{ status: "A", path: " telemetry/delivery-runs/run.json" }],
+    ]) {
+      await expect(
+        evaluatePrePushValidationProof(rootDir, {
+          spawn: createSpawn({
+            headTreeSha: "tree-with-unsafe-delta",
+            indexTreeSha: "tree-with-unsafe-delta",
+            changedTreeEntries,
+          }),
+        }),
+      ).resolves.toMatchObject({
+        reusable: false,
+        status: "stale",
+        reason: "HEAD tree changed outside post-gate validation-neutral paths",
+      });
+    }
+  });
+
   it("does not record staged proof when unstaged files are also present", async () => {
     const rootDir = await createFixtureRoot();
 
@@ -369,12 +490,16 @@ describe("pre-push validation proof", () => {
           headSha: "head-after",
           headTreeSha: "tree-other",
           indexTreeSha: "tree-other",
+          changedTreeFiles: ["src/app.ts"],
+          treeContents: {
+            "tree-other": "100644 blob blob-b\tsrc/app.ts",
+          },
         }),
       }),
     ).resolves.toMatchObject({
       reusable: false,
       status: "stale",
-      reason: "HEAD tree changed since pr:athena recorded its proof",
+      reason: "HEAD tree changed outside post-gate validation-neutral paths",
     });
   });
 

--- a/scripts/pre-push-validation-proof.test.ts
+++ b/scripts/pre-push-validation-proof.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+  assertPostGateTelemetryChanges,
   assertPrAthenaProofReady,
   evaluatePrePushValidationProof,
   recordPrePushValidationProof,
@@ -160,6 +161,19 @@ afterEach(async () => {
 });
 
 describe("pre-push validation proof", () => {
+  it("strictly validates post-gate telemetry even without a matching local ledger", () => {
+    let observedRoot = "";
+    let observedOptions: { ciMode?: boolean } | undefined;
+
+    assertPostGateTelemetryChanges("/repo", (rootDir, options) => {
+      observedRoot = rootDir;
+      observedOptions = options;
+    });
+
+    expect(observedRoot).toBe("/repo");
+    expect(observedOptions).toEqual({ ciMode: true });
+  });
+
   it("prepares a clean tree for pr:athena proof recording", async () => {
     const rootDir = await createFixtureRoot();
     const logs: string[] = [];

--- a/scripts/pre-push-validation-proof.ts
+++ b/scripts/pre-push-validation-proof.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 
 import { captureStableHarnessCandidate } from "./harness-candidate";
 import { assertDeliveryRunTelemetryCheck } from "./delivery-run-telemetry";
+import type { DeliveryRunTelemetryCheckOptions } from "./delivery-run-telemetry";
 import { isPostGateValidationNeutralPath } from "./harness-review-identity";
 
 export const PRE_PUSH_VALIDATION_PROOF_SCHEMA_VERSION = 2;
@@ -73,6 +74,18 @@ type ProofRuntimeOptions = {
 };
 
 type ProofSnapshotMode = "evaluate" | "record";
+
+type DeliveryTelemetryCheck = (
+  rootDir: string,
+  options?: DeliveryRunTelemetryCheckOptions,
+) => void;
+
+export function assertPostGateTelemetryChanges(
+  rootDir: string,
+  check: DeliveryTelemetryCheck = assertDeliveryRunTelemetryCheck,
+) {
+  check(rootDir, { ciMode: true });
+}
 
 function normalizeRepoPath(repoPath: string) {
   return repoPath.replaceAll("\\", "/").replace(/^\.\//, "");
@@ -519,8 +532,7 @@ export async function evaluatePrePushValidationProof(
     }
     try {
       await (options.validatePostGateNeutralChanges ??
-        ((nextRootDir: string) =>
-          assertDeliveryRunTelemetryCheck(nextRootDir)))(rootDir);
+        assertPostGateTelemetryChanges)(rootDir);
     } catch (error) {
       return {
         reusable: false,

--- a/scripts/pre-push-validation-proof.ts
+++ b/scripts/pre-push-validation-proof.ts
@@ -3,6 +3,8 @@ import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import { captureStableHarnessCandidate } from "./harness-candidate";
+import { assertDeliveryRunTelemetryCheck } from "./delivery-run-telemetry";
+import { isPostGateValidationNeutralPath } from "./harness-review-identity";
 
 export const PRE_PUSH_VALIDATION_PROOF_SCHEMA_VERSION = 2;
 export const PR_ATHENA_PROOF_BASE_REF = "origin/main";
@@ -67,6 +69,7 @@ type ProofRuntimeOptions = {
   spawn?: CommandRunner;
   readFile?: typeof readFile;
   readdir?: typeof readdir;
+  validatePostGateNeutralChanges?: (rootDir: string) => void | Promise<void>;
 };
 
 type ProofSnapshotMode = "evaluate" | "record";
@@ -117,6 +120,45 @@ function parsePorcelainPaths(status: string) {
 
 function formatPathList(paths: string[]) {
   return paths.map((repoPath) => `  - ${repoPath}`).join("\n");
+}
+
+async function collectTreeChangedPaths(
+  rootDir: string,
+  beforeTreeSha: string,
+  afterTreeSha: string,
+  spawn: CommandRunner,
+) {
+  const proc = spawn(
+    [
+      "git",
+      "diff",
+      "--name-status",
+      "-z",
+      "--no-renames",
+      beforeTreeSha,
+      afterTreeSha,
+    ],
+    { cwd: rootDir, stdout: "pipe", stderr: "pipe" },
+  );
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exitCode !== 0) {
+    throw new Error(stderr || "git diff could not compare validation trees");
+  }
+  const records = stdout.split("\0");
+  const changes: Array<{ status: string; path: string }> = [];
+  for (let index = 0; index < records.length - 1; index += 2) {
+    const status = records[index];
+    const repoPath = records[index + 1];
+    if (!status || !repoPath) {
+      throw new Error("git diff returned malformed NUL-delimited status output");
+    }
+    changes.push({ status, path: repoPath });
+  }
+  return changes;
 }
 
 async function collectUnstagedFiles(
@@ -441,6 +483,56 @@ export async function evaluatePrePushValidationProof(
     };
   }
 
+  if (proof.validatedTreeSha !== snapshot.validatedTreeSha) {
+    let changes: Array<{ status: string; path: string }>;
+    try {
+      changes = await collectTreeChangedPaths(
+        rootDir,
+        proof.validatedTreeSha,
+        snapshot.validatedTreeSha,
+        options.spawn ?? Bun.spawn,
+      );
+    } catch (error) {
+      return {
+        reusable: false,
+        status: "stale",
+        reason: `could not verify post-gate tree delta: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        proofPath: snapshot.proofPath,
+      };
+    }
+    if (
+      changes.length === 0 ||
+      changes.some(
+        (change) =>
+          change.status !== "A" ||
+          !isPostGateValidationNeutralPath(change.path),
+      )
+    ) {
+      return {
+        reusable: false,
+        status: "stale",
+        reason: "HEAD tree changed outside post-gate validation-neutral paths",
+        proofPath: snapshot.proofPath,
+      };
+    }
+    try {
+      await (options.validatePostGateNeutralChanges ??
+        ((nextRootDir: string) =>
+          assertDeliveryRunTelemetryCheck(nextRootDir)))(rootDir);
+    } catch (error) {
+      return {
+        reusable: false,
+        status: "stale",
+        reason: `post-gate telemetry validation failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        proofPath: snapshot.proofPath,
+      };
+    }
+  }
+
   const comparisons: Array<
     [
       keyof PrePushValidationProof,
@@ -448,11 +540,6 @@ export async function evaluatePrePushValidationProof(
       string,
     ]
   > = [
-    [
-      "validatedTreeSha",
-      "stale",
-      "HEAD tree changed since pr:athena recorded its proof",
-    ],
     [
       "baseSha",
       "base_changed",

--- a/scripts/worktree-bootstrap-check.test.ts
+++ b/scripts/worktree-bootstrap-check.test.ts
@@ -7,12 +7,14 @@ import {
   WORKTREE_BOOTSTRAP_MARKER_PATH,
   validateWorktreeBootstrap,
 } from "./worktree-bootstrap-check";
+import { withoutGitRepositoryContext } from "./git-environment";
 
 const tempRoots: string[] = [];
 
 async function runGit(cwd: string, ...args: string[]) {
   const result = Bun.spawnSync(["git", ...args], {
     cwd,
+    env: withoutGitRepositoryContext(),
     stderr: "pipe",
     stdout: "pipe",
   });

--- a/telemetry/delivery-runs/2026-08-14T05-12-30-649Z-codex-v26-1220-git-hook-isolation.json
+++ b/telemetry/delivery-runs/2026-08-14T05-12-30-649Z-codex-v26-1220-git-hook-isolation.json
@@ -1,0 +1,33 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-08-14T05:12:30.649Z",
+  "branch": "codex/v26-1220-git-hook-isolation",
+  "headSha": "b271119c6b55b870d968404f18100f0bedb4e2e8",
+  "deliverableDiffFingerprint": "8cbd008877cdbe118f1dac8b52f478905e33c3ce4ace7938ad506c3944fc9826",
+  "status": "pass",
+  "proofState": "proof_recorded",
+  "summary": {
+    "commandCount": 5,
+    "failedCommandCount": 0,
+    "duplicateCommandCount": 0,
+    "duplicatePackageSuiteCount": 0,
+    "providerSkippedCount": 0,
+    "gateDecisionCount": 2,
+    "totalDurationMs": 561543.5022509999
+  },
+  "reviewLoop": {
+    "providerId": "execute",
+    "runId": "v26-1220-review-20260814",
+    "finalPassId": "pass-2",
+    "recordedAt": "2026-08-14T05:03:05.687Z",
+    "iterationCount": 2,
+    "findingCounts": {
+      "P0": 0,
+      "P1": 1,
+      "P2": 0,
+      "P3": 0
+    },
+    "deferredExpansionCount": 0,
+    "deferredIssueIds": []
+  }
+}

--- a/telemetry/delivery-runs/2026-08-14T06-18-23-971Z-codex-v26-1220-git-hook-isolation.json
+++ b/telemetry/delivery-runs/2026-08-14T06-18-23-971Z-codex-v26-1220-git-hook-isolation.json
@@ -1,0 +1,33 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-08-14T06:18:23.971Z",
+  "branch": "codex/v26-1220-git-hook-isolation",
+  "headSha": "4b00f7d131a114070392eeb164065d6971bd0f38",
+  "deliverableDiffFingerprint": "dc7e06e5e32d6f2caa9c5a18ec2eba5bfc20aab09586e7d0f69208f467c9bf50",
+  "status": "pass",
+  "proofState": "proof_recorded",
+  "summary": {
+    "commandCount": 5,
+    "failedCommandCount": 0,
+    "duplicateCommandCount": 0,
+    "duplicatePackageSuiteCount": 0,
+    "providerSkippedCount": 0,
+    "gateDecisionCount": 2,
+    "totalDurationMs": 556034.1677919999
+  },
+  "reviewLoop": {
+    "providerId": "execute",
+    "runId": "v26-1201-v26-1221",
+    "finalPassId": "pass-3",
+    "recordedAt": "2026-08-14T06:09:02.000Z",
+    "iterationCount": 3,
+    "findingCounts": {
+      "P0": 0,
+      "P1": 1,
+      "P2": 1,
+      "P3": 0
+    },
+    "deferredExpansionCount": 0,
+    "deferredIssueIds": []
+  }
+}


### PR DESCRIPTION
## Summary

- scrub inherited `GIT_*` repository context at both tracked hook boundaries and owned nested-repository subprocesses
- prove disposable fixture mutations cannot alter the parent repository configuration, refs, or index
- reuse a current `pr:athena` proof only after newly added canonical delivery telemetry passes strict validation
- include durable solution guidance and a reviewed landed-change report

## Why

The V26-1219 delivery exposed that Git hook context could leak into nested fixture repositories and mutate the shared checkout. The immediate V26-1220 harness fix was consolidated into the broader V26-1201 hook contract. V26-1221 closes the related finish-line loop where committing the required post-gate telemetry receipt unnecessarily invalidated a valid merge-grade proof.

## Validation

- `bun test scripts/pre-push-hook.test.ts scripts/pre-push-review.test.ts scripts/pre-push-validation-proof.test.ts scripts/harness-review-identity.test.ts scripts/worktree-bootstrap-check.test.ts scripts/harness-gate-admission.test.ts scripts/harness-test.test.ts` — 134 passed
- `bun run harness:test` — 945 passed
- `bun run pr:athena` — pass, 5 commands, 0 failures, 0 duplicates, proof recorded
- three-round independent review — unanimous final approval; resolved P1 strict telemetry enforcement and P2 report evidence freshness
- normal `git push` — hook reported `validation=skipped; proof=reusable`; no `--no-verify`
- `core.bare=false`, clean worktree/index after push

## Delivery records

- Linear: https://linear.app/v26-labs/issue/V26-1201
- Linear: https://linear.app/v26-labs/issue/V26-1221
- Report: `docs/reports/2026-08-14-hook-safe-validation-proof-reuse-report.html`
- Solution: `docs/solutions/harness/daily-operations-hydration-and-hook-env-2026-06-30.md`

Draft until GitHub checks are green. No validation bypass remains.