### PR TITLE
[V26-1225]: Alert managers when Daily Close remains stale

### DIFF
--- a/docs/reports/2026-08-14-stale-daily-close-manager-alerts-report.html
+++ b/docs/reports/2026-08-14-stale-daily-close-manager-alerts-report.html
@@ -176,11 +176,11 @@
         <p data-quiz-prompt>Which validation is complete at the time of this candidate report?</p>
         <ol data-quiz-options>
           <li>The full merge gate and required GitHub checks</li>
-          <li data-quiz-correct>The focused 204-test slice and mechanical preparation</li>
+          <li data-quiz-correct>Expanded focused regression suites, mechanical checks, and the final required reviewer set</li>
           <li>The merged-main production Convex deploy</li>
           <li>Only the email template test, with backend suites deferred</li>
         </ol>
-        <p data-quiz-explanation>The report intentionally distinguishes completed focused/mechanical proof from pending final-green review, broad gate, CI, merge, and deploy steps.</p>
+        <p data-quiz-explanation>The report records green focused/mechanical proof and the final required reviewer set while keeping the broad gate, CI, merge, and deploy pending.</p>
       </li>
       <li data-quiz-question>
         <p data-quiz-prompt>What is the correct extension path if product later wants repeated reminders?</p>

--- a/docs/reports/2026-08-14-stale-daily-close-manager-alerts-report.html
+++ b/docs/reports/2026-08-14-stale-daily-close-manager-alerts-report.html
@@ -5,7 +5,7 @@
   <title>Stale Daily Close Manager Alerts</title>
 </head>
 <body>
-<article data-athena-landed-change-report="v2" data-athena-report-diff-fingerprint="adb026b1ca192cde48edd16b3b03fd6c48b25bd15d279e9428f4f39330b5b274">
+<article data-athena-landed-change-report="v2" data-athena-report-diff-fingerprint="f1b03948f9d7115a7bfde4ec846014cb7d8f6489a9d470237b7faa260034ef1e">
   <header data-report-section="header">
     <h1>Stale Daily Close Manager Alerts</h1>
     <p>How bounded close evidence now remains actionable without creating duplicate manager email</p>
@@ -45,7 +45,7 @@
   </section>
   <section data-report-section="changes">
     <h2>What changed and what did not</h2>
-      <p>Changed: human, scheduled, and historic close paths share the source-specific completeness rule; persisted carry-forward counts remain meaningful under saturation; the notification registry owns a new email-only eod.stale_daily_close kind; enabled EOD policies are processed in bounded 50-store pages with scheduled continuation; the bounded three-date attempt window rotates by UTC hour so both hourly and two-hourly schedules cover every four-to-seven-day backlog; only attempted dates escalate; and configured EOD subscribers receive calm manager-facing copy with one EOD Review action.</p>
+      <p>Changed: human, scheduled, and historic close paths share the source-specific completeness rule; persisted carry-forward counts remain meaningful under saturation; the notification registry owns a new email-only eod.stale_daily_close kind; enabled EOD policies are processed in bounded 50-store pages whose continuation is persisted before per-store work; the bounded three-date attempt window rotates by UTC hour so both hourly and two-hourly schedules cover every four-to-seven-day backlog; only attempted dates escalate; and configured EOD subscribers receive calm manager-facing copy with one EOD Review action.</p>
       <p>Unchanged: the seven-day owed lookback, maximum three owed dates per store per sweep, two-day stale threshold, operational stale event, recipient subscriptions, delivery retries, and all true financial or transactional blockers. There is no browser route or direct email send from the sweep.</p>
   </section>
   <section data-report-section="failure-boundaries">
@@ -56,6 +56,7 @@
         <li>If the close completes, preparation returns no email; later dry-run rows do not hide an earlier qualifying skipped or failed run while the close remains open.</li>
         <li>Every other incomplete source continues to block or quarantine completion.</li>
         <li>The stale operational event and notification intent share one Convex mutation, avoiding partial durable state.</li>
+        <li>A throwing store can fail its current page loudly, but cannot erase the already-persisted continuation for later policy pages; every page carries the root sweep timestamp.</li>
       </ul>
   </section>
   <section data-report-section="validation">

--- a/docs/reports/2026-08-14-stale-daily-close-manager-alerts-report.html
+++ b/docs/reports/2026-08-14-stale-daily-close-manager-alerts-report.html
@@ -5,7 +5,7 @@
   <title>Stale Daily Close Manager Alerts</title>
 </head>
 <body>
-<article data-athena-landed-change-report="v2" data-athena-report-diff-fingerprint="d3ad655637832fae3c74d18ced92c32374c03d73a6ef086a394873cee5946b86">
+<article data-athena-landed-change-report="v2" data-athena-report-diff-fingerprint="8035c815d7ad5629114e446ee7a7fcd14aa72e24052839bf8c55e4f06ad354bf">
   <header data-report-section="header">
     <h1>Stale Daily Close Manager Alerts</h1>
     <p>How bounded close evidence now remains actionable without creating duplicate manager email</p>
@@ -41,7 +41,7 @@
   <section data-report-section="before-after">
     <h2>Before and after</h2>
       <p>Before: the owed sweep retried a historic close, every incomplete source blocked completion, and the stale threshold produced only an operational event. Open-work saturation at 201 rows looked the same as missing financial evidence.</p>
-      <p>After: non-open-work incomplete sources still fail closed. Open-work membership probes the open and in-progress statuses independently up to 500 rows plus a sentinel; either status returning a 501st row marks membership incomplete while preserving observed evidence and count without speculative per-item carry-forward writes. At the stale threshold, the same mutation emits a deduplicated email intent that resolves fresh blocker data and an EOD Review URL at send time.</p>
+      <p>After: non-open-work incomplete sources still fail closed. Open-work membership probes the open and in-progress statuses independently up to 500 rows plus a sentinel; either status returning a 501st row marks membership incomplete while preserving every safely observed ID, item, logical group, and observed count. Unobserved rows are never invented. At the stale threshold, the same mutation emits a deduplicated email intent that resolves fresh blocker data and an EOD Review URL at send time.</p>
   </section>
   <section data-report-section="changes">
     <h2>What changed and what did not</h2>
@@ -51,7 +51,7 @@
   <section data-report-section="failure-boundaries">
     <h2>Failure boundaries</h2>
       <ul>
-        <li>When either open-work status returns a 501st row, Athena records incomplete membership and an observed logical count but cannot enumerate every member; persisted incomplete group arrays remain empty and downstream readers must honor the completeness metadata.</li>
+        <li>When either open-work status returns a 501st row, Athena records incomplete membership and an observed logical count, persists all safely observed handoffs, and excludes the unobserved sentinel; downstream readers must still honor the completeness metadata.</li>
         <li>The store/date dedupe key deliberately sends one stale alert, not a daily reminder sequence; only a prior no-audience suppression may re-arm the same intent after subscription setup, refreshing its age while preserving sent-recipient dedupe.</li>
         <li>If the close completes, preparation returns no email; later dry-run rows do not hide an earlier qualifying skipped or failed run while the close remains open.</li>
         <li>Every other incomplete source continues to block or quarantine completion.</li>
@@ -71,7 +71,7 @@
         <li>Classify completeness per source and document safe fallback semantics instead of relying on one aggregate boolean.</li>
         <li>When bounded evidence proceeds, preserve observed counts and incomplete metadata; never turn truncation into zero.</li>
         <li>Use the notification registry for policy, recipient selection, retry, dedupe, and send-time truth checks.</li>
-        <li>Extend tests at the cap boundary and across repeated, recent, completed, and no-longer-qualifying stale states.</li>
+        <li>Extend tests at the cap boundary through completion, next-Opening handoff, and carry-forward resolution, plus repeated, recent, completed, and no-longer-qualifying stale states.</li>
       </ul>
   </section>
   <section data-report-section="key-files">

--- a/docs/reports/2026-08-14-stale-daily-close-manager-alerts-report.html
+++ b/docs/reports/2026-08-14-stale-daily-close-manager-alerts-report.html
@@ -5,7 +5,7 @@
   <title>Stale Daily Close Manager Alerts</title>
 </head>
 <body>
-<article data-athena-landed-change-report="v2" data-athena-report-diff-fingerprint="c27cb5ba912519fd6459c6f6770a61115315eba8108e292891646d3ff2c608a3">
+<article data-athena-landed-change-report="v2" data-athena-report-diff-fingerprint="f1183a3dceb9d4ea172fbc5291134360b910016d3756ca78b7b9516729f02f7c">
   <header data-report-section="header">
     <h1>Stale Daily Close Manager Alerts</h1>
     <p>How bounded close evidence now remains actionable without creating duplicate manager email</p>
@@ -45,13 +45,13 @@
   </section>
   <section data-report-section="changes">
     <h2>What changed and what did not</h2>
-      <p>Changed: human, scheduled, and historic close paths share the source-specific completeness rule; persisted carry-forward counts remain meaningful under saturation; the notification registry owns a new email-only eod.stale_daily_close kind; only dates attempted in the current sweep escalate; and configured EOD subscribers receive calm manager-facing copy with one EOD Review action.</p>
-      <p>Unchanged: the seven-day owed lookback, maximum three owed dates per store per sweep, two-day stale threshold, operational stale event, recipient subscriptions, delivery retries, and all true financial or transactional blockers. There is no schema migration, browser route, or direct email send from the sweep.</p>
+      <p>Changed: human, scheduled, and historic close paths share the source-specific completeness rule; persisted carry-forward counts remain meaningful under saturation; the notification registry owns a new email-only eod.stale_daily_close kind; the bounded three-date attempt window rotates by scheduled sweep slot so later dates cannot starve; only attempted dates escalate; and configured EOD subscribers receive calm manager-facing copy with one EOD Review action.</p>
+      <p>Unchanged: the seven-day owed lookback, maximum three owed dates per store per sweep, two-day stale threshold, operational stale event, recipient subscriptions, delivery retries, and all true financial or transactional blockers. There is no browser route or direct email send from the sweep.</p>
   </section>
   <section data-report-section="failure-boundaries">
     <h2>Failure boundaries</h2>
       <ul>
-        <li>When either open-work status returns a 501st row, Athena records incomplete membership and an observed logical count but cannot enumerate every member; downstream readers must honor the completeness metadata.</li>
+        <li>When either open-work status returns a 501st row, Athena records incomplete membership and an observed logical count but cannot enumerate every member; persisted incomplete group arrays remain empty and downstream readers must honor the completeness metadata.</li>
         <li>The store/date dedupe key deliberately sends one stale alert, not a daily reminder sequence; only a prior no-audience suppression may re-arm the same intent after subscription setup.</li>
         <li>If the close completes, preparation returns no email; later dry-run rows do not hide an earlier qualifying skipped or failed run while the close remains open.</li>
         <li>Every other incomplete source continues to block or quarantine completion.</li>
@@ -60,7 +60,7 @@
   </section>
   <section data-report-section="validation">
     <h2>Validation and delivery status</h2>
-      <p>Focused Vitest coverage first passed 204 of 204 tests across the notification registry, Daily Close, Daily Operations automation, owed-close integration, and React Email template. After review fixes, a focused 143-test regression slice passed alongside changed-Convex lint, TypeScript, Graphify rebuild, and git diff validation.</p>
+      <p>Focused Vitest coverage first passed 204 of 204 tests across the notification registry, Daily Close, Daily Operations automation, owed-close integration, and React Email template. After two review-fix rounds, the expanded focused regression slice passed 306 tests alongside changed-Convex lint, TypeScript, Graphify rebuild, solution/report checks, and git diff validation.</p>
       <p>The repository merge gate has not yet completed its broad test and final-green review stages. The PR, CI, merge, root fast-forward, and production Convex deploy are pending and must not be inferred from this candidate report.</p>
   </section>
   <section data-report-section="guidance">

--- a/docs/reports/2026-08-14-stale-daily-close-manager-alerts-report.html
+++ b/docs/reports/2026-08-14-stale-daily-close-manager-alerts-report.html
@@ -5,7 +5,7 @@
   <title>Stale Daily Close Manager Alerts</title>
 </head>
 <body>
-<article data-athena-landed-change-report="v2" data-athena-report-diff-fingerprint="f1b03948f9d7115a7bfde4ec846014cb7d8f6489a9d470237b7faa260034ef1e">
+<article data-athena-landed-change-report="v2" data-athena-report-diff-fingerprint="d3ad655637832fae3c74d18ced92c32374c03d73a6ef086a394873cee5946b86">
   <header data-report-section="header">
     <h1>Stale Daily Close Manager Alerts</h1>
     <p>How bounded close evidence now remains actionable without creating duplicate manager email</p>
@@ -56,7 +56,7 @@
         <li>If the close completes, preparation returns no email; later dry-run rows do not hide an earlier qualifying skipped or failed run while the close remains open.</li>
         <li>Every other incomplete source continues to block or quarantine completion.</li>
         <li>The stale operational event and notification intent share one Convex mutation, avoiding partial durable state.</li>
-        <li>A throwing store can fail its current page loudly, but cannot erase the already-persisted continuation for later policy pages; every page carries the root sweep timestamp.</li>
+        <li>A throwing store can fail its current page loudly, but cannot erase the already-persisted continuation for later policy pages; candidate discovery, rotation, store work, and every continuation share one root-derived timestamp.</li>
       </ul>
   </section>
   <section data-report-section="validation">

--- a/docs/reports/2026-08-14-stale-daily-close-manager-alerts-report.html
+++ b/docs/reports/2026-08-14-stale-daily-close-manager-alerts-report.html
@@ -5,18 +5,18 @@
   <title>Stale Daily Close Manager Alerts</title>
 </head>
 <body>
-<article data-athena-landed-change-report="v2" data-athena-report-diff-fingerprint="8035c815d7ad5629114e446ee7a7fcd14aa72e24052839bf8c55e4f06ad354bf">
+<article data-athena-landed-change-report="v2" data-athena-report-diff-fingerprint="ae53a0e83dda3f8c3ebcafe871cce5babefc5f2fb3486c990ce6b5afc13cbc29">
   <header data-report-section="header">
     <h1>Stale Daily Close Manager Alerts</h1>
     <p>How bounded close evidence now remains actionable without creating duplicate manager email</p>
     <ul data-report-pills>
       <li>Delivery candidate</li>
       <li>Branch codex/stale-eod-manager-email</li>
-      <li>Focused tests 204/204 green</li>
+      <li>Expanded focused regression suites green</li>
       <li>Merge and Convex production deploy pending</li>
     </ul>
     <dl data-report-meta>
-      <dt>Candidate head</dt><dd>42fe22f9</dd>
+      <dt>Candidate head</dt><dd>ed544ebc</dd>
       <dt>Base</dt><dd>origin/main at 2864580c</dd>
       <dt>PR</dt><dd>Pending creation</dd>
       <dt>Production</dt><dd>Pending Convex deploy</dd>
@@ -56,13 +56,13 @@
         <li>If the close completes, preparation returns no email; later dry-run rows do not hide an earlier qualifying skipped or failed run while the close remains open.</li>
         <li>Every other incomplete source continues to block or quarantine completion.</li>
         <li>The stale operational event and notification intent share one Convex mutation, avoiding partial durable state.</li>
-        <li>A throwing store can fail its current page loudly, but cannot erase the already-persisted continuation for later policy pages; candidate discovery, rotation, store work, and every continuation share one root-derived timestamp.</li>
+        <li>A throwing store is recorded as a failed candidate without starving later stores on the same page, and cannot erase the already-persisted continuation for later policy pages; candidate discovery, rotation, store work, and every continuation share one root-derived timestamp.</li>
       </ul>
   </section>
   <section data-report-section="validation">
     <h2>Validation and delivery status</h2>
-      <p>Focused Vitest coverage first passed 204 of 204 tests across the notification registry, Daily Close, Daily Operations automation, owed-close integration, and React Email template. After two review-fix rounds, the expanded focused regression slice passed 306 tests alongside changed-Convex lint, TypeScript, Graphify rebuild, solution/report checks, and git diff validation.</p>
-      <p>The repository merge gate has not yet completed its broad test and final-green review stages. The PR, CI, merge, root fast-forward, and production Convex deploy are pending and must not be inferred from this candidate report.</p>
+      <p>Focused Vitest coverage spans the notification registry and rail, Daily Close, Daily Operations automation, owed-close unit and integration behavior, and the React Email template. The expanded regression slices passed alongside changed-Convex lint, TypeScript, Graphify rebuild, solution/report checks, and git diff validation.</p>
+      <p>The final required reviewer set is green. The repository merge gate, PR CI, merge, root fast-forward, and production Convex deploy remain pending and must not be inferred from this candidate report.</p>
   </section>
   <section data-report-section="guidance">
     <h2>Next-time guidance</h2>

--- a/docs/reports/2026-08-14-stale-daily-close-manager-alerts-report.html
+++ b/docs/reports/2026-08-14-stale-daily-close-manager-alerts-report.html
@@ -1,0 +1,206 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Stale Daily Close Manager Alerts</title>
+</head>
+<body>
+<article data-athena-landed-change-report="v2" data-athena-report-diff-fingerprint="6913199099f2cb022d01367b82ea272f2f18bdc67a89ab107138aff295325c59">
+  <header data-report-section="header">
+    <h1>Stale Daily Close Manager Alerts</h1>
+    <p>How bounded close evidence now remains actionable without creating duplicate manager email</p>
+    <ul data-report-pills>
+      <li>Delivery candidate</li>
+      <li>Branch codex/stale-eod-manager-email</li>
+      <li>Focused tests 204/204 green</li>
+      <li>Merge and Convex production deploy pending</li>
+    </ul>
+    <dl data-report-meta>
+      <dt>Candidate head</dt><dd>42fe22f9</dd>
+      <dt>Base</dt><dd>origin/main at 2864580c</dd>
+      <dt>PR</dt><dd>Pending creation</dd>
+      <dt>Production</dt><dd>Pending Convex deploy</dd>
+      <dt>Root alignment</dt><dd>Pending merge</dd>
+    </dl>
+  </header>
+  <section data-report-section="summary">
+    <h2>Executive summary</h2>
+      <p>This candidate lets Daily Close proceed conservatively when only the open-operational-work membership read is capped, while retaining explicit incomplete evidence and the observed carry-forward count. A day that remains owed for two days now emits one manager-facing EOD alert through Athena&#x27;s existing notification rail.</p>
+      <p>The alert is deduplicated by store and operating date, rebuilds blocker context at send time, and suppresses itself if the close is no longer open or the latest automation run no longer requires attention.</p>
+  </section>
+  <section data-report-section="problem">
+    <h2>Problem and context</h2>
+      <p>A production investigation initially appeared to implicate a rejected register closeout, but that closeout belonged to the next operating date. The actual stale day had 204 raw open-work rows, representing 61 logical carry-forward groups. Athena&#x27;s shared 200-row read cap marked the source incomplete and the global fail-closed guard quarantined the day even though open operational work is specifically allowed to carry forward.</p>
+      <p>The owed-close sweep already retried stale days and wrote a deduplicated operational event at the two-day threshold. It did not create a manager-facing notification, so the system had internal evidence without a direct path for the operator to review the close.</p>
+  </section>
+  <section data-report-section="mental-model">
+    <h2>Mental model</h2>
+      <p>Think of source completeness as a set of circuit breakers, not one master switch. Missing financial or transactional evidence keeps Daily Close stopped. A capped list of open operational work can proceed conservatively because Athena carries forward every observed group, records that membership is incomplete, and does not invent unobserved members.</p>
+      <p>The alert is a durable intent, not a direct send. The sweep records the stale state and notification intent atomically; the existing delivery rail later rechecks the live close and latest automation run before rendering the email.</p>
+  </section>
+  <section data-report-section="before-after">
+    <h2>Before and after</h2>
+      <p>Before: the owed sweep retried a historic close, every incomplete source blocked completion, and the stale threshold produced only an operational event. Open-work saturation at 201 rows looked the same as missing financial evidence.</p>
+      <p>After: non-open-work incomplete sources still fail closed. Open-work membership probes the open and in-progress statuses independently up to 500 rows plus a sentinel; either status returning a 501st row marks membership incomplete while preserving observed evidence and count without speculative per-item carry-forward writes. At the stale threshold, the same mutation emits a deduplicated email intent that resolves fresh blocker data and an EOD Review URL at send time.</p>
+  </section>
+  <section data-report-section="changes">
+    <h2>What changed and what did not</h2>
+      <p>Changed: human, scheduled, and historic close paths share the source-specific completeness rule; persisted carry-forward counts remain meaningful under saturation; the notification registry owns a new email-only eod.stale_daily_close kind; and configured EOD subscribers receive calm manager-facing copy with one EOD Review action.</p>
+      <p>Unchanged: the seven-day owed lookback, maximum three owed dates per store per sweep, two-day stale threshold, operational stale event, recipient subscriptions, delivery retries, and all true financial or transactional blockers. There is no schema migration, browser route, or direct email send from the sweep.</p>
+  </section>
+  <section data-report-section="failure-boundaries">
+    <h2>Failure boundaries</h2>
+      <ul>
+        <li>When either open-work status returns a 501st row, Athena records incomplete membership and an observed logical count but cannot enumerate every member; downstream readers must honor the completeness metadata.</li>
+        <li>The store/date dedupe key deliberately sends one stale alert, not a daily reminder or re-armed sequence.</li>
+        <li>If the close completes or the latest EOD automation run is no longer skipped or failed, preparation returns no email.</li>
+        <li>Every other incomplete source continues to block or quarantine completion.</li>
+        <li>The stale operational event and notification intent share one Convex mutation, avoiding partial durable state.</li>
+      </ul>
+  </section>
+  <section data-report-section="validation">
+    <h2>Validation and delivery status</h2>
+      <p>Focused Vitest coverage passed 204 of 204 tests across the notification registry, Daily Close, Daily Operations automation, owed-close integration, and React Email template. Mechanical preparation passed changed-Convex lint and TypeScript after replacing unbounded test reads with take(2) and constructing the preview text as one string.</p>
+      <p>The repository merge gate has not yet completed its broad test and final-green review stages. The PR, CI, merge, root fast-forward, and production Convex deploy are pending and must not be inferred from this candidate report.</p>
+  </section>
+  <section data-report-section="guidance">
+    <h2>Next-time guidance</h2>
+      <ul>
+        <li>Validate the operating date attached to each apparent blocker before attributing a stale day to adjacent-day activity.</li>
+        <li>Classify completeness per source and document safe fallback semantics instead of relying on one aggregate boolean.</li>
+        <li>When bounded evidence proceeds, preserve observed counts and incomplete metadata; never turn truncation into zero.</li>
+        <li>Use the notification registry for policy, recipient selection, retry, dedupe, and send-time truth checks.</li>
+        <li>Extend tests at the cap boundary and across repeated, recent, completed, and no-longer-qualifying stale states.</li>
+      </ul>
+  </section>
+  <section data-report-section="key-files">
+    <h2>Key files</h2>
+    <table>
+      <thead><tr><th>File</th><th>Why it matters</th></tr></thead>
+      <tbody>
+        <tr><td><code>packages/athena-webapp/convex/operations/dailyClose.ts</code></td><td>Defines source-specific completion blockers and conservative saturated open-work persistence.</td></tr>
+        <tr><td><code>packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts</code></td><td>Applies the same rule to historic automatic close attempts.</td></tr>
+        <tr><td><code>packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts</code></td><td>Emits the stale event and durable notification intent at the existing threshold.</td></tr>
+        <tr><td><code>packages/athena-webapp/convex/notifications/registry.ts</code></td><td>Owns stable store/date dedupe and fresh send-time preparation.</td></tr>
+        <tr><td><code>packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts</code></td><td>Reuses authoritative store, blocker, cash-position, and report-link semantics.</td></tr>
+        <tr><td><code>packages/athena-webapp/convex/emails/StaleDailyCloseAlert.tsx</code></td><td>Renders restrained manager copy and the single EOD Review action.</td></tr>
+      </tbody>
+    </table>
+  </section>
+  <section data-report-section="quiz" data-quiz-pass-threshold="8">
+    <h2>Comprehension quiz</h2>
+    <p>Pass required: 8 of 10.</p>
+    <ol data-quiz>
+      <li data-quiz-question>
+        <p data-quiz-prompt>Why can an incomplete open-work membership read proceed when other incomplete sources cannot?</p>
+        <ol data-quiz-options>
+          <li>Open work is ignored during close</li>
+          <li data-quiz-correct>Observed open work can be carried forward conservatively while missing financial evidence could corrupt the close</li>
+          <li>The query always returns every row</li>
+          <li>Managers manually approve every truncated read</li>
+        </ol>
+        <p data-quiz-explanation>The rule is source-specific: observed operational work has a conservative carry-forward fallback, while financial and transactional sources still require exhaustive evidence.</p>
+      </li>
+      <li data-quiz-question>
+        <p data-quiz-prompt>What exactly triggers incomplete open-work membership?</p>
+        <ol data-quiz-options>
+          <li>The combined open and in-progress total exceeds 500</li>
+          <li data-quiz-correct>Either the open or in-progress status query returns a 501st row</li>
+          <li>The selected carry-forward IDs exceed 500 after grouping</li>
+          <li>Any operational work remains at the end of day</li>
+        </ol>
+        <p data-quiz-explanation>Each status is bounded independently with take(501); the 501st row in either status proves that status membership was truncated.</p>
+      </li>
+      <li data-quiz-question>
+        <p data-quiz-prompt>Where is the manager-facing email first represented durably?</p>
+        <ol data-quiz-options>
+          <li>As rendered HTML stored by the sweep before the transaction commits</li>
+          <li data-quiz-correct>As a notification intent emitted through the registry rail</li>
+          <li>As a delivery attempt created only after recipient resolution</li>
+          <li>As a new email-specific ledger introduced by this branch</li>
+        </ol>
+        <p data-quiz-explanation>The sweep emits a registry-owned notification intent; existing delivery machinery later handles recipients, retry, preparation, and sending.</p>
+      </li>
+      <li data-quiz-question>
+        <p data-quiz-prompt>What prevents repeated sweeps from emailing repeatedly?</p>
+        <ol data-quiz-options>
+          <li>A random UUID</li>
+          <li>The manager&#x27;s browser session</li>
+          <li data-quiz-correct>A stable kind/store/operating-date dedupe key</li>
+          <li>The seven-day lookback alone</li>
+        </ol>
+        <p data-quiz-explanation>The business identity eod.stale_daily_close:&lt;storeId&gt;:&lt;operatingDate&gt; remains stable across retries.</p>
+      </li>
+      <li data-quiz-question>
+        <p data-quiz-prompt>When will preparation suppress an already-created stale intent?</p>
+        <ol data-quiz-options>
+          <li data-quiz-correct>When the close is completed or the latest automation run is no longer skipped or failed</li>
+          <li>Only when the intent was already deduplicated at creation time</li>
+          <li>When recipient resolution finds more than one EOD subscriber</li>
+          <li>Only when the seven-day owed lookback expires</li>
+        </ol>
+        <p data-quiz-explanation>Preparation rechecks live close and automation state so queued work cannot send stale guidance; creation-time dedupe alone does not prove the alert is still relevant.</p>
+      </li>
+      <li data-quiz-question>
+        <p data-quiz-prompt>Which behavior intentionally remains fail-closed?</p>
+        <ol data-quiz-options>
+          <li data-quiz-correct>Incomplete non-operational-work sources</li>
+          <li>A repeated stale sweep</li>
+          <li>A completed close</li>
+          <li>The email template fallback text</li>
+        </ol>
+        <p data-quiz-explanation>Only operational-work membership has the conservative saturated fallback; other incomplete evidence still blocks completion.</p>
+      </li>
+      <li data-quiz-question>
+        <p data-quiz-prompt>Why is the observed logical count used instead of the selected member count under saturation?</p>
+        <ol data-quiz-options>
+          <li data-quiz-correct>The selected list is intentionally empty when membership is truncated, so its length would understate observed grouped work</li>
+          <li>The combined status cap guarantees the selected list contains exactly 500 logical groups</li>
+          <li>The notification dedupe key requires the count to remain stable</li>
+          <li>The observed count includes financial sources that the selected list excludes</li>
+        </ol>
+        <p data-quiz-explanation>When either per-status query is truncated, Athena avoids speculative per-item carry-forward writes; the selected list therefore cannot represent all observed logical groups.</p>
+      </li>
+      <li data-quiz-question>
+        <p data-quiz-prompt>What was the key production-diagnosis correction?</p>
+        <ol data-quiz-options>
+          <li>The email service was offline</li>
+          <li data-quiz-correct>A rejected register belonged to the next day; the stale day was blocked by open-work query saturation</li>
+          <li>The store had no timezone</li>
+          <li>The manager subscription was deleted</li>
+        </ol>
+        <p data-quiz-explanation>Operating-date ownership ruled out the adjacent-day register event and exposed the artificial source-cap blocker.</p>
+      </li>
+      <li data-quiz-question>
+        <p data-quiz-prompt>Which validation is complete at the time of this candidate report?</p>
+        <ol data-quiz-options>
+          <li>The full merge gate and required GitHub checks</li>
+          <li data-quiz-correct>The focused 204-test slice and mechanical preparation</li>
+          <li>The merged-main production Convex deploy</li>
+          <li>Only the email template test, with backend suites deferred</li>
+        </ol>
+        <p data-quiz-explanation>The report intentionally distinguishes completed focused/mechanical proof from pending final-green review, broad gate, CI, merge, and deploy steps.</p>
+      </li>
+      <li data-quiz-question>
+        <p data-quiz-prompt>What is the correct extension path if product later wants repeated reminders?</p>
+        <ol data-quiz-options>
+          <li>Remove all deduplication</li>
+          <li data-quiz-correct>Add an explicit reminder or re-arm epoch contract and test it</li>
+          <li>Send directly from the sweep</li>
+          <li>Treat financial sources as non-blocking</li>
+        </ol>
+        <p data-quiz-explanation>The current one-alert contract is deliberate; repeated reminders need a durable sequence or re-arm identity rather than weakening idempotency.</p>
+      </li>
+    </ol>
+  </section>
+  <section data-report-section="subagent-evidence">
+    <h2>Subagent evidence</h2>
+    <dl>
+      <dt>session context historian</dt><dd>Reconstructed the production diagnosis correction, copy decisions, discarded screenshot, prior validation, and still-pending finish line from recent Codex sessions.</dd>
+      <dt>delivered diff explorer</dt><dd>Mapped the changed layers, before/after flow, failure boundaries, generated artifacts, test coverage, and intentionally unchanged behavior from git and source.</dd>
+      <dt>quiz and report reviewer</dt><dd>Corrected the per-status source boundary and subscriber policy wording, and strengthened quiz alternatives so they test the actual delivery contract.</dd>
+    </dl>
+  </section>
+</article>
+</body>
+</html>

--- a/docs/reports/2026-08-14-stale-daily-close-manager-alerts-report.html
+++ b/docs/reports/2026-08-14-stale-daily-close-manager-alerts-report.html
@@ -5,7 +5,7 @@
   <title>Stale Daily Close Manager Alerts</title>
 </head>
 <body>
-<article data-athena-landed-change-report="v2" data-athena-report-diff-fingerprint="f1183a3dceb9d4ea172fbc5291134360b910016d3756ca78b7b9516729f02f7c">
+<article data-athena-landed-change-report="v2" data-athena-report-diff-fingerprint="3d160abf4ea34d91f563030a38c71162137fb2632d5764fbe517e00f918c049b">
   <header data-report-section="header">
     <h1>Stale Daily Close Manager Alerts</h1>
     <p>How bounded close evidence now remains actionable without creating duplicate manager email</p>
@@ -45,7 +45,7 @@
   </section>
   <section data-report-section="changes">
     <h2>What changed and what did not</h2>
-      <p>Changed: human, scheduled, and historic close paths share the source-specific completeness rule; persisted carry-forward counts remain meaningful under saturation; the notification registry owns a new email-only eod.stale_daily_close kind; the bounded three-date attempt window rotates by scheduled sweep slot so later dates cannot starve; only attempted dates escalate; and configured EOD subscribers receive calm manager-facing copy with one EOD Review action.</p>
+      <p>Changed: human, scheduled, and historic close paths share the source-specific completeness rule; persisted carry-forward counts remain meaningful under saturation; the notification registry owns a new email-only eod.stale_daily_close kind; the bounded three-date attempt window rotates by UTC hour so both hourly and two-hourly schedules cover every four-to-seven-day backlog; only attempted dates escalate; and configured EOD subscribers receive calm manager-facing copy with one EOD Review action.</p>
       <p>Unchanged: the seven-day owed lookback, maximum three owed dates per store per sweep, two-day stale threshold, operational stale event, recipient subscriptions, delivery retries, and all true financial or transactional blockers. There is no browser route or direct email send from the sweep.</p>
   </section>
   <section data-report-section="failure-boundaries">

--- a/docs/reports/2026-08-14-stale-daily-close-manager-alerts-report.html
+++ b/docs/reports/2026-08-14-stale-daily-close-manager-alerts-report.html
@@ -5,7 +5,7 @@
   <title>Stale Daily Close Manager Alerts</title>
 </head>
 <body>
-<article data-athena-landed-change-report="v2" data-athena-report-diff-fingerprint="6913199099f2cb022d01367b82ea272f2f18bdc67a89ab107138aff295325c59">
+<article data-athena-landed-change-report="v2" data-athena-report-diff-fingerprint="c27cb5ba912519fd6459c6f6770a61115315eba8108e292891646d3ff2c608a3">
   <header data-report-section="header">
     <h1>Stale Daily Close Manager Alerts</h1>
     <p>How bounded close evidence now remains actionable without creating duplicate manager email</p>
@@ -26,7 +26,7 @@
   <section data-report-section="summary">
     <h2>Executive summary</h2>
       <p>This candidate lets Daily Close proceed conservatively when only the open-operational-work membership read is capped, while retaining explicit incomplete evidence and the observed carry-forward count. A day that remains owed for two days now emits one manager-facing EOD alert through Athena&#x27;s existing notification rail.</p>
-      <p>The alert is deduplicated by store and operating date, rebuilds blocker context at send time, and suppresses itself if the close is no longer open or the latest automation run no longer requires attention.</p>
+      <p>The alert is deduplicated by store and operating date, rebuilds blocker context from the latest qualifying skipped or failed run, and suppresses itself if the close is no longer open. A no-audience dispatch remains re-armable so adding an EOD subscriber does not permanently consume the alert.</p>
   </section>
   <section data-report-section="problem">
     <h2>Problem and context</h2>
@@ -45,22 +45,22 @@
   </section>
   <section data-report-section="changes">
     <h2>What changed and what did not</h2>
-      <p>Changed: human, scheduled, and historic close paths share the source-specific completeness rule; persisted carry-forward counts remain meaningful under saturation; the notification registry owns a new email-only eod.stale_daily_close kind; and configured EOD subscribers receive calm manager-facing copy with one EOD Review action.</p>
+      <p>Changed: human, scheduled, and historic close paths share the source-specific completeness rule; persisted carry-forward counts remain meaningful under saturation; the notification registry owns a new email-only eod.stale_daily_close kind; only dates attempted in the current sweep escalate; and configured EOD subscribers receive calm manager-facing copy with one EOD Review action.</p>
       <p>Unchanged: the seven-day owed lookback, maximum three owed dates per store per sweep, two-day stale threshold, operational stale event, recipient subscriptions, delivery retries, and all true financial or transactional blockers. There is no schema migration, browser route, or direct email send from the sweep.</p>
   </section>
   <section data-report-section="failure-boundaries">
     <h2>Failure boundaries</h2>
       <ul>
         <li>When either open-work status returns a 501st row, Athena records incomplete membership and an observed logical count but cannot enumerate every member; downstream readers must honor the completeness metadata.</li>
-        <li>The store/date dedupe key deliberately sends one stale alert, not a daily reminder or re-armed sequence.</li>
-        <li>If the close completes or the latest EOD automation run is no longer skipped or failed, preparation returns no email.</li>
+        <li>The store/date dedupe key deliberately sends one stale alert, not a daily reminder sequence; only a prior no-audience suppression may re-arm the same intent after subscription setup.</li>
+        <li>If the close completes, preparation returns no email; later dry-run rows do not hide an earlier qualifying skipped or failed run while the close remains open.</li>
         <li>Every other incomplete source continues to block or quarantine completion.</li>
         <li>The stale operational event and notification intent share one Convex mutation, avoiding partial durable state.</li>
       </ul>
   </section>
   <section data-report-section="validation">
     <h2>Validation and delivery status</h2>
-      <p>Focused Vitest coverage passed 204 of 204 tests across the notification registry, Daily Close, Daily Operations automation, owed-close integration, and React Email template. Mechanical preparation passed changed-Convex lint and TypeScript after replacing unbounded test reads with take(2) and constructing the preview text as one string.</p>
+      <p>Focused Vitest coverage first passed 204 of 204 tests across the notification registry, Daily Close, Daily Operations automation, owed-close integration, and React Email template. After review fixes, a focused 143-test regression slice passed alongside changed-Convex lint, TypeScript, Graphify rebuild, and git diff validation.</p>
       <p>The repository merge gate has not yet completed its broad test and final-green review stages. The PR, CI, merge, root fast-forward, and production Convex deploy are pending and must not be inferred from this candidate report.</p>
   </section>
   <section data-report-section="guidance">

--- a/docs/reports/2026-08-14-stale-daily-close-manager-alerts-report.html
+++ b/docs/reports/2026-08-14-stale-daily-close-manager-alerts-report.html
@@ -5,7 +5,7 @@
   <title>Stale Daily Close Manager Alerts</title>
 </head>
 <body>
-<article data-athena-landed-change-report="v2" data-athena-report-diff-fingerprint="3d160abf4ea34d91f563030a38c71162137fb2632d5764fbe517e00f918c049b">
+<article data-athena-landed-change-report="v2" data-athena-report-diff-fingerprint="adb026b1ca192cde48edd16b3b03fd6c48b25bd15d279e9428f4f39330b5b274">
   <header data-report-section="header">
     <h1>Stale Daily Close Manager Alerts</h1>
     <p>How bounded close evidence now remains actionable without creating duplicate manager email</p>
@@ -26,7 +26,7 @@
   <section data-report-section="summary">
     <h2>Executive summary</h2>
       <p>This candidate lets Daily Close proceed conservatively when only the open-operational-work membership read is capped, while retaining explicit incomplete evidence and the observed carry-forward count. A day that remains owed for two days now emits one manager-facing EOD alert through Athena&#x27;s existing notification rail.</p>
-      <p>The alert is deduplicated by store and operating date, rebuilds blocker context from the latest qualifying skipped or failed run, and suppresses itself if the close is no longer open. A no-audience dispatch remains re-armable so adding an EOD subscriber does not permanently consume the alert.</p>
+      <p>The alert is deduplicated by store and operating date, rebuilds blocker context from the latest qualifying skipped or failed run, and suppresses itself if the close is no longer open. A no-audience dispatch remains re-armable with the latest age payload, so adding an EOD subscriber does not permanently consume or stale the alert.</p>
   </section>
   <section data-report-section="problem">
     <h2>Problem and context</h2>
@@ -45,14 +45,14 @@
   </section>
   <section data-report-section="changes">
     <h2>What changed and what did not</h2>
-      <p>Changed: human, scheduled, and historic close paths share the source-specific completeness rule; persisted carry-forward counts remain meaningful under saturation; the notification registry owns a new email-only eod.stale_daily_close kind; the bounded three-date attempt window rotates by UTC hour so both hourly and two-hourly schedules cover every four-to-seven-day backlog; only attempted dates escalate; and configured EOD subscribers receive calm manager-facing copy with one EOD Review action.</p>
+      <p>Changed: human, scheduled, and historic close paths share the source-specific completeness rule; persisted carry-forward counts remain meaningful under saturation; the notification registry owns a new email-only eod.stale_daily_close kind; enabled EOD policies are processed in bounded 50-store pages with scheduled continuation; the bounded three-date attempt window rotates by UTC hour so both hourly and two-hourly schedules cover every four-to-seven-day backlog; only attempted dates escalate; and configured EOD subscribers receive calm manager-facing copy with one EOD Review action.</p>
       <p>Unchanged: the seven-day owed lookback, maximum three owed dates per store per sweep, two-day stale threshold, operational stale event, recipient subscriptions, delivery retries, and all true financial or transactional blockers. There is no browser route or direct email send from the sweep.</p>
   </section>
   <section data-report-section="failure-boundaries">
     <h2>Failure boundaries</h2>
       <ul>
         <li>When either open-work status returns a 501st row, Athena records incomplete membership and an observed logical count but cannot enumerate every member; persisted incomplete group arrays remain empty and downstream readers must honor the completeness metadata.</li>
-        <li>The store/date dedupe key deliberately sends one stale alert, not a daily reminder sequence; only a prior no-audience suppression may re-arm the same intent after subscription setup.</li>
+        <li>The store/date dedupe key deliberately sends one stale alert, not a daily reminder sequence; only a prior no-audience suppression may re-arm the same intent after subscription setup, refreshing its age while preserving sent-recipient dedupe.</li>
         <li>If the close completes, preparation returns no email; later dry-run rows do not hide an earlier qualifying skipped or failed run while the close remains open.</li>
         <li>Every other incomplete source continues to block or quarantine completion.</li>
         <li>The stale operational event and notification intent share one Convex mutation, avoiding partial durable state.</li>

--- a/docs/solutions/logic-errors/daily-close-saturation-and-stale-manager-alerts-2026-08-14.md
+++ b/docs/solutions/logic-errors/daily-close-saturation-and-stale-manager-alerts-2026-08-14.md
@@ -12,7 +12,7 @@ root_cause: logic_error
 resolution_type: code_fix
 severity: high
 tags: [daily-close, automation, notifications, source-completeness, deduplication]
-delivery_diff_fingerprint: d3ad655637832fae3c74d18ced92c32374c03d73a6ef086a394873cee5946b86
+delivery_diff_fingerprint: 8035c815d7ad5629114e446ee7a7fcd14aa72e24052839bf8c55e4f06ad354bf
 ---
 
 # Daily Close saturation must preserve evidence and alert once
@@ -74,9 +74,10 @@ age, so delayed delivery renders current staleness rather than the age observed
 before the audience was configured.
 
 When operational-work membership is incomplete, the completed close persists
-the incomplete membership marker and observed logical count, but not the
-probe's synthetic incomplete groups. Those groups cannot truthfully identify
-members; the count remains evidence while the item/group arrays stay empty.
+the incomplete membership marker, observed logical count, and every safely
+observed work ID and item. Daily Opening can therefore receive and resolve the
+observed handoffs without claiming exhaustive membership or inventing IDs for
+the unobserved remainder.
 
 ## Why This Works
 

--- a/docs/solutions/logic-errors/daily-close-saturation-and-stale-manager-alerts-2026-08-14.md
+++ b/docs/solutions/logic-errors/daily-close-saturation-and-stale-manager-alerts-2026-08-14.md
@@ -12,7 +12,7 @@ root_cause: logic_error
 resolution_type: code_fix
 severity: high
 tags: [daily-close, automation, notifications, source-completeness, deduplication]
-delivery_diff_fingerprint: f1b03948f9d7115a7bfde4ec846014cb7d8f6489a9d470237b7faa260034ef1e
+delivery_diff_fingerprint: d3ad655637832fae3c74d18ced92c32374c03d73a6ef086a394873cee5946b86
 ---
 
 # Daily Close saturation must preserve evidence and alert once
@@ -60,8 +60,10 @@ Enabled policies are read in 50-row indexed pages. Each action schedules the
 next cursor before processing any store on its page, so a throwing first-page
 store cannot strand the 51st store and beyond. Continuations carry the one
 timestamp derived by the root action, keeping operating-date and rotation
-decisions consistent across the sweep without turning one action into an
-unbounded cross-store job.
+decisions consistent across the sweep. The root candidate query receives that
+same derived timestamp too, so even the first page cannot observe a different
+operating-date boundary from rotation or its continuations. This avoids
+turning one action into an unbounded cross-store job.
 
 If a stale intent initially finds no EOD subscribers, a later owed-date retry
 re-arms that same suppressed intent after subscription setup. The intent and

--- a/docs/solutions/logic-errors/daily-close-saturation-and-stale-manager-alerts-2026-08-14.md
+++ b/docs/solutions/logic-errors/daily-close-saturation-and-stale-manager-alerts-2026-08-14.md
@@ -1,0 +1,65 @@
+---
+title: Daily Close saturation must preserve evidence and alert once
+date: 2026-08-14
+category: logic-errors
+module: daily_operations
+problem_type: logic_error
+component: background_job
+symptoms:
+  - Daily Close automation could quarantine a day solely because open operational work exceeded a read cap.
+  - A repeatedly owed operating day remained visible only in internal sweep evidence and did not notify a manager.
+root_cause: logic_error
+resolution_type: code_fix
+severity: high
+tags: [daily-close, automation, notifications, source-completeness, deduplication]
+delivery_diff_fingerprint: 6913199099f2cb022d01367b82ea272f2f18bdc67a89ab107138aff295325c59
+---
+
+# Daily Close saturation must preserve evidence and alert once
+
+## Problem
+
+Daily Close treated every incomplete source read as a completion blocker. That was too broad for open operational work: exceeding its bounded read cap means the snapshot cannot enumerate every member, but it does not make the observed open-work evidence unsafe to carry forward. Separately, the owed-close sweep recorded a stale event without creating a manager-facing notification.
+
+## Symptoms
+
+- A store with more open operational work than the source cap could remain quarantined even though the work was safe to carry forward.
+- Repeated sweeps accumulated internal retry evidence without giving managers a direct EOD Review action.
+- A naive notification emitted on every retry would risk duplicate email.
+
+## What Didn't Work
+
+- Treating `snapshot.sourceCompleteness.complete` as one global completion predicate erased the distinction between sources that must be exhaustive and operational work that can be conservatively carried forward.
+- Using the normal selected-member count under saturation understated the persisted carry-forward count because the selected IDs are necessarily incomplete.
+- Sending directly from the sweep would bypass the notification registry's durable deduplication and recipient policy.
+
+## Solution
+
+Classify incomplete source reads by whether they block completion. Daily Close still blocks on incomplete financial or transactional sources, while an incomplete `operational_work_item` source preserves all observed carry-forward items and records the observed logical count. Historic automation applies the same classification.
+
+Emit `eod.stale_daily_close` through the notification registry from the existing stale-escalation mutation. Its dedupe key is stable for one store and operating date:
+
+```text
+eod.stale_daily_close:<storeId>:<operatingDate>
+```
+
+The notification prepares its email only while the close is still open and the latest EOD automation run is skipped or failed. It reuses the Daily Manager Report payload builder for store schedule, blocker, cash-position, and EOD Review URL semantics rather than reconstructing those rules in the sweep.
+
+## Why This Works
+
+Source completeness remains authoritative where missing rows could corrupt a close. Open operational work uses a different conservative rule: preserve every observed group, acknowledge that enumeration was capped, and carry forward the observed count instead of pretending the source was empty or complete.
+
+The stale alert stays idempotent because operational-event deduplication and notification-intent deduplication share the stable store/date identity. Preparation rechecks live state, so a close completed after intent creation produces no stale email.
+
+## Prevention
+
+- Do not collapse heterogeneous source-completeness entries into a single boolean when sources have different safe fallback behavior.
+- When a bounded read is allowed to proceed, persist explicit observed-count and completeness evidence; never infer zero from a truncated member list.
+- Route manager email through the notification registry with a stable business dedupe key and a send-time state recheck.
+- Test cap boundaries, repeated sweeps, recently owed days, completed-close suppression, and null preparation when the automation run no longer qualifies.
+
+## Related Issues
+
+- `packages/athena-webapp/convex/operations/dailyClose.ts`
+- `packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts`
+- `packages/athena-webapp/convex/notifications/registry.ts`

--- a/docs/solutions/logic-errors/daily-close-saturation-and-stale-manager-alerts-2026-08-14.md
+++ b/docs/solutions/logic-errors/daily-close-saturation-and-stale-manager-alerts-2026-08-14.md
@@ -12,7 +12,7 @@ root_cause: logic_error
 resolution_type: code_fix
 severity: high
 tags: [daily-close, automation, notifications, source-completeness, deduplication]
-delivery_diff_fingerprint: f1183a3dceb9d4ea172fbc5291134360b910016d3756ca78b7b9516729f02f7c
+delivery_diff_fingerprint: 3d160abf4ea34d91f563030a38c71162137fb2632d5764fbe517e00f918c049b
 ---
 
 # Daily Close saturation must preserve evidence and alert once
@@ -46,9 +46,12 @@ eod.stale_daily_close:<storeId>:<operatingDate>
 The notification prepares its email only while the close is still open and the latest EOD automation run is skipped or failed. It reuses the Daily Manager Report payload builder for store schedule, blocker, cash-position, and EOD Review URL semantics rather than reconstructing those rules in the sweep.
 
 The sweep escalates only dates it actually attempted in that invocation. Its
-three-date attempt window rotates by scheduled sweep slot, so permanently
-blocked oldest dates cannot starve later stale dates while the close-attempt
-budget stays bounded. This keeps an unattempted eligible close from consuming
+three-date attempt window rotates by UTC hour. That advances one position at
+the production hourly cadence and two positions at the non-production
+two-hour cadence; the three-date window covers every backlog length from four
+through the seven-day cap under either stride. Permanently blocked oldest dates
+therefore cannot starve later stale dates while the close-attempt budget stays
+bounded. This keeps an unattempted eligible close from consuming
 its permanent store/date intent. A successful historic close reports `applied`
 and is excluded from escalation. The escalation mutation also rechecks the
 active completed close inside its transaction.

--- a/docs/solutions/logic-errors/daily-close-saturation-and-stale-manager-alerts-2026-08-14.md
+++ b/docs/solutions/logic-errors/daily-close-saturation-and-stale-manager-alerts-2026-08-14.md
@@ -12,7 +12,7 @@ root_cause: logic_error
 resolution_type: code_fix
 severity: high
 tags: [daily-close, automation, notifications, source-completeness, deduplication]
-delivery_diff_fingerprint: a84960b776e6117a6f9dba10e4efc48a3749876958e6c4fd4e6e4260c6d4a56a
+delivery_diff_fingerprint: 2c25684535c7544f78b0b51a26acc39c8eb0eeaea0d56cf5dc65081ea0c341d5
 ---
 
 # Daily Close saturation must preserve evidence and alert once
@@ -36,6 +36,9 @@ Daily Close treated every incomplete source read as a completion blocker. That w
 ## Solution
 
 Classify incomplete source reads by whether they block completion. Daily Close still blocks on incomplete financial or transactional sources, while an incomplete `operational_work_item` source preserves all observed carry-forward items and records the observed logical count. Historic automation applies the same classification.
+Direct, normal automation, and historic automation all consume the same
+exported predicate for that exception so the tolerated-source policy cannot
+drift between completion paths.
 
 Emit `eod.stale_daily_close` through the notification registry from the existing stale-escalation mutation. Its dedupe key is stable for one store and operating date:
 
@@ -55,6 +58,8 @@ bounded. This keeps an unattempted eligible close from consuming
 its permanent store/date intent. A successful historic close reports `applied`
 and is excluded from escalation. The escalation mutation also rechecks the
 active completed close inside its transaction.
+Owed-date discovery returns only owed and stale evidence; the separate
+rotation selector exclusively owns the bounded attempt set used by production.
 
 Enabled policies are read in 50-row indexed pages. Each action schedules the
 next cursor before processing any store on its page, so a throwing first-page

--- a/docs/solutions/logic-errors/daily-close-saturation-and-stale-manager-alerts-2026-08-14.md
+++ b/docs/solutions/logic-errors/daily-close-saturation-and-stale-manager-alerts-2026-08-14.md
@@ -12,7 +12,7 @@ root_cause: logic_error
 resolution_type: code_fix
 severity: high
 tags: [daily-close, automation, notifications, source-completeness, deduplication]
-delivery_diff_fingerprint: adb026b1ca192cde48edd16b3b03fd6c48b25bd15d279e9428f4f39330b5b274
+delivery_diff_fingerprint: f1b03948f9d7115a7bfde4ec846014cb7d8f6489a9d470237b7faa260034ef1e
 ---
 
 # Daily Close saturation must preserve evidence and alert once
@@ -57,8 +57,11 @@ and is excluded from escalation. The escalation mutation also rechecks the
 active completed close inside its transaction.
 
 Enabled policies are read in 50-row indexed pages. Each action schedules the
-next cursor after finishing its page, so the 51st store and beyond are reached
-without turning one action into an unbounded cross-store job.
+next cursor before processing any store on its page, so a throwing first-page
+store cannot strand the 51st store and beyond. Continuations carry the one
+timestamp derived by the root action, keeping operating-date and rotation
+decisions consistent across the sweep without turning one action into an
+unbounded cross-store job.
 
 If a stale intent initially finds no EOD subscribers, a later owed-date retry
 re-arms that same suppressed intent after subscription setup. The intent and

--- a/docs/solutions/logic-errors/daily-close-saturation-and-stale-manager-alerts-2026-08-14.md
+++ b/docs/solutions/logic-errors/daily-close-saturation-and-stale-manager-alerts-2026-08-14.md
@@ -12,7 +12,7 @@ root_cause: logic_error
 resolution_type: code_fix
 severity: high
 tags: [daily-close, automation, notifications, source-completeness, deduplication]
-delivery_diff_fingerprint: 3d160abf4ea34d91f563030a38c71162137fb2632d5764fbe517e00f918c049b
+delivery_diff_fingerprint: adb026b1ca192cde48edd16b3b03fd6c48b25bd15d279e9428f4f39330b5b274
 ---
 
 # Daily Close saturation must preserve evidence and alert once
@@ -56,10 +56,17 @@ its permanent store/date intent. A successful historic close reports `applied`
 and is excluded from escalation. The escalation mutation also rechecks the
 active completed close inside its transaction.
 
+Enabled policies are read in 50-row indexed pages. Each action schedules the
+next cursor after finishing its page, so the 51st store and beyond are reached
+without turning one action into an unbounded cross-store job.
+
 If a stale intent initially finds no EOD subscribers, a later owed-date retry
 re-arms that same suppressed intent after subscription setup. The intent and
 recipient dedupe keys remain unchanged, so recovery does not weaken duplicate
 delivery protection.
+Re-arming also replaces the intent's reference payload with the latest valid
+age, so delayed delivery renders current staleness rather than the age observed
+before the audience was configured.
 
 When operational-work membership is incomplete, the completed close persists
 the incomplete membership marker and observed logical count, but not the

--- a/docs/solutions/logic-errors/daily-close-saturation-and-stale-manager-alerts-2026-08-14.md
+++ b/docs/solutions/logic-errors/daily-close-saturation-and-stale-manager-alerts-2026-08-14.md
@@ -12,7 +12,7 @@ root_cause: logic_error
 resolution_type: code_fix
 severity: high
 tags: [daily-close, automation, notifications, source-completeness, deduplication]
-delivery_diff_fingerprint: c27cb5ba912519fd6459c6f6770a61115315eba8108e292891646d3ff2c608a3
+delivery_diff_fingerprint: f1183a3dceb9d4ea172fbc5291134360b910016d3756ca78b7b9516729f02f7c
 ---
 
 # Daily Close saturation must preserve evidence and alert once
@@ -45,16 +45,23 @@ eod.stale_daily_close:<storeId>:<operatingDate>
 
 The notification prepares its email only while the close is still open and the latest EOD automation run is skipped or failed. It reuses the Daily Manager Report payload builder for store schedule, blocker, cash-position, and EOD Review URL semantics rather than reconstructing those rules in the sweep.
 
-The sweep escalates only dates it actually attempted in that invocation. This
-keeps dates beyond the three-date work bound from consuming their permanent
-store/date intent before the backlog reaches them. A successful historic
-close reports `applied` and is excluded from escalation. The escalation
-mutation also rechecks the active completed close inside its transaction.
+The sweep escalates only dates it actually attempted in that invocation. Its
+three-date attempt window rotates by scheduled sweep slot, so permanently
+blocked oldest dates cannot starve later stale dates while the close-attempt
+budget stays bounded. This keeps an unattempted eligible close from consuming
+its permanent store/date intent. A successful historic close reports `applied`
+and is excluded from escalation. The escalation mutation also rechecks the
+active completed close inside its transaction.
 
 If a stale intent initially finds no EOD subscribers, a later owed-date retry
 re-arms that same suppressed intent after subscription setup. The intent and
 recipient dedupe keys remain unchanged, so recovery does not weaken duplicate
 delivery protection.
+
+When operational-work membership is incomplete, the completed close persists
+the incomplete membership marker and observed logical count, but not the
+probe's synthetic incomplete groups. Those groups cannot truthfully identify
+members; the count remains evidence while the item/group arrays stay empty.
 
 ## Why This Works
 

--- a/docs/solutions/logic-errors/daily-close-saturation-and-stale-manager-alerts-2026-08-14.md
+++ b/docs/solutions/logic-errors/daily-close-saturation-and-stale-manager-alerts-2026-08-14.md
@@ -12,7 +12,7 @@ root_cause: logic_error
 resolution_type: code_fix
 severity: high
 tags: [daily-close, automation, notifications, source-completeness, deduplication]
-delivery_diff_fingerprint: 2c25684535c7544f78b0b51a26acc39c8eb0eeaea0d56cf5dc65081ea0c341d5
+delivery_diff_fingerprint: ae53a0e83dda3f8c3ebcafe871cce5babefc5f2fb3486c990ce6b5afc13cbc29
 ---
 
 # Daily Close saturation must preserve evidence and alert once
@@ -46,7 +46,7 @@ Emit `eod.stale_daily_close` through the notification registry from the existing
 eod.stale_daily_close:<storeId>:<operatingDate>
 ```
 
-The notification prepares its email only while the close is still open and the latest EOD automation run is skipped or failed. It reuses the Daily Manager Report payload builder for store schedule, blocker, cash-position, and EOD Review URL semantics rather than reconstructing those rules in the sweep.
+The notification prepares its email only while the close is still open and the latest qualifying skipped or failed EOD automation run still supports the alert. It reuses the Daily Manager Report payload builder for store schedule, blocker, cash-position, and EOD Review URL semantics rather than reconstructing those rules in the sweep.
 
 The sweep escalates only dates it actually attempted in that invocation. Its
 three-date attempt window rotates by UTC hour. That advances one position at
@@ -69,6 +69,10 @@ decisions consistent across the sweep. The root candidate query receives that
 same derived timestamp too, so even the first page cannot observe a different
 operating-date boundary from rotation or its continuations. This avoids
 turning one action into an unbounded cross-store job.
+Each candidate's automation and escalation mutations also have a store-level
+error boundary: failures are returned with store/date diagnostics while later
+candidates on the same page continue. Page reads and continuation scheduling
+remain outside that boundary so infrastructure failures stay visible.
 
 If a stale intent initially finds no EOD subscribers, a later owed-date retry
 re-arms that same suppressed intent after subscription setup. The intent and

--- a/docs/solutions/logic-errors/daily-close-saturation-and-stale-manager-alerts-2026-08-14.md
+++ b/docs/solutions/logic-errors/daily-close-saturation-and-stale-manager-alerts-2026-08-14.md
@@ -12,7 +12,7 @@ root_cause: logic_error
 resolution_type: code_fix
 severity: high
 tags: [daily-close, automation, notifications, source-completeness, deduplication]
-delivery_diff_fingerprint: 6913199099f2cb022d01367b82ea272f2f18bdc67a89ab107138aff295325c59
+delivery_diff_fingerprint: c27cb5ba912519fd6459c6f6770a61115315eba8108e292891646d3ff2c608a3
 ---
 
 # Daily Close saturation must preserve evidence and alert once
@@ -44,6 +44,17 @@ eod.stale_daily_close:<storeId>:<operatingDate>
 ```
 
 The notification prepares its email only while the close is still open and the latest EOD automation run is skipped or failed. It reuses the Daily Manager Report payload builder for store schedule, blocker, cash-position, and EOD Review URL semantics rather than reconstructing those rules in the sweep.
+
+The sweep escalates only dates it actually attempted in that invocation. This
+keeps dates beyond the three-date work bound from consuming their permanent
+store/date intent before the backlog reaches them. A successful historic
+close reports `applied` and is excluded from escalation. The escalation
+mutation also rechecks the active completed close inside its transaction.
+
+If a stale intent initially finds no EOD subscribers, a later owed-date retry
+re-arms that same suppressed intent after subscription setup. The intent and
+recipient dedupe keys remain unchanged, so recovery does not weaken duplicate
+delivery protection.
 
 ## Why This Works
 

--- a/docs/solutions/logic-errors/daily-close-saturation-and-stale-manager-alerts-2026-08-14.md
+++ b/docs/solutions/logic-errors/daily-close-saturation-and-stale-manager-alerts-2026-08-14.md
@@ -12,7 +12,7 @@ root_cause: logic_error
 resolution_type: code_fix
 severity: high
 tags: [daily-close, automation, notifications, source-completeness, deduplication]
-delivery_diff_fingerprint: 8035c815d7ad5629114e446ee7a7fcd14aa72e24052839bf8c55e4f06ad354bf
+delivery_diff_fingerprint: a84960b776e6117a6f9dba10e4efc48a3749876958e6c4fd4e6e4260c6d4a56a
 ---
 
 # Daily Close saturation must preserve evidence and alert once
@@ -68,7 +68,11 @@ turning one action into an unbounded cross-store job.
 If a stale intent initially finds no EOD subscribers, a later owed-date retry
 re-arms that same suppressed intent after subscription setup. The intent and
 recipient dedupe keys remain unchanged, so recovery does not weaken duplicate
-delivery protection.
+delivery protection. Re-arming restarts the intent's abandonment clock and
+sweep-attempt counter, so an intent older than the six-hour recovery window is
+not immediately abandoned before its revived delivery runs. Already-sent
+recipient deliveries remain terminal and deduped; only deliveries suppressed
+by the no-audience path are revived.
 Re-arming also replaces the intent's reference payload with the latest valid
 age, so delayed delivery renders current staleness rather than the age observed
 before the audience was configured.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 12275 nodes · 15119 edges · 2810 communities detected
+- 12276 nodes · 15122 edges · 2810 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -3837,59 +3837,59 @@ Nodes (2): isValidEmail(), validateCustomerInfo()
 
 ### Community 247 - "Community 247"
 Cohesion: 0.33
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
-
-### Community 248 - "Community 248"
-Cohesion: 0.33
 Nodes (8): landingFunnelHourlyLimit(), parseBoundedPositiveInteger(), resolveWalkthroughAllowedOrigins(), walkthroughAllowedOrigins(), walkthroughDailyPerEmailLimit(), walkthroughHourlyGlobalLimit(), walkthroughHourlyNotificationLimit(), walkthroughMaxBodyBytes()
 
-### Community 249 - "Community 249"
+### Community 248 - "Community 248"
 Cohesion: 0.36
 Nodes (8): costOverlayStoreWriteOperation(), cycleCountDraftStoreWriteOperation(), defineOperation(), inventoryImportReviewPayloadWriteOperation(), notificationSubscriptionRowWriteOperation(), orderStoreWriteOperation(), storeWriteOperation(), transactionStoreWriteOperation()
 
-### Community 250 - "Community 250"
+### Community 249 - "Community 249"
 Cohesion: 0.29
 Nodes (7): adjustmentSalesDelta(), adjustmentSettlementAmount(), buildAdjustmentPaymentTotals(), buildAdjustmentReportTotals(), listAppliedTransactionAdjustmentsForDay(), readAppliedTransactionAdjustmentsForDay(), sourceCompletenessEntry()
 
-### Community 251 - "Community 251"
+### Community 250 - "Community 250"
 Cohesion: 0.38
 Nodes (7): assertNoBusinessEventConflict(), buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
-### Community 252 - "Community 252"
+### Community 251 - "Community 251"
 Cohesion: 0.33
 Nodes (8): buildOperationalEvent(), buildTraceMetadata(), isRecord(), matchesExistingEvent(), metadataDedupeKeysMatch(), normalizeOperationalEventTraceFields(), recordOperationalEventWithCtx(), shouldNormalizePosTrace()
 
-### Community 253 - "Community 253"
+### Community 252 - "Community 252"
 Cohesion: 0.58
 Nodes (9): amendRepairWithCtx(), createRepairWithCtx(), pauseRepair(), processRepairBatchWithCtx(), readCurrentGroup(), recordRepairAuditEvent(), requireEvidence(), resumeRepairWithCtx() (+1 more)
 
-### Community 254 - "Community 254"
+### Community 253 - "Community 253"
 Cohesion: 0.38
 Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
-### Community 255 - "Community 255"
+### Community 254 - "Community 254"
 Cohesion: 0.33
 Nodes (8): classifyFinalizedLineageRepairConflicts(), classifyRepairCandidate(), countRepairableFinalizedLineageLines(), getProvisionalImportSku(), isClosedRegisterRepairReplayConflict(), isFinalizedLineageRepairConflict(), isProvisionalRowChangedConflict(), skipped()
 
-### Community 256 - "Community 256"
+### Community 255 - "Community 255"
 Cohesion: 0.27
 Nodes (5): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository(), dedupeRecoveryConflictsById(), listTerminalRecoveryConflictsForRepair(), listTerminalRecoveryConflictSources()
 
-### Community 257 - "Community 257"
+### Community 256 - "Community 256"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 258 - "Community 258"
+### Community 257 - "Community 257"
 Cohesion: 0.36
 Nodes (9): aggregateSkuDays(), computeRange(), computeRequestKey(), inclusiveDaySpan(), isValidOperatingDate(), requestRangeCore(), sumDays(), utcMillisForLabel() (+1 more)
 
-### Community 259 - "Community 259"
+### Community 258 - "Community 258"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 260 - "Community 260"
+### Community 259 - "Community 259"
 Cohesion: 0.36
 Nodes (8): buildClassification(), classifyDayResult(), classifyWeekResult(), confirmsClean(), explainMetricDifference(), fingerprintDifferences(), nextStreakState(), partitionDifferences()
+
+### Community 260 - "Community 260"
+Cohesion: 0.33
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 261 - "Community 261"
 Cohesion: 0.31
@@ -4120,20 +4120,20 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 318 - "Community 318"
-Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
-
-### Community 319 - "Community 319"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 320 - "Community 320"
+### Community 319 - "Community 319"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 321 - "Community 321"
+### Community 320 - "Community 320"
 Cohesion: 0.22
 Nodes (0):
+
+### Community 321 - "Community 321"
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
 ### Community 322 - "Community 322"
 Cohesion: 0.39
@@ -4188,16 +4188,16 @@ Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
 ### Community 335 - "Community 335"
+Cohesion: 0.39
+Nodes (6): candidatesForPolicies(), completedOperatingDatesForStore(), daysBetweenOperatingDates(), runOwedDailyCloseSweepWithCtx(), selectOwedDailyCloseDates(), selectRotatingOwedDailyCloseAttempt()
+
+### Community 336 - "Community 336"
 Cohesion: 0.36
 Nodes (4): hasCompletedWeeklyObservedAtVerification(), hasCompletedWeeklyReportingCycleAnchorVerification(), isWeeklyReportingEnabledForStore(), isWeeklyReportingEnabledForStoreDoc()
 
-### Community 336 - "Community 336"
+### Community 337 - "Community 337"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
-
-### Community 337 - "Community 337"
-Cohesion: 0.25
-Nodes (0):
 
 ### Community 338 - "Community 338"
 Cohesion: 0.25
@@ -4208,192 +4208,192 @@ Cohesion: 0.25
 Nodes (0):
 
 ### Community 340 - "Community 340"
-Cohesion: 0.36
-Nodes (4): buildCtx(), buildStaffProfile(), buildStore(), buildTerminal()
+Cohesion: 0.25
+Nodes (0):
 
 ### Community 341 - "Community 341"
 Cohesion: 0.36
-Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
+Nodes (4): buildCtx(), buildStaffProfile(), buildStore(), buildTerminal()
 
 ### Community 342 - "Community 342"
-Cohesion: 0.39
-Nodes (5): boundedLimit(), countStaleFoldVersionDaysWithCtx(), countUncertifiedDaysWithCtx(), dayPage(), markStaleFoldVersionDaysWithCtx()
+Cohesion: 0.36
+Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
 
 ### Community 343 - "Community 343"
-Cohesion: 0.25
-Nodes (0):
+Cohesion: 0.39
+Nodes (5): boundedLimit(), countStaleFoldVersionDaysWithCtx(), countUncertifiedDaysWithCtx(), dayPage(), markStaleFoldVersionDaysWithCtx()
 
 ### Community 344 - "Community 344"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 345 - "Community 345"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 346 - "Community 346"
 Cohesion: 0.29
 Nodes (2): measurePublicProjectionRead(), percentile95()
 
-### Community 346 - "Community 346"
+### Community 347 - "Community 347"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 347 - "Community 347"
+### Community 348 - "Community 348"
 Cohesion: 0.39
 Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 348 - "Community 348"
+### Community 349 - "Community 349"
 Cohesion: 0.5
 Nodes (7): assertDefaultWorkflowTraceAccess(), assertWorkflowTraceAccess(), getRegisterSessionTraceIdentity(), getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx(), requireAdminWorkflowTraceAccess(), requireFullAdminOrManagerElevationTraceAccess()
 
-### Community 349 - "Community 349"
+### Community 350 - "Community 350"
 Cohesion: 0.25
 Nodes (1): DataTableRowActions()
 
-### Community 350 - "Community 350"
+### Community 351 - "Community 351"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 351 - "Community 351"
+### Community 352 - "Community 352"
 Cohesion: 0.43
 Nodes (7): clearAthenaAuthSyncHandoff(), failAthenaAuthSyncHandoff(), getAthenaAuthSyncHandoffStatus(), normalizeAuthSyncRedirect(), parseHandoff(), readRawHandoff(), startAthenaAuthSyncHandoff()
 
-### Community 352 - "Community 352"
+### Community 353 - "Community 353"
 Cohesion: 0.5
 Nodes (6): apply(), beginPan(), distance(), onEnd(), onMove(), onStart()
 
-### Community 353 - "Community 353"
+### Community 354 - "Community 354"
 Cohesion: 0.32
 Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
 
-### Community 354 - "Community 354"
-Cohesion: 0.25
-Nodes (1): ResizeObserverStub
-
 ### Community 355 - "Community 355"
 Cohesion: 0.25
-Nodes (0):
+Nodes (1): ResizeObserverStub
 
 ### Community 356 - "Community 356"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 357 - "Community 357"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 358 - "Community 358"
 Cohesion: 0.46
 Nodes (6): claimRuntimeHostForTerminal(), createRuntimeHostOwnerId(), getRemoteAssistRuntimeState(), getRuntimeHostClaimStorage(), PosRemoteAssistRuntimeHost(), releaseRuntimeHostClaim()
 
-### Community 358 - "Community 358"
+### Community 359 - "Community 359"
 Cohesion: 0.32
 Nodes (4): addDaysToDate(), isoWeekStart(), liveDay(), quickAddDay()
 
-### Community 359 - "Community 359"
+### Community 360 - "Community 360"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 360 - "Community 360"
+### Community 361 - "Community 361"
 Cohesion: 0.43
 Nodes (5): getSessionStorage(), getSharedDemoSessionOrderStoragePrefix(), readSharedDemoSessionOrderPatch(), readSharedDemoSessionOrderPatches(), writeSharedDemoSessionOrderPatch()
 
-### Community 361 - "Community 361"
+### Community 362 - "Community 362"
 Cohesion: 0.39
 Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
-### Community 362 - "Community 362"
+### Community 363 - "Community 363"
 Cohesion: 0.39
 Nodes (4): createOptimisticExpenseItemId(), expenseCartItemSourceKey(), expenseLineMatchesProduct(), expenseLineSourceKey()
 
-### Community 363 - "Community 363"
+### Community 364 - "Community 364"
 Cohesion: 0.39
 Nodes (5): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState(), isServerConfirmedLocalResolution(), isServerConvergedSyncEvent()
 
-### Community 364 - "Community 364"
+### Community 365 - "Community 365"
 Cohesion: 0.29
 Nodes (2): createStore(), renderRuntime()
 
-### Community 365 - "Community 365"
+### Community 366 - "Community 366"
 Cohesion: 0.29
 Nodes (2): hasRegisterOperatorRole(), validateRestoredCashierPresence()
 
-### Community 366 - "Community 366"
+### Community 367 - "Community 367"
 Cohesion: 0.46
 Nodes (6): isLocalDevAppShellDisabled(), readCachedPosAppShellReadiness(), readPosAppShellReadiness(), resolveRegisterPath(), waitForActiveServiceWorker(), warmPosAppShellReadiness()
 
-### Community 367 - "Community 367"
+### Community 368 - "Community 368"
 Cohesion: 0.46
 Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
 
-### Community 368 - "Community 368"
+### Community 369 - "Community 369"
 Cohesion: 0.43
 Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
 
-### Community 369 - "Community 369"
+### Community 370 - "Community 370"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 370 - "Community 370"
+### Community 371 - "Community 371"
 Cohesion: 0.39
 Nodes (5): createPackage(), installFixtureToolchain(), linkWorkspacePackage(), writeFixtureManifests(), writeJson()
 
-### Community 371 - "Community 371"
+### Community 372 - "Community 372"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 372 - "Community 372"
+### Community 373 - "Community 373"
 Cohesion: 0.39
 Nodes (6): createSpawn(), git(), gitFixture(), headTreeIdentity(), identityFor(), lsTreeOutput()
 
-### Community 373 - "Community 373"
+### Community 374 - "Community 374"
 Cohesion: 0.43
 Nodes (6): blocked(), computePrAthenaPreparationFingerprint(), evaluatePrAthenaPreparationReceipt(), isReceipt(), publishReceipt(), runPrAthenaPreparation()
 
-### Community 374 - "Community 374"
+### Community 375 - "Community 375"
 Cohesion: 0.38
 Nodes (3): createAuthorizedRegisterDepositCtx(), createProjectedInventoryReviewQueryCtx(), createQueryCtx()
 
-### Community 375 - "Community 375"
+### Community 376 - "Community 376"
 Cohesion: 0.48
 Nodes (5): containsSensitiveText(), invalidPayloadMessage(), isPublicContextValue(), validatePayloadValue(), validateRegisteredContextEventPayload()
 
-### Community 376 - "Community 376"
+### Community 377 - "Community 377"
 Cohesion: 0.52
 Nodes (6): addTo(), byVisitorsThen(), foldSharedDemoActivity(), increment(), median(), readText()
 
-### Community 377 - "Community 377"
+### Community 378 - "Community 378"
 Cohesion: 0.52
 Nodes (5): getWhatsAppReceiptConfig(), getWhatsAppWebhookAppSecret(), getWhatsAppWebhookVerifyToken(), optionalEnv(), requiredEnv()
 
-### Community 378 - "Community 378"
+### Community 379 - "Community 379"
 Cohesion: 0.57
 Nodes (5): createExpenseTransactionFromSessionHandler(), expenseItemHasTrustedAvailabilityHold(), expenseItemUsesTrustedInventory(), expenseTransactionError(), voidExpenseTransactionHandler()
 
-### Community 379 - "Community 379"
+### Community 380 - "Community 380"
 Cohesion: 0.57
 Nodes (6): createWalkthroughDedupeHmac(), getActiveWalkthroughHmacKey(), getWalkthroughHmacSecret(), getWalkthroughHmacVerificationKeys(), matchesWalkthroughTombstone(), priorKeyring()
 
-### Community 380 - "Community 380"
+### Community 381 - "Community 381"
 Cohesion: 0.52
 Nodes (6): backfillAthenaUserNormalizedEmailBatchWithCtx(), boundedLimit(), candidateForUserWithCtx(), normalizedIdentityFingerprint(), recordIdentityConflictWithCtx(), toHex()
 
-### Community 381 - "Community 381"
+### Community 382 - "Community 382"
 Cohesion: 0.52
 Nodes (6): backfillReportFactObservedAtWithCtx(), boundedLimit(), factPage(), storeFactPage(), verifyReportFactObservedAtWithCtx(), verifyStoreReportFactObservedAtWithCtx()
 
-### Community 382 - "Community 382"
+### Community 383 - "Community 383"
 Cohesion: 0.52
 Nodes (6): backfillReportingCycleStartWithCtx(), boundedLimit(), schedulePage(), storeSchedulePage(), verifyReportingCycleStartWithCtx(), verifyStoreReportingCycleStartWithCtx()
 
-### Community 383 - "Community 383"
+### Community 384 - "Community 384"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 384 - "Community 384"
+### Community 385 - "Community 385"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 385 - "Community 385"
+### Community 386 - "Community 386"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
-
-### Community 386 - "Community 386"
-Cohesion: 0.38
-Nodes (3): candidatesForPolicies(), completedOperatingDatesForStore(), selectOwedDailyCloseDates()
 
 ### Community 387 - "Community 387"
 Cohesion: 0.38
@@ -4876,68 +4876,68 @@ Cohesion: 0.4
 Nodes (2): isValidRecipientEmail(), normalizeRecipientEmailInput()
 
 ### Community 507 - "Community 507"
-Cohesion: 0.6
-Nodes (5): deriveStoreFrontFromAdminHost(), getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 508 - "Community 508"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.6
+Nodes (5): deriveStoreFrontFromAdminHost(), getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
 ### Community 509 - "Community 509"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 510 - "Community 510"
-Cohesion: 0.73
-Nodes (5): canAccessCashControlsSurface(), canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
-
-### Community 511 - "Community 511"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 511 - "Community 511"
+Cohesion: 0.73
+Nodes (5): canAccessCashControlsSurface(), canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
 ### Community 512 - "Community 512"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 513 - "Community 513"
-Cohesion: 0.4
-Nodes (2): deriveRegisterLifecycleAuthorityCandidates(), mappingCandidate()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 514 - "Community 514"
 Cohesion: 0.4
-Nodes (2): buildRecoveryCommandStore(), storeFactory()
+Nodes (2): deriveRegisterLifecycleAuthorityCandidates(), mappingCandidate()
 
 ### Community 515 - "Community 515"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): buildRecoveryCommandStore(), storeFactory()
 
 ### Community 516 - "Community 516"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 517 - "Community 517"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 518 - "Community 518"
 Cohesion: 0.4
 Nodes (2): encodeFocusKey(), encodeSheetReturn()
 
-### Community 518 - "Community 518"
+### Community 519 - "Community 519"
 Cohesion: 0.47
 Nodes (3): buildAdminSkuSearchOption(), compactJoin(), presentationText()
 
-### Community 519 - "Community 519"
+### Community 520 - "Community 520"
 Cohesion: 0.53
 Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
 
-### Community 520 - "Community 520"
+### Community 521 - "Community 521"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 521 - "Community 521"
-Cohesion: 0.33
-Nodes (1): MemoryCache
-
 ### Community 522 - "Community 522"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): MemoryCache
 
 ### Community 523 - "Community 523"
 Cohesion: 0.33
@@ -4952,52 +4952,52 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 526 - "Community 526"
-Cohesion: 0.47
-Nodes (3): completePendingAuthSync(), navigationTargetForRedirect(), sleep()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 527 - "Community 527"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.47
+Nodes (3): completePendingAuthSync(), navigationTargetForRedirect(), sleep()
 
 ### Community 528 - "Community 528"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 529 - "Community 529"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
+### Community 530 - "Community 530"
 Cohesion: 0.6
 Nodes (5): useDailyCloseFixture(), useDailyOpeningFixture(), useDailyOperationsFixture(), usePosHubFixture(), useWorkspaceFixture()
 
-### Community 530 - "Community 530"
+### Community 531 - "Community 531"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 531 - "Community 531"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 532 - "Community 532"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 533 - "Community 533"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
 ### Community 534 - "Community 534"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 535 - "Community 535"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
-
-### Community 536 - "Community 536"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 536 - "Community 536"
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
+
 ### Community 537 - "Community 537"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 538 - "Community 538"
 Cohesion: 0.53
@@ -5628,40 +5628,40 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 695 - "Community 695"
-Cohesion: 0.5
-Nodes (1): buildCtx()
-
-### Community 696 - "Community 696"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 697 - "Community 697"
+### Community 696 - "Community 696"
 Cohesion: 0.83
 Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
-### Community 698 - "Community 698"
+### Community 697 - "Community 697"
 Cohesion: 0.83
 Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
-### Community 699 - "Community 699"
+### Community 698 - "Community 698"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 700 - "Community 700"
+### Community 699 - "Community 699"
 Cohesion: 0.67
 Nodes (2): buildActivity(), buildReport()
 
-### Community 701 - "Community 701"
+### Community 700 - "Community 700"
 Cohesion: 0.83
 Nodes (3): advanceRegisterCatalogRevision(), readRegisterCatalogRevision(), readRegisterCatalogRevisionRow()
 
-### Community 702 - "Community 702"
+### Community 701 - "Community 701"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 703 - "Community 703"
+### Community 702 - "Community 702"
 Cohesion: 0.83
 Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
+
+### Community 703 - "Community 703"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 704 - "Community 704"
 Cohesion: 0.5
@@ -5673,7 +5673,7 @@ Nodes (0):
 
 ### Community 706 - "Community 706"
 Cohesion: 0.5
-Nodes (0):
+Nodes (1): buildCtx()
 
 ### Community 707 - "Community 707"
 Cohesion: 0.5

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 12277 nodes · 15128 edges · 2810 communities detected
+- 12278 nodes · 15128 edges · 2810 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -3596,76 +3596,76 @@ Cohesion: 0.26
 Nodes (12): deleteHeadBranch(), enablePullRequestAutoMerge(), encodeGitRefPath(), ghJson(), HelpRequested, mergePullRequest(), parseArgs(), parseMergeMethod() (+4 more)
 
 ### Community 187 - "Community 187"
+Cohesion: 0.23
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
+
+### Community 188 - "Community 188"
 Cohesion: 0.31
 Nodes (12): backfillStoreSchedulesFromLegacyPolicyWithCtx(), buildBackfillRow(), buildCandidateWeeklyWindows(), compatibilityMetadata(), compatibilityOnlyRow(), findExistingScheduleToSkip(), firstPolicy(), isValidMinute() (+4 more)
 
-### Community 188 - "Community 188"
+### Community 189 - "Community 189"
 Cohesion: 0.28
 Nodes (11): defineCashControlsRead(), defineDailyCloseRead(), defineDailyOperationsRead(), defineInventoryCatalogRead(), defineInventoryCostOverlayRead(), defineOnlineOrdersRead(), defineOperationalWorkRead(), defineOrganizationRead() (+3 more)
 
-### Community 189 - "Community 189"
+### Community 190 - "Community 190"
 Cohesion: 0.33
 Nodes (11): closeCandidateOperatingRange(), emptyCloseSummary(), exactStatuses(), frozenFinancialSourceCounts(), frozenWeekMetricForDate(), matchesRequestedOperatingRange(), normalizeFrozenPaymentTotals(), recordValue() (+3 more)
 
-### Community 190 - "Community 190"
+### Community 191 - "Community 191"
 Cohesion: 0.29
 Nodes (12): buildCtx(), buildInventoryMovement(), buildMapping(), buildProductSku(), buildRegisterSession(), buildStaffProfile(), buildStore(), buildTerminal() (+4 more)
 
-### Community 191 - "Community 191"
+### Community 192 - "Community 192"
 Cohesion: 0.26
 Nodes (10): createCustomer(), fullNameFromParts(), guestResult(), linkToGuest(), linkToStoreFrontUser(), posCustomerResult(), resolveGuestMatch(), resolvePosCustomerSelection() (+2 more)
 
-### Community 192 - "Community 192"
+### Community 193 - "Community 193"
 Cohesion: 0.18
 Nodes (4): findActivePendingCheckoutLookupAliasByCode(), listProductSkusByProductId(), normalizeLookupCode(), readAllQueryResults()
 
-### Community 193 - "Community 193"
+### Community 194 - "Community 194"
 Cohesion: 0.23
 Nodes (7): admitOne(), allow(), ensure(), headerByKey(), seedSkus(), seedStore(), twoDayFixture()
 
-### Community 194 - "Community 194"
+### Community 195 - "Community 195"
 Cohesion: 0.26
 Nodes (10): archivedProductNestedOrigin(), buildVariantSkuMoneyPayload(), createVariantSku(), decodeOriginValue(), deleteActiveProduct(), getArchivedProductRedirect(), modifyProduct(), onSubmit() (+2 more)
 
-### Community 195 - "Community 195"
+### Community 196 - "Community 196"
 Cohesion: 0.17
 Nodes (2): formatRegisterLabel(), getRegisterLabel()
 
-### Community 196 - "Community 196"
+### Community 197 - "Community 197"
 Cohesion: 0.22
 Nodes (6): blocked(), evaluateLocalPosReadiness(), hasSettledLocalCloseout(), localReadinessMatchesInput(), localReadinessRecordFromSnapshots(), refreshLocalPosReadinessFromSnapshots()
 
-### Community 197 - "Community 197"
+### Community 198 - "Community 198"
 Cohesion: 0.31
 Nodes (12): captureRegisterCatalogRuntimePin(), chooseRegisterCatalogRuntimeOwnerId(), clearRegisterCatalogRuntimeActionGuard(), clearRegisterCatalogRuntimeSelection(), getRegisterCatalogRuntimeOwnerId(), hasRegisterCatalogRuntimeActionGuard(), keyForScope(), maintainOwnerClaim() (+4 more)
 
-### Community 198 - "Community 198"
+### Community 199 - "Community 199"
 Cohesion: 0.31
 Nodes (11): appendEvent(), beginPrintAttempt(), buildMetadata(), finalizePrintAttempt(), getPrintRejectionMetadata(), getReasonMessage(), isTargetTerminal(), mintAttemptId() (+3 more)
 
-### Community 199 - "Community 199"
+### Community 200 - "Community 200"
 Cohesion: 0.32
 Nodes (11): clearPosClientTelemetryBuffer(), enqueuePosClientEvent(), mintClientEventId(), normalizePosTelemetryError(), peekPosClientEventBatch(), posClientTelemetryBufferSize(), readBuffer(), removePosClientEvents() (+3 more)
 
-### Community 200 - "Community 200"
+### Community 201 - "Community 201"
 Cohesion: 0.19
 Nodes (5): buildCompletedSalePayload(), completedCustomerInfo(), hasCustomerDetails(), isPosPaymentMethod(), mapLocalPaymentToPayment()
 
-### Community 201 - "Community 201"
+### Community 202 - "Community 202"
 Cohesion: 0.22
 Nodes (9): findRegisterCloseoutReviewItem(), formatCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionId(), getLatestLocalRegisterLifecycleEvent(), getPendingLocalCashVoidApprovals(), getPendingLocalCloseoutRegisterSession(), readLocalSyncStatus() (+1 more)
 
-### Community 202 - "Community 202"
+### Community 203 - "Community 203"
 Cohesion: 0.38
 Nodes (12): base64ToBytes(), bytesToBase64(), createLocalPinVerifier(), cryptoRefDecrypt(), derivePinHash(), deriveWrappingKey(), getCrypto(), isLocalPinVerifierMetadata() (+4 more)
 
-### Community 203 - "Community 203"
+### Community 204 - "Community 204"
 Cohesion: 0.29
 Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
-
-### Community 204 - "Community 204"
-Cohesion: 0.23
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 205 - "Community 205"
 Cohesion: 0.28
@@ -3837,59 +3837,59 @@ Nodes (2): isValidEmail(), validateCustomerInfo()
 
 ### Community 247 - "Community 247"
 Cohesion: 0.33
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
-
-### Community 248 - "Community 248"
-Cohesion: 0.33
 Nodes (8): landingFunnelHourlyLimit(), parseBoundedPositiveInteger(), resolveWalkthroughAllowedOrigins(), walkthroughAllowedOrigins(), walkthroughDailyPerEmailLimit(), walkthroughHourlyGlobalLimit(), walkthroughHourlyNotificationLimit(), walkthroughMaxBodyBytes()
 
-### Community 249 - "Community 249"
+### Community 248 - "Community 248"
 Cohesion: 0.36
 Nodes (8): costOverlayStoreWriteOperation(), cycleCountDraftStoreWriteOperation(), defineOperation(), inventoryImportReviewPayloadWriteOperation(), notificationSubscriptionRowWriteOperation(), orderStoreWriteOperation(), storeWriteOperation(), transactionStoreWriteOperation()
 
-### Community 250 - "Community 250"
+### Community 249 - "Community 249"
 Cohesion: 0.29
 Nodes (7): adjustmentSalesDelta(), adjustmentSettlementAmount(), buildAdjustmentPaymentTotals(), buildAdjustmentReportTotals(), listAppliedTransactionAdjustmentsForDay(), readAppliedTransactionAdjustmentsForDay(), sourceCompletenessEntry()
 
-### Community 251 - "Community 251"
+### Community 250 - "Community 250"
 Cohesion: 0.38
 Nodes (7): assertNoBusinessEventConflict(), buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
-### Community 252 - "Community 252"
+### Community 251 - "Community 251"
 Cohesion: 0.33
 Nodes (8): buildOperationalEvent(), buildTraceMetadata(), isRecord(), matchesExistingEvent(), metadataDedupeKeysMatch(), normalizeOperationalEventTraceFields(), recordOperationalEventWithCtx(), shouldNormalizePosTrace()
 
-### Community 253 - "Community 253"
+### Community 252 - "Community 252"
 Cohesion: 0.58
 Nodes (9): amendRepairWithCtx(), createRepairWithCtx(), pauseRepair(), processRepairBatchWithCtx(), readCurrentGroup(), recordRepairAuditEvent(), requireEvidence(), resumeRepairWithCtx() (+1 more)
 
-### Community 254 - "Community 254"
+### Community 253 - "Community 253"
 Cohesion: 0.38
 Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
-### Community 255 - "Community 255"
+### Community 254 - "Community 254"
 Cohesion: 0.33
 Nodes (8): classifyFinalizedLineageRepairConflicts(), classifyRepairCandidate(), countRepairableFinalizedLineageLines(), getProvisionalImportSku(), isClosedRegisterRepairReplayConflict(), isFinalizedLineageRepairConflict(), isProvisionalRowChangedConflict(), skipped()
 
-### Community 256 - "Community 256"
+### Community 255 - "Community 255"
 Cohesion: 0.27
 Nodes (5): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository(), dedupeRecoveryConflictsById(), listTerminalRecoveryConflictsForRepair(), listTerminalRecoveryConflictSources()
 
-### Community 257 - "Community 257"
+### Community 256 - "Community 256"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 258 - "Community 258"
+### Community 257 - "Community 257"
 Cohesion: 0.36
 Nodes (9): aggregateSkuDays(), computeRange(), computeRequestKey(), inclusiveDaySpan(), isValidOperatingDate(), requestRangeCore(), sumDays(), utcMillisForLabel() (+1 more)
 
-### Community 259 - "Community 259"
+### Community 258 - "Community 258"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 260 - "Community 260"
+### Community 259 - "Community 259"
 Cohesion: 0.36
 Nodes (8): buildClassification(), classifyDayResult(), classifyWeekResult(), confirmsClean(), explainMetricDifference(), fingerprintDifferences(), nextStreakState(), partitionDifferences()
+
+### Community 260 - "Community 260"
+Cohesion: 0.33
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 261 - "Community 261"
 Cohesion: 0.31
@@ -4136,12 +4136,12 @@ Cohesion: 0.22
 Nodes (0):
 
 ### Community 322 - "Community 322"
-Cohesion: 0.39
-Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
-
-### Community 323 - "Community 323"
 Cohesion: 0.31
 Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+
+### Community 323 - "Community 323"
+Cohesion: 0.39
+Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
 
 ### Community 324 - "Community 324"
 Cohesion: 0.22
@@ -5628,40 +5628,40 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 695 - "Community 695"
-Cohesion: 0.83
-Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
+Cohesion: 0.5
+Nodes (1): buildCtx()
 
 ### Community 696 - "Community 696"
 Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
+Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
 ### Community 697 - "Community 697"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 698 - "Community 698"
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+
+### Community 699 - "Community 699"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 699 - "Community 699"
+### Community 700 - "Community 700"
 Cohesion: 0.67
 Nodes (2): buildActivity(), buildReport()
 
-### Community 700 - "Community 700"
+### Community 701 - "Community 701"
 Cohesion: 0.83
 Nodes (3): advanceRegisterCatalogRevision(), readRegisterCatalogRevision(), readRegisterCatalogRevisionRow()
 
-### Community 701 - "Community 701"
+### Community 702 - "Community 702"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 702 - "Community 702"
-Cohesion: 0.83
-Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 703 - "Community 703"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 704 - "Community 704"
 Cohesion: 0.5
@@ -5673,7 +5673,7 @@ Nodes (0):
 
 ### Community 706 - "Community 706"
 Cohesion: 0.5
-Nodes (1): buildCtx()
+Nodes (0):
 
 ### Community 707 - "Community 707"
 Cohesion: 0.5

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 12270 nodes · 15111 edges · 2810 communities detected
+- 12274 nodes · 15116 edges · 2810 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -3688,72 +3688,72 @@ Cohesion: 0.17
 Nodes (0):
 
 ### Community 210 - "Community 210"
+Cohesion: 0.17
+Nodes (0):
+
+### Community 211 - "Community 211"
 Cohesion: 0.33
 Nodes (11): buildFingerprintPayload(), getSkuDisplayName(), getSkuDisplaySku(), getSkuPrice(), hasOwnValue(), hasUnsupportedManualFields(), isSkuAvailableForAddition(), isWholeQuantity() (+3 more)
 
-### Community 211 - "Community 211"
+### Community 212 - "Community 212"
 Cohesion: 0.2
 Nodes (3): createAuthorizedItemAdjustmentCtx(), createAuthorizedVoidCtx(), mockAdmissionAwareAuth()
 
-### Community 212 - "Community 212"
+### Community 213 - "Community 213"
 Cohesion: 0.35
 Nodes (11): addDaysToDate(), affectedPeriodKeys(), aggregateSkuDays(), formatOperatingDate(), isoWeekStart(), measuresEqual(), periodDateRange(), rebuildPeriodRollup() (+3 more)
 
-### Community 213 - "Community 213"
+### Community 214 - "Community 214"
 Cohesion: 0.17
 Nodes (0):
 
-### Community 214 - "Community 214"
+### Community 215 - "Community 215"
 Cohesion: 0.21
 Nodes (4): getConversionRequestId(), handleClick(), handleFinalize(), normalizeCommandMessage()
 
-### Community 215 - "Community 215"
+### Community 216 - "Community 216"
 Cohesion: 0.33
 Nodes (11): buildSkuActivityUntrustedSalesViewModel(), buildSourceRow(), buildTransactionRow(), capitalizeWords(), formatEvidenceLabel(), formatProductName(), getEmptyMessage(), getLookupLabel() (+3 more)
 
-### Community 216 - "Community 216"
+### Community 217 - "Community 217"
 Cohesion: 0.18
 Nodes (2): formatServiceLabel(), formatServiceLineMeta()
 
-### Community 217 - "Community 217"
+### Community 218 - "Community 218"
 Cohesion: 0.17
 Nodes (0):
 
-### Community 218 - "Community 218"
+### Community 219 - "Community 219"
 Cohesion: 0.21
 Nodes (5): formatDeposit(), formatMoney(), handleCancelEdit(), handleSaveEdit(), summarizeService()
 
-### Community 219 - "Community 219"
+### Community 220 - "Community 220"
 Cohesion: 0.38
 Nodes (11): normalizeKey(), normalizeLegacyRow(), normalizeLegacyRows(), parseInventoryImportContent(), readInteger(), readMoney(), readOptionalMoney(), readOptionalNumber() (+3 more)
 
-### Community 220 - "Community 220"
+### Community 221 - "Community 221"
 Cohesion: 0.27
 Nodes (9): allowValue(), classifyPressure(), observePosLocalStorageHealth(), safeCapacity(), safeEventCount(), safeTimestamp(), storageHealthFreshness(), toSafePosLocalStorageHealthDiagnostic() (+1 more)
 
-### Community 221 - "Community 221"
+### Community 222 - "Community 222"
 Cohesion: 0.18
 Nodes (2): expenseItemSourceKey(), sessionItemRepresentsCartItem()
 
-### Community 222 - "Community 222"
+### Community 223 - "Community 223"
 Cohesion: 0.29
 Nodes (8): isFiniteNumber(), isPointInsideViewport(), isPositiveFiniteNumber(), isRecord(), isValidViewport(), validateKeyEvent(), validatePointerEvent(), validateRemoteAssistControlEvent()
 
-### Community 223 - "Community 223"
+### Community 224 - "Community 224"
 Cohesion: 0.26
 Nodes (8): formatMechanicalCheckFailure(), isMechanicalRawCommand(), isMechanicalScript(), main(), matchesTouchedPath(), normalizeRepoPath(), runHarnessMechanicalCheck(), selectMechanicalCommands()
 
-### Community 224 - "Community 224"
+### Community 225 - "Community 225"
 Cohesion: 0.2
 Nodes (2): productHasPendingCheckoutRegisterCatalogDependency(), removeProductAndRefreshCatalog()
 
-### Community 225 - "Community 225"
+### Community 226 - "Community 226"
 Cohesion: 0.29
 Nodes (8): activeSchedulesOverlap(), findActiveScheduleForStoreAt(), getStoreScheduleContextForStoreAtWithCtx(), listActiveSchedulesForStore(), resolveStoreOperatingRangeForDateWithCtx(), toDraft(), toSummary(), upsertStoreScheduleCommandWithCtx()
-
-### Community 226 - "Community 226"
-Cohesion: 0.18
-Nodes (0):
 
 ### Community 227 - "Community 227"
 Cohesion: 0.18
@@ -3837,59 +3837,59 @@ Nodes (2): isValidEmail(), validateCustomerInfo()
 
 ### Community 247 - "Community 247"
 Cohesion: 0.33
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
-
-### Community 248 - "Community 248"
-Cohesion: 0.33
 Nodes (8): landingFunnelHourlyLimit(), parseBoundedPositiveInteger(), resolveWalkthroughAllowedOrigins(), walkthroughAllowedOrigins(), walkthroughDailyPerEmailLimit(), walkthroughHourlyGlobalLimit(), walkthroughHourlyNotificationLimit(), walkthroughMaxBodyBytes()
 
-### Community 249 - "Community 249"
+### Community 248 - "Community 248"
 Cohesion: 0.36
 Nodes (8): costOverlayStoreWriteOperation(), cycleCountDraftStoreWriteOperation(), defineOperation(), inventoryImportReviewPayloadWriteOperation(), notificationSubscriptionRowWriteOperation(), orderStoreWriteOperation(), storeWriteOperation(), transactionStoreWriteOperation()
 
-### Community 250 - "Community 250"
+### Community 249 - "Community 249"
 Cohesion: 0.29
 Nodes (7): adjustmentSalesDelta(), adjustmentSettlementAmount(), buildAdjustmentPaymentTotals(), buildAdjustmentReportTotals(), listAppliedTransactionAdjustmentsForDay(), readAppliedTransactionAdjustmentsForDay(), sourceCompletenessEntry()
 
-### Community 251 - "Community 251"
+### Community 250 - "Community 250"
 Cohesion: 0.38
 Nodes (7): assertNoBusinessEventConflict(), buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
-### Community 252 - "Community 252"
+### Community 251 - "Community 251"
 Cohesion: 0.33
 Nodes (8): buildOperationalEvent(), buildTraceMetadata(), isRecord(), matchesExistingEvent(), metadataDedupeKeysMatch(), normalizeOperationalEventTraceFields(), recordOperationalEventWithCtx(), shouldNormalizePosTrace()
 
-### Community 253 - "Community 253"
+### Community 252 - "Community 252"
 Cohesion: 0.58
 Nodes (9): amendRepairWithCtx(), createRepairWithCtx(), pauseRepair(), processRepairBatchWithCtx(), readCurrentGroup(), recordRepairAuditEvent(), requireEvidence(), resumeRepairWithCtx() (+1 more)
 
-### Community 254 - "Community 254"
+### Community 253 - "Community 253"
 Cohesion: 0.38
 Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
-### Community 255 - "Community 255"
+### Community 254 - "Community 254"
 Cohesion: 0.33
 Nodes (8): classifyFinalizedLineageRepairConflicts(), classifyRepairCandidate(), countRepairableFinalizedLineageLines(), getProvisionalImportSku(), isClosedRegisterRepairReplayConflict(), isFinalizedLineageRepairConflict(), isProvisionalRowChangedConflict(), skipped()
 
-### Community 256 - "Community 256"
+### Community 255 - "Community 255"
 Cohesion: 0.27
 Nodes (5): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository(), dedupeRecoveryConflictsById(), listTerminalRecoveryConflictsForRepair(), listTerminalRecoveryConflictSources()
 
-### Community 257 - "Community 257"
+### Community 256 - "Community 256"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 258 - "Community 258"
+### Community 257 - "Community 257"
 Cohesion: 0.36
 Nodes (9): aggregateSkuDays(), computeRange(), computeRequestKey(), inclusiveDaySpan(), isValidOperatingDate(), requestRangeCore(), sumDays(), utcMillisForLabel() (+1 more)
 
-### Community 259 - "Community 259"
+### Community 258 - "Community 258"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 260 - "Community 260"
+### Community 259 - "Community 259"
 Cohesion: 0.36
 Nodes (8): buildClassification(), classifyDayResult(), classifyWeekResult(), confirmsClean(), explainMetricDifference(), fingerprintDifferences(), nextStreakState(), partitionDifferences()
+
+### Community 260 - "Community 260"
+Cohesion: 0.33
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 261 - "Community 261"
 Cohesion: 0.31
@@ -4120,24 +4120,24 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 318 - "Community 318"
-Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
-
-### Community 319 - "Community 319"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 320 - "Community 320"
+### Community 319 - "Community 319"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 321 - "Community 321"
+### Community 320 - "Community 320"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 322 - "Community 322"
+### Community 321 - "Community 321"
 Cohesion: 0.31
 Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+
+### Community 322 - "Community 322"
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
 ### Community 323 - "Community 323"
 Cohesion: 0.39
@@ -4648,192 +4648,192 @@ Cohesion: 0.6
 Nodes (5): backfillStoreCurrencyCaseWithCtx(), boundedLimit(), needsNormalization(), storePage(), verifyStoreCurrencyCaseWithCtx()
 
 ### Community 450 - "Community 450"
+Cohesion: 0.47
+Nodes (4): findNotificationKind(), getNotificationKind(), isStaleDailyClosePayload(), requireStaleDailyClosePayload()
+
+### Community 451 - "Community 451"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 451 - "Community 451"
+### Community 452 - "Community 452"
 Cohesion: 0.47
 Nodes (4): buildDailyCloseApprovalSubject(), buildDailyCloseCarryForwardApprovalRequirement(), buildDailyCloseCarryForwardApprovalSubject(), buildDailyCloseCompletionApprovalRequirement()
 
-### Community 452 - "Community 452"
+### Community 453 - "Community 453"
 Cohesion: 0.6
 Nodes (5): buildOnlineOrderOperationalEventMessage(), buildOperationalEventMessage(), buildStockAdjustmentOperationalEventMessage(), formatOnlineOrderLabel(), formatStockAdjustmentSubjectDetail()
 
-### Community 453 - "Community 453"
+### Community 454 - "Community 454"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 454 - "Community 454"
-Cohesion: 0.4
-Nodes (2): evidenceCoverage(), makeCloseEvidence()
 
 ### Community 455 - "Community 455"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 456 - "Community 456"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): evidenceCoverage(), makeCloseEvidence()
 
 ### Community 457 - "Community 457"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 458 - "Community 458"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 459 - "Community 459"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 460 - "Community 460"
 Cohesion: 0.4
 Nodes (2): scheduleRegisterCloseoutNotifications(), wasVarianceNotifiedBeforeRail()
 
-### Community 459 - "Community 459"
+### Community 461 - "Community 461"
 Cohesion: 0.6
 Nodes (4): cleanEventText(), cleanOptionalEventText(), sanitizeClientEventMetadata(), truncate()
 
-### Community 460 - "Community 460"
+### Community 462 - "Community 462"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 461 - "Community 461"
+### Community 463 - "Community 463"
 Cohesion: 0.47
 Nodes (3): foldDay(), revenueContribution(), zeroDayMetrics()
 
-### Community 462 - "Community 462"
+### Community 464 - "Community 464"
 Cohesion: 0.6
 Nodes (5): configuredTimezone(), isValidTimezone(), localDateLabel(), resolveOperatingDate(), resolveStoreTimezone()
 
-### Community 463 - "Community 463"
+### Community 465 - "Community 465"
 Cohesion: 0.4
 Nodes (2): at(), seedFullDay()
 
-### Community 464 - "Community 464"
+### Community 466 - "Community 466"
 Cohesion: 0.47
 Nodes (3): projectFrozenWeeklyInventoryAttention(), projectLiveWeeklyInventoryAttention(), summarizeWeeklyInventoryAttention()
 
-### Community 465 - "Community 465"
+### Community 467 - "Community 467"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 466 - "Community 466"
+### Community 468 - "Community 468"
 Cohesion: 0.6
 Nodes (5): getSharedDemoActorWithCtx(), requireReadySharedDemoStoreCapabilityIfApplicable(), requireSharedDemoActorWithCtx(), requireSharedDemoCapabilityIfApplicable(), requireSharedDemoStoreCapabilityIfApplicable()
 
-### Community 467 - "Community 467"
+### Community 469 - "Community 469"
 Cohesion: 0.53
 Nodes (4): provisionForScheduledWorkWithCtx(), runDailyRestoreWithCtx(), runHourlyProvisionHealWithCtx(), sharedDemoRestoreEnabled()
 
-### Community 468 - "Community 468"
+### Community 470 - "Community 470"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 469 - "Community 469"
+### Community 471 - "Community 471"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 470 - "Community 470"
+### Community 472 - "Community 472"
 Cohesion: 0.53
 Nodes (4): buildOnlineOrderReportedReturns(), buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 471 - "Community 471"
+### Community 473 - "Community 473"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 472 - "Community 472"
+### Community 474 - "Community 474"
 Cohesion: 0.4
 Nodes (2): localDate(), resolveStoreTimeAuthority()
 
-### Community 473 - "Community 473"
+### Community 475 - "Community 475"
 Cohesion: 0.53
 Nodes (4): buildPurchaseOrderTraceSeed(), compactDetails(), formatPurchaseOrderLabel(), normalizeLookup()
 
-### Community 474 - "Community 474"
+### Community 476 - "Community 476"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 475 - "Community 475"
+### Community 477 - "Community 477"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 476 - "Community 476"
+### Community 478 - "Community 478"
 Cohesion: 0.4
 Nodes (2): compareHomepageRankedItems(), getHomepageSortRank()
 
-### Community 477 - "Community 477"
+### Community 479 - "Community 479"
 Cohesion: 0.47
 Nodes (3): canUploadPosLocalSyncLocalEventType(), getPosLocalSyncEventContractForLocalEventType(), getPosLocalSyncEventTypeForLocalEventType()
 
-### Community 478 - "Community 478"
+### Community 480 - "Community 480"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 479 - "Community 479"
+### Community 481 - "Community 481"
 Cohesion: 0.47
 Nodes (4): assertObjectKeysAreMinimized(), assertWorkflowTraceDetailsAreMinimized(), createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 480 - "Community 480"
+### Community 482 - "Community 482"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 481 - "Community 481"
-Cohesion: 0.33
-Nodes (1): DataTableToolbar()
-
-### Community 482 - "Community 482"
-Cohesion: 0.53
-Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
 ### Community 483 - "Community 483"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): DataTableToolbar()
 
 ### Community 484 - "Community 484"
+Cohesion: 0.53
+Nodes (2): SelectedProductsProvider(), useSelectedProducts()
+
+### Community 485 - "Community 485"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 485 - "Community 485"
+### Community 486 - "Community 486"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 487 - "Community 487"
 Cohesion: 0.4
 Nodes (2): moveBestSeller(), saveOrder()
 
-### Community 486 - "Community 486"
+### Community 488 - "Community 488"
 Cohesion: 0.4
 Nodes (2): moveFeaturedItem(), saveOrder()
-
-### Community 487 - "Community 487"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 488 - "Community 488"
-Cohesion: 0.47
-Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
 
 ### Community 489 - "Community 489"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 490 - "Community 490"
+Cohesion: 0.47
+Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
+
+### Community 491 - "Community 491"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 491 - "Community 491"
+### Community 492 - "Community 492"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 493 - "Community 493"
 Cohesion: 0.4
 Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
-### Community 492 - "Community 492"
+### Community 494 - "Community 494"
 Cohesion: 0.47
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
 
-### Community 493 - "Community 493"
+### Community 495 - "Community 495"
 Cohesion: 0.47
 Nodes (3): formatNextOpeningLabel(), formatStoreHoursTimeLabel(), formatStoreLocalDateLabel()
 
-### Community 494 - "Community 494"
+### Community 496 - "Community 496"
 Cohesion: 0.4
 Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
-
-### Community 495 - "Community 495"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 496 - "Community 496"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 497 - "Community 497"
 Cohesion: 0.33
@@ -4844,96 +4844,96 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 499 - "Community 499"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 500 - "Community 500"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 501 - "Community 501"
 Cohesion: 0.4
 Nodes (2): parseServiceCatalogCreateForm(), parseServiceCatalogUpdateForm()
 
-### Community 500 - "Community 500"
+### Community 502 - "Community 502"
 Cohesion: 0.6
 Nodes (5): identity(), liveResult(), metrics(), quickAddIdentity(), skuMetrics()
 
-### Community 501 - "Community 501"
+### Community 503 - "Community 503"
 Cohesion: 0.6
 Nodes (5): addSkuMetrics(), sharedDemoFixtureSkuId(), toSharedDemoLiveReportsDay(), toSharedDemoLiveSkuStock(), zeroDayMetrics()
 
-### Community 502 - "Community 502"
+### Community 504 - "Community 504"
 Cohesion: 0.6
 Nodes (5): classifyAthenaViewSurface(), isSharedDemoSurfaceVisible(), normalizePathname(), resolveAthenaViewRoute(), routeTemplateMatches()
 
-### Community 503 - "Community 503"
+### Community 505 - "Community 505"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
-### Community 504 - "Community 504"
+### Community 506 - "Community 506"
 Cohesion: 0.4
 Nodes (2): isValidRecipientEmail(), normalizeRecipientEmailInput()
 
-### Community 505 - "Community 505"
+### Community 507 - "Community 507"
 Cohesion: 0.6
 Nodes (5): deriveStoreFrontFromAdminHost(), getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
-### Community 506 - "Community 506"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 507 - "Community 507"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 508 - "Community 508"
-Cohesion: 0.73
-Nodes (5): canAccessCashControlsSurface(), canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 509 - "Community 509"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 510 - "Community 510"
+Cohesion: 0.73
+Nodes (5): canAccessCashControlsSurface(), canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
+
+### Community 511 - "Community 511"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 511 - "Community 511"
+### Community 512 - "Community 512"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 513 - "Community 513"
 Cohesion: 0.4
 Nodes (2): deriveRegisterLifecycleAuthorityCandidates(), mappingCandidate()
 
-### Community 512 - "Community 512"
+### Community 514 - "Community 514"
 Cohesion: 0.4
 Nodes (2): buildRecoveryCommandStore(), storeFactory()
 
-### Community 513 - "Community 513"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 514 - "Community 514"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 515 - "Community 515"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 516 - "Community 516"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 517 - "Community 517"
 Cohesion: 0.4
 Nodes (2): encodeFocusKey(), encodeSheetReturn()
 
-### Community 516 - "Community 516"
+### Community 518 - "Community 518"
 Cohesion: 0.47
 Nodes (3): buildAdminSkuSearchOption(), compactJoin(), presentationText()
 
-### Community 517 - "Community 517"
+### Community 519 - "Community 519"
 Cohesion: 0.53
 Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
 
-### Community 518 - "Community 518"
+### Community 520 - "Community 520"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 519 - "Community 519"
-Cohesion: 0.33
-Nodes (1): MemoryCache
-
-### Community 520 - "Community 520"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 521 - "Community 521"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): MemoryCache
 
 ### Community 522 - "Community 522"
 Cohesion: 0.33
@@ -4944,300 +4944,300 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 524 - "Community 524"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 525 - "Community 525"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 526 - "Community 526"
 Cohesion: 0.47
 Nodes (3): completePendingAuthSync(), navigationTargetForRedirect(), sleep()
 
-### Community 525 - "Community 525"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 526 - "Community 526"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
 ### Community 527 - "Community 527"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
+### Community 528 - "Community 528"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
+### Community 529 - "Community 529"
 Cohesion: 0.6
 Nodes (5): useDailyCloseFixture(), useDailyOpeningFixture(), useDailyOperationsFixture(), usePosHubFixture(), useWorkspaceFixture()
 
-### Community 528 - "Community 528"
+### Community 530 - "Community 530"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 529 - "Community 529"
+### Community 531 - "Community 531"
 Cohesion: 0.47
 Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
-### Community 530 - "Community 530"
+### Community 532 - "Community 532"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
-### Community 531 - "Community 531"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 532 - "Community 532"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 533 - "Community 533"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 534 - "Community 534"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 535 - "Community 535"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
 
 ### Community 536 - "Community 536"
-Cohesion: 0.53
-Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 537 - "Community 537"
 Cohesion: 0.47
-Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 538 - "Community 538"
 Cohesion: 0.53
-Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
+Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
 ### Community 539 - "Community 539"
+Cohesion: 0.47
+Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
+
+### Community 540 - "Community 540"
+Cohesion: 0.53
+Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
+
+### Community 541 - "Community 541"
 Cohesion: 0.67
 Nodes (5): assertDocsLinks(), classifyLink(), collectDocsLinkFindings(), collectSolutionSlugs(), solutionsRoot()
 
-### Community 540 - "Community 540"
+### Community 542 - "Community 542"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 541 - "Community 541"
+### Community 543 - "Community 543"
 Cohesion: 0.47
 Nodes (4): commitFixtureRepo(), createFixtureRepo(), runFixtureCommand(), write()
 
-### Community 542 - "Community 542"
+### Community 544 - "Community 544"
 Cohesion: 0.47
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
-### Community 543 - "Community 543"
+### Community 545 - "Community 545"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 544 - "Community 544"
+### Community 546 - "Community 546"
 Cohesion: 0.53
 Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
-
-### Community 545 - "Community 545"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 546 - "Community 546"
-Cohesion: 0.6
-Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
 
 ### Community 547 - "Community 547"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 548 - "Community 548"
+Cohesion: 0.6
+Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
+
+### Community 549 - "Community 549"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 549 - "Community 549"
+### Community 550 - "Community 550"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 551 - "Community 551"
 Cohesion: 0.6
 Nodes (3): isDisplayableMarker(), presentSnapshotAtRequestTime(), resolveHomepageSnapshotBootstrap()
 
-### Community 550 - "Community 550"
+### Community 552 - "Community 552"
 Cohesion: 0.6
 Nodes (4): assertArtifactTransition(), assertRunTransition(), canTransitionArtifact(), canTransitionRun()
-
-### Community 551 - "Community 551"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 552 - "Community 552"
-Cohesion: 0.5
-Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
 
 ### Community 553 - "Community 553"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 554 - "Community 554"
-Cohesion: 0.6
-Nodes (4): applyCommerceInventoryEffectWithCtx(), outboundBasisFromEffect(), reportingLineCostFromEffect(), uncostedOutboundBasis()
+Cohesion: 0.5
+Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
 
 ### Community 555 - "Community 555"
-Cohesion: 0.5
-Nodes (2): historicalCostLane(), materializeDeferredAdjustmentWithCtx()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 556 - "Community 556"
 Cohesion: 0.6
-Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
+Nodes (4): applyCommerceInventoryEffectWithCtx(), outboundBasisFromEffect(), reportingLineCostFromEffect(), uncostedOutboundBasis()
 
 ### Community 557 - "Community 557"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): historicalCostLane(), materializeDeferredAdjustmentWithCtx()
 
 ### Community 558 - "Community 558"
+Cohesion: 0.6
+Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
+
+### Community 559 - "Community 559"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 559 - "Community 559"
+### Community 560 - "Community 560"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 561 - "Community 561"
 Cohesion: 0.7
 Nodes (4): backfillStoreTimezoneAuthorityWithCtx(), buildRow(), listSchedulesForStore(), normalizeLimit()
 
-### Community 560 - "Community 560"
+### Community 562 - "Community 562"
 Cohesion: 0.5
 Nodes (2): recordNotificationFailureEventWithCtx(), recordTerminalDeliveryFailureEvent()
 
-### Community 561 - "Community 561"
+### Community 563 - "Community 563"
 Cohesion: 0.6
 Nodes (4): dedupeKey(), keyFor(), prepare(), stubCtx()
 
-### Community 562 - "Community 562"
+### Community 564 - "Community 564"
 Cohesion: 0.7
 Nodes (4): createNormalUserOperationAdapter(), createPublicOperationAdapter(), isAdmitted(), resolveOperationAdmission()
 
-### Community 563 - "Community 563"
+### Community 565 - "Community 565"
 Cohesion: 0.6
 Nodes (4): consumeApprovalRequesterChallengeWithCtx(), createApprovalRequesterChallengeWithCtx(), invalidApprovalRequesterChallengeResult(), toRequesterBinding()
 
-### Community 564 - "Community 564"
+### Community 566 - "Community 566"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 565 - "Community 565"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 566 - "Community 566"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 567 - "Community 567"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 568 - "Community 568"
 Cohesion: 0.6
 Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
 
-### Community 568 - "Community 568"
+### Community 569 - "Community 569"
 Cohesion: 0.5
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
 
-### Community 569 - "Community 569"
+### Community 570 - "Community 570"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 570 - "Community 570"
-Cohesion: 0.7
-Nodes (4): acknowledgeRegisterLifecycleAuthority(), equivalentAcknowledgement(), isRevision(), normalizeSafeMetadata()
 
 ### Community 571 - "Community 571"
 Cohesion: 0.7
-Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
+Nodes (4): acknowledgeRegisterLifecycleAuthority(), equivalentAcknowledgement(), isRevision(), normalizeSafeMetadata()
 
 ### Community 572 - "Community 572"
+Cohesion: 0.7
+Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
+
+### Community 573 - "Community 573"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 573 - "Community 573"
+### Community 574 - "Community 574"
 Cohesion: 0.5
 Nodes (2): baseInput(), buildRuntimeStatus()
 
-### Community 574 - "Community 574"
+### Community 575 - "Community 575"
 Cohesion: 0.6
 Nodes (4): buildCtx(), buildQueryCtx(), filterRows(), orderedRows()
 
-### Community 575 - "Community 575"
+### Community 576 - "Community 576"
 Cohesion: 0.6
 Nodes (4): requirePosCustomerAccessById(), requirePosCustomerReadAccessById(), requirePosCustomerStoreAccess(), requirePosCustomerStoreReadAccess()
-
-### Community 576 - "Community 576"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 577 - "Community 577"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 578 - "Community 578"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 579 - "Community 579"
 Cohesion: 0.5
 Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
-### Community 579 - "Community 579"
+### Community 580 - "Community 580"
 Cohesion: 0.6
 Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
 
-### Community 580 - "Community 580"
+### Community 581 - "Community 581"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 581 - "Community 581"
+### Community 582 - "Community 582"
 Cohesion: 0.7
 Nodes (4): factFingerprint(), fingerprintPayload(), matchesStoredFingerprint(), stableStringHash()
 
-### Community 582 - "Community 582"
+### Community 583 - "Community 583"
 Cohesion: 0.6
 Nodes (3): fact(), receipt(), sale()
 
-### Community 583 - "Community 583"
+### Community 584 - "Community 584"
 Cohesion: 0.5
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 584 - "Community 584"
+### Community 585 - "Community 585"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 585 - "Community 585"
+### Community 586 - "Community 586"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 586 - "Community 586"
+### Community 587 - "Community 587"
 Cohesion: 0.6
 Nodes (3): isSharedDemoEnabled(), readRuntimeSharedDemoConfig(), readSharedDemoConfig()
 
-### Community 587 - "Community 587"
+### Community 588 - "Community 588"
 Cohesion: 0.8
 Nodes (4): buildSharedDemoOpeningBaseline(), buildSharedDemoStoreDayEvent(), rollSharedDemoOpeningBaselineWithCtx(), sharedDemoOperatingDateRange()
 
-### Community 588 - "Community 588"
+### Community 589 - "Community 589"
 Cohesion: 0.5
 Nodes (2): sharedDemoDenialError(), sharedDemoDenied()
 
-### Community 589 - "Community 589"
+### Community 590 - "Community 590"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
-### Community 590 - "Community 590"
+### Community 591 - "Community 591"
 Cohesion: 0.7
 Nodes (4): buildLookup(), buildOnlineOrderTraceSeed(), buildSafeExternalReferenceRef(), stableFingerprint()
 
-### Community 591 - "Community 591"
+### Community 592 - "Community 592"
 Cohesion: 0.5
 Nodes (2): createAdminTraceReadCtx(), createTestCtx()
-
-### Community 592 - "Community 592"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 593 - "Community 593"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 594 - "Community 594"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 595 - "Community 595"
 Cohesion: 0.5
 Nodes (2): cancel(), handleClick()
 
-### Community 595 - "Community 595"
+### Community 596 - "Community 596"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 596 - "Community 596"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 597 - "Community 597"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 598 - "Community 598"
 Cohesion: 0.4
@@ -5248,12 +5248,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 600 - "Community 600"
-Cohesion: 0.5
-Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
-
-### Community 601 - "Community 601"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 601 - "Community 601"
+Cohesion: 0.5
+Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 602 - "Community 602"
 Cohesion: 0.4
@@ -5292,72 +5292,72 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 611 - "Community 611"
-Cohesion: 0.5
-Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 612 - "Community 612"
 Cohesion: 0.5
-Nodes (2): getSelectedAppMessage(), sortAppMessages()
+Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
 ### Community 613 - "Community 613"
 Cohesion: 0.5
-Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
+Nodes (2): getSelectedAppMessage(), sortAppMessages()
 
 ### Community 614 - "Community 614"
+Cohesion: 0.5
+Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
+
+### Community 615 - "Community 615"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 615 - "Community 615"
+### Community 616 - "Community 616"
 Cohesion: 0.6
 Nodes (3): extractTraceId(), getSharedDemoDenial(), runCommand()
 
-### Community 616 - "Community 616"
+### Community 617 - "Community 617"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 617 - "Community 617"
+### Community 618 - "Community 618"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 618 - "Community 618"
+### Community 619 - "Community 619"
 Cohesion: 0.5
 Nodes (2): mapRegisterStateDto(), useConvexRegisterState()
 
-### Community 619 - "Community 619"
+### Community 620 - "Community 620"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 620 - "Community 620"
+### Community 621 - "Community 621"
 Cohesion: 0.6
 Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
-### Community 621 - "Community 621"
+### Community 622 - "Community 622"
 Cohesion: 0.8
 Nodes (4): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPagesOrFallback(), readScopedPosLocalEvents()
 
-### Community 622 - "Community 622"
+### Community 623 - "Community 623"
 Cohesion: 0.6
 Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
-### Community 623 - "Community 623"
+### Community 624 - "Community 624"
 Cohesion: 0.6
 Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
 
-### Community 624 - "Community 624"
+### Community 625 - "Community 625"
 Cohesion: 0.6
 Nodes (3): applySnapshot(), isRegisterLifecycleRepairClassification(), toObservation()
 
-### Community 625 - "Community 625"
+### Community 626 - "Community 626"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 626 - "Community 626"
-Cohesion: 0.7
-Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
 
 ### Community 627 - "Community 627"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
 
 ### Community 628 - "Community 628"
 Cohesion: 0.4
@@ -5372,68 +5372,68 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 631 - "Community 631"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 632 - "Community 632"
 Cohesion: 0.5
 Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
 
-### Community 632 - "Community 632"
+### Community 633 - "Community 633"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 633 - "Community 633"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 634 - "Community 634"
 Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 635 - "Community 635"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 636 - "Community 636"
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+
+### Community 637 - "Community 637"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 637 - "Community 637"
+### Community 638 - "Community 638"
 Cohesion: 0.6
 Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
 
-### Community 638 - "Community 638"
+### Community 639 - "Community 639"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 639 - "Community 639"
+### Community 640 - "Community 640"
 Cohesion: 0.7
 Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
-### Community 640 - "Community 640"
+### Community 641 - "Community 641"
 Cohesion: 0.6
 Nodes (4): checkRegisterSessionAuthorityWriters(), collectRegisterSessionAuthorityWriterFindings(), listTypeScriptFiles(), normalizePath()
 
-### Community 641 - "Community 641"
+### Community 642 - "Community 642"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 642 - "Community 642"
+### Community 643 - "Community 643"
 Cohesion: 0.5
 Nodes (2): createSiblingPolicyFixture(), runGit()
 
-### Community 643 - "Community 643"
+### Community 644 - "Community 644"
 Cohesion: 0.6
 Nodes (3): errorMessage(), formatHumanReport(), runHarnessContractPreflight()
 
-### Community 644 - "Community 644"
+### Community 645 - "Community 645"
 Cohesion: 0.5
 Nodes (2): evidence(), input()
 
-### Community 645 - "Community 645"
+### Community 646 - "Community 646"
 Cohesion: 0.7
 Nodes (4): buildOperationalWorkRepairInvocation(), main(), parseOperationalWorkRepairArgs(), requireValue()
-
-### Community 646 - "Community 646"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 647 - "Community 647"
 Cohesion: 0.4
@@ -5448,40 +5448,40 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 650 - "Community 650"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 651 - "Community 651"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 651 - "Community 651"
+### Community 652 - "Community 652"
 Cohesion: 0.83
 Nodes (3): automationActionKey(), defineAutomationAction(), registerAutomationActions()
 
-### Community 652 - "Community 652"
+### Community 653 - "Community 653"
 Cohesion: 0.83
 Nodes (3): evaluateAutomationActionWithCtx(), isValidOperatingDate(), validateAdapterDecision()
-
-### Community 653 - "Community 653"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 654 - "Community 654"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 655 - "Community 655"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 656 - "Community 656"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 656 - "Community 656"
+### Community 657 - "Community 657"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 657 - "Community 657"
+### Community 658 - "Community 658"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
-
-### Community 658 - "Community 658"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 659 - "Community 659"
 Cohesion: 0.5
@@ -5496,20 +5496,20 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 662 - "Community 662"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 663 - "Community 663"
 Cohesion: 0.67
 Nodes (2): normalizeDisplayText(), presentPublicBannerMessage()
 
-### Community 663 - "Community 663"
+### Community 664 - "Community 664"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 664 - "Community 664"
-Cohesion: 0.67
-Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
 
 ### Community 665 - "Community 665"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
 
 ### Community 666 - "Community 666"
 Cohesion: 0.5
@@ -5524,12 +5524,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 669 - "Community 669"
-Cohesion: 0.83
-Nodes (3): canonicalizeCostOverlayLineages(), frozenCostOverlayLineagesMatch(), readCostOverlaySkuLineagesWithCtx()
-
-### Community 670 - "Community 670"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 670 - "Community 670"
+Cohesion: 0.83
+Nodes (3): canonicalizeCostOverlayLineages(), frozenCostOverlayLineagesMatch(), readCostOverlaySkuLineagesWithCtx()
 
 ### Community 671 - "Community 671"
 Cohesion: 0.5
@@ -5544,36 +5544,36 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 674 - "Community 674"
-Cohesion: 0.67
-Nodes (2): deleteWeeklyReportingForStoreWithCtx(), removeStoreWithCtx()
-
-### Community 675 - "Community 675"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 675 - "Community 675"
+Cohesion: 0.67
+Nodes (2): deleteWeeklyReportingForStoreWithCtx(), removeStoreWithCtx()
 
 ### Community 676 - "Community 676"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 677 - "Community 677"
-Cohesion: 0.67
-Nodes (2): audit(), boundedText()
-
-### Community 678 - "Community 678"
 Cohesion: 0.5
 Nodes (0):
 
+### Community 678 - "Community 678"
+Cohesion: 0.67
+Nodes (2): audit(), boundedText()
+
 ### Community 679 - "Community 679"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 680 - "Community 680"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 680 - "Community 680"
-Cohesion: 0.67
-Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
-
 ### Community 681 - "Community 681"
 Cohesion: 0.67
-Nodes (2): findNotificationKind(), getNotificationKind()
+Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
 ### Community 682 - "Community 682"
 Cohesion: 0.67
@@ -5628,40 +5628,40 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 695 - "Community 695"
-Cohesion: 0.5
-Nodes (1): buildCtx()
-
-### Community 696 - "Community 696"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 697 - "Community 697"
+### Community 696 - "Community 696"
 Cohesion: 0.83
 Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
-### Community 698 - "Community 698"
+### Community 697 - "Community 697"
 Cohesion: 0.83
 Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
-### Community 699 - "Community 699"
+### Community 698 - "Community 698"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 700 - "Community 700"
+### Community 699 - "Community 699"
 Cohesion: 0.67
 Nodes (2): buildActivity(), buildReport()
 
-### Community 701 - "Community 701"
+### Community 700 - "Community 700"
 Cohesion: 0.83
 Nodes (3): advanceRegisterCatalogRevision(), readRegisterCatalogRevision(), readRegisterCatalogRevisionRow()
 
-### Community 702 - "Community 702"
+### Community 701 - "Community 701"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 703 - "Community 703"
+### Community 702 - "Community 702"
 Cohesion: 0.83
 Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
+
+### Community 703 - "Community 703"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 704 - "Community 704"
 Cohesion: 0.5
@@ -5673,7 +5673,7 @@ Nodes (0):
 
 ### Community 706 - "Community 706"
 Cohesion: 0.5
-Nodes (0):
+Nodes (1): buildCtx()
 
 ### Community 707 - "Community 707"
 Cohesion: 0.5

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 12276 nodes · 15122 edges · 2810 communities detected
+- 12277 nodes · 15128 edges · 2810 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2830,7 +2830,7 @@
 6. `submitTerminalRuntimeStatus()` - 21 edges
 7. `buildDailyOpeningSnapshotWithCtx()` - 20 edges
 8. `materializeAcceptedWeek()` - 20 edges
-9. `completeDailyCloseWithCtx()` - 17 edges
+9. `completeDailyCloseWithCtx()` - 18 edges
 10. `buildDailyOperationsSnapshotWithCtx()` - 17 edges
 
 ## Surprising Connections (you probably didn't know these)
@@ -2849,7 +2849,7 @@
 
 ### Community 0 - "Community 0"
 Cohesion: 0.05
-Nodes (90): approvalBelongsToRange(), approvalRequestTypeLabel(), asCarryForwardItem(), buildApprovalRequestsById(), buildCompletedOnlineOrderTotals(), buildDailyCloseExpenseProductEvidence(), buildDailyCloseLifecycleGateWithCtx(), buildDailyCloseReportSnapshot() (+82 more)
+Nodes (91): approvalBelongsToRange(), approvalRequestTypeLabel(), asCarryForwardItem(), buildApprovalRequestsById(), buildCompletedOnlineOrderTotals(), buildDailyCloseExpenseProductEvidence(), buildDailyCloseLifecycleGateWithCtx(), buildDailyCloseReportSnapshot() (+83 more)
 
 ### Community 1 - "Community 1"
 Cohesion: 0.03
@@ -3628,44 +3628,44 @@ Cohesion: 0.26
 Nodes (10): archivedProductNestedOrigin(), buildVariantSkuMoneyPayload(), createVariantSku(), decodeOriginValue(), deleteActiveProduct(), getArchivedProductRedirect(), modifyProduct(), onSubmit() (+2 more)
 
 ### Community 195 - "Community 195"
-Cohesion: 0.23
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
-
-### Community 196 - "Community 196"
 Cohesion: 0.17
 Nodes (2): formatRegisterLabel(), getRegisterLabel()
 
-### Community 197 - "Community 197"
+### Community 196 - "Community 196"
 Cohesion: 0.22
 Nodes (6): blocked(), evaluateLocalPosReadiness(), hasSettledLocalCloseout(), localReadinessMatchesInput(), localReadinessRecordFromSnapshots(), refreshLocalPosReadinessFromSnapshots()
 
-### Community 198 - "Community 198"
+### Community 197 - "Community 197"
 Cohesion: 0.31
 Nodes (12): captureRegisterCatalogRuntimePin(), chooseRegisterCatalogRuntimeOwnerId(), clearRegisterCatalogRuntimeActionGuard(), clearRegisterCatalogRuntimeSelection(), getRegisterCatalogRuntimeOwnerId(), hasRegisterCatalogRuntimeActionGuard(), keyForScope(), maintainOwnerClaim() (+4 more)
 
-### Community 199 - "Community 199"
+### Community 198 - "Community 198"
 Cohesion: 0.31
 Nodes (11): appendEvent(), beginPrintAttempt(), buildMetadata(), finalizePrintAttempt(), getPrintRejectionMetadata(), getReasonMessage(), isTargetTerminal(), mintAttemptId() (+3 more)
 
-### Community 200 - "Community 200"
+### Community 199 - "Community 199"
 Cohesion: 0.32
 Nodes (11): clearPosClientTelemetryBuffer(), enqueuePosClientEvent(), mintClientEventId(), normalizePosTelemetryError(), peekPosClientEventBatch(), posClientTelemetryBufferSize(), readBuffer(), removePosClientEvents() (+3 more)
 
-### Community 201 - "Community 201"
+### Community 200 - "Community 200"
 Cohesion: 0.19
 Nodes (5): buildCompletedSalePayload(), completedCustomerInfo(), hasCustomerDetails(), isPosPaymentMethod(), mapLocalPaymentToPayment()
 
-### Community 202 - "Community 202"
+### Community 201 - "Community 201"
 Cohesion: 0.22
 Nodes (9): findRegisterCloseoutReviewItem(), formatCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionId(), getLatestLocalRegisterLifecycleEvent(), getPendingLocalCashVoidApprovals(), getPendingLocalCloseoutRegisterSession(), readLocalSyncStatus() (+1 more)
 
-### Community 203 - "Community 203"
+### Community 202 - "Community 202"
 Cohesion: 0.38
 Nodes (12): base64ToBytes(), bytesToBase64(), createLocalPinVerifier(), cryptoRefDecrypt(), derivePinHash(), deriveWrappingKey(), getCrypto(), isLocalPinVerifierMetadata() (+4 more)
 
-### Community 204 - "Community 204"
+### Community 203 - "Community 203"
 Cohesion: 0.29
 Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
+
+### Community 204 - "Community 204"
+Cohesion: 0.23
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 205 - "Community 205"
 Cohesion: 0.28
@@ -3837,59 +3837,59 @@ Nodes (2): isValidEmail(), validateCustomerInfo()
 
 ### Community 247 - "Community 247"
 Cohesion: 0.33
-Nodes (8): landingFunnelHourlyLimit(), parseBoundedPositiveInteger(), resolveWalkthroughAllowedOrigins(), walkthroughAllowedOrigins(), walkthroughDailyPerEmailLimit(), walkthroughHourlyGlobalLimit(), walkthroughHourlyNotificationLimit(), walkthroughMaxBodyBytes()
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 248 - "Community 248"
+Cohesion: 0.33
+Nodes (8): landingFunnelHourlyLimit(), parseBoundedPositiveInteger(), resolveWalkthroughAllowedOrigins(), walkthroughAllowedOrigins(), walkthroughDailyPerEmailLimit(), walkthroughHourlyGlobalLimit(), walkthroughHourlyNotificationLimit(), walkthroughMaxBodyBytes()
+
+### Community 249 - "Community 249"
 Cohesion: 0.36
 Nodes (8): costOverlayStoreWriteOperation(), cycleCountDraftStoreWriteOperation(), defineOperation(), inventoryImportReviewPayloadWriteOperation(), notificationSubscriptionRowWriteOperation(), orderStoreWriteOperation(), storeWriteOperation(), transactionStoreWriteOperation()
 
-### Community 249 - "Community 249"
+### Community 250 - "Community 250"
 Cohesion: 0.29
 Nodes (7): adjustmentSalesDelta(), adjustmentSettlementAmount(), buildAdjustmentPaymentTotals(), buildAdjustmentReportTotals(), listAppliedTransactionAdjustmentsForDay(), readAppliedTransactionAdjustmentsForDay(), sourceCompletenessEntry()
 
-### Community 250 - "Community 250"
+### Community 251 - "Community 251"
 Cohesion: 0.38
 Nodes (7): assertNoBusinessEventConflict(), buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
-### Community 251 - "Community 251"
+### Community 252 - "Community 252"
 Cohesion: 0.33
 Nodes (8): buildOperationalEvent(), buildTraceMetadata(), isRecord(), matchesExistingEvent(), metadataDedupeKeysMatch(), normalizeOperationalEventTraceFields(), recordOperationalEventWithCtx(), shouldNormalizePosTrace()
 
-### Community 252 - "Community 252"
+### Community 253 - "Community 253"
 Cohesion: 0.58
 Nodes (9): amendRepairWithCtx(), createRepairWithCtx(), pauseRepair(), processRepairBatchWithCtx(), readCurrentGroup(), recordRepairAuditEvent(), requireEvidence(), resumeRepairWithCtx() (+1 more)
 
-### Community 253 - "Community 253"
+### Community 254 - "Community 254"
 Cohesion: 0.38
 Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
-### Community 254 - "Community 254"
+### Community 255 - "Community 255"
 Cohesion: 0.33
 Nodes (8): classifyFinalizedLineageRepairConflicts(), classifyRepairCandidate(), countRepairableFinalizedLineageLines(), getProvisionalImportSku(), isClosedRegisterRepairReplayConflict(), isFinalizedLineageRepairConflict(), isProvisionalRowChangedConflict(), skipped()
 
-### Community 255 - "Community 255"
+### Community 256 - "Community 256"
 Cohesion: 0.27
 Nodes (5): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository(), dedupeRecoveryConflictsById(), listTerminalRecoveryConflictsForRepair(), listTerminalRecoveryConflictSources()
 
-### Community 256 - "Community 256"
+### Community 257 - "Community 257"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 257 - "Community 257"
+### Community 258 - "Community 258"
 Cohesion: 0.36
 Nodes (9): aggregateSkuDays(), computeRange(), computeRequestKey(), inclusiveDaySpan(), isValidOperatingDate(), requestRangeCore(), sumDays(), utcMillisForLabel() (+1 more)
 
-### Community 258 - "Community 258"
+### Community 259 - "Community 259"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 259 - "Community 259"
+### Community 260 - "Community 260"
 Cohesion: 0.36
 Nodes (8): buildClassification(), classifyDayResult(), classifyWeekResult(), confirmsClean(), explainMetricDifference(), fingerprintDifferences(), nextStreakState(), partitionDifferences()
-
-### Community 260 - "Community 260"
-Cohesion: 0.33
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 261 - "Community 261"
 Cohesion: 0.31
@@ -4120,20 +4120,20 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 318 - "Community 318"
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
+
+### Community 319 - "Community 319"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 319 - "Community 319"
+### Community 320 - "Community 320"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 320 - "Community 320"
+### Community 321 - "Community 321"
 Cohesion: 0.22
 Nodes (0):
-
-### Community 321 - "Community 321"
-Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
 ### Community 322 - "Community 322"
 Cohesion: 0.39
@@ -4876,68 +4876,68 @@ Cohesion: 0.4
 Nodes (2): isValidRecipientEmail(), normalizeRecipientEmailInput()
 
 ### Community 507 - "Community 507"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
-
-### Community 508 - "Community 508"
 Cohesion: 0.6
 Nodes (5): deriveStoreFrontFromAdminHost(), getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
+
+### Community 508 - "Community 508"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 509 - "Community 509"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 510 - "Community 510"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 511 - "Community 511"
 Cohesion: 0.73
 Nodes (5): canAccessCashControlsSurface(), canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
+
+### Community 511 - "Community 511"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 512 - "Community 512"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 513 - "Community 513"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 514 - "Community 514"
 Cohesion: 0.4
 Nodes (2): deriveRegisterLifecycleAuthorityCandidates(), mappingCandidate()
 
-### Community 515 - "Community 515"
+### Community 514 - "Community 514"
 Cohesion: 0.4
 Nodes (2): buildRecoveryCommandStore(), storeFactory()
+
+### Community 515 - "Community 515"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 516 - "Community 516"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 517 - "Community 517"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 518 - "Community 518"
 Cohesion: 0.4
 Nodes (2): encodeFocusKey(), encodeSheetReturn()
 
-### Community 519 - "Community 519"
+### Community 518 - "Community 518"
 Cohesion: 0.47
 Nodes (3): buildAdminSkuSearchOption(), compactJoin(), presentationText()
 
-### Community 520 - "Community 520"
+### Community 519 - "Community 519"
 Cohesion: 0.53
 Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
 
-### Community 521 - "Community 521"
+### Community 520 - "Community 520"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 522 - "Community 522"
+### Community 521 - "Community 521"
 Cohesion: 0.33
 Nodes (1): MemoryCache
+
+### Community 522 - "Community 522"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 523 - "Community 523"
 Cohesion: 0.33
@@ -4952,52 +4952,52 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 526 - "Community 526"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 527 - "Community 527"
 Cohesion: 0.47
 Nodes (3): completePendingAuthSync(), navigationTargetForRedirect(), sleep()
+
+### Community 527 - "Community 527"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 528 - "Community 528"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 529 - "Community 529"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 530 - "Community 530"
 Cohesion: 0.6
 Nodes (5): useDailyCloseFixture(), useDailyOpeningFixture(), useDailyOperationsFixture(), usePosHubFixture(), useWorkspaceFixture()
 
-### Community 531 - "Community 531"
+### Community 530 - "Community 530"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 532 - "Community 532"
+### Community 531 - "Community 531"
 Cohesion: 0.47
 Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
-### Community 533 - "Community 533"
+### Community 532 - "Community 532"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 533 - "Community 533"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 534 - "Community 534"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 535 - "Community 535"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 536 - "Community 536"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 537 - "Community 537"
+### Community 536 - "Community 536"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 537 - "Community 537"
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 538 - "Community 538"
 Cohesion: 0.53

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 12275 nodes · 15117 edges · 2810 communities detected
+- 12275 nodes · 15119 edges · 2810 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -4392,8 +4392,8 @@ Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
 ### Community 386 - "Community 386"
-Cohesion: 0.29
-Nodes (0):
+Cohesion: 0.38
+Nodes (3): candidatesForPolicies(), completedOperatingDatesForStore(), selectOwedDailyCloseDates()
 
 ### Community 387 - "Community 387"
 Cohesion: 0.38

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 2883 files · ~0 words
+- 2885 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 12266 nodes · 15104 edges · 2808 communities detected
+- 12270 nodes · 15111 edges · 2810 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2818,6 +2818,8 @@
 - [[_COMMUNITY_Community 2805|Community 2805]]
 - [[_COMMUNITY_Community 2806|Community 2806]]
 - [[_COMMUNITY_Community 2807|Community 2807]]
+- [[_COMMUNITY_Community 2808|Community 2808]]
+- [[_COMMUNITY_Community 2809|Community 2809]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -2828,8 +2830,8 @@
 6. `submitTerminalRuntimeStatus()` - 21 edges
 7. `buildDailyOpeningSnapshotWithCtx()` - 20 edges
 8. `materializeAcceptedWeek()` - 20 edges
-9. `buildDailyOperationsSnapshotWithCtx()` - 17 edges
-10. `completeTransaction()` - 17 edges
+9. `completeDailyCloseWithCtx()` - 17 edges
+10. `buildDailyOperationsSnapshotWithCtx()` - 17 edges
 
 ## Surprising Connections (you probably didn't know these)
 - `getAmountPaidForOrder()` --calls--> `getDiscountValue()`  [EXTRACTED]
@@ -2847,7 +2849,7 @@
 
 ### Community 0 - "Community 0"
 Cohesion: 0.05
-Nodes (88): approvalBelongsToRange(), approvalRequestTypeLabel(), asCarryForwardItem(), buildApprovalRequestsById(), buildCompletedOnlineOrderTotals(), buildDailyCloseExpenseProductEvidence(), buildDailyCloseLifecycleGateWithCtx(), buildDailyCloseReportSnapshot() (+80 more)
+Nodes (90): approvalBelongsToRange(), approvalRequestTypeLabel(), asCarryForwardItem(), buildApprovalRequestsById(), buildCompletedOnlineOrderTotals(), buildDailyCloseExpenseProductEvidence(), buildDailyCloseLifecycleGateWithCtx(), buildDailyCloseReportSnapshot() (+82 more)
 
 ### Community 1 - "Community 1"
 Cohesion: 0.03
@@ -3594,40 +3596,40 @@ Cohesion: 0.26
 Nodes (12): deleteHeadBranch(), enablePullRequestAutoMerge(), encodeGitRefPath(), ghJson(), HelpRequested, mergePullRequest(), parseArgs(), parseMergeMethod() (+4 more)
 
 ### Community 187 - "Community 187"
+Cohesion: 0.23
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
+
+### Community 188 - "Community 188"
 Cohesion: 0.31
 Nodes (12): backfillStoreSchedulesFromLegacyPolicyWithCtx(), buildBackfillRow(), buildCandidateWeeklyWindows(), compatibilityMetadata(), compatibilityOnlyRow(), findExistingScheduleToSkip(), firstPolicy(), isValidMinute() (+4 more)
 
-### Community 188 - "Community 188"
+### Community 189 - "Community 189"
 Cohesion: 0.28
 Nodes (11): defineCashControlsRead(), defineDailyCloseRead(), defineDailyOperationsRead(), defineInventoryCatalogRead(), defineInventoryCostOverlayRead(), defineOnlineOrdersRead(), defineOperationalWorkRead(), defineOrganizationRead() (+3 more)
 
-### Community 189 - "Community 189"
+### Community 190 - "Community 190"
 Cohesion: 0.33
 Nodes (11): closeCandidateOperatingRange(), emptyCloseSummary(), exactStatuses(), frozenFinancialSourceCounts(), frozenWeekMetricForDate(), matchesRequestedOperatingRange(), normalizeFrozenPaymentTotals(), recordValue() (+3 more)
 
-### Community 190 - "Community 190"
+### Community 191 - "Community 191"
 Cohesion: 0.29
 Nodes (12): buildCtx(), buildInventoryMovement(), buildMapping(), buildProductSku(), buildRegisterSession(), buildStaffProfile(), buildStore(), buildTerminal() (+4 more)
 
-### Community 191 - "Community 191"
+### Community 192 - "Community 192"
 Cohesion: 0.26
 Nodes (10): createCustomer(), fullNameFromParts(), guestResult(), linkToGuest(), linkToStoreFrontUser(), posCustomerResult(), resolveGuestMatch(), resolvePosCustomerSelection() (+2 more)
 
-### Community 192 - "Community 192"
+### Community 193 - "Community 193"
 Cohesion: 0.18
 Nodes (4): findActivePendingCheckoutLookupAliasByCode(), listProductSkusByProductId(), normalizeLookupCode(), readAllQueryResults()
 
-### Community 193 - "Community 193"
+### Community 194 - "Community 194"
 Cohesion: 0.23
 Nodes (7): admitOne(), allow(), ensure(), headerByKey(), seedSkus(), seedStore(), twoDayFixture()
 
-### Community 194 - "Community 194"
+### Community 195 - "Community 195"
 Cohesion: 0.26
 Nodes (10): archivedProductNestedOrigin(), buildVariantSkuMoneyPayload(), createVariantSku(), decodeOriginValue(), deleteActiveProduct(), getArchivedProductRedirect(), modifyProduct(), onSubmit() (+2 more)
-
-### Community 195 - "Community 195"
-Cohesion: 0.23
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 196 - "Community 196"
 Cohesion: 0.17
@@ -3835,59 +3837,59 @@ Nodes (2): isValidEmail(), validateCustomerInfo()
 
 ### Community 247 - "Community 247"
 Cohesion: 0.33
-Nodes (8): landingFunnelHourlyLimit(), parseBoundedPositiveInteger(), resolveWalkthroughAllowedOrigins(), walkthroughAllowedOrigins(), walkthroughDailyPerEmailLimit(), walkthroughHourlyGlobalLimit(), walkthroughHourlyNotificationLimit(), walkthroughMaxBodyBytes()
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 248 - "Community 248"
+Cohesion: 0.33
+Nodes (8): landingFunnelHourlyLimit(), parseBoundedPositiveInteger(), resolveWalkthroughAllowedOrigins(), walkthroughAllowedOrigins(), walkthroughDailyPerEmailLimit(), walkthroughHourlyGlobalLimit(), walkthroughHourlyNotificationLimit(), walkthroughMaxBodyBytes()
+
+### Community 249 - "Community 249"
 Cohesion: 0.36
 Nodes (8): costOverlayStoreWriteOperation(), cycleCountDraftStoreWriteOperation(), defineOperation(), inventoryImportReviewPayloadWriteOperation(), notificationSubscriptionRowWriteOperation(), orderStoreWriteOperation(), storeWriteOperation(), transactionStoreWriteOperation()
 
-### Community 249 - "Community 249"
+### Community 250 - "Community 250"
 Cohesion: 0.29
 Nodes (7): adjustmentSalesDelta(), adjustmentSettlementAmount(), buildAdjustmentPaymentTotals(), buildAdjustmentReportTotals(), listAppliedTransactionAdjustmentsForDay(), readAppliedTransactionAdjustmentsForDay(), sourceCompletenessEntry()
 
-### Community 250 - "Community 250"
+### Community 251 - "Community 251"
 Cohesion: 0.38
 Nodes (7): assertNoBusinessEventConflict(), buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
-### Community 251 - "Community 251"
+### Community 252 - "Community 252"
 Cohesion: 0.33
 Nodes (8): buildOperationalEvent(), buildTraceMetadata(), isRecord(), matchesExistingEvent(), metadataDedupeKeysMatch(), normalizeOperationalEventTraceFields(), recordOperationalEventWithCtx(), shouldNormalizePosTrace()
 
-### Community 252 - "Community 252"
+### Community 253 - "Community 253"
 Cohesion: 0.58
 Nodes (9): amendRepairWithCtx(), createRepairWithCtx(), pauseRepair(), processRepairBatchWithCtx(), readCurrentGroup(), recordRepairAuditEvent(), requireEvidence(), resumeRepairWithCtx() (+1 more)
 
-### Community 253 - "Community 253"
+### Community 254 - "Community 254"
 Cohesion: 0.38
 Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
-### Community 254 - "Community 254"
+### Community 255 - "Community 255"
 Cohesion: 0.33
 Nodes (8): classifyFinalizedLineageRepairConflicts(), classifyRepairCandidate(), countRepairableFinalizedLineageLines(), getProvisionalImportSku(), isClosedRegisterRepairReplayConflict(), isFinalizedLineageRepairConflict(), isProvisionalRowChangedConflict(), skipped()
 
-### Community 255 - "Community 255"
+### Community 256 - "Community 256"
 Cohesion: 0.27
 Nodes (5): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository(), dedupeRecoveryConflictsById(), listTerminalRecoveryConflictsForRepair(), listTerminalRecoveryConflictSources()
 
-### Community 256 - "Community 256"
+### Community 257 - "Community 257"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 257 - "Community 257"
+### Community 258 - "Community 258"
 Cohesion: 0.36
 Nodes (9): aggregateSkuDays(), computeRange(), computeRequestKey(), inclusiveDaySpan(), isValidOperatingDate(), requestRangeCore(), sumDays(), utcMillisForLabel() (+1 more)
 
-### Community 258 - "Community 258"
+### Community 259 - "Community 259"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 259 - "Community 259"
+### Community 260 - "Community 260"
 Cohesion: 0.36
 Nodes (8): buildClassification(), classifyDayResult(), classifyWeekResult(), confirmsClean(), explainMetricDifference(), fingerprintDifferences(), nextStreakState(), partitionDifferences()
-
-### Community 260 - "Community 260"
-Cohesion: 0.33
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 261 - "Community 261"
 Cohesion: 0.31
@@ -4118,24 +4120,24 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 318 - "Community 318"
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
+
+### Community 319 - "Community 319"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 319 - "Community 319"
+### Community 320 - "Community 320"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 320 - "Community 320"
+### Community 321 - "Community 321"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 321 - "Community 321"
-Cohesion: 0.31
-Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
-
 ### Community 322 - "Community 322"
 Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
+Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
 
 ### Community 323 - "Community 323"
 Cohesion: 0.39
@@ -4866,68 +4868,68 @@ Cohesion: 0.4
 Nodes (2): isValidRecipientEmail(), normalizeRecipientEmailInput()
 
 ### Community 505 - "Community 505"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
-
-### Community 506 - "Community 506"
 Cohesion: 0.6
 Nodes (5): deriveStoreFrontFromAdminHost(), getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
+
+### Community 506 - "Community 506"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 507 - "Community 507"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 508 - "Community 508"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 509 - "Community 509"
 Cohesion: 0.73
 Nodes (5): canAccessCashControlsSurface(), canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
+
+### Community 509 - "Community 509"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 510 - "Community 510"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 511 - "Community 511"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 512 - "Community 512"
 Cohesion: 0.4
 Nodes (2): deriveRegisterLifecycleAuthorityCandidates(), mappingCandidate()
 
-### Community 513 - "Community 513"
+### Community 512 - "Community 512"
 Cohesion: 0.4
 Nodes (2): buildRecoveryCommandStore(), storeFactory()
+
+### Community 513 - "Community 513"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 514 - "Community 514"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 515 - "Community 515"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 516 - "Community 516"
 Cohesion: 0.4
 Nodes (2): encodeFocusKey(), encodeSheetReturn()
 
-### Community 517 - "Community 517"
+### Community 516 - "Community 516"
 Cohesion: 0.47
 Nodes (3): buildAdminSkuSearchOption(), compactJoin(), presentationText()
 
-### Community 518 - "Community 518"
+### Community 517 - "Community 517"
 Cohesion: 0.53
 Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
 
-### Community 519 - "Community 519"
+### Community 518 - "Community 518"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 520 - "Community 520"
+### Community 519 - "Community 519"
 Cohesion: 0.33
 Nodes (1): MemoryCache
+
+### Community 520 - "Community 520"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 521 - "Community 521"
 Cohesion: 0.33
@@ -4942,52 +4944,52 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 524 - "Community 524"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 525 - "Community 525"
 Cohesion: 0.47
 Nodes (3): completePendingAuthSync(), navigationTargetForRedirect(), sleep()
+
+### Community 525 - "Community 525"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 526 - "Community 526"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 527 - "Community 527"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 528 - "Community 528"
 Cohesion: 0.6
 Nodes (5): useDailyCloseFixture(), useDailyOpeningFixture(), useDailyOperationsFixture(), usePosHubFixture(), useWorkspaceFixture()
 
-### Community 529 - "Community 529"
+### Community 528 - "Community 528"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 530 - "Community 530"
+### Community 529 - "Community 529"
 Cohesion: 0.47
 Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
-### Community 531 - "Community 531"
+### Community 530 - "Community 530"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 531 - "Community 531"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 532 - "Community 532"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 533 - "Community 533"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 534 - "Community 534"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 535 - "Community 535"
+### Community 534 - "Community 534"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 535 - "Community 535"
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 536 - "Community 536"
 Cohesion: 0.53
@@ -14077,6 +14079,14 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 2808 - "Community 2808"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 2809 - "Community 2809"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **3 isolated node(s):** `StaleConstructionError`, `FakeMessageChannel`, `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
@@ -15468,2021 +15478,2025 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1799`** (1 nodes): `ReportVerificationAlert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1800`** (1 nodes): `WalkthroughRequestNotification.test.tsx`
+- **Thin community `Community 1800`** (1 nodes): `StaleDailyCloseAlert.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1801`** (1 nodes): `WeeklyManagerReport.test.tsx`
+- **Thin community `Community 1801`** (1 nodes): `StaleDailyCloseAlert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1802`** (1 nodes): `emailOperationalCtaStyles.ts`
+- **Thin community `Community 1802`** (1 nodes): `WalkthroughRequestNotification.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1803`** (1 nodes): `env.ts`
+- **Thin community `Community 1803`** (1 nodes): `WeeklyManagerReport.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1804`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1804`** (1 nodes): `emailOperationalCtaStyles.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1805`** (1 nodes): `auth.ts`
+- **Thin community `Community 1805`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1806`** (1 nodes): `bannerMessage.test.ts`
+- **Thin community `Community 1806`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1807`** (1 nodes): `colors.ts`
+- **Thin community `Community 1807`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1808`** (1 nodes): `index.ts`
+- **Thin community `Community 1808`** (1 nodes): `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1809`** (1 nodes): `landingFunnelEvents.test.ts`
+- **Thin community `Community 1809`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1810`** (1 nodes): `landingFunnelEvents.ts`
+- **Thin community `Community 1810`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1811`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1811`** (1 nodes): `landingFunnelEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1812`** (1 nodes): `products.ts`
+- **Thin community `Community 1812`** (1 nodes): `landingFunnelEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1813`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 1813`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1814`** (1 nodes): `stores.ts`
+- **Thin community `Community 1814`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1815`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 1815`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1816`** (1 nodes): `walkthroughRequests.test.ts`
+- **Thin community `Community 1816`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1817`** (1 nodes): `bag.ts`
+- **Thin community `Community 1817`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1818`** (1 nodes): `guest.ts`
+- **Thin community `Community 1818`** (1 nodes): `walkthroughRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1819`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 1819`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1820`** (1 nodes): `index.ts`
+- **Thin community `Community 1820`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1821`** (1 nodes): `me.ts`
+- **Thin community `Community 1821`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1822`** (1 nodes): `offers.ts`
+- **Thin community `Community 1822`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1823`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1823`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1824`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1824`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1825`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1825`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1826`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1826`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1827`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1827`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1828`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1828`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1829`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1829`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1830`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1830`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1831`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1831`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1832`** (1 nodes): `user.ts`
+- **Thin community `Community 1832`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1833`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1833`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1834`** (1 nodes): `index.ts`
+- **Thin community `Community 1834`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1835`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1835`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1836`** (1 nodes): `http.ts`
+- **Thin community `Community 1836`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1837`** (1 nodes): `access.ts`
+- **Thin community `Community 1837`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1838`** (1 nodes): `actions.test.ts`
+- **Thin community `Community 1838`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1839`** (1 nodes): `insights.test.ts`
+- **Thin community `Community 1839`** (1 nodes): `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1840`** (1 nodes): `lifecycle.test.ts`
+- **Thin community `Community 1840`** (1 nodes): `actions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1841`** (1 nodes): `index.ts`
+- **Thin community `Community 1841`** (1 nodes): `insights.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1842`** (1 nodes): `providerFoundation.test.ts`
+- **Thin community `Community 1842`** (1 nodes): `lifecycle.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1843`** (1 nodes): `types.ts`
+- **Thin community `Community 1843`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1844`** (1 nodes): `athenaUser.test.ts`
+- **Thin community `Community 1844`** (1 nodes): `providerFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1845`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1845`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1846`** (1 nodes): `categories.ts`
+- **Thin community `Community 1846`** (1 nodes): `athenaUser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1847`** (1 nodes): `colors.ts`
+- **Thin community `Community 1847`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1848`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1848`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1849`** (1 nodes): `inviteCode.test.ts`
+- **Thin community `Community 1849`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1850`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1850`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1851`** (1 nodes): `organizationMembers.test.ts`
+- **Thin community `Community 1851`** (1 nodes): `inviteCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1852`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1852`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1853`** (1 nodes): `pos.ts`
+- **Thin community `Community 1853`** (1 nodes): `organizationMembers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1854`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1854`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1855`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1855`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1856`** (1 nodes): `productSku.test.ts`
+- **Thin community `Community 1856`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1857`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1857`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1858`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1858`** (1 nodes): `productSku.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1859`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1859`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1860`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1860`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1861`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1861`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1862`** (1 nodes): `corrections.ts`
+- **Thin community `Community 1862`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1863`** (1 nodes): `deficitResolutionWork.test.ts`
+- **Thin community `Community 1863`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1864`** (1 nodes): `types.ts`
+- **Thin community `Community 1864`** (1 nodes): `corrections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1865`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1865`** (1 nodes): `deficitResolutionWork.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1866`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1866`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1867`** (1 nodes): `storeMemberAccess.test.ts`
+- **Thin community `Community 1867`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1868`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1868`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1869`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1869`** (1 nodes): `storeMemberAccess.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1870`** (1 nodes): `landingFunnelEvents.test.ts`
+- **Thin community `Community 1870`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1871`** (1 nodes): `landingFunnelRetention.test.ts`
+- **Thin community `Community 1871`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1872`** (1 nodes): `walkthroughConfig.test.ts`
+- **Thin community `Community 1872`** (1 nodes): `landingFunnelEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1873`** (1 nodes): `walkthroughRequestRetention.test.ts`
+- **Thin community `Community 1873`** (1 nodes): `landingFunnelRetention.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1874`** (1 nodes): `walkthroughRequests.test.ts`
+- **Thin community `Community 1874`** (1 nodes): `walkthroughConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1875`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1875`** (1 nodes): `walkthroughRequestRetention.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1876`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1876`** (1 nodes): `walkthroughRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1877`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1877`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1878`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1878`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1879`** (1 nodes): `types.ts`
+- **Thin community `Community 1879`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1880`** (1 nodes): `deliveryPolicy.test.ts`
+- **Thin community `Community 1880`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1881`** (1 nodes): `seed.ts`
+- **Thin community `Community 1881`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1882`** (1 nodes): `actionAdmission.test.ts`
+- **Thin community `Community 1882`** (1 nodes): `deliveryPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1883`** (1 nodes): `adapters.test.ts`
+- **Thin community `Community 1883`** (1 nodes): `seed.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1884`** (1 nodes): `capabilities.ts`
+- **Thin community `Community 1884`** (1 nodes): `actionAdmission.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1885`** (1 nodes): `definitions.test.ts`
+- **Thin community `Community 1885`** (1 nodes): `adapters.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1886`** (1 nodes): `migrationInventory.test.ts`
+- **Thin community `Community 1886`** (1 nodes): `capabilities.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1887`** (1 nodes): `migrationInventory.ts`
+- **Thin community `Community 1887`** (1 nodes): `definitions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1888`** (1 nodes): `publicMutation.test.ts`
+- **Thin community `Community 1888`** (1 nodes): `migrationInventory.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1889`** (1 nodes): `publicQuery.test.ts`
+- **Thin community `Community 1889`** (1 nodes): `migrationInventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1890`** (1 nodes): `readDefinitions.test.ts`
+- **Thin community `Community 1890`** (1 nodes): `publicMutation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1891`** (1 nodes): `types.ts`
+- **Thin community `Community 1891`** (1 nodes): `publicQuery.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1892`** (1 nodes): `approvalRequests.sharedDemo.test.ts`
+- **Thin community `Community 1892`** (1 nodes): `readDefinitions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1893`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1893`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1894`** (1 nodes): `adjustmentReports.test.ts`
+- **Thin community `Community 1894`** (1 nodes): `approvalRequests.sharedDemo.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1895`** (1 nodes): `approval.test.ts`
+- **Thin community `Community 1895`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1896`** (1 nodes): `automationPolicy.test.ts`
+- **Thin community `Community 1896`** (1 nodes): `adjustmentReports.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1897`** (1 nodes): `eventBuilders.test.ts`
+- **Thin community `Community 1897`** (1 nodes): `approval.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1898`** (1 nodes): `posTerminalHealthAlertEmail.ts`
+- **Thin community `Community 1898`** (1 nodes): `automationPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1899`** (1 nodes): `registerSessionAuthorityRevision.test.ts`
+- **Thin community `Community 1899`** (1 nodes): `eventBuilders.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1900`** (1 nodes): `registerSessionCloseoutGate.test.ts`
+- **Thin community `Community 1900`** (1 nodes): `posTerminalHealthAlertEmail.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1901`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1901`** (1 nodes): `registerSessionAuthorityRevision.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1902`** (1 nodes): `appLoginEmailAllowlist.test.ts`
+- **Thin community `Community 1902`** (1 nodes): `registerSessionCloseoutGate.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1903`** (1 nodes): `capabilityCatalog.test.ts`
+- **Thin community `Community 1903`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1904`** (1 nodes): `registerLifecycleAuthority.test.ts`
+- **Thin community `Community 1904`** (1 nodes): `appLoginEmailAllowlist.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1905`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1905`** (1 nodes): `capabilityCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1906`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1906`** (1 nodes): `registerLifecycleAuthority.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1907`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1907`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1908`** (1 nodes): `dto.ts`
+- **Thin community `Community 1908`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1909`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1909`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1910`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1910`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1911`** (1 nodes): `searchCatalog.test.ts`
+- **Thin community `Community 1911`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1912`** (1 nodes): `localSyncReportingTypes.ts`
+- **Thin community `Community 1912`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1913`** (1 nodes): `registerMappingAuthorityRevision.test.ts`
+- **Thin community `Community 1913`** (1 nodes): `searchCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1914`** (1 nodes): `registerSessionCloseoutHolds.test.ts`
+- **Thin community `Community 1914`** (1 nodes): `localSyncReportingTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1915`** (1 nodes): `registerSessionSyncReview.classify.test.ts`
+- **Thin community `Community 1915`** (1 nodes): `registerMappingAuthorityRevision.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1916`** (1 nodes): `types.ts`
+- **Thin community `Community 1916`** (1 nodes): `registerSessionCloseoutHolds.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1917`** (1 nodes): `facts.ts`
+- **Thin community `Community 1917`** (1 nodes): `registerSessionSyncReview.classify.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1918`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1919`** (1 nodes): `types.ts`
+- **Thin community `Community 1919`** (1 nodes): `facts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1920`** (1 nodes): `terminalHealthAlerts.test.ts`
+- **Thin community `Community 1920`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1921`** (1 nodes): `terminalSyncEvidence.ts`
+- **Thin community `Community 1921`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1922`** (1 nodes): `types.ts`
+- **Thin community `Community 1922`** (1 nodes): `terminalHealthAlerts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1923`** (1 nodes): `registerLifecycleAuthorityRepository.test.ts`
+- **Thin community `Community 1923`** (1 nodes): `terminalSyncEvidence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1924`** (1 nodes): `registerLifecycleAuthorityStatusRepository.test.ts`
+- **Thin community `Community 1924`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1925`** (1 nodes): `transactionRepository.test.ts`
+- **Thin community `Community 1925`** (1 nodes): `registerLifecycleAuthorityRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1926`** (1 nodes): `register.ts`
+- **Thin community `Community 1926`** (1 nodes): `registerLifecycleAuthorityStatusRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1927`** (1 nodes): `posRuntimeAdapter.test.ts`
+- **Thin community `Community 1927`** (1 nodes): `transactionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1928`** (1 nodes): `types.test.ts`
+- **Thin community `Community 1928`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1929`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 1929`** (1 nodes): `posRuntimeAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1930`** (1 nodes): `schema.ts`
+- **Thin community `Community 1930`** (1 nodes): `types.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1931`** (1 nodes): `automation.ts`
+- **Thin community `Community 1931`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1932`** (1 nodes): `contextTracking.ts`
+- **Thin community `Community 1932`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1933`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1933`** (1 nodes): `automation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1934`** (1 nodes): `index.ts`
+- **Thin community `Community 1934`** (1 nodes): `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1935`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1935`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1936`** (1 nodes): `intelligence.ts`
+- **Thin community `Community 1936`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1937`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1937`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1938`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1938`** (1 nodes): `intelligence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1939`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1939`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1940`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1940`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1941`** (1 nodes): `catalogSummary.ts`
+- **Thin community `Community 1941`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1942`** (1 nodes): `category.ts`
+- **Thin community `Community 1942`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1943`** (1 nodes): `color.ts`
+- **Thin community `Community 1943`** (1 nodes): `catalogSummary.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1944`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1944`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1945`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1945`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1946`** (1 nodes): `index.ts`
+- **Thin community `Community 1946`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1947`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1947`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1948`** (1 nodes): `inventoryImportCostOverlayBulkDecisionRequest.ts`
+- **Thin community `Community 1948`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1949`** (1 nodes): `inventoryImportCostOverlayRow.ts`
+- **Thin community `Community 1949`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1950`** (1 nodes): `inventoryImportCostOverlayRun.ts`
+- **Thin community `Community 1950`** (1 nodes): `inventoryImportCostOverlayBulkDecisionRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1951`** (1 nodes): `inventoryImportProvisionalSku.ts`
+- **Thin community `Community 1951`** (1 nodes): `inventoryImportCostOverlayRow.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1952`** (1 nodes): `inventoryImportReviewVersion.ts`
+- **Thin community `Community 1952`** (1 nodes): `inventoryImportCostOverlayRun.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1953`** (1 nodes): `inventoryImportReviewVersionPayloadChunk.ts`
+- **Thin community `Community 1953`** (1 nodes): `inventoryImportProvisionalSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1954`** (1 nodes): `inventoryImportReviewVersionPayloadUpload.ts`
+- **Thin community `Community 1954`** (1 nodes): `inventoryImportReviewVersion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1955`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1955`** (1 nodes): `inventoryImportReviewVersionPayloadChunk.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1956`** (1 nodes): `organization.ts`
+- **Thin community `Community 1956`** (1 nodes): `inventoryImportReviewVersionPayloadUpload.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1957`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1957`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1958`** (1 nodes): `posRegisterCatalogRevision.ts`
+- **Thin community `Community 1958`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1959`** (1 nodes): `product.ts`
+- **Thin community `Community 1959`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1960`** (1 nodes): `productSkuSearch.ts`
+- **Thin community `Community 1960`** (1 nodes): `posRegisterCatalogRevision.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1961`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1961`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1962`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1962`** (1 nodes): `productSkuSearch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1963`** (1 nodes): `store.ts`
+- **Thin community `Community 1963`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1964`** (1 nodes): `storeSchedule.ts`
+- **Thin community `Community 1964`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1965`** (1 nodes): `storeTimezone.ts`
+- **Thin community `Community 1965`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1966`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1966`** (1 nodes): `storeSchedule.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1967`** (1 nodes): `index.ts`
+- **Thin community `Community 1967`** (1 nodes): `storeTimezone.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1968`** (1 nodes): `landingFunnelEvent.ts`
+- **Thin community `Community 1968`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1969`** (1 nodes): `walkthroughRequest.ts`
+- **Thin community `Community 1969`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1970`** (1 nodes): `index.ts`
+- **Thin community `Community 1970`** (1 nodes): `landingFunnelEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1971`** (1 nodes): `notifications.ts`
+- **Thin community `Community 1971`** (1 nodes): `walkthroughRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1972`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1973`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1973`** (1 nodes): `notifications.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1974`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1974`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1975`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1975`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1976`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1976`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1977`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1977`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1978`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1978`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1979`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1979`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1980`** (1 nodes): `index.ts`
+- **Thin community `Community 1980`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1981`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1981`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1982`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1982`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1983`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1983`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1984`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1984`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1985`** (1 nodes): `oversizedOperationalWorkRepair.ts`
+- **Thin community `Community 1985`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1986`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1986`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1987`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1987`** (1 nodes): `oversizedOperationalWorkRepair.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1988`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1988`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1989`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1989`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1990`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1990`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1991`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1991`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1992`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1992`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1993`** (1 nodes): `customer.ts`
+- **Thin community `Community 1993`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1994`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1994`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1995`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1995`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1996`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1996`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1997`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1997`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1998`** (1 nodes): `index.ts`
+- **Thin community `Community 1998`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1999`** (1 nodes): `posAmountMigrationRun.ts`
+- **Thin community `Community 1999`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2000`** (1 nodes): `posClientEvent.ts`
+- **Thin community `Community 2000`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2001`** (1 nodes): `posLifecycleJournal.ts`
+- **Thin community `Community 2001`** (1 nodes): `posAmountMigrationRun.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2002`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 2002`** (1 nodes): `posClientEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2003`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 2003`** (1 nodes): `posLifecycleJournal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2004`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 2004`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2005`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 2005`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2006`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 2006`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2007`** (1 nodes): `posPendingCheckoutItem.ts`
+- **Thin community `Community 2007`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2008`** (1 nodes): `posPendingCheckoutLookupAlias.ts`
+- **Thin community `Community 2008`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2009`** (1 nodes): `posRecoveryCredential.ts`
+- **Thin community `Community 2009`** (1 nodes): `posPendingCheckoutItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2010`** (1 nodes): `posRegisterAuthorityReplicationStatus.ts`
+- **Thin community `Community 2010`** (1 nodes): `posPendingCheckoutLookupAlias.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2011`** (1 nodes): `posRegisterMappingAuthority.ts`
+- **Thin community `Community 2011`** (1 nodes): `posRecoveryCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2012`** (1 nodes): `posRegisterSessionActivity.ts`
+- **Thin community `Community 2012`** (1 nodes): `posRegisterAuthorityReplicationStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2013`** (1 nodes): `posRegisterSessionActivityCheckpoint.ts`
+- **Thin community `Community 2013`** (1 nodes): `posRegisterMappingAuthority.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2014`** (1 nodes): `posSession.ts`
+- **Thin community `Community 2014`** (1 nodes): `posRegisterSessionActivity.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2015`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 2015`** (1 nodes): `posRegisterSessionActivityCheckpoint.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2016`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 2016`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2017`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 2017`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2018`** (1 nodes): `posTerminalRecovery.ts`
+- **Thin community `Community 2018`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2019`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 2019`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2020`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 2020`** (1 nodes): `posTerminalRecovery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2021`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 2021`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2022`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 2022`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2023`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 2023`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2024`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 2024`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2025`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 2025`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2026`** (1 nodes): `index.ts`
+- **Thin community `Community 2026`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2027`** (1 nodes): `remoteAssistClient.ts`
+- **Thin community `Community 2027`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2028`** (1 nodes): `remoteAssistSession.ts`
+- **Thin community `Community 2028`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2029`** (1 nodes): `derived.ts`
+- **Thin community `Community 2029`** (1 nodes): `remoteAssistClient.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2030`** (1 nodes): `facts.ts`
+- **Thin community `Community 2030`** (1 nodes): `remoteAssistSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2031`** (1 nodes): `index.ts`
+- **Thin community `Community 2031`** (1 nodes): `derived.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2032`** (1 nodes): `verificationRuns.ts`
+- **Thin community `Community 2032`** (1 nodes): `facts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 2033`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2034`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 2034`** (1 nodes): `verificationRuns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2035`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 2035`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2036`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 2036`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2037`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 2037`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2038`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 2038`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2039`** (1 nodes): `sharedDemo.ts`
+- **Thin community `Community 2039`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2040`** (1 nodes): `staffMessages.ts`
+- **Thin community `Community 2040`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2041`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 2041`** (1 nodes): `sharedDemo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2042`** (1 nodes): `index.ts`
+- **Thin community `Community 2042`** (1 nodes): `staffMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2043`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 2043`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2044`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 2044`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2045`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 2045`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2046`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 2046`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2047`** (1 nodes): `vendor.ts`
+- **Thin community `Community 2047`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2048`** (1 nodes): `analytics.ts`
+- **Thin community `Community 2048`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2049`** (1 nodes): `bag.ts`
+- **Thin community `Community 2049`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2050`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 2050`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2051`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 2051`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2052`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 2052`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2053`** (1 nodes): `guest.ts`
+- **Thin community `Community 2053`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2054`** (1 nodes): `index.ts`
+- **Thin community `Community 2054`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2055`** (1 nodes): `offer.ts`
+- **Thin community `Community 2055`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2056`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 2056`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2057`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 2057`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2058`** (1 nodes): `review.ts`
+- **Thin community `Community 2058`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2059`** (1 nodes): `rewards.ts`
+- **Thin community `Community 2059`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2060`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 2060`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2061`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 2061`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2062`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 2062`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2063`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 2063`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2064`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 2064`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2065`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 2065`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2066`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 2066`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2067`** (1 nodes): `authBoundary.test.ts`
+- **Thin community `Community 2067`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2068`** (1 nodes): `config.test.ts`
+- **Thin community `Community 2068`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2069`** (1 nodes): `domainRestore.test.ts`
+- **Thin community `Community 2069`** (1 nodes): `authBoundary.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2070`** (1 nodes): `foundation.test.ts`
+- **Thin community `Community 2070`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2071`** (1 nodes): `openingBaseline.test.ts`
+- **Thin community `Community 2071`** (1 nodes): `domainRestore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2072`** (1 nodes): `policy.test.ts`
+- **Thin community `Community 2072`** (1 nodes): `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2073`** (1 nodes): `public.test.ts`
+- **Thin community `Community 2073`** (1 nodes): `openingBaseline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2074`** (1 nodes): `serviceEffectBoundaryCoverage.test.ts`
+- **Thin community `Community 2074`** (1 nodes): `policy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2075`** (1 nodes): `bag.ts`
+- **Thin community `Community 2075`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2076`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 2076`** (1 nodes): `serviceEffectBoundaryCoverage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2077`** (1 nodes): `customer.ts`
+- **Thin community `Community 2077`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2078`** (1 nodes): `guest.ts`
+- **Thin community `Community 2078`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2079`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 2079`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2080`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 2080`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2081`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 2081`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2082`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 2082`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2083`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 2083`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2084`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 2084`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2085`** (1 nodes): `userStoreActivity.test.ts`
+- **Thin community `Community 2085`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2086`** (1 nodes): `users.ts`
+- **Thin community `Community 2086`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2087`** (1 nodes): `storeTimeAuthority.test.ts`
+- **Thin community `Community 2087`** (1 nodes): `userStoreActivity.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2088`** (1 nodes): `payment.ts`
+- **Thin community `Community 2088`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2089`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2089`** (1 nodes): `storeTimeAuthority.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2090`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 2090`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2091`** (1 nodes): `purchaseOrder.test.ts`
+- **Thin community `Community 2091`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2092`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 2092`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2093`** (1 nodes): `serviceCase.test.ts`
+- **Thin community `Community 2093`** (1 nodes): `purchaseOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2094`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 2094`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2095`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 2095`** (1 nodes): `serviceCase.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2096`** (1 nodes): `index.ts`
+- **Thin community `Community 2096`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2097`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 2097`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2098`** (1 nodes): `playwright.prod.config.ts`
+- **Thin community `Community 2098`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2099`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 2099`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2100`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 2100`** (1 nodes): `playwright.prod.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2101`** (1 nodes): `auth.ts`
+- **Thin community `Community 2101`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2102`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 2102`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2103`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 2103`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2104`** (1 nodes): `homepageRanking.test.ts`
+- **Thin community `Community 2104`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2105`** (1 nodes): `contextBundleTypes.ts`
+- **Thin community `Community 2105`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2106`** (1 nodes): `contextEventTypes.ts`
+- **Thin community `Community 2106`** (1 nodes): `homepageRanking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2107`** (1 nodes): `contextTracking.test.ts`
+- **Thin community `Community 2107`** (1 nodes): `contextBundleTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2108`** (1 nodes): `contextTypes.ts`
+- **Thin community `Community 2108`** (1 nodes): `contextEventTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2109`** (1 nodes): `index.ts`
+- **Thin community `Community 2109`** (1 nodes): `contextTracking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2110`** (1 nodes): `providerTypes.ts`
+- **Thin community `Community 2110`** (1 nodes): `contextTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2111`** (1 nodes): `inventoryImportReviewPayload.test.ts`
+- **Thin community `Community 2111`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2112`** (1 nodes): `inventoryImportSource.test.ts`
+- **Thin community `Community 2112`** (1 nodes): `providerTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2113`** (1 nodes): `terminalRuntimeMaterial.test.ts`
+- **Thin community `Community 2113`** (1 nodes): `inventoryImportReviewPayload.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2114`** (1 nodes): `posRegisterSessionActivityContract.test.ts`
+- **Thin community `Community 2114`** (1 nodes): `inventoryImportSource.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2115`** (1 nodes): `productDisplayName.test.ts`
+- **Thin community `Community 2115`** (1 nodes): `terminalRuntimeMaterial.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2116`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
+- **Thin community `Community 2116`** (1 nodes): `posRegisterSessionActivityContract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2117`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 2117`** (1 nodes): `productDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2118`** (1 nodes): `sharedDemoRegisterError.test.ts`
+- **Thin community `Community 2118`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2119`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 2119`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2120`** (1 nodes): `storefrontVisibility.test.ts`
+- **Thin community `Community 2120`** (1 nodes): `sharedDemoRegisterError.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2121`** (1 nodes): `appRouter.ts`
+- **Thin community `Community 2121`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2122`** (1 nodes): `convexAuthUrl.test.ts`
+- **Thin community `Community 2122`** (1 nodes): `storefrontVisibility.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2123`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 2123`** (1 nodes): `appRouter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2124`** (1 nodes): `Navbar.test.tsx`
+- **Thin community `Community 2124`** (1 nodes): `convexAuthUrl.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2125`** (1 nodes): `Navbar.tsx`
+- **Thin community `Community 2125`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2126`** (1 nodes): `OrganizationView.test.tsx`
+- **Thin community `Community 2126`** (1 nodes): `Navbar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2127`** (1 nodes): `ProtectedRoute.test.tsx`
+- **Thin community `Community 2127`** (1 nodes): `Navbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2128`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 2128`** (1 nodes): `OrganizationView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2129`** (1 nodes): `StoreView.test.tsx`
+- **Thin community `Community 2129`** (1 nodes): `ProtectedRoute.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2130`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 2130`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2131`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 2131`** (1 nodes): `StoreView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2132`** (1 nodes): `View.test.tsx`
+- **Thin community `Community 2132`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2133`** (1 nodes): `AttributesTable.test.ts`
+- **Thin community `Community 2133`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2134`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 2134`** (1 nodes): `View.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2135`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 2135`** (1 nodes): `AttributesTable.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2136`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 2136`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2137`** (1 nodes): `ProductCategorization.test.ts`
+- **Thin community `Community 2137`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2138`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 2138`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2139`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 2139`** (1 nodes): `ProductCategorization.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2140`** (1 nodes): `CopyImagesView.test.tsx`
+- **Thin community `Community 2140`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2141`** (1 nodes): `constants.ts`
+- **Thin community `Community 2141`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2142`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2142`** (1 nodes): `CopyImagesView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2143`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2143`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2144`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2144`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2145`** (1 nodes): `types.ts`
+- **Thin community `Community 2145`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2146`** (1 nodes): `AnalyticsView.test.tsx`
+- **Thin community `Community 2146`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2147`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 2147`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2148`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 2148`** (1 nodes): `AnalyticsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2149`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 2149`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2150`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2150`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2151`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2151`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2152`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2152`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2153`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2153`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2154`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2154`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2155`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2155`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2156`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2156`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2157`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2157`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2158`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2158`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2159`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2159`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2160`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2160`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2161`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2161`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2162`** (1 nodes): `chart.tsx`
+- **Thin community `Community 2162`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2163`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2163`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2164`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2164`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2165`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2165`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2166`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2166`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2167`** (1 nodes): `constants.ts`
+- **Thin community `Community 2167`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2168`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2168`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2169`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2169`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2170`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2170`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2171`** (1 nodes): `data.ts`
+- **Thin community `Community 2171`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2172`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2172`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2173`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2173`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2174`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2174`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2175`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2175`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2176`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2176`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2177`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2177`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2178`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2178`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2179`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2179`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2180`** (1 nodes): `AppSettingsView.test.tsx`
+- **Thin community `Community 2180`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2181`** (1 nodes): `app-sidebar.test.tsx`
+- **Thin community `Community 2181`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2182`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 2182`** (1 nodes): `AppSettingsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2183`** (1 nodes): `constants.ts`
+- **Thin community `Community 2183`** (1 nodes): `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2184`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2184`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2185`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2185`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2186`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2186`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2187`** (1 nodes): `data.ts`
+- **Thin community `Community 2187`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2188`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 2188`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2189`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 2189`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2190`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 2190`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2191`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
+- **Thin community `Community 2191`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2192`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2192`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2193`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2193`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2194`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2194`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2195`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2195`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2196`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2196`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2197`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2197`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2198`** (1 nodes): `constants.ts`
+- **Thin community `Community 2198`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2199`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2199`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2200`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2200`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2201`** (1 nodes): `data-table.test.tsx`
+- **Thin community `Community 2201`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2202`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2202`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2203`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 2203`** (1 nodes): `data-table.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2204`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 2204`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2205`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 2205`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2206`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 2206`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2207`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 2207`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2208`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 2208`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2209`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 2209`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2210`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 2210`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2211`** (1 nodes): `registerSessionTimestamps.test.ts`
+- **Thin community `Community 2211`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2212`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2212`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2213`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2213`** (1 nodes): `registerSessionTimestamps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2214`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2214`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2215`** (1 nodes): `AnimatedDataState.test.tsx`
+- **Thin community `Community 2215`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2216`** (1 nodes): `ListPagination.test.tsx`
+- **Thin community `Community 2216`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2217`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 2217`** (1 nodes): `AnimatedDataState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2218`** (1 nodes): `PageHeader.test.tsx`
+- **Thin community `Community 2218`** (1 nodes): `ListPagination.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2219`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 2219`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2220`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 2220`** (1 nodes): `PageHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2221`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 2221`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2222`** (1 nodes): `DocsReportView.tsx`
+- **Thin community `Community 2222`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2223`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 2223`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2224`** (1 nodes): `Home.test.tsx`
+- **Thin community `Community 2224`** (1 nodes): `DocsReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2225`** (1 nodes): `HomepagePlacementProductImage.test.ts`
+- **Thin community `Community 2225`** (1 nodes): `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2226`** (1 nodes): `ShopLookImageUploader.test.tsx`
+- **Thin community `Community 2226`** (1 nodes): `Home.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2227`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 2227`** (1 nodes): `HomepagePlacementProductImage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2228`** (1 nodes): `demoDay.test.ts`
+- **Thin community `Community 2228`** (1 nodes): `ShopLookImageUploader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2229`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 2229`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2230`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 2230`** (1 nodes): `demoDay.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2231`** (1 nodes): `OperationsSummaryMetric.test.tsx`
+- **Thin community `Community 2231`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2232`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 2232`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2233`** (1 nodes): `openWorkInventoryReport.test.ts`
+- **Thin community `Community 2233`** (1 nodes): `OperationsSummaryMetric.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2234`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 2234`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2235`** (1 nodes): `skuActivityUntrustedSalesAdapter.test.ts`
+- **Thin community `Community 2235`** (1 nodes): `openWorkInventoryReport.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2236`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 2236`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2237`** (1 nodes): `CustomerDetailsView.test.tsx`
+- **Thin community `Community 2237`** (1 nodes): `skuActivityUntrustedSalesAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2238`** (1 nodes): `CustomerDetailsView.tsx`
+- **Thin community `Community 2238`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2239`** (1 nodes): `OrderDetailsView.test.tsx`
+- **Thin community `Community 2239`** (1 nodes): `CustomerDetailsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2240`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 2240`** (1 nodes): `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2241`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 2241`** (1 nodes): `OrderDetailsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2242`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 2242`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2243`** (1 nodes): `OrderView.test.tsx`
+- **Thin community `Community 2243`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2244`** (1 nodes): `OrdersView.test.tsx`
+- **Thin community `Community 2244`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2245`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 2245`** (1 nodes): `OrderView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2246`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 2246`** (1 nodes): `OrdersView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2247`** (1 nodes): `constants.ts`
+- **Thin community `Community 2247`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2248`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2248`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2249`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2249`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2250`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2250`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2251`** (1 nodes): `data.ts`
+- **Thin community `Community 2251`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2252`** (1 nodes): `orderColumns.test.tsx`
+- **Thin community `Community 2252`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2253`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 2253`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2254`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2254`** (1 nodes): `orderColumns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2255`** (1 nodes): `constants.ts`
+- **Thin community `Community 2255`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2256`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2256`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2257`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2257`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2258`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2258`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2259`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2259`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2260`** (1 nodes): `data.ts`
+- **Thin community `Community 2260`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2261`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 2261`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2262`** (1 nodes): `constants.ts`
+- **Thin community `Community 2262`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2263`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2263`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2264`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2264`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2265`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2265`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2266`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2266`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2267`** (1 nodes): `data.ts`
+- **Thin community `Community 2267`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2268`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 2268`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2269`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 2269`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2270`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 2270`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2271`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 2271`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2272`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 2272`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2273`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 2273`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2274`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 2274`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2275`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 2275`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2276`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 2276`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2277`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 2277`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2278`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 2278`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2279`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 2279`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2280`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 2280`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2281`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 2281`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2282`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 2282`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2283`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 2283`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2284`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 2284`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2285`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 2285`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2286`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 2286`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2287`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 2287`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2288`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 2288`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2289`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 2289`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2290`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 2290`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2291`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 2291`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2292`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 2292`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2293`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 2293`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2294`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 2294`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2295`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 2295`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2296`** (1 nodes): `types.ts`
+- **Thin community `Community 2296`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2297`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 2297`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2298`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 2298`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2299`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 2299`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2300`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 2300`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2301`** (1 nodes): `ImagesView.test.tsx`
+- **Thin community `Community 2301`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2302`** (1 nodes): `ProductDetailView.test.tsx`
+- **Thin community `Community 2302`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2303`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 2303`** (1 nodes): `ImagesView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2304`** (1 nodes): `productStockPresentation.test.ts`
+- **Thin community `Community 2304`** (1 nodes): `ProductDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2305`** (1 nodes): `ArchivedProducts.test.tsx`
+- **Thin community `Community 2305`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2306`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 2306`** (1 nodes): `productStockPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2307`** (1 nodes): `ProductsListView.test.ts`
+- **Thin community `Community 2307`** (1 nodes): `ArchivedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2308`** (1 nodes): `ProductsListView.test.tsx`
+- **Thin community `Community 2308`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2309`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 2309`** (1 nodes): `ProductsListView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2310`** (1 nodes): `UnresolvedProducts.test.tsx`
+- **Thin community `Community 2310`** (1 nodes): `ProductsListView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2311`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 2311`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2312`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 2312`** (1 nodes): `UnresolvedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2313`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 2313`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2314`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2314`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2315`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2315`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2316`** (1 nodes): `data-table-toolbar.test.tsx`
+- **Thin community `Community 2316`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2317`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2317`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2318`** (1 nodes): `data-table.test.tsx`
+- **Thin community `Community 2318`** (1 nodes): `data-table-toolbar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2319`** (1 nodes): `data.ts`
+- **Thin community `Community 2319`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2320`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 2320`** (1 nodes): `data-table.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2321`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 2321`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2322`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 2322`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2323`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 2323`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2324`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 2324`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2325`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 2325`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2326`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2326`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2327`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2327`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2328`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2328`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2329`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2329`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2330`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2330`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2331`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2331`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2332`** (1 nodes): `constants.ts`
+- **Thin community `Community 2332`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2333`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2333`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2334`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2334`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2335`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2335`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2336`** (1 nodes): `data.ts`
+- **Thin community `Community 2336`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2337`** (1 nodes): `types.ts`
+- **Thin community `Community 2337`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2338`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 2338`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2339`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
+- **Thin community `Community 2339`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2340`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
+- **Thin community `Community 2340`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2341`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
+- **Thin community `Community 2341`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2342`** (1 nodes): `RemoteAssistSupportConsole.tsx`
+- **Thin community `Community 2342`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2343`** (1 nodes): `index.ts`
+- **Thin community `Community 2343`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2344`** (1 nodes): `ReportCalendar.test.tsx`
+- **Thin community `Community 2344`** (1 nodes): `RemoteAssistSupportConsole.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2345`** (1 nodes): `ReportCustomRangePanel.test.tsx`
+- **Thin community `Community 2345`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2346`** (1 nodes): `ReportDateRangeField.test.tsx`
+- **Thin community `Community 2346`** (1 nodes): `ReportCalendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2347`** (1 nodes): `ReportSegmentedTabs.test.tsx`
+- **Thin community `Community 2347`** (1 nodes): `ReportCustomRangePanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2348`** (1 nodes): `ReportSegmentedTabs.tsx`
+- **Thin community `Community 2348`** (1 nodes): `ReportDateRangeField.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2349`** (1 nodes): `ReportSkuMixChart.test.tsx`
+- **Thin community `Community 2349`** (1 nodes): `ReportSegmentedTabs.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2350`** (1 nodes): `reportFormat.test.ts`
+- **Thin community `Community 2350`** (1 nodes): `ReportSegmentedTabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2351`** (1 nodes): `reportPeriodKeys.test.ts`
+- **Thin community `Community 2351`** (1 nodes): `ReportSkuMixChart.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2352`** (1 nodes): `reportRouteSearch.test.ts`
+- **Thin community `Community 2352`** (1 nodes): `reportFormat.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2353`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 2353`** (1 nodes): `reportPeriodKeys.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2354`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 2354`** (1 nodes): `reportRouteSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2355`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 2355`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2356`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 2356`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2357`** (1 nodes): `SharedDemoExperience.test.tsx`
+- **Thin community `Community 2357`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2358`** (1 nodes): `SharedDemoRestoreOverlay.test.tsx`
+- **Thin community `Community 2358`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2359`** (1 nodes): `sharedDemoLocalBootstrap.test.ts`
+- **Thin community `Community 2359`** (1 nodes): `SharedDemoExperience.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2360`** (1 nodes): `sharedDemoRestoreOverlay.test.ts`
+- **Thin community `Community 2360`** (1 nodes): `SharedDemoRestoreOverlay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2361`** (1 nodes): `sharedDemoRestoreOverlay.tsx`
+- **Thin community `Community 2361`** (1 nodes): `sharedDemoLocalBootstrap.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2362`** (1 nodes): `index.tsx`
+- **Thin community `Community 2362`** (1 nodes): `sharedDemoRestoreOverlay.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2363`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 2363`** (1 nodes): `sharedDemoRestoreOverlay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2364`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 2364`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2365`** (1 nodes): `NotFound.test.tsx`
+- **Thin community `Community 2365`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2366`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 2366`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2367`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 2367`** (1 nodes): `NotFound.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2368`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 2368`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2369`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 2369`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2370`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 2370`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2371`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 2371`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2372`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
+- **Thin community `Community 2372`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2373`** (1 nodes): `index.tsx`
+- **Thin community `Community 2373`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2374`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 2374`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2375`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 2375`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2376`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 2376`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2377`** (1 nodes): `button.tsx`
+- **Thin community `Community 2377`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2378`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 2378`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2379`** (1 nodes): `card.tsx`
+- **Thin community `Community 2379`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2380`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 2380`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2381`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 2381`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2382`** (1 nodes): `command.tsx`
+- **Thin community `Community 2382`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2383`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 2383`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2384`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 2384`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2385`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 2385`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2386`** (1 nodes): `form.tsx`
+- **Thin community `Community 2386`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2387`** (1 nodes): `icons.tsx`
+- **Thin community `Community 2387`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2388`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 2388`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2389`** (1 nodes): `input.test.tsx`
+- **Thin community `Community 2389`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2390`** (1 nodes): `input.tsx`
+- **Thin community `Community 2390`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2391`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 2391`** (1 nodes): `input.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2392`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 2392`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2393`** (1 nodes): `popover.tsx`
+- **Thin community `Community 2393`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2394`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 2394`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2395`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 2395`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2396`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 2396`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2397`** (1 nodes): `select.tsx`
+- **Thin community `Community 2397`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2398`** (1 nodes): `separator.tsx`
+- **Thin community `Community 2398`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2399`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 2399`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2400`** (1 nodes): `switch.tsx`
+- **Thin community `Community 2400`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2401`** (1 nodes): `table.test.tsx`
+- **Thin community `Community 2401`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2402`** (1 nodes): `table.tsx`
+- **Thin community `Community 2402`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2403`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 2403`** (1 nodes): `table.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2404`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 2404`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2405`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 2405`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2406`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 2406`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2407`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 2407`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2408`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 2408`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2409`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 2409`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2410`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2410`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2411`** (1 nodes): `constants.ts`
+- **Thin community `Community 2411`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2412`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2412`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2413`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2413`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2414`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2414`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2415`** (1 nodes): `data.ts`
+- **Thin community `Community 2415`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2416`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 2416`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2417`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 2417`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2418`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2418`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2419`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2419`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2420`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2420`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2421`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2421`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2422`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2422`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2423`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 2423`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2424`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 2424`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2425`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 2425`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2426`** (1 nodes): `index.ts`
+- **Thin community `Community 2426`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2427`** (1 nodes): `config.test.ts`
+- **Thin community `Community 2427`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2428`** (1 nodes): `docsWorkspaceTracking.test.ts`
+- **Thin community `Community 2428`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2429`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 2429`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2430`** (1 nodes): `onlineOrderSessionOverlay.test.ts`
+- **Thin community `Community 2430`** (1 nodes): `docsWorkspaceTracking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2431`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 2431`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2432`** (1 nodes): `use-pagination-persistence.test.ts`
+- **Thin community `Community 2432`** (1 nodes): `onlineOrderSessionOverlay.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2433`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 2433`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2434`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 2434`** (1 nodes): `use-pagination-persistence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2435`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 2435`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2436`** (1 nodes): `useGetActiveStore.test.ts`
+- **Thin community `Community 2436`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2437`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 2437`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2438`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 2438`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2439`** (1 nodes): `usePOSProducts.test.ts`
+- **Thin community `Community 2439`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2440`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 2440`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2441`** (1 nodes): `useSharedDemoContext.test.ts`
+- **Thin community `Community 2441`** (1 nodes): `usePOSProducts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2442`** (1 nodes): `useStoreOperatingClock.test.tsx`
+- **Thin community `Community 2442`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2443`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 2443`** (1 nodes): `useSharedDemoContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2444`** (1 nodes): `AppMessagesContext.ts`
+- **Thin community `Community 2444`** (1 nodes): `useStoreOperatingClock.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2445`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
+- **Thin community `Community 2445`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2446`** (1 nodes): `index.ts`
+- **Thin community `Community 2446`** (1 nodes): `AppMessagesContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2447`** (1 nodes): `appUpdateActions.ts`
+- **Thin community `Community 2447`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 2448`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2449`** (1 nodes): `updateCommunicationPreferenceContext.ts`
+- **Thin community `Community 2449`** (1 nodes): `appUpdateActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2450`** (1 nodes): `updateCoordinator.test.ts`
+- **Thin community `Community 2450`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2451`** (1 nodes): `aws.ts`
+- **Thin community `Community 2451`** (1 nodes): `updateCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2452`** (1 nodes): `constants.ts`
+- **Thin community `Community 2452`** (1 nodes): `updateCoordinator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2453`** (1 nodes): `countries.ts`
+- **Thin community `Community 2453`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2454`** (1 nodes): `access.test.ts`
+- **Thin community `Community 2454`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2455`** (1 nodes): `content.test.ts`
+- **Thin community `Community 2455`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2456`** (1 nodes): `navigation.test.ts`
+- **Thin community `Community 2456`** (1 nodes): `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2457`** (1 nodes): `parsing.test.ts`
+- **Thin community `Community 2457`** (1 nodes): `content.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2458`** (1 nodes): `reportContract.test.ts`
+- **Thin community `Community 2458`** (1 nodes): `navigation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2459`** (1 nodes): `scrollProgress.test.ts`
+- **Thin community `Community 2459`** (1 nodes): `parsing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2460`** (1 nodes): `virtual-docs-index.d.ts`
+- **Thin community `Community 2460`** (1 nodes): `reportContract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2461`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 2461`** (1 nodes): `scrollProgress.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2462`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 2462`** (1 nodes): `virtual-docs-index.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2463`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 2463`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2464`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 2464`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2465`** (1 nodes): `ghana.ts`
+- **Thin community `Community 2465`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2466`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 2466`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2467`** (1 nodes): `inventoryImportParser.test.ts`
+- **Thin community `Community 2467`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2468`** (1 nodes): `landingFunnelClient.test.ts`
+- **Thin community `Community 2468`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2469`** (1 nodes): `walkthroughPrivacy.ts`
+- **Thin community `Community 2469`** (1 nodes): `inventoryImportParser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2470`** (1 nodes): `walkthroughRequestClient.test.ts`
+- **Thin community `Community 2470`** (1 nodes): `landingFunnelClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2471`** (1 nodes): `appEntryRoutes.test.ts`
+- **Thin community `Community 2471`** (1 nodes): `walkthroughPrivacy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2472`** (1 nodes): `storeEntryRoute.test.ts`
+- **Thin community `Community 2472`** (1 nodes): `walkthroughRequestClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2473`** (1 nodes): `operatingDate.test.ts`
+- **Thin community `Community 2473`** (1 nodes): `appEntryRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2474`** (1 nodes): `dto.ts`
+- **Thin community `Community 2474`** (1 nodes): `storeEntryRoute.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2475`** (1 nodes): `ports.ts`
+- **Thin community `Community 2475`** (1 nodes): `operatingDate.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2476`** (1 nodes): `posLocalStorePort.ts`
+- **Thin community `Community 2476`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2477`** (1 nodes): `results.test.ts`
+- **Thin community `Community 2477`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2478`** (1 nodes): `constants.ts`
+- **Thin community `Community 2478`** (1 nodes): `posLocalStorePort.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2479`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 2479`** (1 nodes): `results.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2480`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 2480`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2481`** (1 nodes): `index.ts`
+- **Thin community `Community 2481`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2482`** (1 nodes): `session.test.ts`
+- **Thin community `Community 2482`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2483`** (1 nodes): `types.ts`
+- **Thin community `Community 2483`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2484`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 2484`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2485`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 2485`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2486`** (1 nodes): `registerLifecycleAuthorityGateway.test.ts`
+- **Thin community `Community 2486`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2487`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 2487`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2488`** (1 nodes): `drawerAuthorityReconciliation.test.ts`
+- **Thin community `Community 2488`** (1 nodes): `registerLifecycleAuthorityGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2489`** (1 nodes): `indexedDbPosLocalStorageEngine.test.ts`
+- **Thin community `Community 2489`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2490`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 2490`** (1 nodes): `drawerAuthorityReconciliation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2491`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 2491`** (1 nodes): `indexedDbPosLocalStorageEngine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2492`** (1 nodes): `posLocalLedgerPolicy.test.ts`
+- **Thin community `Community 2492`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2493`** (1 nodes): `posLocalStorageHealth.test.ts`
+- **Thin community `Community 2493`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2494`** (1 nodes): `posLocalStorageRuntime.test.ts`
+- **Thin community `Community 2494`** (1 nodes): `posLocalLedgerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2495`** (1 nodes): `posLocalStoreInitialization.test.ts`
+- **Thin community `Community 2495`** (1 nodes): `posLocalStorageHealth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2496`** (1 nodes): `posLocalStoreMaintenance.test.ts`
+- **Thin community `Community 2496`** (1 nodes): `posLocalStorageRuntime.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2497`** (1 nodes): `posLocalStoreMigrations.test.ts`
+- **Thin community `Community 2497`** (1 nodes): `posLocalStoreInitialization.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2498`** (1 nodes): `posLocalStoreSnapshot.test.ts`
+- **Thin community `Community 2498`** (1 nodes): `posLocalStoreMaintenance.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2499`** (1 nodes): `registerCatalogPinRuntime.test.ts`
+- **Thin community `Community 2499`** (1 nodes): `posLocalStoreMigrations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2500`** (1 nodes): `registerLifecycleAuthorityRollout.test.ts`
+- **Thin community `Community 2500`** (1 nodes): `posLocalStoreSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2501`** (1 nodes): `registerSessionAuthorityBootstrap.test.ts`
+- **Thin community `Community 2501`** (1 nodes): `registerCatalogPinRuntime.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2502`** (1 nodes): `saleBlockerPolicy.test.ts`
+- **Thin community `Community 2502`** (1 nodes): `registerLifecycleAuthorityRollout.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2503`** (1 nodes): `syncGapDiagnosis.test.ts`
+- **Thin community `Community 2503`** (1 nodes): `registerSessionAuthorityBootstrap.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2504`** (1 nodes): `printAttemptTelemetry.test.ts`
+- **Thin community `Community 2504`** (1 nodes): `saleBlockerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2505`** (1 nodes): `runtimeCounters.test.ts`
+- **Thin community `Community 2505`** (1 nodes): `syncGapDiagnosis.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2506`** (1 nodes): `telemetryBuffer.test.ts`
+- **Thin community `Community 2506`** (1 nodes): `printAttemptTelemetry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2507`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 2507`** (1 nodes): `runtimeCounters.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2508`** (1 nodes): `catalogSearchPresentation.test.ts`
+- **Thin community `Community 2508`** (1 nodes): `telemetryBuffer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2509`** (1 nodes): `registerCashierPresence.test.ts`
+- **Thin community `Community 2509`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2510`** (1 nodes): `registerCheckoutProjection.test.ts`
+- **Thin community `Community 2510`** (1 nodes): `catalogSearchPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2511`** (1 nodes): `registerUiState.test.ts`
+- **Thin community `Community 2511`** (1 nodes): `registerCashierPresence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2512`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
+- **Thin community `Community 2512`** (1 nodes): `registerCheckoutProjection.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2513`** (1 nodes): `registerSessionCode.test.ts`
+- **Thin community `Community 2513`** (1 nodes): `registerUiState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2514`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 2514`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2515`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 2515`** (1 nodes): `registerSessionCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2516`** (1 nodes): `contract.test.ts`
+- **Thin community `Community 2516`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2517`** (1 nodes): `guardrails.test.ts`
+- **Thin community `Community 2517`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2518`** (1 nodes): `index.ts`
+- **Thin community `Community 2518`** (1 nodes): `contract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2519`** (1 nodes): `runtimeBuildMetadata.test.ts`
+- **Thin community `Community 2519`** (1 nodes): `guardrails.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2520`** (1 nodes): `category.ts`
+- **Thin community `Community 2520`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2521`** (1 nodes): `product.ts`
+- **Thin community `Community 2521`** (1 nodes): `runtimeBuildMetadata.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2522`** (1 nodes): `store.ts`
+- **Thin community `Community 2522`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2523`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 2523`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2524`** (1 nodes): `user.ts`
+- **Thin community `Community 2524`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2525`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 2525`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2526`** (1 nodes): `sheetReturn.test.ts`
+- **Thin community `Community 2526`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2527`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 2527`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2528`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 2528`** (1 nodes): `sheetReturn.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2529`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 2529`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2530`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2530`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2531`** (1 nodes): `main.tsx`
+- **Thin community `Community 2531`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2532`** (1 nodes): `posAppShellReadiness.test.ts`
+- **Thin community `Community 2532`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2533`** (1 nodes): `posAppShellRoutes.test.ts`
+- **Thin community `Community 2533`** (1 nodes): `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2534`** (1 nodes): `posOfflineReadiness.test.ts`
+- **Thin community `Community 2534`** (1 nodes): `posAppShellReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2535`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
+- **Thin community `Community 2535`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2536`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 2536`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2537`** (1 nodes): `-app-entry-route.tsx`
+- **Thin community `Community 2537`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2538`** (1 nodes): `-privacy-page.tsx`
+- **Thin community `Community 2538`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2539`** (1 nodes): `-root-page-search.ts`
+- **Thin community `Community 2539`** (1 nodes): `-app-entry-route.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2540`** (1 nodes): `-shared-demo-entry.tsx`
+- **Thin community `Community 2540`** (1 nodes): `-privacy-page.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2541`** (1 nodes): `-walkthrough-page.tsx`
+- **Thin community `Community 2541`** (1 nodes): `-root-page-search.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2542`** (1 nodes): `__root.test.ts`
+- **Thin community `Community 2542`** (1 nodes): `-shared-demo-entry.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2543`** (1 nodes): `index.tsx`
+- **Thin community `Community 2543`** (1 nodes): `-walkthrough-page.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2544`** (1 nodes): `index.tsx`
+- **Thin community `Community 2544`** (1 nodes): `__root.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 2545`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2546`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 2546`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2547`** (1 nodes): `app-settings.tsx`
+- **Thin community `Community 2547`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2548`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 2548`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2549`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 2549`** (1 nodes): `app-settings.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2550`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 2550`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2551`** (1 nodes): `index.tsx`
+- **Thin community `Community 2551`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2552`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 2552`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2553`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 2553`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2554`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 2554`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2555`** (1 nodes): `home.tsx`
+- **Thin community `Community 2555`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2556`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 2556`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2557`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 2557`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2558`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 2558`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2559`** (1 nodes): `index.test.ts`
+- **Thin community `Community 2559`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2560`** (1 nodes): `-cost-overlay-search.ts`
+- **Thin community `Community 2560`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2561`** (1 nodes): `cost-overlay.test.ts`
+- **Thin community `Community 2561`** (1 nodes): `index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2562`** (1 nodes): `cost-overlay.tsx`
+- **Thin community `Community 2562`** (1 nodes): `-cost-overlay-search.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2563`** (1 nodes): `review.tsx`
+- **Thin community `Community 2563`** (1 nodes): `cost-overlay.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2564`** (1 nodes): `inventory-import.test.tsx`
+- **Thin community `Community 2564`** (1 nodes): `cost-overlay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2565`** (1 nodes): `inventory-import.tsx`
+- **Thin community `Community 2565`** (1 nodes): `review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2566`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 2566`** (1 nodes): `inventory-import.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2567`** (1 nodes): `index.tsx`
+- **Thin community `Community 2567`** (1 nodes): `inventory-import.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2568`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 2568`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2569`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 2569`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2570`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 2570`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2571`** (1 nodes): `index.tsx`
+- **Thin community `Community 2571`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2572`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 2572`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2573`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 2573`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2574`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 2574`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2575`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 2575`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2576`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 2576`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2577`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 2577`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2578`** (1 nodes): `expense.index.test.tsx`
+- **Thin community `Community 2578`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2579`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 2579`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2580`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 2580`** (1 nodes): `expense.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2581`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 2581`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2582`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 2582`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2583`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 2583`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2584`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 2584`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2585`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 2585`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2586`** (1 nodes): `edit.tsx`
+- **Thin community `Community 2586`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2587`** (1 nodes): `index.tsx`
+- **Thin community `Community 2587`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2588`** (1 nodes): `archived.tsx`
+- **Thin community `Community 2588`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2589`** (1 nodes): `new.tsx`
+- **Thin community `Community 2589`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2590`** (1 nodes): `new.tsx`
+- **Thin community `Community 2590`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2591`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 2591`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2592`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 2592`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2593`** (1 nodes): `index.tsx`
+- **Thin community `Community 2593`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2594`** (1 nodes): `new.tsx`
+- **Thin community `Community 2594`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2595`** (1 nodes): `$productSkuId.test.ts`
+- **Thin community `Community 2595`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2596`** (1 nodes): `index.test.ts`
+- **Thin community `Community 2596`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2597`** (1 nodes): `items.tsx`
+- **Thin community `Community 2597`** (1 nodes): `$productSkuId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2598`** (1 nodes): `weekly.test.ts`
+- **Thin community `Community 2598`** (1 nodes): `index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2599`** (1 nodes): `reports.tsx`
+- **Thin community `Community 2599`** (1 nodes): `items.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2600`** (1 nodes): `index.tsx`
+- **Thin community `Community 2600`** (1 nodes): `weekly.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2601`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 2601`** (1 nodes): `reports.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2602`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 2602`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2603`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 2603`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2604`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 2604`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2605`** (1 nodes): `index.tsx`
+- **Thin community `Community 2605`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2606`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 2606`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2607`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 2607`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2608`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 2608`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2609`** (1 nodes): `index.tsx`
+- **Thin community `Community 2609`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2610`** (1 nodes): `_authed-shell.test.tsx`
+- **Thin community `Community 2610`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2611`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 2611`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2612`** (1 nodes): `app.route.test.tsx`
+- **Thin community `Community 2612`** (1 nodes): `_authed-shell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2613`** (1 nodes): `app.test.tsx`
+- **Thin community `Community 2613`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2614`** (1 nodes): `app.tsx`
+- **Thin community `Community 2614`** (1 nodes): `app.route.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2615`** (1 nodes): `demo.test.tsx`
+- **Thin community `Community 2615`** (1 nodes): `app.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2616`** (1 nodes): `demo.tsx`
+- **Thin community `Community 2616`** (1 nodes): `app.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2617`** (1 nodes): `docs.index.tsx`
+- **Thin community `Community 2617`** (1 nodes): `demo.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2618`** (1 nodes): `docs.reports.$slug.tsx`
+- **Thin community `Community 2618`** (1 nodes): `demo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2619`** (1 nodes): `docs.solutions.$category.$slug.test.tsx`
+- **Thin community `Community 2619`** (1 nodes): `docs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2620`** (1 nodes): `docs.tsx`
+- **Thin community `Community 2620`** (1 nodes): `docs.reports.$slug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2621`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 2621`** (1 nodes): `docs.solutions.$category.$slug.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2622`** (1 nodes): `index.tsx`
+- **Thin community `Community 2622`** (1 nodes): `docs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2623`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 2623`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2624`** (1 nodes): `landing.tsx`
+- **Thin community `Community 2624`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2625`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 2625`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2626`** (1 nodes): `_layout.index.tsx`
+- **Thin community `Community 2626`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2627`** (1 nodes): `_layout.tsx`
+- **Thin community `Community 2627`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2628`** (1 nodes): `privacy.test.tsx`
+- **Thin community `Community 2628`** (1 nodes): `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2629`** (1 nodes): `privacy.tsx`
+- **Thin community `Community 2629`** (1 nodes): `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2630`** (1 nodes): `register-interest.tsx`
+- **Thin community `Community 2630`** (1 nodes): `privacy.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2631`** (1 nodes): `walkthrough.test.tsx`
+- **Thin community `Community 2631`** (1 nodes): `privacy.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2632`** (1 nodes): `walkthrough.tsx`
+- **Thin community `Community 2632`** (1 nodes): `register-interest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2633`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 2633`** (1 nodes): `walkthrough.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2634`** (1 nodes): `expenseStore.test.ts`
+- **Thin community `Community 2634`** (1 nodes): `walkthrough.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2635`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 2635`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2636`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 2636`** (1 nodes): `expenseStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2637`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 2637`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2638`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 2638`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2639`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 2639`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2640`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 2640`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2641`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 2641`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2642`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 2642`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2643`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 2643`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2644`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 2644`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2645`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 2645`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2646`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 2646`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2647`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 2647`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2648`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 2648`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2649`** (1 nodes): `eodReviewFixtures.ts`
+- **Thin community `Community 2649`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2650`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 2650`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2651`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 2651`** (1 nodes): `eodReviewFixtures.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2652`** (1 nodes): `setup.ts`
+- **Thin community `Community 2652`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2653`** (1 nodes): `vite-env.d.ts`
+- **Thin community `Community 2653`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2654`** (1 nodes): `viteConfig.test.ts`
+- **Thin community `Community 2654`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2655`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 2655`** (1 nodes): `vite-env.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2656`** (1 nodes): `types.ts`
+- **Thin community `Community 2656`** (1 nodes): `viteConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2657`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 2657`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2658`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 2658`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2659`** (1 nodes): `global.d.ts`
+- **Thin community `Community 2659`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2660`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 2660`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2661`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 2661`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2662`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 2662`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2663`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 2663`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2664`** (1 nodes): `types.ts`
+- **Thin community `Community 2664`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2665`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 2665`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2666`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 2666`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2667`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 2667`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2668`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 2668`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2669`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 2669`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2670`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 2670`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2671`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 2671`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2672`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 2672`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2673`** (1 nodes): `schema.ts`
+- **Thin community `Community 2673`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2674`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 2674`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2675`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 2675`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2676`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 2676`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2677`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 2677`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2678`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 2678`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2679`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 2679`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2680`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 2680`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2681`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 2681`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2682`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 2682`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2683`** (1 nodes): `types.ts`
+- **Thin community `Community 2683`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2684`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2684`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2685`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 2685`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2686`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 2686`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2687`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 2687`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2688`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 2688`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2689`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 2689`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2690`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 2690`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2691`** (1 nodes): `constants.ts`
+- **Thin community `Community 2691`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2692`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 2692`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2693`** (1 nodes): `About.tsx`
+- **Thin community `Community 2693`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2694`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 2694`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2695`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 2695`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2696`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 2696`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2697`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 2697`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2698`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 2698`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2699`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 2699`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2700`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 2700`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2701`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 2701`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2702`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 2702`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2703`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 2703`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2704`** (1 nodes): `types.ts`
+- **Thin community `Community 2704`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2705`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 2705`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2706`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 2706`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2707`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 2707`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2708`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 2708`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2709`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 2709`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2710`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 2710`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2711`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 2711`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2712`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 2712`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2713`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 2713`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2714`** (1 nodes): `alert.tsx`
+- **Thin community `Community 2714`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2715`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 2715`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2716`** (1 nodes): `button.tsx`
+- **Thin community `Community 2716`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2717`** (1 nodes): `card.tsx`
+- **Thin community `Community 2717`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2718`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 2718`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2719`** (1 nodes): `command.tsx`
+- **Thin community `Community 2719`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2720`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 2720`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2721`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 2721`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2722`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 2722`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2723`** (1 nodes): `form.tsx`
+- **Thin community `Community 2723`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2724`** (1 nodes): `icons.tsx`
+- **Thin community `Community 2724`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2725`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 2725`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2726`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 2726`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2727`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 2727`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2728`** (1 nodes): `input.tsx`
+- **Thin community `Community 2728`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2729`** (1 nodes): `label.tsx`
+- **Thin community `Community 2729`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2730`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 2730`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2731`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 2731`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2732`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 2732`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2733`** (1 nodes): `index.ts`
+- **Thin community `Community 2733`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2734`** (1 nodes): `types.ts`
+- **Thin community `Community 2734`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2735`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 2735`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2736`** (1 nodes): `popover.tsx`
+- **Thin community `Community 2736`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2737`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 2737`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2738`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 2738`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2739`** (1 nodes): `select.tsx`
+- **Thin community `Community 2739`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2740`** (1 nodes): `separator.tsx`
+- **Thin community `Community 2740`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2741`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 2741`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2742`** (1 nodes): `table.tsx`
+- **Thin community `Community 2742`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2743`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 2743`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2744`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 2744`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2745`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 2745`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2746`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 2746`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2747`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 2747`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2748`** (1 nodes): `config.ts`
+- **Thin community `Community 2748`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2749`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
+- **Thin community `Community 2749`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2750`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 2750`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2751`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 2751`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2752`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 2752`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2753`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 2753`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2754`** (1 nodes): `constants.ts`
+- **Thin community `Community 2754`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2755`** (1 nodes): `countries.ts`
+- **Thin community `Community 2755`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2756`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 2756`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2757`** (1 nodes): `ghana.ts`
+- **Thin community `Community 2757`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2758`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 2758`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2759`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 2759`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2760`** (1 nodes): `index.ts`
+- **Thin community `Community 2760`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2761`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 2761`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2762`** (1 nodes): `store.ts`
+- **Thin community `Community 2762`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2763`** (1 nodes): `bag.ts`
+- **Thin community `Community 2763`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2764`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 2764`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2765`** (1 nodes): `category.ts`
+- **Thin community `Community 2765`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2766`** (1 nodes): `organization.ts`
+- **Thin community `Community 2766`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2767`** (1 nodes): `product.ts`
+- **Thin community `Community 2767`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2768`** (1 nodes): `store.ts`
+- **Thin community `Community 2768`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2769`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 2769`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2770`** (1 nodes): `user.ts`
+- **Thin community `Community 2770`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2771`** (1 nodes): `states.ts`
+- **Thin community `Community 2771`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2772`** (1 nodes): `storefrontContextEvents.test.ts`
+- **Thin community `Community 2772`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2773`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 2773`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2774`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 2774`** (1 nodes): `storefrontContextEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2775`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2775`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2776`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 2776`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2777`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 2777`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2778`** (1 nodes): `__root.tsx`
+- **Thin community `Community 2778`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2779`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 2779`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2780`** (1 nodes): `index.tsx`
+- **Thin community `Community 2780`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2781`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 2781`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 2782`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2783`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 2783`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2784`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 2784`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2785`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 2785`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2786`** (1 nodes): `complete.tsx`
+- **Thin community `Community 2786`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2787`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 2787`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2788`** (1 nodes): `index.tsx`
+- **Thin community `Community 2788`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2789`** (1 nodes): `pending.tsx`
+- **Thin community `Community 2789`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2790`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 2790`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2791`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 2791`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2792`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 2792`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2793`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 2793`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2794`** (1 nodes): `index.js`
+- **Thin community `Community 2794`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2795`** (1 nodes): `check-register-session-authority-writers.test.ts`
+- **Thin community `Community 2795`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2796`** (1 nodes): `delivery-documentation-check.test.ts`
+- **Thin community `Community 2796`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2797`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 2797`** (1 nodes): `check-register-session-authority-writers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2798`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 2798`** (1 nodes): `delivery-documentation-check.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2799`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 2799`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2800`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 2800`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2801`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 2801`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2802`** (1 nodes): `harness-execution-context.test.ts`
+- **Thin community `Community 2802`** (1 nodes): `valkey-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2803`** (1 nodes): `harness-gate-registry.test.ts`
+- **Thin community `Community 2803`** (1 nodes): `harness-behavior-scenarios.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2804`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 2804`** (1 nodes): `harness-execution-context.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2805`** (1 nodes): `operational-work-repair.test.ts`
+- **Thin community `Community 2805`** (1 nodes): `harness-gate-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2806`** (1 nodes): `background.js`
+- **Thin community `Community 2806`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2807`** (1 nodes): `popup.js`
+- **Thin community `Community 2807`** (1 nodes): `operational-work-repair.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2808`** (1 nodes): `background.js`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2809`** (1 nodes): `popup.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 12274 nodes · 15116 edges · 2810 communities detected
+- 12275 nodes · 15117 edges · 2810 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -3596,40 +3596,40 @@ Cohesion: 0.26
 Nodes (12): deleteHeadBranch(), enablePullRequestAutoMerge(), encodeGitRefPath(), ghJson(), HelpRequested, mergePullRequest(), parseArgs(), parseMergeMethod() (+4 more)
 
 ### Community 187 - "Community 187"
-Cohesion: 0.23
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
-
-### Community 188 - "Community 188"
 Cohesion: 0.31
 Nodes (12): backfillStoreSchedulesFromLegacyPolicyWithCtx(), buildBackfillRow(), buildCandidateWeeklyWindows(), compatibilityMetadata(), compatibilityOnlyRow(), findExistingScheduleToSkip(), firstPolicy(), isValidMinute() (+4 more)
 
-### Community 189 - "Community 189"
+### Community 188 - "Community 188"
 Cohesion: 0.28
 Nodes (11): defineCashControlsRead(), defineDailyCloseRead(), defineDailyOperationsRead(), defineInventoryCatalogRead(), defineInventoryCostOverlayRead(), defineOnlineOrdersRead(), defineOperationalWorkRead(), defineOrganizationRead() (+3 more)
 
-### Community 190 - "Community 190"
+### Community 189 - "Community 189"
 Cohesion: 0.33
 Nodes (11): closeCandidateOperatingRange(), emptyCloseSummary(), exactStatuses(), frozenFinancialSourceCounts(), frozenWeekMetricForDate(), matchesRequestedOperatingRange(), normalizeFrozenPaymentTotals(), recordValue() (+3 more)
 
-### Community 191 - "Community 191"
+### Community 190 - "Community 190"
 Cohesion: 0.29
 Nodes (12): buildCtx(), buildInventoryMovement(), buildMapping(), buildProductSku(), buildRegisterSession(), buildStaffProfile(), buildStore(), buildTerminal() (+4 more)
 
-### Community 192 - "Community 192"
+### Community 191 - "Community 191"
 Cohesion: 0.26
 Nodes (10): createCustomer(), fullNameFromParts(), guestResult(), linkToGuest(), linkToStoreFrontUser(), posCustomerResult(), resolveGuestMatch(), resolvePosCustomerSelection() (+2 more)
 
-### Community 193 - "Community 193"
+### Community 192 - "Community 192"
 Cohesion: 0.18
 Nodes (4): findActivePendingCheckoutLookupAliasByCode(), listProductSkusByProductId(), normalizeLookupCode(), readAllQueryResults()
 
-### Community 194 - "Community 194"
+### Community 193 - "Community 193"
 Cohesion: 0.23
 Nodes (7): admitOne(), allow(), ensure(), headerByKey(), seedSkus(), seedStore(), twoDayFixture()
 
-### Community 195 - "Community 195"
+### Community 194 - "Community 194"
 Cohesion: 0.26
 Nodes (10): archivedProductNestedOrigin(), buildVariantSkuMoneyPayload(), createVariantSku(), decodeOriginValue(), deleteActiveProduct(), getArchivedProductRedirect(), modifyProduct(), onSubmit() (+2 more)
+
+### Community 195 - "Community 195"
+Cohesion: 0.23
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 196 - "Community 196"
 Cohesion: 0.17
@@ -3837,59 +3837,59 @@ Nodes (2): isValidEmail(), validateCustomerInfo()
 
 ### Community 247 - "Community 247"
 Cohesion: 0.33
-Nodes (8): landingFunnelHourlyLimit(), parseBoundedPositiveInteger(), resolveWalkthroughAllowedOrigins(), walkthroughAllowedOrigins(), walkthroughDailyPerEmailLimit(), walkthroughHourlyGlobalLimit(), walkthroughHourlyNotificationLimit(), walkthroughMaxBodyBytes()
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 248 - "Community 248"
+Cohesion: 0.33
+Nodes (8): landingFunnelHourlyLimit(), parseBoundedPositiveInteger(), resolveWalkthroughAllowedOrigins(), walkthroughAllowedOrigins(), walkthroughDailyPerEmailLimit(), walkthroughHourlyGlobalLimit(), walkthroughHourlyNotificationLimit(), walkthroughMaxBodyBytes()
+
+### Community 249 - "Community 249"
 Cohesion: 0.36
 Nodes (8): costOverlayStoreWriteOperation(), cycleCountDraftStoreWriteOperation(), defineOperation(), inventoryImportReviewPayloadWriteOperation(), notificationSubscriptionRowWriteOperation(), orderStoreWriteOperation(), storeWriteOperation(), transactionStoreWriteOperation()
 
-### Community 249 - "Community 249"
+### Community 250 - "Community 250"
 Cohesion: 0.29
 Nodes (7): adjustmentSalesDelta(), adjustmentSettlementAmount(), buildAdjustmentPaymentTotals(), buildAdjustmentReportTotals(), listAppliedTransactionAdjustmentsForDay(), readAppliedTransactionAdjustmentsForDay(), sourceCompletenessEntry()
 
-### Community 250 - "Community 250"
+### Community 251 - "Community 251"
 Cohesion: 0.38
 Nodes (7): assertNoBusinessEventConflict(), buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
-### Community 251 - "Community 251"
+### Community 252 - "Community 252"
 Cohesion: 0.33
 Nodes (8): buildOperationalEvent(), buildTraceMetadata(), isRecord(), matchesExistingEvent(), metadataDedupeKeysMatch(), normalizeOperationalEventTraceFields(), recordOperationalEventWithCtx(), shouldNormalizePosTrace()
 
-### Community 252 - "Community 252"
+### Community 253 - "Community 253"
 Cohesion: 0.58
 Nodes (9): amendRepairWithCtx(), createRepairWithCtx(), pauseRepair(), processRepairBatchWithCtx(), readCurrentGroup(), recordRepairAuditEvent(), requireEvidence(), resumeRepairWithCtx() (+1 more)
 
-### Community 253 - "Community 253"
+### Community 254 - "Community 254"
 Cohesion: 0.38
 Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
-### Community 254 - "Community 254"
+### Community 255 - "Community 255"
 Cohesion: 0.33
 Nodes (8): classifyFinalizedLineageRepairConflicts(), classifyRepairCandidate(), countRepairableFinalizedLineageLines(), getProvisionalImportSku(), isClosedRegisterRepairReplayConflict(), isFinalizedLineageRepairConflict(), isProvisionalRowChangedConflict(), skipped()
 
-### Community 255 - "Community 255"
+### Community 256 - "Community 256"
 Cohesion: 0.27
 Nodes (5): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository(), dedupeRecoveryConflictsById(), listTerminalRecoveryConflictsForRepair(), listTerminalRecoveryConflictSources()
 
-### Community 256 - "Community 256"
+### Community 257 - "Community 257"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 257 - "Community 257"
+### Community 258 - "Community 258"
 Cohesion: 0.36
 Nodes (9): aggregateSkuDays(), computeRange(), computeRequestKey(), inclusiveDaySpan(), isValidOperatingDate(), requestRangeCore(), sumDays(), utcMillisForLabel() (+1 more)
 
-### Community 258 - "Community 258"
+### Community 259 - "Community 259"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 259 - "Community 259"
+### Community 260 - "Community 260"
 Cohesion: 0.36
 Nodes (8): buildClassification(), classifyDayResult(), classifyWeekResult(), confirmsClean(), explainMetricDifference(), fingerprintDifferences(), nextStreakState(), partitionDifferences()
-
-### Community 260 - "Community 260"
-Cohesion: 0.33
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 261 - "Community 261"
 Cohesion: 0.31
@@ -4120,28 +4120,28 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 318 - "Community 318"
-Cohesion: 0.42
-Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
-
-### Community 319 - "Community 319"
-Cohesion: 0.36
-Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
-
-### Community 320 - "Community 320"
-Cohesion: 0.22
-Nodes (0):
-
-### Community 321 - "Community 321"
-Cohesion: 0.31
-Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
-
-### Community 322 - "Community 322"
 Cohesion: 0.31
 Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
-### Community 323 - "Community 323"
+### Community 319 - "Community 319"
+Cohesion: 0.42
+Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
+
+### Community 320 - "Community 320"
+Cohesion: 0.36
+Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
+
+### Community 321 - "Community 321"
+Cohesion: 0.22
+Nodes (0):
+
+### Community 322 - "Community 322"
 Cohesion: 0.39
 Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
+
+### Community 323 - "Community 323"
+Cohesion: 0.31
+Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
 
 ### Community 324 - "Community 324"
 Cohesion: 0.22
@@ -4392,280 +4392,280 @@ Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
 ### Community 386 - "Community 386"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 387 - "Community 387"
 Cohesion: 0.38
 Nodes (4): buildRegisterSessionAuthorityPatch(), initialRegisterSessionAuthorityRevision(), insertRegisterSessionWithAuthority(), patchRegisterSessionWithAuthority()
 
-### Community 387 - "Community 387"
+### Community 388 - "Community 388"
 Cohesion: 0.43
 Nodes (4): asBoolean(), asNumber(), asRecord(), getCashControlsConfig()
 
-### Community 388 - "Community 388"
+### Community 389 - "Community 389"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 389 - "Community 389"
+### Community 390 - "Community 390"
 Cohesion: 0.29
 Nodes (0):
-
-### Community 390 - "Community 390"
-Cohesion: 0.52
-Nodes (6): classifyProvisionalImportLineage(), findMixedTrustedAndProvisionalSkuId(), isFinalizationClosed(), isTrustedInventorySaleItem(), saleInventoryLineKey(), shouldRecordProvisionalImportSaleEvidence()
 
 ### Community 391 - "Community 391"
 Cohesion: 0.52
-Nodes (6): advanceRegisterMappingAuthority(), buildNextRegisterMappingAuthority(), createPosLocalSyncMappingWithAuthority(), markRegisterMappingAuthorityAmbiguous(), markRegisterMappingAuthorityMapped(), tombstoneRegisterMappingAuthority()
+Nodes (6): classifyProvisionalImportLineage(), findMixedTrustedAndProvisionalSkuId(), isFinalizationClosed(), isTrustedInventorySaleItem(), saleInventoryLineKey(), shouldRecordProvisionalImportSaleEvidence()
 
 ### Community 392 - "Community 392"
+Cohesion: 0.52
+Nodes (6): advanceRegisterMappingAuthority(), buildNextRegisterMappingAuthority(), createPosLocalSyncMappingWithAuthority(), markRegisterMappingAuthorityAmbiguous(), markRegisterMappingAuthorityMapped(), tombstoneRegisterMappingAuthority()
+
+### Community 393 - "Community 393"
 Cohesion: 0.48
 Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
 
-### Community 393 - "Community 393"
+### Community 394 - "Community 394"
 Cohesion: 0.52
 Nodes (5): getBlockingRegisterSessionIdFromConflict(), isRegisterSessionConflict(), resolveScopedRegisterSession(), resolveTerminalRegisterConflict(), resolveTerminalRegisterSessionConflict()
 
-### Community 394 - "Community 394"
+### Community 395 - "Community 395"
 Cohesion: 0.52
 Nodes (6): blocked(), buildRecoveryAttemptId(), getOrganizationMemberForAccount(), recordRecoveryEvent(), validatePosAppAccount(), validateTerminalAppSessionRecoveryWithCtx()
 
-### Community 395 - "Community 395"
+### Community 396 - "Community 396"
 Cohesion: 0.33
 Nodes (2): findReusableRemoteAssistSession(), startRemoteAssistSession()
 
-### Community 396 - "Community 396"
+### Community 397 - "Community 397"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 397 - "Community 397"
+### Community 398 - "Community 398"
 Cohesion: 0.62
 Nodes (6): aggregateWeeklyCloseEvidence(), completeExpenseEvidence(), coverage(), isNonnegativeSafeInteger(), remainder(), safeSum()
 
-### Community 398 - "Community 398"
+### Community 399 - "Community 399"
 Cohesion: 0.57
 Nodes (6): isIncludedDate(), parseDate(), resolveWeeklyPeriod(), scheduleForDate(), shiftDate(), weekday()
 
-### Community 399 - "Community 399"
+### Community 400 - "Community 400"
 Cohesion: 0.43
 Nodes (5): buildPosServiceCatalogRow(), buildPosServiceCheckoutReadiness(), buildServiceCatalogItem(), normalizeServiceCatalogNameKey(), suggestedDepositAmount()
 
-### Community 400 - "Community 400"
+### Community 401 - "Community 401"
 Cohesion: 0.48
 Nodes (5): bestEffortRecordPurchaseOrderReceivingTraceWithCtx(), bestEffortRecordPurchaseOrderStatusTraceWithCtx(), compactDetails(), ensurePurchaseOrderTraceWithCtx(), getPurchaseOrderTraceStatusAt()
 
-### Community 401 - "Community 401"
+### Community 402 - "Community 402"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 402 - "Community 402"
+### Community 403 - "Community 403"
 Cohesion: 0.33
 Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
 
-### Community 403 - "Community 403"
+### Community 404 - "Community 404"
 Cohesion: 0.38
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 404 - "Community 404"
+### Community 405 - "Community 405"
 Cohesion: 0.57
 Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
 
-### Community 405 - "Community 405"
+### Community 406 - "Community 406"
 Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
-### Community 406 - "Community 406"
+### Community 407 - "Community 407"
 Cohesion: 0.52
 Nodes (6): buildContextEventEnvelope(), buildContextEventIdempotencyKey(), compactContextPayload(), compactContextValue(), hashStableValue(), stableContextStringify()
 
-### Community 407 - "Community 407"
+### Community 408 - "Community 408"
 Cohesion: 0.57
 Nodes (6): buildInventoryImportReviewPayload(), getInventoryImportReviewPayloadChunkByteLength(), getUtf8ByteLength(), isHighSurrogate(), splitInventoryImportReviewRawContent(), splitInventoryImportReviewRowDecisions()
 
-### Community 408 - "Community 408"
+### Community 409 - "Community 409"
 Cohesion: 0.33
 Nodes (2): sharedDemoPickupOrderAmount(), sharedDemoProductBySku()
 
-### Community 409 - "Community 409"
+### Community 410 - "Community 410"
 Cohesion: 0.33
 Nodes (2): calculateCycleCountQuantityDelta(), resolveStockAdjustmentQuantityDelta()
-
-### Community 410 - "Community 410"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 411 - "Community 411"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 412 - "Community 412"
-Cohesion: 0.33
-Nodes (2): handlePinChange(), normalizeOtpCode()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 413 - "Community 413"
 Cohesion: 0.33
-Nodes (2): getReviewOverlayElement(), getReviewOverlaySection()
+Nodes (2): handlePinChange(), normalizeOtpCode()
 
 ### Community 414 - "Community 414"
-Cohesion: 0.29
-Nodes (0):
+Cohesion: 0.33
+Nodes (2): getReviewOverlayElement(), getReviewOverlaySection()
 
 ### Community 415 - "Community 415"
 Cohesion: 0.29
-Nodes (1): ResizeObserverStub
+Nodes (0):
 
 ### Community 416 - "Community 416"
-Cohesion: 0.33
-Nodes (2): formatCartAttributeParts(), normalizeCartAttribute()
+Cohesion: 0.29
+Nodes (1): ResizeObserverStub
 
 ### Community 417 - "Community 417"
 Cohesion: 0.33
-Nodes (2): handleKeypadPress(), setAmountFromTouch()
+Nodes (2): formatCartAttributeParts(), normalizeCartAttribute()
 
 ### Community 418 - "Community 418"
-Cohesion: 0.29
-Nodes (0):
+Cohesion: 0.33
+Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
 ### Community 419 - "Community 419"
 Cohesion: 0.29
-Nodes (1): ResizeObserverStub
+Nodes (0):
 
 ### Community 420 - "Community 420"
 Cohesion: 0.29
 Nodes (1): ResizeObserverStub
 
 ### Community 421 - "Community 421"
+Cohesion: 0.29
+Nodes (1): ResizeObserverStub
+
+### Community 422 - "Community 422"
 Cohesion: 0.33
 Nodes (2): isSelectedDay(), selectDay()
 
-### Community 422 - "Community 422"
+### Community 423 - "Community 423"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 423 - "Community 423"
+### Community 424 - "Community 424"
 Cohesion: 0.33
 Nodes (2): handleReset(), handleSubmit()
 
-### Community 424 - "Community 424"
+### Community 425 - "Community 425"
 Cohesion: 0.52
 Nodes (5): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), normalizeNonCashOverpayment(), roundPosAmount()
 
-### Community 425 - "Community 425"
+### Community 426 - "Community 426"
 Cohesion: 0.52
 Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
 
-### Community 426 - "Community 426"
+### Community 427 - "Community 427"
 Cohesion: 0.33
 Nodes (2): buildRuntimeSyncDebug(), getReviewDiagnosticsEvents()
 
-### Community 427 - "Community 427"
+### Community 428 - "Community 428"
 Cohesion: 0.38
 Nodes (3): getRegisterLifecycleAuthorityRolloutPolicy(), isRolloutMode(), resolveRegisterLifecycleAuthorityRolloutPolicy()
 
-### Community 428 - "Community 428"
+### Community 429 - "Community 429"
 Cohesion: 0.52
 Nodes (6): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isDuplicateLocalIdReviewItem(), isDuplicatePosSessionSaleReviewItem(), isRegisterCloseoutReviewItem(), normalizeStatus()
-
-### Community 429 - "Community 429"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 430 - "Community 430"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 431 - "Community 431"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 432 - "Community 432"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
-### Community 432 - "Community 432"
+### Community 433 - "Community 433"
 Cohesion: 0.48
 Nodes (6): collectDeliverableDiffFingerprint(), gitEnv(), isDeliverableFingerprintPath(), normalizeRepoPath(), runGit(), sortUniquePaths()
 
-### Community 433 - "Community 433"
+### Community 434 - "Community 434"
 Cohesion: 0.43
 Nodes (4): assertDeliveryDocumentationCheck(), evaluateDeliveryDocumentationCheck(), findingsFrom(), isPolicyFailure()
 
-### Community 434 - "Community 434"
+### Community 435 - "Community 435"
 Cohesion: 0.43
 Nodes (4): createPackage(), installFixturePackages(), writeFixtureManifests(), writeJson()
 
-### Community 435 - "Community 435"
+### Community 436 - "Community 436"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 436 - "Community 436"
+### Community 437 - "Community 437"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 437 - "Community 437"
+### Community 438 - "Community 438"
 Cohesion: 0.48
 Nodes (6): computeDeliverableTreeIdentity(), digestDeliverableEntries(), isPostGateValidationNeutralPath(), isReviewNeutralPath(), normalizeRepoPath(), parseTreeEntries()
 
-### Community 438 - "Community 438"
+### Community 439 - "Community 439"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 439 - "Community 439"
+### Community 440 - "Community 440"
 Cohesion: 0.43
 Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
 
-### Community 440 - "Community 440"
+### Community 441 - "Community 441"
 Cohesion: 0.53
 Nodes (4): bestEffortRecordScheduledRunEvidence(), buildScheduledRunKey(), recordScheduledRunEvidenceWithCtx(), resolveScheduledWindow()
 
-### Community 441 - "Community 441"
+### Community 442 - "Community 442"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 442 - "Community 442"
+### Community 443 - "Community 443"
 Cohesion: 0.6
 Nodes (5): appendContextEventWithCtx(), buildContextEventSemanticEnvelopeHash(), isAllowedGlobalContextEvent(), isContextEventWriteQuotaExceeded(), selectContextEventAppendQuotaDecision()
 
-### Community 443 - "Community 443"
+### Community 444 - "Community 444"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 444 - "Community 444"
+### Community 445 - "Community 445"
 Cohesion: 0.47
 Nodes (3): canonical(), isValidBody(), text()
 
-### Community 445 - "Community 445"
+### Community 446 - "Community 446"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 446 - "Community 446"
-Cohesion: 0.4
-Nodes (2): createMutationCtx(), seedTrustedConversionData()
 
 ### Community 447 - "Community 447"
 Cohesion: 0.4
-Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
+Nodes (2): createMutationCtx(), seedTrustedConversionData()
 
 ### Community 448 - "Community 448"
+Cohesion: 0.4
+Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
+
+### Community 449 - "Community 449"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 449 - "Community 449"
+### Community 450 - "Community 450"
 Cohesion: 0.6
 Nodes (5): backfillStoreCurrencyCaseWithCtx(), boundedLimit(), needsNormalization(), storePage(), verifyStoreCurrencyCaseWithCtx()
 
-### Community 450 - "Community 450"
+### Community 451 - "Community 451"
 Cohesion: 0.47
 Nodes (4): findNotificationKind(), getNotificationKind(), isStaleDailyClosePayload(), requireStaleDailyClosePayload()
 
-### Community 451 - "Community 451"
+### Community 452 - "Community 452"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 452 - "Community 452"
+### Community 453 - "Community 453"
 Cohesion: 0.47
 Nodes (4): buildDailyCloseApprovalSubject(), buildDailyCloseCarryForwardApprovalRequirement(), buildDailyCloseCarryForwardApprovalSubject(), buildDailyCloseCompletionApprovalRequirement()
 
-### Community 453 - "Community 453"
+### Community 454 - "Community 454"
 Cohesion: 0.6
 Nodes (5): buildOnlineOrderOperationalEventMessage(), buildOperationalEventMessage(), buildStockAdjustmentOperationalEventMessage(), formatOnlineOrderLabel(), formatStockAdjustmentSubjectDetail()
-
-### Community 454 - "Community 454"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 455 - "Community 455"
 Cohesion: 0.33
@@ -5628,40 +5628,40 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 695 - "Community 695"
-Cohesion: 0.83
-Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
+Cohesion: 0.5
+Nodes (1): buildCtx()
 
 ### Community 696 - "Community 696"
 Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
+Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
 ### Community 697 - "Community 697"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 698 - "Community 698"
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+
+### Community 699 - "Community 699"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 699 - "Community 699"
+### Community 700 - "Community 700"
 Cohesion: 0.67
 Nodes (2): buildActivity(), buildReport()
 
-### Community 700 - "Community 700"
+### Community 701 - "Community 701"
 Cohesion: 0.83
 Nodes (3): advanceRegisterCatalogRevision(), readRegisterCatalogRevision(), readRegisterCatalogRevisionRow()
 
-### Community 701 - "Community 701"
+### Community 702 - "Community 702"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 702 - "Community 702"
-Cohesion: 0.83
-Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 703 - "Community 703"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 704 - "Community 704"
 Cohesion: 0.5
@@ -5673,7 +5673,7 @@ Nodes (0):
 
 ### Community 706 - "Community 706"
 Cohesion: 0.5
-Nodes (1): buildCtx()
+Nodes (0):
 
 ### Community 707 - "Community 707"
 Cohesion: 0.5

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -47567,7 +47567,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_rail_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L2612",
+      "source_location": "L2797",
       "target": "rail_test_emitapprovalrequestcreated",
       "weight": 1
     },
@@ -47579,7 +47579,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_rail_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L2921",
+      "source_location": "L3106",
       "target": "rail_test_emitverificationdiscrepancy",
       "weight": 1
     },
@@ -47591,7 +47591,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_rail_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L1669",
+      "source_location": "L1854",
       "target": "rail_test_insertdelivery",
       "weight": 1
     },
@@ -47639,7 +47639,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_rail_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L1047",
+      "source_location": "L1232",
       "target": "rail_test_reserveone",
       "weight": 1
     },
@@ -47663,7 +47663,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_rail_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L2583",
+      "source_location": "L2768",
       "target": "rail_test_seedpendingapprovalrequest",
       "weight": 1
     },
@@ -47675,7 +47675,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_rail_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L1697",
+      "source_location": "L1882",
       "target": "rail_test_seedsweeperfixture",
       "weight": 1
     },
@@ -47699,7 +47699,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_rail_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L2869",
+      "source_location": "L3054",
       "target": "rail_test_seedverificationrun",
       "weight": 1
     },
@@ -47711,7 +47711,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_rail_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L2852",
+      "source_location": "L3037",
       "target": "rail_test_stubprodtransport",
       "weight": 1
     },
@@ -210970,7 +210970,7 @@
       "label": "emitApprovalRequestCreated()",
       "norm_label": "emitapprovalrequestcreated()",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L2612"
+      "source_location": "L2797"
     },
     {
       "community": 170,
@@ -210979,7 +210979,7 @@
       "label": "emitVerificationDiscrepancy()",
       "norm_label": "emitverificationdiscrepancy()",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L2921"
+      "source_location": "L3106"
     },
     {
       "community": 170,
@@ -210988,7 +210988,7 @@
       "label": "insertDelivery()",
       "norm_label": "insertdelivery()",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L1669"
+      "source_location": "L1854"
     },
     {
       "community": 170,
@@ -211024,7 +211024,7 @@
       "label": "reserveOne()",
       "norm_label": "reserveone()",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L1047"
+      "source_location": "L1232"
     },
     {
       "community": 170,
@@ -211042,7 +211042,7 @@
       "label": "seedPendingApprovalRequest()",
       "norm_label": "seedpendingapprovalrequest()",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L2583"
+      "source_location": "L2768"
     },
     {
       "community": 170,
@@ -211051,7 +211051,7 @@
       "label": "seedSweeperFixture()",
       "norm_label": "seedsweeperfixture()",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L1697"
+      "source_location": "L1882"
     },
     {
       "community": 170,
@@ -211069,7 +211069,7 @@
       "label": "seedVerificationRun()",
       "norm_label": "seedverificationrun()",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L2869"
+      "source_location": "L3054"
     },
     {
       "community": 170,
@@ -211078,7 +211078,7 @@
       "label": "stubProdTransport()",
       "norm_label": "stubprodtransport()",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L1238"
+      "source_location": "L1423"
     },
     {
       "community": 1700,

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -9803,7 +9803,7 @@
       "relation": "calls",
       "source": "dailyclose_isinrange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1503",
+      "source_location": "L1504",
       "target": "dailyclose_approvalbelongstorange",
       "weight": 1
     },
@@ -9815,7 +9815,7 @@
       "relation": "calls",
       "source": "dailyclose_registersessionbelongstorange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1520",
+      "source_location": "L1521",
       "target": "dailyclose_approvalbelongstorange",
       "weight": 1
     },
@@ -9827,7 +9827,7 @@
       "relation": "calls",
       "source": "dailyclose_formatpaymentmethodlabel",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L840",
+      "source_location": "L841",
       "target": "dailyclose_approvalrequesttypelabel",
       "weight": 1
     },
@@ -9839,7 +9839,7 @@
       "relation": "calls",
       "source": "dailyclose_ascarryforwarditem",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L981",
+      "source_location": "L982",
       "target": "dailyclose_carryforwardbusinessdate",
       "weight": 1
     },
@@ -9851,7 +9851,7 @@
       "relation": "calls",
       "source": "dailyclose_ascarryforwarditem",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L985",
+      "source_location": "L986",
       "target": "dailyclose_carryforwardsourceid",
       "weight": 1
     },
@@ -9863,7 +9863,7 @@
       "relation": "calls",
       "source": "dailyclose_ascarryforwarditem",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L983",
+      "source_location": "L984",
       "target": "dailyclose_stringfrommetadata",
       "weight": 1
     },
@@ -9875,7 +9875,7 @@
       "relation": "calls",
       "source": "dailyclose_sourcecompletenessentry",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1842",
+      "source_location": "L1843",
       "target": "dailyclose_buildcompletedonlineordertotals",
       "weight": 1
     },
@@ -9887,7 +9887,7 @@
       "relation": "calls",
       "source": "dailyclose_getdailyclosefordate",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1176",
+      "source_location": "L1177",
       "target": "dailyclose_builddailycloselifecyclegatewithctx",
       "weight": 1
     },
@@ -9899,8 +9899,20 @@
       "relation": "calls",
       "source": "dailyclose_resolveoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1167",
+      "source_location": "L1168",
       "target": "dailyclose_builddailycloselifecyclegatewithctx",
+      "weight": 1
+    },
+    {
+      "_src": "dailyclose_builddailyclosereportsnapshot",
+      "_tgt": "dailyclose_hasincompleteoperationalwork",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailyclose_builddailyclosereportsnapshot",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L2266",
+      "target": "dailyclose_hasincompleteoperationalwork",
       "weight": 1
     },
     {
@@ -9911,7 +9923,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosereportsnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2351",
+      "source_location": "L2352",
       "target": "dailyclose_snapshotrevieweditems",
       "weight": 1
     },
@@ -9923,7 +9935,7 @@
       "relation": "calls",
       "source": "dailyclose_uniquedailycloseitems",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2281",
+      "source_location": "L2282",
       "target": "dailyclose_builddailyclosereportsnapshot",
       "weight": 1
     },
@@ -9935,7 +9947,7 @@
       "relation": "calls",
       "source": "dailyclose_buildapprovalrequestsbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2896",
+      "source_location": "L2909",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -9947,7 +9959,7 @@
       "relation": "calls",
       "source": "dailyclose_buildcompletedonlineordertotals",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2830",
+      "source_location": "L2843",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -9959,7 +9971,7 @@
       "relation": "calls",
       "source": "dailyclose_buildexpensesessionsbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2951",
+      "source_location": "L2964",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -9971,7 +9983,7 @@
       "relation": "calls",
       "source": "dailyclose_buildexpensetransactionitemcountsbytransactionid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2843",
+      "source_location": "L2856",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -9983,7 +9995,7 @@
       "relation": "calls",
       "source": "dailyclose_buildreadiness",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3699",
+      "source_location": "L3712",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -9995,7 +10007,7 @@
       "relation": "calls",
       "source": "dailyclose_buildregistersessionsbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2944",
+      "source_location": "L2957",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10007,7 +10019,7 @@
       "relation": "calls",
       "source": "dailyclose_buildstaffnamesbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2759",
+      "source_location": "L2772",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10019,7 +10031,7 @@
       "relation": "calls",
       "source": "dailyclose_buildterminallabelsbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2966",
+      "source_location": "L2979",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10031,7 +10043,7 @@
       "relation": "calls",
       "source": "dailyclose_buildtransactionitemcountsbytransactionid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2838",
+      "source_location": "L2851",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10043,7 +10055,7 @@
       "relation": "calls",
       "source": "dailyclose_cashdeltasbyregistersessionid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2941",
+      "source_location": "L2954",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10055,7 +10067,7 @@
       "relation": "calls",
       "source": "dailyclose_completesourcecompleteness",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2737",
+      "source_location": "L2750",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10067,7 +10079,7 @@
       "relation": "calls",
       "source": "dailyclose_emptysummary",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2731",
+      "source_location": "L2744",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10079,7 +10091,7 @@
       "relation": "calls",
       "source": "dailyclose_filterregistersessionsbelongingtorange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2884",
+      "source_location": "L2897",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10091,7 +10103,7 @@
       "relation": "calls",
       "source": "dailyclose_frozensyncedsaleinventoryreviewgroups",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3781",
+      "source_location": "L3794",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10103,7 +10115,7 @@
       "relation": "calls",
       "source": "dailyclose_getdailyclosecompletioneventstaffprofileid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2755",
+      "source_location": "L2768",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10115,7 +10127,7 @@
       "relation": "calls",
       "source": "dailyclose_getdailyclosefordate",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2750",
+      "source_location": "L2763",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10127,7 +10139,7 @@
       "relation": "calls",
       "source": "dailyclose_getpriorcompleteddailyclose",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2762",
+      "source_location": "L2775",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10139,7 +10151,7 @@
       "relation": "calls",
       "source": "dailyclose_getstore",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2687",
+      "source_location": "L2700",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10151,7 +10163,7 @@
       "relation": "calls",
       "source": "dailyclose_listactiveoversizedoperationalworkrepairs",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2805",
+      "source_location": "L2818",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10163,7 +10175,7 @@
       "relation": "calls",
       "source": "dailyclose_listcompletedonlineordersforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2811",
+      "source_location": "L2824",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10175,7 +10187,7 @@
       "relation": "calls",
       "source": "dailyclose_listdepositsforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2825",
+      "source_location": "L2838",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10187,7 +10199,7 @@
       "relation": "calls",
       "source": "dailyclose_listexpensesforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2824",
+      "source_location": "L2837",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10199,7 +10211,7 @@
       "relation": "calls",
       "source": "dailyclose_listopenoperationalworkitems",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2804",
+      "source_location": "L2817",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10211,7 +10223,7 @@
       "relation": "calls",
       "source": "dailyclose_listopenpossessions",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2803",
+      "source_location": "L2816",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10223,7 +10235,7 @@
       "relation": "calls",
       "source": "dailyclose_listpendingcloseoutapprovals",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2802",
+      "source_location": "L2815",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10235,7 +10247,7 @@
       "relation": "calls",
       "source": "dailyclose_listregistersessionsfordailyclose",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2797",
+      "source_location": "L2810",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10247,7 +10259,7 @@
       "relation": "calls",
       "source": "dailyclose_listtransactionsforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2806",
+      "source_location": "L2819",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10259,7 +10271,7 @@
       "relation": "calls",
       "source": "dailyclose_mayberedactdailyclosesnapshotforbroadview",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2773",
+      "source_location": "L2786",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10271,7 +10283,7 @@
       "relation": "calls",
       "source": "dailyclose_mergesourcecompleteness",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2868",
+      "source_location": "L2881",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10283,7 +10295,7 @@
       "relation": "calls",
       "source": "dailyclose_normalizecompleteddailyclosesnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2763",
+      "source_location": "L2776",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10295,7 +10307,7 @@
       "relation": "calls",
       "source": "dailyclose_normalizedailyclosesummary",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3770",
+      "source_location": "L3783",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10307,7 +10319,7 @@
       "relation": "calls",
       "source": "dailyclose_resolveoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2686",
+      "source_location": "L2699",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10319,7 +10331,7 @@
       "relation": "calls",
       "source": "dailyclose_sortdailycloseblockers",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3698",
+      "source_location": "L3711",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10331,7 +10343,7 @@
       "relation": "calls",
       "source": "dailyclose_uniquesourcesubjects",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3787",
+      "source_location": "L3800",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10343,7 +10355,7 @@
       "relation": "calls",
       "source": "dailyclose_buildexpensetransactionitemcountsbytransactionid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1961",
+      "source_location": "L1962",
       "target": "dailyclose_builddailycloseexpenseproductevidence",
       "weight": 1
     },
@@ -10355,7 +10367,7 @@
       "relation": "calls",
       "source": "dailyclose_stringfrommetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3892",
+      "source_location": "L3905",
       "target": "dailyclose_carryforwardbusinessdate",
       "weight": 1
     },
@@ -10367,7 +10379,7 @@
       "relation": "calls",
       "source": "dailyclose_carryforwardbusinessdate",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3924",
+      "source_location": "L3937",
       "target": "dailyclose_carryforwardmetadatamatches",
       "weight": 1
     },
@@ -10379,7 +10391,7 @@
       "relation": "calls",
       "source": "dailyclose_carryforwardsourceid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3925",
+      "source_location": "L3938",
       "target": "dailyclose_carryforwardmetadatamatches",
       "weight": 1
     },
@@ -10391,7 +10403,7 @@
       "relation": "calls",
       "source": "dailyclose_stringfrommetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3901",
+      "source_location": "L3914",
       "target": "dailyclose_carryforwardsourceid",
       "weight": 1
     },
@@ -10403,7 +10415,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosereportsnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4845",
+      "source_location": "L4863",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10415,7 +10427,19 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosesnapshotwithctx",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4658",
+      "source_location": "L4674",
+      "target": "dailyclose_completedailycloseforautomationwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "dailyclose_completedailycloseforautomationwithctx",
+      "_tgt": "dailyclose_completionblockingincompletesources",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailyclose_completionblockingincompletesources",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L4741",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10427,7 +10451,7 @@
       "relation": "calls",
       "source": "dailyclose_getnonactivedailyclosefordate",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4690",
+      "source_location": "L4706",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10439,19 +10463,19 @@
       "relation": "calls",
       "source": "dailyclose_getstore",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4633",
+      "source_location": "L4649",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
     {
       "_src": "dailyclose_completedailycloseforautomationwithctx",
-      "_tgt": "dailyclose_incompletesourcecompletenessentries",
+      "_tgt": "dailyclose_hasincompleteoperationalwork",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "calls",
-      "source": "dailyclose_incompletesourcecompletenessentries",
+      "source": "dailyclose_hasincompleteoperationalwork",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4725",
+      "source_location": "L4795",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10463,7 +10487,7 @@
       "relation": "calls",
       "source": "dailyclose_logicalcarryforwardselectioncount",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4799",
+      "source_location": "L4814",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10475,7 +10499,7 @@
       "relation": "calls",
       "source": "dailyclose_markotherdailyclosesnotcurrent",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4876",
+      "source_location": "L4894",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10487,7 +10511,7 @@
       "relation": "calls",
       "source": "dailyclose_patchdailyclosecarryforwardworkitemmetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4906",
+      "source_location": "L4924",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10499,7 +10523,7 @@
       "relation": "calls",
       "source": "dailyclose_recorddailyclosecompletedevent",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4912",
+      "source_location": "L4930",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10511,7 +10535,7 @@
       "relation": "calls",
       "source": "dailyclose_recorddailyclosecompletedreportfacts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4901",
+      "source_location": "L4919",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10523,7 +10547,7 @@
       "relation": "calls",
       "source": "dailyclose_resolveoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4649",
+      "source_location": "L4665",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10535,7 +10559,7 @@
       "relation": "calls",
       "source": "dailyclose_validateautomationcarryforwardworkitems",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4779",
+      "source_location": "L4797",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10547,7 +10571,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosereportsnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4518",
+      "source_location": "L4534",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10559,7 +10583,19 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosesnapshotwithctx",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4344",
+      "source_location": "L4357",
+      "target": "dailyclose_completedailyclosewithctx",
+      "weight": 1
+    },
+    {
+      "_src": "dailyclose_completedailyclosewithctx",
+      "_tgt": "dailyclose_completionblockingincompletesources",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailyclose_completionblockingincompletesources",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L4380",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10571,7 +10607,7 @@
       "relation": "calls",
       "source": "dailyclose_createcarryforwardworkitems",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4441",
+      "source_location": "L4454",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10583,19 +10619,19 @@
       "relation": "calls",
       "source": "dailyclose_getstore",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4319",
+      "source_location": "L4332",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
     {
       "_src": "dailyclose_completedailyclosewithctx",
-      "_tgt": "dailyclose_incompletesourcecompletenessentries",
+      "_tgt": "dailyclose_hasincompleteoperationalwork",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "calls",
-      "source": "dailyclose_incompletesourcecompletenessentries",
+      "source": "dailyclose_hasincompleteoperationalwork",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4367",
+      "source_location": "L4495",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10607,7 +10643,7 @@
       "relation": "calls",
       "source": "dailyclose_logicalcarryforwardselectioncount",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4478",
+      "source_location": "L4491",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10619,7 +10655,7 @@
       "relation": "calls",
       "source": "dailyclose_markotherdailyclosesnotcurrent",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4551",
+      "source_location": "L4567",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10631,7 +10667,7 @@
       "relation": "calls",
       "source": "dailyclose_patchdailyclosecarryforwardworkitemmetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4580",
+      "source_location": "L4596",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10643,7 +10679,7 @@
       "relation": "calls",
       "source": "dailyclose_recorddailyclosecompletedevent",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4586",
+      "source_location": "L4602",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10655,7 +10691,7 @@
       "relation": "calls",
       "source": "dailyclose_recorddailyclosecompletedreportfacts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4575",
+      "source_location": "L4591",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10667,7 +10703,7 @@
       "relation": "calls",
       "source": "dailyclose_resolveoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4335",
+      "source_location": "L4348",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10679,7 +10715,7 @@
       "relation": "calls",
       "source": "dailyclose_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4477",
+      "source_location": "L4490",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10691,7 +10727,7 @@
       "relation": "calls",
       "source": "dailyclose_uniqueoperationalworkitemids",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4387",
+      "source_location": "L4400",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10703,7 +10739,7 @@
       "relation": "calls",
       "source": "dailyclose_validatecarryforwardworkitemids",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4404",
+      "source_location": "L4417",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10715,8 +10751,20 @@
       "relation": "calls",
       "source": "dailyclose_validateselectedcarryforwardgroups",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4390",
+      "source_location": "L4403",
       "target": "dailyclose_completedailyclosewithctx",
+      "weight": 1
+    },
+    {
+      "_src": "dailyclose_completionblockingincompletesources",
+      "_tgt": "dailyclose_incompletesourcecompletenessentries",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailyclose_incompletesourcecompletenessentries",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L2404",
+      "target": "dailyclose_completionblockingincompletesources",
       "weight": 1
     },
     {
@@ -10727,7 +10775,7 @@
       "relation": "calls",
       "source": "dailyclose_findcurrentcarryforwardworkitembysource",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4080",
+      "source_location": "L4093",
       "target": "dailyclose_createcarryforwardworkitems",
       "weight": 1
     },
@@ -10739,7 +10787,7 @@
       "relation": "calls",
       "source": "dailyclose_sourceidfromcarryforwardinput",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4077",
+      "source_location": "L4090",
       "target": "dailyclose_createcarryforwardworkitems",
       "weight": 1
     },
@@ -10751,7 +10799,7 @@
       "relation": "calls",
       "source": "dailyclose_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4068",
+      "source_location": "L4081",
       "target": "dailyclose_createcarryforwardworkitems",
       "weight": 1
     },
@@ -10763,7 +10811,7 @@
       "relation": "calls",
       "source": "dailyclose_buildapprovalrequestsbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L938",
+      "source_location": "L939",
       "target": "dailyclose_filterregistersessionsbelongingtorange",
       "weight": 1
     },
@@ -10775,7 +10823,7 @@
       "relation": "calls",
       "source": "dailyclose_buildstaffnamesbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5606",
+      "source_location": "L5624",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -10787,7 +10835,7 @@
       "relation": "calls",
       "source": "dailyclose_completionattributionfordailyclose",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5609",
+      "source_location": "L5627",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -10799,7 +10847,7 @@
       "relation": "calls",
       "source": "dailyclose_getdailyclosecompletioneventstaffprofileid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5602",
+      "source_location": "L5620",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -10811,7 +10859,7 @@
       "relation": "calls",
       "source": "dailyclose_redactdailyclosereportsnapshotforbroadview",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5632",
+      "source_location": "L5650",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -10823,8 +10871,20 @@
       "relation": "calls",
       "source": "dailyclose_getpriorcompleteddailyclose",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5474",
+      "source_location": "L5492",
       "target": "dailyclose_getdailycloseopeningcontextwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "dailyclose_hasincompleteoperationalwork",
+      "_tgt": "dailyclose_incompletesourcecompletenessentries",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailyclose_incompletesourcecompletenessentries",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L2410",
+      "target": "dailyclose_hasincompleteoperationalwork",
       "weight": 1
     },
     {
@@ -10835,7 +10895,7 @@
       "relation": "calls",
       "source": "dailyclose_sourcecompletenessentry",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1673",
+      "source_location": "L1674",
       "target": "dailyclose_listactiveoversizedoperationalworkrepairs",
       "weight": 1
     },
@@ -10847,7 +10907,7 @@
       "relation": "calls",
       "source": "dailyclose_buildstaffnamesbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5562",
+      "source_location": "L5580",
       "target": "dailyclose_listcompleteddailyclosehistorywithctx",
       "weight": 1
     },
@@ -10859,7 +10919,7 @@
       "relation": "calls",
       "source": "dailyclose_sourcecompletenessentry",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1774",
+      "source_location": "L1775",
       "target": "dailyclose_listcompletedonlineordersforday",
       "weight": 1
     },
@@ -10871,7 +10931,7 @@
       "relation": "calls",
       "source": "dailyclose_sourcecompletenessentry",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2107",
+      "source_location": "L2108",
       "target": "dailyclose_listdepositsforday",
       "weight": 1
     },
@@ -10883,7 +10943,7 @@
       "relation": "calls",
       "source": "dailyclose_sourcecompletenessentry",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1876",
+      "source_location": "L1877",
       "target": "dailyclose_listexpensesforday",
       "weight": 1
     },
@@ -10895,7 +10955,7 @@
       "relation": "calls",
       "source": "dailyclose_sourcecompletenessentry",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1636",
+      "source_location": "L1637",
       "target": "dailyclose_listopenoperationalworkitems",
       "weight": 1
     },
@@ -10907,7 +10967,7 @@
       "relation": "calls",
       "source": "dailyclose_sourcecompletenessentry",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1601",
+      "source_location": "L1602",
       "target": "dailyclose_listopenpossessions",
       "weight": 1
     },
@@ -10919,7 +10979,7 @@
       "relation": "calls",
       "source": "dailyclose_sourcecompletenessentry",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1561",
+      "source_location": "L1562",
       "target": "dailyclose_listpendingcloseoutapprovals",
       "weight": 1
     },
@@ -10931,7 +10991,7 @@
       "relation": "calls",
       "source": "dailyclose_completesourcecompleteness",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1368",
+      "source_location": "L1369",
       "target": "dailyclose_listregistersessionsfordailyclose",
       "weight": 1
     },
@@ -10943,7 +11003,7 @@
       "relation": "calls",
       "source": "dailyclose_sourcecompletenessentry",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1413",
+      "source_location": "L1414",
       "target": "dailyclose_listregistersessionsfordailyclose",
       "weight": 1
     },
@@ -10955,7 +11015,7 @@
       "relation": "calls",
       "source": "dailyclose_readcappedsource",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1725",
+      "source_location": "L1726",
       "target": "dailyclose_listtransactionsforday",
       "weight": 1
     },
@@ -10967,7 +11027,7 @@
       "relation": "calls",
       "source": "dailyclose_ascarryforwarditem",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1058",
+      "source_location": "L1059",
       "target": "dailyclose_logicalgroupascarryforwarditem",
       "weight": 1
     },
@@ -10979,7 +11039,7 @@
       "relation": "calls",
       "source": "dailyclose_mayberedactdailyclosesnapshotforbroadview",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2568",
+      "source_location": "L2581",
       "target": "dailyclose_emptysummary",
       "weight": 1
     },
@@ -10991,7 +11051,7 @@
       "relation": "calls",
       "source": "dailyclose_redactdailyclosesummaryforbroadview",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2569",
+      "source_location": "L2582",
       "target": "dailyclose_mayberedactdailyclosesnapshotforbroadview",
       "weight": 1
     },
@@ -11003,7 +11063,7 @@
       "relation": "calls",
       "source": "dailyclose_completesourcecompleteness",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L495",
+      "source_location": "L496",
       "target": "dailyclose_mergesourcecompleteness",
       "weight": 1
     },
@@ -11015,7 +11075,7 @@
       "relation": "calls",
       "source": "dailyclose_normalizecompleteddailyclosesnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L449",
+      "source_location": "L450",
       "target": "dailyclose_completesourcecompleteness",
       "weight": 1
     },
@@ -11027,7 +11087,7 @@
       "relation": "calls",
       "source": "dailyclose_normalizecompleteddailyclosesnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L389",
+      "source_location": "L390",
       "target": "dailyclose_completionattributionfordailyclose",
       "weight": 1
     },
@@ -11039,7 +11099,7 @@
       "relation": "calls",
       "source": "dailyclose_normalizecompleteddailyclosesnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L430",
+      "source_location": "L431",
       "target": "dailyclose_normalizedailyclosesummary",
       "weight": 1
     },
@@ -11051,7 +11111,7 @@
       "relation": "calls",
       "source": "dailyclose_normalizedailyclosesummary",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L519",
+      "source_location": "L520",
       "target": "dailyclose_emptysummary",
       "weight": 1
     },
@@ -11063,7 +11123,7 @@
       "relation": "calls",
       "source": "dailyclose_patchdailyclosecarryforwardworkitemmetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1103",
+      "source_location": "L1104",
       "target": "dailyclose_carryforwardbusinessdate",
       "weight": 1
     },
@@ -11075,7 +11135,7 @@
       "relation": "calls",
       "source": "dailyclose_patchdailyclosecarryforwardworkitemmetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1104",
+      "source_location": "L1105",
       "target": "dailyclose_carryforwardsourceid",
       "weight": 1
     },
@@ -11087,7 +11147,7 @@
       "relation": "calls",
       "source": "dailyclose_sourcecompletenessentry",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1702",
+      "source_location": "L1703",
       "target": "dailyclose_readcappedsource",
       "weight": 1
     },
@@ -11099,7 +11159,7 @@
       "relation": "calls",
       "source": "dailyclose_markreportdaydirty",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4307",
+      "source_location": "L4320",
       "target": "dailyclose_recorddailyclosecompletedreportfacts",
       "weight": 1
     },
@@ -11111,7 +11171,7 @@
       "relation": "calls",
       "source": "dailyclose_redactdailyclosesummaryforbroadview",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2528",
+      "source_location": "L2541",
       "target": "dailyclose_redactdailyclosereportsnapshotforbroadview",
       "weight": 1
     },
@@ -11123,7 +11183,7 @@
       "relation": "calls",
       "source": "dailyclose_normalizedailyclosesummary",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2491",
+      "source_location": "L2504",
       "target": "dailyclose_redactdailyclosesummaryforbroadview",
       "weight": 1
     },
@@ -11135,7 +11195,7 @@
       "relation": "calls",
       "source": "dailyclose_isinrange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1465",
+      "source_location": "L1466",
       "target": "dailyclose_registersessionbelongstorange",
       "weight": 1
     },
@@ -11147,7 +11207,7 @@
       "relation": "calls",
       "source": "dailyclose_registersessioncloseoutoperatingat",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1459",
+      "source_location": "L1460",
       "target": "dailyclose_registersessionbelongstorange",
       "weight": 1
     },
@@ -11159,7 +11219,7 @@
       "relation": "calls",
       "source": "dailyclose_registersessionintersectsrange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1468",
+      "source_location": "L1469",
       "target": "dailyclose_registersessionbelongstorange",
       "weight": 1
     },
@@ -11171,7 +11231,7 @@
       "relation": "calls",
       "source": "dailyclose_registersessioncloseoutoperatingat",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L755",
+      "source_location": "L756",
       "target": "dailyclose_issubmittedvariancecloseout",
       "weight": 1
     },
@@ -11183,7 +11243,7 @@
       "relation": "calls",
       "source": "dailyclose_markotherdailyclosesnotcurrent",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5402",
+      "source_location": "L5420",
       "target": "dailyclose_reopendailyclosewithctx",
       "weight": 1
     },
@@ -11195,7 +11255,7 @@
       "relation": "calls",
       "source": "dailyclose_markreportdaydirty",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5453",
+      "source_location": "L5471",
       "target": "dailyclose_reopendailyclosewithctx",
       "weight": 1
     },
@@ -11207,7 +11267,7 @@
       "relation": "calls",
       "source": "dailyclose_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5239",
+      "source_location": "L5257",
       "target": "dailyclose_reopendailyclosewithctx",
       "weight": 1
     },
@@ -11219,7 +11279,7 @@
       "relation": "calls",
       "source": "dailyclose_carryforwardbusinessdate",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5057",
+      "source_location": "L5075",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -11231,7 +11291,7 @@
       "relation": "calls",
       "source": "dailyclose_carryforwardresolutionvalidationerror",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5008",
+      "source_location": "L5026",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -11243,7 +11303,7 @@
       "relation": "calls",
       "source": "dailyclose_carryforwardsourceid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5084",
+      "source_location": "L5102",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -11255,7 +11315,7 @@
       "relation": "calls",
       "source": "dailyclose_getstore",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4982",
+      "source_location": "L5000",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -11267,7 +11327,7 @@
       "relation": "calls",
       "source": "dailyclose_listdailyopeninghandoffsforcarryforward",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5129",
+      "source_location": "L5147",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -11279,7 +11339,7 @@
       "relation": "calls",
       "source": "dailyclose_stringfrommetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5066",
+      "source_location": "L5084",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -11291,7 +11351,7 @@
       "relation": "calls",
       "source": "dailyclose_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4973",
+      "source_location": "L4991",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -11303,7 +11363,7 @@
       "relation": "calls",
       "source": "dailyclose_isvalidoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L733",
+      "source_location": "L734",
       "target": "dailyclose_resolveoperatingdaterange",
       "weight": 1
     },
@@ -11315,7 +11375,7 @@
       "relation": "calls",
       "source": "dailyclose_safeoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L727",
+      "source_location": "L728",
       "target": "dailyclose_resolveoperatingdaterange",
       "weight": 1
     },
@@ -11327,7 +11387,7 @@
       "relation": "calls",
       "source": "dailyclose_stringfrommetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3913",
+      "source_location": "L3926",
       "target": "dailyclose_sourceidfromcarryforwardinput",
       "weight": 1
     },
@@ -11351,7 +11411,7 @@
       "relation": "calls",
       "source": "dailyclose_completionattributionfordailyclose",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2581",
+      "source_location": "L2594",
       "target": "dailyclose_todailyclosehistorylistitem",
       "weight": 1
     },
@@ -11363,7 +11423,7 @@
       "relation": "calls",
       "source": "dailyclose_redactdailyclosesummaryforbroadview",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2610",
+      "source_location": "L2623",
       "target": "dailyclose_todailyclosehistorylistitem",
       "weight": 1
     },
@@ -11375,7 +11435,7 @@
       "relation": "calls",
       "source": "dailyclose_formatpaymentmethodlabel",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L819",
+      "source_location": "L820",
       "target": "dailyclose_transactionpaymentsummary",
       "weight": 1
     },
@@ -11747,7 +11807,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildcashmetrics",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1027",
+      "source_location": "L1086",
       "target": "dailymanagerreportemail_comparisonfromsummary",
       "weight": 1
     },
@@ -11759,7 +11819,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildcashmetrics",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1015",
+      "source_location": "L1074",
       "target": "dailymanagerreportemail_numberfromsummary",
       "weight": 1
     },
@@ -11771,7 +11831,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildcashmetrics",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1017",
+      "source_location": "L1076",
       "target": "dailymanagerreportemail_numberfromsummarywithfallback",
       "weight": 1
     },
@@ -11783,7 +11843,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_builddailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L577",
+      "source_location": "L636",
       "target": "dailymanagerreportemail_buildblockers",
       "weight": 1
     },
@@ -11795,7 +11855,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_builddailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L576",
+      "source_location": "L635",
       "target": "dailymanagerreportemail_buildcarryforwarditems",
       "weight": 1
     },
@@ -11807,7 +11867,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_builddailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L584",
+      "source_location": "L643",
       "target": "dailymanagerreportemail_buildcashmetrics",
       "weight": 1
     },
@@ -11819,7 +11879,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_builddailytopmoversurl",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L571",
+      "source_location": "L630",
       "target": "dailymanagerreportemail_builddailymanagerreportpayload",
       "weight": 1
     },
@@ -11831,7 +11891,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_builddailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L585",
+      "source_location": "L644",
       "target": "dailymanagerreportemail_buildpaymenttotals",
       "weight": 1
     },
@@ -11843,7 +11903,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_builddailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L575",
+      "source_location": "L634",
       "target": "dailymanagerreportemail_buildrevieweditems",
       "weight": 1
     },
@@ -11855,7 +11915,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_builddailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L578",
+      "source_location": "L637",
       "target": "dailymanagerreportemail_buildsummarymetrics",
       "weight": 1
     },
@@ -11867,7 +11927,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_builddailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L554",
+      "source_location": "L613",
       "target": "dailymanagerreportemail_formatcompletedat",
       "weight": 1
     },
@@ -11879,7 +11939,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_builddailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L553",
+      "source_location": "L612",
       "target": "dailymanagerreportemail_formatoperatingdate",
       "weight": 1
     },
@@ -11891,7 +11951,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_builddailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L541",
+      "source_location": "L600",
       "target": "dailymanagerreportemail_moneyformatter",
       "weight": 1
     },
@@ -11903,7 +11963,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_builddailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L540",
+      "source_location": "L599",
       "target": "dailymanagerreportemail_normalizecurrency",
       "weight": 1
     },
@@ -11915,7 +11975,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_builddailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L548",
+      "source_location": "L607",
       "target": "dailymanagerreportemail_resolveappurl",
       "weight": 1
     },
@@ -11927,7 +11987,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_builddailytopmoversurl",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L527",
+      "source_location": "L586",
       "target": "dailymanagerreportemail_resolveappurl",
       "weight": 1
     },
@@ -11939,7 +11999,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildopendailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L637",
+      "source_location": "L696",
       "target": "dailymanagerreportemail_buildcashmetrics",
       "weight": 1
     },
@@ -11951,7 +12011,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildopendailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L638",
+      "source_location": "L697",
       "target": "dailymanagerreportemail_buildpaymenttotals",
       "weight": 1
     },
@@ -11963,7 +12023,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildopendailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L635",
+      "source_location": "L694",
       "target": "dailymanagerreportemail_buildpreparedblockers",
       "weight": 1
     },
@@ -11975,7 +12035,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildopendailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L634",
+      "source_location": "L693",
       "target": "dailymanagerreportemail_buildpreparedcarryforwarditems",
       "weight": 1
     },
@@ -11987,7 +12047,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildopendailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L633",
+      "source_location": "L692",
       "target": "dailymanagerreportemail_buildpreparedreviewitems",
       "weight": 1
     },
@@ -11999,7 +12059,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildopendailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L636",
+      "source_location": "L695",
       "target": "dailymanagerreportemail_buildsummarymetrics",
       "weight": 1
     },
@@ -12011,7 +12071,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildopendailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L628",
+      "source_location": "L687",
       "target": "dailymanagerreportemail_formatcompletedat",
       "weight": 1
     },
@@ -12023,7 +12083,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildopendailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L627",
+      "source_location": "L686",
       "target": "dailymanagerreportemail_formatoperatingdate",
       "weight": 1
     },
@@ -12035,7 +12095,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildopendailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L616",
+      "source_location": "L675",
       "target": "dailymanagerreportemail_moneyformatter",
       "weight": 1
     },
@@ -12047,7 +12107,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildopendailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L615",
+      "source_location": "L674",
       "target": "dailymanagerreportemail_normalizecurrency",
       "weight": 1
     },
@@ -12059,7 +12119,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildopendailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L622",
+      "source_location": "L681",
       "target": "dailymanagerreportemail_resolveappurl",
       "weight": 1
     },
@@ -12071,7 +12131,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildprepareddailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L597",
+      "source_location": "L656",
       "target": "dailymanagerreportemail_buildopendailymanagerreportpayload",
       "weight": 1
     },
@@ -12083,7 +12143,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildrevieweditems",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L761",
+      "source_location": "L820",
       "target": "dailymanagerreportemail_comparisonfromsummary",
       "weight": 1
     },
@@ -12095,7 +12155,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildrevieweditems",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L740",
+      "source_location": "L799",
       "target": "dailymanagerreportemail_numberfromsummary",
       "weight": 1
     },
@@ -12107,7 +12167,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildrevieweditems",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L748",
+      "source_location": "L807",
       "target": "dailymanagerreportemail_numberfromsummarywithfallback",
       "weight": 1
     },
@@ -12119,7 +12179,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildsummarymetrics",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L943",
+      "source_location": "L1002",
       "target": "dailymanagerreportemail_comparisonfromsummary",
       "weight": 1
     },
@@ -12131,7 +12191,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildsummarymetrics",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L948",
+      "source_location": "L1007",
       "target": "dailymanagerreportemail_countlabel",
       "weight": 1
     },
@@ -12143,7 +12203,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildsummarymetrics",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L968",
+      "source_location": "L1027",
       "target": "dailymanagerreportemail_formatpriordaycomparison",
       "weight": 1
     },
@@ -12155,7 +12215,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildsummarymetrics",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L965",
+      "source_location": "L1024",
       "target": "dailymanagerreportemail_formatunitcount",
       "weight": 1
     },
@@ -12167,7 +12227,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildsummarymetrics",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L934",
+      "source_location": "L993",
       "target": "dailymanagerreportemail_numberfromsummary",
       "weight": 1
     },
@@ -12179,7 +12239,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_readunitssoldforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L489",
+      "source_location": "L548",
       "target": "dailymanagerreportemail_buildunitssoldsummary",
       "weight": 1
     },
@@ -12191,7 +12251,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_comparisonfromsummary",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1096",
+      "source_location": "L1155",
       "target": "dailymanagerreportemail_formatpriordaycomparison",
       "weight": 1
     },
@@ -12203,7 +12263,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_numberfromsummary",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1098",
+      "source_location": "L1157",
       "target": "dailymanagerreportemail_comparisonfromsummary",
       "weight": 1
     },
@@ -12215,7 +12275,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_formatblockermessage",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L873",
+      "source_location": "L932",
       "target": "dailymanagerreportemail_optionalmetadatalabel",
       "weight": 1
     },
@@ -12227,7 +12287,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_resolveappurl",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1181",
+      "source_location": "L1240",
       "target": "dailymanagerreportemail_trimtrailingslash",
       "weight": 1
     },
@@ -13967,7 +14027,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_eodpolicycompletionatforstoreday",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1641",
+      "source_location": "L1646",
       "target": "dailyoperationsautomation_configuredeodautocompletestoredaycontext",
       "weight": 1
     },
@@ -13979,7 +14039,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_openingpolicystartatforstoreday",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1596",
+      "source_location": "L1601",
       "target": "dailyoperationsautomation_configuredopeningoperatingdate",
       "weight": 1
     },
@@ -14003,7 +14063,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_localdateforpolicy",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1768",
+      "source_location": "L1773",
       "target": "dailyoperationsautomation_eodautocompletepolicycronwindow",
       "weight": 1
     },
@@ -14015,7 +14075,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_localdateforpolicy",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1697",
+      "source_location": "L1702",
       "target": "dailyoperationsautomation_eodautocompletetiming",
       "weight": 1
     },
@@ -14027,7 +14087,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_scheduleevidenceforstoredaycontext",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1690",
+      "source_location": "L1695",
       "target": "dailyoperationsautomation_eodautocompletetiming",
       "weight": 1
     },
@@ -14051,7 +14111,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_eodlocalcompletionwindowminutesforpolicy",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1568",
+      "source_location": "L1573",
       "target": "dailyoperationsautomation_eodpolicycompletionatforstoreday",
       "weight": 1
     },
@@ -14063,7 +14123,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_normalizedpolicyoffsetfromschedulestart",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1567",
+      "source_location": "L1572",
       "target": "dailyoperationsautomation_eodpolicycompletionatforstoreday",
       "weight": 1
     },
@@ -14147,7 +14207,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_localdateforpolicy",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1460",
+      "source_location": "L1465",
       "target": "dailyoperationsautomation_openingpolicycronwindow",
       "weight": 1
     },
@@ -14159,7 +14219,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_normalizedpolicyoffsetfromschedulestart",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1548",
+      "source_location": "L1553",
       "target": "dailyoperationsautomation_openingpolicystartatforstoreday",
       "weight": 1
     },
@@ -14171,7 +14231,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_openinglocalstartminutesforpolicy",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1549",
+      "source_location": "L1554",
       "target": "dailyoperationsautomation_openingpolicystartatforstoreday",
       "weight": 1
     },
@@ -14183,7 +14243,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_operatingdateforpolicy",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1431",
+      "source_location": "L1436",
       "target": "dailyoperationsautomation_localdateforpolicy",
       "weight": 1
     },
@@ -14219,7 +14279,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_automationerrormessage",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1823",
+      "source_location": "L1828",
       "target": "dailyoperationsautomation_recordconfiguredautomationfailurewithctx",
       "weight": 1
     },
@@ -14255,7 +14315,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_listconfiguredautomationpolicies",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1985",
+      "source_location": "L1990",
       "target": "dailyoperationsautomation_runconfigureddailyoperationsautomationwithctx",
       "weight": 1
     },
@@ -14267,7 +14327,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_recordconfiguredautomationfailurewithctx",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1862",
+      "source_location": "L1867",
       "target": "dailyoperationsautomation_runconfiguredpolicysafely",
       "weight": 1
     },
@@ -14351,7 +14411,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_adddaystooperatingdate",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L2284",
+      "source_location": "L2289",
       "target": "dailyoperationsautomation_runhistoriceodautoclosebatchactionwithctx",
       "weight": 1
     },
@@ -14363,7 +14423,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_isvalidoperatingdate",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L2243",
+      "source_location": "L2248",
       "target": "dailyoperationsautomation_runhistoriceodautoclosebatchactionwithctx",
       "weight": 1
     },
@@ -14375,7 +14435,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_summarizehistoriceodautoclosebatch",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L2287",
+      "source_location": "L2292",
       "target": "dailyoperationsautomation_runhistoriceodautoclosebatchactionwithctx",
       "weight": 1
     },
@@ -14387,7 +14447,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_adddaystooperatingdate",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1391",
+      "source_location": "L1396",
       "target": "dailyoperationsautomation_runhistoriceodautoclosebatchwithctx",
       "weight": 1
     },
@@ -14399,7 +14459,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_isvalidoperatingdate",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1354",
+      "source_location": "L1359",
       "target": "dailyoperationsautomation_runhistoriceodautoclosebatchwithctx",
       "weight": 1
     },
@@ -14411,7 +14471,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_runhistoriceodautoclosefordatewithctx",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1383",
+      "source_location": "L1388",
       "target": "dailyoperationsautomation_runhistoriceodautoclosebatchwithctx",
       "weight": 1
     },
@@ -14423,7 +14483,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_runhistoriceodautoclosebatchwithctx",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1394",
+      "source_location": "L1399",
       "target": "dailyoperationsautomation_summarizehistoriceodautoclosebatch",
       "weight": 1
     },
@@ -14435,7 +14495,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_eodautocompletedecision",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1203",
+      "source_location": "L1208",
       "target": "dailyoperationsautomation_runhistoriceodautoclosefordatewithctx",
       "weight": 1
     },
@@ -14495,7 +14555,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_listconfiguredautomationpolicies",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1917",
+      "source_location": "L1922",
       "target": "dailyoperationsautomation_runscheduleddailyoperationsautomationwithctx",
       "weight": 1
     },
@@ -47555,7 +47615,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_registry_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/registry.test.ts",
-      "source_location": "L558",
+      "source_location": "L609",
       "target": "registry_test_dedupekey",
       "weight": 1
     },
@@ -47567,7 +47627,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_registry_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/registry.test.ts",
-      "source_location": "L733",
+      "source_location": "L794",
       "target": "registry_test_keyfor",
       "weight": 1
     },
@@ -47603,7 +47663,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_registry_ts",
       "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
-      "source_location": "L358",
+      "source_location": "L395",
       "target": "registry_findnotificationkind",
       "weight": 1
     },
@@ -47615,7 +47675,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_registry_ts",
       "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
-      "source_location": "L368",
+      "source_location": "L405",
       "target": "registry_getnotificationkind",
       "weight": 1
     },
@@ -47627,7 +47687,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_registry_ts",
       "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
-      "source_location": "L376",
+      "source_location": "L413",
       "target": "registry_listnotificationkinds",
       "weight": 1
     },
@@ -49307,7 +49367,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L6311",
+      "source_location": "L6335",
       "target": "dailyclose_test_createcommandargs",
       "weight": 1
     },
@@ -49427,7 +49487,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1487",
+      "source_location": "L1488",
       "target": "dailyclose_approvalbelongstorange",
       "weight": 1
     },
@@ -49439,7 +49499,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L827",
+      "source_location": "L828",
       "target": "dailyclose_approvalrequesttypelabel",
       "weight": 1
     },
@@ -49451,7 +49511,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L972",
+      "source_location": "L973",
       "target": "dailyclose_ascarryforwarditem",
       "weight": 1
     },
@@ -49463,7 +49523,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L903",
+      "source_location": "L904",
       "target": "dailyclose_buildapprovalrequestsbyid",
       "weight": 1
     },
@@ -49475,7 +49535,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1787",
+      "source_location": "L1788",
       "target": "dailyclose_buildcompletedonlineordertotals",
       "weight": 1
     },
@@ -49487,7 +49547,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1971",
+      "source_location": "L1972",
       "target": "dailyclose_builddailycloseexpenseproductevidence",
       "weight": 1
     },
@@ -49499,7 +49559,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1158",
+      "source_location": "L1159",
       "target": "dailyclose_builddailycloselifecyclegatewithctx",
       "weight": 1
     },
@@ -49511,7 +49571,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2241",
+      "source_location": "L2242",
       "target": "dailyclose_builddailyclosereportsnapshot",
       "weight": 1
     },
@@ -49523,7 +49583,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2674",
+      "source_location": "L2687",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -49535,7 +49595,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L952",
+      "source_location": "L953",
       "target": "dailyclose_buildexpensesessionsbyid",
       "weight": 1
     },
@@ -49547,7 +49607,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1917",
+      "source_location": "L1918",
       "target": "dailyclose_buildexpensetransactionitemcountsbytransactionid",
       "weight": 1
     },
@@ -49559,7 +49619,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2138",
+      "source_location": "L2139",
       "target": "dailyclose_buildreadiness",
       "weight": 1
     },
@@ -49571,7 +49631,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L883",
+      "source_location": "L884",
       "target": "dailyclose_buildregistersessionsbyid",
       "weight": 1
     },
@@ -49583,7 +49643,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L863",
+      "source_location": "L864",
       "target": "dailyclose_buildstaffnamesbyid",
       "weight": 1
     },
@@ -49595,7 +49655,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L843",
+      "source_location": "L844",
       "target": "dailyclose_buildterminallabelsbyid",
       "weight": 1
     },
@@ -49607,7 +49667,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1889",
+      "source_location": "L1890",
       "target": "dailyclose_buildtransactionitemcountsbytransactionid",
       "weight": 1
     },
@@ -49619,7 +49679,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3888",
+      "source_location": "L3901",
       "target": "dailyclose_carryforwardbusinessdate",
       "weight": 1
     },
@@ -49631,7 +49691,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3918",
+      "source_location": "L3931",
       "target": "dailyclose_carryforwardmetadatamatches",
       "weight": 1
     },
@@ -49643,7 +49703,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4962",
+      "source_location": "L4980",
       "target": "dailyclose_carryforwardresolutionvalidationerror",
       "weight": 1
     },
@@ -49655,7 +49715,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3897",
+      "source_location": "L3910",
       "target": "dailyclose_carryforwardsourceid",
       "weight": 1
     },
@@ -49667,7 +49727,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3962",
+      "source_location": "L3975",
       "target": "dailyclose_carryforwardworkitemidfromitem",
       "weight": 1
     },
@@ -49679,7 +49739,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2120",
+      "source_location": "L2121",
       "target": "dailyclose_cashdeltasbyregistersessionid",
       "weight": 1
     },
@@ -49691,7 +49751,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L923",
+      "source_location": "L924",
       "target": "dailyclose_closeoutapprovalforregistersession",
       "weight": 1
     },
@@ -49703,7 +49763,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4627",
+      "source_location": "L4643",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -49715,7 +49775,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4315",
+      "source_location": "L4328",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -49727,7 +49787,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L453",
+      "source_location": "L454",
       "target": "dailyclose_completesourcecompleteness",
       "weight": 1
     },
@@ -49739,8 +49799,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2402",
+      "source_location": "L2415",
       "target": "dailyclose_completionattributionfordailyclose",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_operations_dailyclose_ts",
+      "_tgt": "dailyclose_completionblockingincompletesources",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L2403",
+      "target": "dailyclose_completionblockingincompletesources",
       "weight": 1
     },
     {
@@ -49751,7 +49823,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4053",
+      "source_location": "L4066",
       "target": "dailyclose_createcarryforwardworkitems",
       "weight": 1
     },
@@ -49763,7 +49835,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2641",
+      "source_location": "L2654",
       "target": "dailyclose_emptysummary",
       "weight": 1
     },
@@ -49775,7 +49847,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L935",
+      "source_location": "L936",
       "target": "dailyclose_filterregistersessionsbelongingtorange",
       "weight": 1
     },
@@ -49787,7 +49859,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3929",
+      "source_location": "L3942",
       "target": "dailyclose_findcurrentcarryforwardworkitembysource",
       "weight": 1
     },
@@ -49799,7 +49871,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L799",
+      "source_location": "L800",
       "target": "dailyclose_formatpaymentmethodlabel",
       "weight": 1
     },
@@ -49811,7 +49883,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2214",
+      "source_location": "L2215",
       "target": "dailyclose_frozensyncedsaleinventoryreviewgroups",
       "weight": 1
     },
@@ -49823,7 +49895,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5581",
+      "source_location": "L5599",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -49835,7 +49907,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2614",
+      "source_location": "L2627",
       "target": "dailyclose_getdailyclosecompletioneventstaffprofileid",
       "weight": 1
     },
@@ -49847,7 +49919,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1119",
+      "source_location": "L1120",
       "target": "dailyclose_getdailyclosefordate",
       "weight": 1
     },
@@ -49859,7 +49931,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5467",
+      "source_location": "L5485",
       "target": "dailyclose_getdailycloseopeningcontextwithctx",
       "weight": 1
     },
@@ -49871,7 +49943,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4152",
+      "source_location": "L4165",
       "target": "dailyclose_getnonactivedailyclosefordate",
       "weight": 1
     },
@@ -49883,7 +49955,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1194",
+      "source_location": "L1195",
       "target": "dailyclose_getpriorcompleteddailyclose",
       "weight": 1
     },
@@ -49895,8 +49967,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1112",
+      "source_location": "L1113",
       "target": "dailyclose_getstore",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_operations_dailyclose_ts",
+      "_tgt": "dailyclose_hasincompleteoperationalwork",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L2409",
+      "target": "dailyclose_hasincompleteoperationalwork",
       "weight": 1
     },
     {
@@ -49907,7 +49991,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2398",
+      "source_location": "L2399",
       "target": "dailyclose_incompletesourcecompletenessentries",
       "weight": 1
     },
@@ -49919,7 +50003,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L743",
+      "source_location": "L744",
       "target": "dailyclose_isinrange",
       "weight": 1
     },
@@ -49931,7 +50015,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L767",
+      "source_location": "L768",
       "target": "dailyclose_issubmittedvariancecloseout",
       "weight": 1
     },
@@ -49943,7 +50027,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L711",
+      "source_location": "L712",
       "target": "dailyclose_isvalidoperatingdaterange",
       "weight": 1
     },
@@ -49955,7 +50039,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1653",
+      "source_location": "L1654",
       "target": "dailyclose_listactiveoversizedoperationalworkrepairs",
       "weight": 1
     },
@@ -49967,7 +50051,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5528",
+      "source_location": "L5546",
       "target": "dailyclose_listcompleteddailyclosehistorywithctx",
       "weight": 1
     },
@@ -49979,7 +50063,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1744",
+      "source_location": "L1745",
       "target": "dailyclose_listcompletedonlineordersforday",
       "weight": 1
     },
@@ -49991,7 +50075,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4933",
+      "source_location": "L4951",
       "target": "dailyclose_listdailyopeninghandoffsforcarryforward",
       "weight": 1
     },
@@ -50003,7 +50087,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2082",
+      "source_location": "L2083",
       "target": "dailyclose_listdepositsforday",
       "weight": 1
     },
@@ -50015,7 +50099,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1853",
+      "source_location": "L1854",
       "target": "dailyclose_listexpensesforday",
       "weight": 1
     },
@@ -50027,7 +50111,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1616",
+      "source_location": "L1617",
       "target": "dailyclose_listopenoperationalworkitems",
       "weight": 1
     },
@@ -50039,7 +50123,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1573",
+      "source_location": "L1574",
       "target": "dailyclose_listopenpossessions",
       "weight": 1
     },
@@ -50051,7 +50135,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1527",
+      "source_location": "L1528",
       "target": "dailyclose_listpendingcloseoutapprovals",
       "weight": 1
     },
@@ -50063,7 +50147,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1227",
+      "source_location": "L1228",
       "target": "dailyclose_listregistersessionsfordailyclose",
       "weight": 1
     },
@@ -50075,7 +50159,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1714",
+      "source_location": "L1715",
       "target": "dailyclose_listtransactionsforday",
       "weight": 1
     },
@@ -50087,7 +50171,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3847",
+      "source_location": "L3860",
       "target": "dailyclose_logicalcarryforwardselectioncount",
       "weight": 1
     },
@@ -50099,7 +50183,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1020",
+      "source_location": "L1021",
       "target": "dailyclose_logicalgroupascarryforwarditem",
       "weight": 1
     },
@@ -50111,7 +50195,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4129",
+      "source_location": "L4142",
       "target": "dailyclose_markotherdailyclosesnotcurrent",
       "weight": 1
     },
@@ -50123,7 +50207,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4236",
+      "source_location": "L4249",
       "target": "dailyclose_markreportdaydirty",
       "weight": 1
     },
@@ -50135,7 +50219,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2540",
+      "source_location": "L2553",
       "target": "dailyclose_mayberedactdailyclosesnapshotforbroadview",
       "weight": 1
     },
@@ -50147,7 +50231,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L490",
+      "source_location": "L491",
       "target": "dailyclose_mergesourcecompleteness",
       "weight": 1
     },
@@ -50159,7 +50243,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L823",
+      "source_location": "L824",
       "target": "dailyclose_nonzerovariancemetadata",
       "weight": 1
     },
@@ -50171,7 +50255,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2451",
+      "source_location": "L2464",
       "target": "dailyclose_normalizebroadviewmetadatalabel",
       "weight": 1
     },
@@ -50183,7 +50267,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L377",
+      "source_location": "L378",
       "target": "dailyclose_normalizecompleteddailyclosesnapshot",
       "weight": 1
     },
@@ -50195,7 +50279,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L502",
+      "source_location": "L503",
       "target": "dailyclose_normalizedailyclosesummary",
       "weight": 1
     },
@@ -50207,7 +50291,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1087",
+      "source_location": "L1088",
       "target": "dailyclose_patchdailyclosecarryforwardworkitemmetadata",
       "weight": 1
     },
@@ -50219,7 +50303,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1471",
+      "source_location": "L1472",
       "target": "dailyclose_possessionintersectsrange",
       "weight": 1
     },
@@ -50231,7 +50315,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1690",
+      "source_location": "L1691",
       "target": "dailyclose_readcappedsource",
       "weight": 1
     },
@@ -50243,7 +50327,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4175",
+      "source_location": "L4188",
       "target": "dailyclose_recorddailyclosecompletedevent",
       "weight": 1
     },
@@ -50255,7 +50339,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4269",
+      "source_location": "L4282",
       "target": "dailyclose_recorddailyclosecompletedreportfacts",
       "weight": 1
     },
@@ -50267,7 +50351,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2455",
+      "source_location": "L2468",
       "target": "dailyclose_redactdailycloseitemforbroadview",
       "weight": 1
     },
@@ -50279,7 +50363,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5503",
+      "source_location": "L5521",
       "target": "dailyclose_redactdailycloseopeningcontextforbroadview",
       "weight": 1
     },
@@ -50291,7 +50375,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2508",
+      "source_location": "L2521",
       "target": "dailyclose_redactdailyclosereportsnapshotforbroadview",
       "weight": 1
     },
@@ -50303,7 +50387,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2488",
+      "source_location": "L2501",
       "target": "dailyclose_redactdailyclosesummaryforbroadview",
       "weight": 1
     },
@@ -50315,7 +50399,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L786",
+      "source_location": "L787",
       "target": "dailyclose_registermetadatalabel",
       "weight": 1
     },
@@ -50327,7 +50411,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1454",
+      "source_location": "L1455",
       "target": "dailyclose_registersessionbelongstorange",
       "weight": 1
     },
@@ -50339,7 +50423,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L747",
+      "source_location": "L748",
       "target": "dailyclose_registersessioncloseoutoperatingat",
       "weight": 1
     },
@@ -50351,7 +50435,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1444",
+      "source_location": "L1445",
       "target": "dailyclose_registersessionintersectsrange",
       "weight": 1
     },
@@ -50363,7 +50447,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L778",
+      "source_location": "L779",
       "target": "dailyclose_registersessionlabel",
       "weight": 1
     },
@@ -50375,7 +50459,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5235",
+      "source_location": "L5253",
       "target": "dailyclose_reopendailyclosewithctx",
       "weight": 1
     },
@@ -50387,7 +50471,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4969",
+      "source_location": "L4987",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -50399,7 +50483,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L722",
+      "source_location": "L723",
       "target": "dailyclose_resolveoperatingdaterange",
       "weight": 1
     },
@@ -50411,7 +50495,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L694",
+      "source_location": "L695",
       "target": "dailyclose_safeoperatingdaterange",
       "weight": 1
     },
@@ -50423,7 +50507,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2384",
+      "source_location": "L2385",
       "target": "dailyclose_snapshotrevieweditems",
       "weight": 1
     },
@@ -50435,7 +50519,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L323",
+      "source_location": "L324",
       "target": "dailyclose_sortdailycloseblockers",
       "weight": 1
     },
@@ -50447,7 +50531,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L462",
+      "source_location": "L463",
       "target": "dailyclose_sourcecompletenessentry",
       "weight": 1
     },
@@ -50459,7 +50543,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3907",
+      "source_location": "L3920",
       "target": "dailyclose_sourceidfromcarryforwardinput",
       "weight": 1
     },
@@ -50471,7 +50555,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3879",
+      "source_location": "L3892",
       "target": "dailyclose_stringfrommetadata",
       "weight": 1
     },
@@ -50483,7 +50567,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2575",
+      "source_location": "L2588",
       "target": "dailyclose_todailyclosehistorylistitem",
       "weight": 1
     },
@@ -50495,7 +50579,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L805",
+      "source_location": "L806",
       "target": "dailyclose_transactionpaymentsummary",
       "weight": 1
     },
@@ -50507,7 +50591,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L689",
+      "source_location": "L690",
       "target": "dailyclose_trimoptional",
       "weight": 1
     },
@@ -50519,7 +50603,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2176",
+      "source_location": "L2177",
       "target": "dailyclose_trustedsyncedsaleinventoryreviewunits",
       "weight": 1
     },
@@ -50531,7 +50615,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2168",
+      "source_location": "L2169",
       "target": "dailyclose_uniquedailycloseitems",
       "weight": 1
     },
@@ -50543,7 +50627,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3873",
+      "source_location": "L3886",
       "target": "dailyclose_uniqueoperationalworkitemids",
       "weight": 1
     },
@@ -50555,7 +50639,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2158",
+      "source_location": "L2159",
       "target": "dailyclose_uniquesourcesubjects",
       "weight": 1
     },
@@ -50567,7 +50651,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3972",
+      "source_location": "L3985",
       "target": "dailyclose_validateautomationcarryforwardworkitems",
       "weight": 1
     },
@@ -50579,7 +50663,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3793",
+      "source_location": "L3806",
       "target": "dailyclose_validatecarryforwardworkitemids",
       "weight": 1
     },
@@ -50591,7 +50675,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3821",
+      "source_location": "L3834",
       "target": "dailyclose_validateselectedcarryforwardgroups",
       "weight": 1
     },
@@ -50723,7 +50807,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L844",
+      "source_location": "L903",
       "target": "dailymanagerreportemail_buildblockers",
       "weight": 1
     },
@@ -50735,7 +50819,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L820",
+      "source_location": "L879",
       "target": "dailymanagerreportemail_buildcarryforwarditems",
       "weight": 1
     },
@@ -50747,7 +50831,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1010",
+      "source_location": "L1069",
       "target": "dailymanagerreportemail_buildcashmetrics",
       "weight": 1
     },
@@ -50759,7 +50843,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L530",
+      "source_location": "L589",
       "target": "dailymanagerreportemail_builddailymanagerreportpayload",
       "weight": 1
     },
@@ -50771,7 +50855,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L515",
+      "source_location": "L574",
       "target": "dailymanagerreportemail_builddailytopmoversurl",
       "weight": 1
     },
@@ -50783,7 +50867,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L607",
+      "source_location": "L666",
       "target": "dailymanagerreportemail_buildopendailymanagerreportpayload",
       "weight": 1
     },
@@ -50795,7 +50879,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L888",
+      "source_location": "L947",
       "target": "dailymanagerreportemail_buildpaymenttotals",
       "weight": 1
     },
@@ -50807,7 +50891,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L858",
+      "source_location": "L917",
       "target": "dailymanagerreportemail_buildpreparedblockers",
       "weight": 1
     },
@@ -50819,7 +50903,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L833",
+      "source_location": "L892",
       "target": "dailymanagerreportemail_buildpreparedcarryforwarditems",
       "weight": 1
     },
@@ -50831,7 +50915,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L590",
+      "source_location": "L649",
       "target": "dailymanagerreportemail_buildprepareddailymanagerreportpayload",
       "weight": 1
     },
@@ -50843,7 +50927,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L809",
+      "source_location": "L868",
       "target": "dailymanagerreportemail_buildpreparedreviewitems",
       "weight": 1
     },
@@ -50855,7 +50939,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L646",
+      "source_location": "L705",
       "target": "dailymanagerreportemail_buildregistercashpositionsummary",
       "weight": 1
     },
@@ -50867,7 +50951,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L733",
+      "source_location": "L792",
       "target": "dailymanagerreportemail_buildrevieweditems",
       "weight": 1
     },
@@ -50879,7 +50963,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L928",
+      "source_location": "L987",
       "target": "dailymanagerreportemail_buildsummarymetrics",
       "weight": 1
     },
@@ -50891,7 +50975,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L503",
+      "source_location": "L562",
       "target": "dailymanagerreportemail_buildtopitemsforday",
       "weight": 1
     },
@@ -50903,7 +50987,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L485",
+      "source_location": "L544",
       "target": "dailymanagerreportemail_buildunitssoldsummary",
       "weight": 1
     },
@@ -50915,7 +50999,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1088",
+      "source_location": "L1147",
       "target": "dailymanagerreportemail_comparisonfromsummary",
       "weight": 1
     },
@@ -50927,7 +51011,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1124",
+      "source_location": "L1183",
       "target": "dailymanagerreportemail_countlabel",
       "weight": 1
     },
@@ -50939,7 +51023,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L868",
+      "source_location": "L927",
       "target": "dailymanagerreportemail_formatblockermessage",
       "weight": 1
     },
@@ -50951,7 +51035,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1168",
+      "source_location": "L1227",
       "target": "dailymanagerreportemail_formatcompletedat",
       "weight": 1
     },
@@ -50963,7 +51047,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1147",
+      "source_location": "L1206",
       "target": "dailymanagerreportemail_formatoperatingdate",
       "weight": 1
     },
@@ -50975,7 +51059,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1134",
+      "source_location": "L1193",
       "target": "dailymanagerreportemail_formatpaymentmethod",
       "weight": 1
     },
@@ -50987,7 +51071,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1103",
+      "source_location": "L1162",
       "target": "dailymanagerreportemail_formatpriordaycomparison",
       "weight": 1
     },
@@ -50999,7 +51083,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1120",
+      "source_location": "L1179",
       "target": "dailymanagerreportemail_formatunitcount",
       "weight": 1
     },
@@ -51011,7 +51095,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1055",
+      "source_location": "L1114",
       "target": "dailymanagerreportemail_ispaymenttotal",
       "weight": 1
     },
@@ -51023,7 +51107,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1068",
+      "source_location": "L1127",
       "target": "dailymanagerreportemail_moneyformatter",
       "weight": 1
     },
@@ -51035,7 +51119,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1128",
+      "source_location": "L1187",
       "target": "dailymanagerreportemail_normalizecurrency",
       "weight": 1
     },
@@ -51047,7 +51131,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1140",
+      "source_location": "L1199",
       "target": "dailymanagerreportemail_normalizepaymentmethod",
       "weight": 1
     },
@@ -51059,7 +51143,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1074",
+      "source_location": "L1133",
       "target": "dailymanagerreportemail_numberfromsummary",
       "weight": 1
     },
@@ -51071,7 +51155,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1079",
+      "source_location": "L1138",
       "target": "dailymanagerreportemail_numberfromsummarywithfallback",
       "weight": 1
     },
@@ -51083,7 +51167,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L880",
+      "source_location": "L939",
       "target": "dailymanagerreportemail_optionalmetadatalabel",
       "weight": 1
     },
@@ -51095,7 +51179,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L467",
+      "source_location": "L526",
       "target": "dailymanagerreportemail_readunitssoldforday",
       "weight": 1
     },
@@ -51107,7 +51191,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1176",
+      "source_location": "L1235",
       "target": "dailymanagerreportemail_resolveappurl",
       "weight": 1
     },
@@ -51119,7 +51203,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L445",
+      "source_location": "L504",
       "target": "dailymanagerreportemail_resolvestaffname",
       "weight": 1
     },
@@ -51131,7 +51215,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L424",
+      "source_location": "L483",
       "target": "dailymanagerreportemail_resolvestore",
       "weight": 1
     },
@@ -51143,7 +51227,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1160",
+      "source_location": "L1219",
       "target": "dailymanagerreportemail_resolvestorescheduletimezoneforat",
       "weight": 1
     },
@@ -51155,7 +51239,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1189",
+      "source_location": "L1248",
       "target": "dailymanagerreportemail_trimtrailingslash",
       "weight": 1
     },
@@ -53123,7 +53207,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L2432",
+      "source_location": "L2437",
       "target": "dailyoperationsautomation_asrecord",
       "weight": 1
     },
@@ -53135,7 +53219,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1804",
+      "source_location": "L1809",
       "target": "dailyoperationsautomation_automationerrormessage",
       "weight": 1
     },
@@ -53159,7 +53243,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1617",
+      "source_location": "L1622",
       "target": "dailyoperationsautomation_configuredeodautocompletestoredaycontext",
       "weight": 1
     },
@@ -53171,7 +53255,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1577",
+      "source_location": "L1582",
       "target": "dailyoperationsautomation_configuredopeningoperatingdate",
       "weight": 1
     },
@@ -53183,7 +53267,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L2106",
+      "source_location": "L2111",
       "target": "dailyoperationsautomation_dailymanagerreportstatusforeodautocompleteresult",
       "weight": 1
     },
@@ -53195,7 +53279,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L2127",
+      "source_location": "L2132",
       "target": "dailyoperationsautomation_emitdailymanagerreportnotificationsforeodautomationwithctx",
       "weight": 1
     },
@@ -53219,7 +53303,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1764",
+      "source_location": "L1769",
       "target": "dailyoperationsautomation_eodautocompletepolicycronwindow",
       "weight": 1
     },
@@ -53231,7 +53315,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1675",
+      "source_location": "L1680",
       "target": "dailyoperationsautomation_eodautocompletetiming",
       "weight": 1
     },
@@ -53255,7 +53339,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1528",
+      "source_location": "L1533",
       "target": "dailyoperationsautomation_eodlocalcompletionwindowminutesforpolicy",
       "weight": 1
     },
@@ -53267,7 +53351,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1556",
+      "source_location": "L1561",
       "target": "dailyoperationsautomation_eodpolicycompletionatforstoreday",
       "weight": 1
     },
@@ -53363,7 +53447,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1871",
+      "source_location": "L1876",
       "target": "dailyoperationsautomation_listconfiguredautomationpolicies",
       "weight": 1
     },
@@ -53375,7 +53459,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1436",
+      "source_location": "L1441",
       "target": "dailyoperationsautomation_localdateforpolicy",
       "weight": 1
     },
@@ -53387,7 +53471,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1515",
+      "source_location": "L1520",
       "target": "dailyoperationsautomation_normalizedpolicyoffsetfromschedulestart",
       "weight": 1
     },
@@ -53423,7 +53507,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1508",
+      "source_location": "L1513",
       "target": "dailyoperationsautomation_openinglocalstartminutesforpolicy",
       "weight": 1
     },
@@ -53435,7 +53519,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1456",
+      "source_location": "L1461",
       "target": "dailyoperationsautomation_openingpolicycronwindow",
       "weight": 1
     },
@@ -53447,7 +53531,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1537",
+      "source_location": "L1542",
       "target": "dailyoperationsautomation_openingpolicystartatforstoreday",
       "weight": 1
     },
@@ -53459,7 +53543,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1427",
+      "source_location": "L1432",
       "target": "dailyoperationsautomation_operatingdateforpolicy",
       "weight": 1
     },
@@ -53495,7 +53579,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1808",
+      "source_location": "L1813",
       "target": "dailyoperationsautomation_recordconfiguredautomationfailurewithctx",
       "weight": 1
     },
@@ -53531,7 +53615,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1720",
+      "source_location": "L1725",
       "target": "dailyoperationsautomation_resolveconfiguredstoreschedulecontext",
       "weight": 1
     },
@@ -53555,7 +53639,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1976",
+      "source_location": "L1981",
       "target": "dailyoperationsautomation_runconfigureddailyoperationsautomationwithctx",
       "weight": 1
     },
@@ -53567,7 +53651,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1848",
+      "source_location": "L1853",
       "target": "dailyoperationsautomation_runconfiguredpolicysafely",
       "weight": 1
     },
@@ -53603,7 +53687,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L2231",
+      "source_location": "L2236",
       "target": "dailyoperationsautomation_runhistoriceodautoclosebatchactionwithctx",
       "weight": 1
     },
@@ -53615,7 +53699,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1342",
+      "source_location": "L1347",
       "target": "dailyoperationsautomation_runhistoriceodautoclosebatchwithctx",
       "weight": 1
     },
@@ -53639,7 +53723,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1907",
+      "source_location": "L1912",
       "target": "dailyoperationsautomation_runscheduleddailyoperationsautomationwithctx",
       "weight": 1
     },
@@ -53651,7 +53735,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1656",
+      "source_location": "L1661",
       "target": "dailyoperationsautomation_scheduleevidenceforstoredaycontext",
       "weight": 1
     },
@@ -53687,7 +53771,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1400",
+      "source_location": "L1405",
       "target": "dailyoperationsautomation_summarizehistoriceodautoclosebatch",
       "weight": 1
     },
@@ -55223,7 +55307,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L149",
+      "source_location": "L151",
       "target": "oweddailyclosesweep_completedoperatingdatesforstore",
       "weight": 1
     },
@@ -55235,7 +55319,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L354",
+      "source_location": "L369",
       "target": "oweddailyclosesweep_daysbetweenoperatingdates",
       "weight": 1
     },
@@ -55247,7 +55331,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L135",
+      "source_location": "L137",
       "target": "oweddailyclosesweep_listenabledeodpolicies",
       "weight": 1
     },
@@ -55259,7 +55343,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L84",
+      "source_location": "L85",
       "target": "oweddailyclosesweep_selectoweddailyclosedates",
       "weight": 1
     },
@@ -147323,7 +147407,7 @@
       "relation": "calls",
       "source": "registry_findnotificationkind",
       "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
-      "source_location": "L369",
+      "source_location": "L406",
       "target": "registry_getnotificationkind",
       "weight": 1
     },
@@ -147395,7 +147479,7 @@
       "relation": "calls",
       "source": "registry_test_dedupekey",
       "source_file": "packages/athena-webapp/convex/notifications/registry.test.ts",
-      "source_location": "L734",
+      "source_location": "L795",
       "target": "registry_test_keyfor",
       "weight": 1
     },
@@ -181261,7 +181345,7 @@
       "label": "approvalBelongsToRange()",
       "norm_label": "approvalbelongstorange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1487"
+      "source_location": "L1488"
     },
     {
       "community": 0,
@@ -181270,7 +181354,7 @@
       "label": "approvalRequestTypeLabel()",
       "norm_label": "approvalrequesttypelabel()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L827"
+      "source_location": "L828"
     },
     {
       "community": 0,
@@ -181279,7 +181363,7 @@
       "label": "asCarryForwardItem()",
       "norm_label": "ascarryforwarditem()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L972"
+      "source_location": "L973"
     },
     {
       "community": 0,
@@ -181288,7 +181372,7 @@
       "label": "buildApprovalRequestsById()",
       "norm_label": "buildapprovalrequestsbyid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L903"
+      "source_location": "L904"
     },
     {
       "community": 0,
@@ -181297,7 +181381,7 @@
       "label": "buildCompletedOnlineOrderTotals()",
       "norm_label": "buildcompletedonlineordertotals()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1787"
+      "source_location": "L1788"
     },
     {
       "community": 0,
@@ -181306,7 +181390,7 @@
       "label": "buildDailyCloseExpenseProductEvidence()",
       "norm_label": "builddailycloseexpenseproductevidence()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1971"
+      "source_location": "L1972"
     },
     {
       "community": 0,
@@ -181315,7 +181399,7 @@
       "label": "buildDailyCloseLifecycleGateWithCtx()",
       "norm_label": "builddailycloselifecyclegatewithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1158"
+      "source_location": "L1159"
     },
     {
       "community": 0,
@@ -181324,7 +181408,7 @@
       "label": "buildDailyCloseReportSnapshot()",
       "norm_label": "builddailyclosereportsnapshot()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2241"
+      "source_location": "L2242"
     },
     {
       "community": 0,
@@ -181333,7 +181417,7 @@
       "label": "buildDailyCloseSnapshotWithCtx()",
       "norm_label": "builddailyclosesnapshotwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2674"
+      "source_location": "L2687"
     },
     {
       "community": 0,
@@ -181342,7 +181426,7 @@
       "label": "buildExpenseSessionsById()",
       "norm_label": "buildexpensesessionsbyid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L952"
+      "source_location": "L953"
     },
     {
       "community": 0,
@@ -181351,7 +181435,7 @@
       "label": "buildExpenseTransactionItemCountsByTransactionId()",
       "norm_label": "buildexpensetransactionitemcountsbytransactionid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1917"
+      "source_location": "L1918"
     },
     {
       "community": 0,
@@ -181360,7 +181444,7 @@
       "label": "buildReadiness()",
       "norm_label": "buildreadiness()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2138"
+      "source_location": "L2139"
     },
     {
       "community": 0,
@@ -181369,7 +181453,7 @@
       "label": "buildRegisterSessionsById()",
       "norm_label": "buildregistersessionsbyid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L883"
+      "source_location": "L884"
     },
     {
       "community": 0,
@@ -181378,7 +181462,7 @@
       "label": "buildStaffNamesById()",
       "norm_label": "buildstaffnamesbyid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L863"
+      "source_location": "L864"
     },
     {
       "community": 0,
@@ -181387,7 +181471,7 @@
       "label": "buildTerminalLabelsById()",
       "norm_label": "buildterminallabelsbyid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L843"
+      "source_location": "L844"
     },
     {
       "community": 0,
@@ -181396,7 +181480,7 @@
       "label": "buildTransactionItemCountsByTransactionId()",
       "norm_label": "buildtransactionitemcountsbytransactionid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1889"
+      "source_location": "L1890"
     },
     {
       "community": 0,
@@ -181405,7 +181489,7 @@
       "label": "carryForwardBusinessDate()",
       "norm_label": "carryforwardbusinessdate()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3888"
+      "source_location": "L3901"
     },
     {
       "community": 0,
@@ -181414,7 +181498,7 @@
       "label": "carryForwardMetadataMatches()",
       "norm_label": "carryforwardmetadatamatches()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3918"
+      "source_location": "L3931"
     },
     {
       "community": 0,
@@ -181423,7 +181507,7 @@
       "label": "carryForwardResolutionValidationError()",
       "norm_label": "carryforwardresolutionvalidationerror()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4962"
+      "source_location": "L4980"
     },
     {
       "community": 0,
@@ -181432,7 +181516,7 @@
       "label": "carryForwardSourceId()",
       "norm_label": "carryforwardsourceid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3897"
+      "source_location": "L3910"
     },
     {
       "community": 0,
@@ -181441,7 +181525,7 @@
       "label": "carryForwardWorkItemIdFromItem()",
       "norm_label": "carryforwardworkitemidfromitem()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3962"
+      "source_location": "L3975"
     },
     {
       "community": 0,
@@ -181450,7 +181534,7 @@
       "label": "cashDeltasByRegisterSessionId()",
       "norm_label": "cashdeltasbyregistersessionid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2120"
+      "source_location": "L2121"
     },
     {
       "community": 0,
@@ -181459,7 +181543,7 @@
       "label": "closeoutApprovalForRegisterSession()",
       "norm_label": "closeoutapprovalforregistersession()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L923"
+      "source_location": "L924"
     },
     {
       "community": 0,
@@ -181468,7 +181552,7 @@
       "label": "completeDailyCloseForAutomationWithCtx()",
       "norm_label": "completedailycloseforautomationwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4627"
+      "source_location": "L4643"
     },
     {
       "community": 0,
@@ -181477,7 +181561,7 @@
       "label": "completeDailyCloseWithCtx()",
       "norm_label": "completedailyclosewithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4315"
+      "source_location": "L4328"
     },
     {
       "community": 0,
@@ -181486,7 +181570,7 @@
       "label": "completeSourceCompleteness()",
       "norm_label": "completesourcecompleteness()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L453"
+      "source_location": "L454"
     },
     {
       "community": 0,
@@ -181495,7 +181579,16 @@
       "label": "completionAttributionForDailyClose()",
       "norm_label": "completionattributionfordailyclose()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2402"
+      "source_location": "L2415"
+    },
+    {
+      "community": 0,
+      "file_type": "code",
+      "id": "dailyclose_completionblockingincompletesources",
+      "label": "completionBlockingIncompleteSources()",
+      "norm_label": "completionblockingincompletesources()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L2403"
     },
     {
       "community": 0,
@@ -181504,7 +181597,7 @@
       "label": "createCarryForwardWorkItems()",
       "norm_label": "createcarryforwardworkitems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4053"
+      "source_location": "L4066"
     },
     {
       "community": 0,
@@ -181513,7 +181606,7 @@
       "label": "emptySummary()",
       "norm_label": "emptysummary()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2641"
+      "source_location": "L2654"
     },
     {
       "community": 0,
@@ -181522,7 +181615,7 @@
       "label": "filterRegisterSessionsBelongingToRange()",
       "norm_label": "filterregistersessionsbelongingtorange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L935"
+      "source_location": "L936"
     },
     {
       "community": 0,
@@ -181531,7 +181624,7 @@
       "label": "findCurrentCarryForwardWorkItemBySource()",
       "norm_label": "findcurrentcarryforwardworkitembysource()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3929"
+      "source_location": "L3942"
     },
     {
       "community": 0,
@@ -181540,7 +181633,7 @@
       "label": "formatPaymentMethodLabel()",
       "norm_label": "formatpaymentmethodlabel()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L799"
+      "source_location": "L800"
     },
     {
       "community": 0,
@@ -181549,7 +181642,7 @@
       "label": "frozenSyncedSaleInventoryReviewGroups()",
       "norm_label": "frozensyncedsaleinventoryreviewgroups()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2214"
+      "source_location": "L2215"
     },
     {
       "community": 0,
@@ -181558,7 +181651,7 @@
       "label": "getCompletedDailyCloseHistoryDetailWithCtx()",
       "norm_label": "getcompleteddailyclosehistorydetailwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5581"
+      "source_location": "L5599"
     },
     {
       "community": 0,
@@ -181567,7 +181660,7 @@
       "label": "getDailyCloseCompletionEventStaffProfileId()",
       "norm_label": "getdailyclosecompletioneventstaffprofileid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2614"
+      "source_location": "L2627"
     },
     {
       "community": 0,
@@ -181576,7 +181669,7 @@
       "label": "getDailyCloseForDate()",
       "norm_label": "getdailyclosefordate()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1119"
+      "source_location": "L1120"
     },
     {
       "community": 0,
@@ -181585,7 +181678,7 @@
       "label": "getDailyCloseOpeningContextWithCtx()",
       "norm_label": "getdailycloseopeningcontextwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5467"
+      "source_location": "L5485"
     },
     {
       "community": 0,
@@ -181594,7 +181687,7 @@
       "label": "getNonActiveDailyCloseForDate()",
       "norm_label": "getnonactivedailyclosefordate()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4152"
+      "source_location": "L4165"
     },
     {
       "community": 0,
@@ -181603,7 +181696,7 @@
       "label": "getPriorCompletedDailyClose()",
       "norm_label": "getpriorcompleteddailyclose()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1194"
+      "source_location": "L1195"
     },
     {
       "community": 0,
@@ -181612,7 +181705,16 @@
       "label": "getStore()",
       "norm_label": "getstore()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1112"
+      "source_location": "L1113"
+    },
+    {
+      "community": 0,
+      "file_type": "code",
+      "id": "dailyclose_hasincompleteoperationalwork",
+      "label": "hasIncompleteOperationalWork()",
+      "norm_label": "hasincompleteoperationalwork()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L2409"
     },
     {
       "community": 0,
@@ -181621,7 +181723,7 @@
       "label": "incompleteSourceCompletenessEntries()",
       "norm_label": "incompletesourcecompletenessentries()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2398"
+      "source_location": "L2399"
     },
     {
       "community": 0,
@@ -181630,7 +181732,7 @@
       "label": "isInRange()",
       "norm_label": "isinrange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L743"
+      "source_location": "L744"
     },
     {
       "community": 0,
@@ -181639,7 +181741,7 @@
       "label": "isSubmittedVarianceCloseout()",
       "norm_label": "issubmittedvariancecloseout()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L767"
+      "source_location": "L768"
     },
     {
       "community": 0,
@@ -181648,7 +181750,7 @@
       "label": "isValidOperatingDateRange()",
       "norm_label": "isvalidoperatingdaterange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L711"
+      "source_location": "L712"
     },
     {
       "community": 0,
@@ -181657,7 +181759,7 @@
       "label": "listActiveOversizedOperationalWorkRepairs()",
       "norm_label": "listactiveoversizedoperationalworkrepairs()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1653"
+      "source_location": "L1654"
     },
     {
       "community": 0,
@@ -181666,7 +181768,7 @@
       "label": "listCompletedDailyCloseHistoryWithCtx()",
       "norm_label": "listcompleteddailyclosehistorywithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5528"
+      "source_location": "L5546"
     },
     {
       "community": 0,
@@ -181675,7 +181777,7 @@
       "label": "listCompletedOnlineOrdersForDay()",
       "norm_label": "listcompletedonlineordersforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1744"
+      "source_location": "L1745"
     },
     {
       "community": 0,
@@ -181684,7 +181786,7 @@
       "label": "listDailyOpeningHandoffsForCarryForward()",
       "norm_label": "listdailyopeninghandoffsforcarryforward()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4933"
+      "source_location": "L4951"
     },
     {
       "community": 0,
@@ -181693,7 +181795,7 @@
       "label": "listDepositsForDay()",
       "norm_label": "listdepositsforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2082"
+      "source_location": "L2083"
     },
     {
       "community": 0,
@@ -181702,7 +181804,7 @@
       "label": "listExpensesForDay()",
       "norm_label": "listexpensesforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1853"
+      "source_location": "L1854"
     },
     {
       "community": 0,
@@ -181711,7 +181813,7 @@
       "label": "listOpenOperationalWorkItems()",
       "norm_label": "listopenoperationalworkitems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1616"
+      "source_location": "L1617"
     },
     {
       "community": 0,
@@ -181720,7 +181822,7 @@
       "label": "listOpenPosSessions()",
       "norm_label": "listopenpossessions()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1573"
+      "source_location": "L1574"
     },
     {
       "community": 0,
@@ -181729,7 +181831,7 @@
       "label": "listPendingCloseoutApprovals()",
       "norm_label": "listpendingcloseoutapprovals()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1527"
+      "source_location": "L1528"
     },
     {
       "community": 0,
@@ -181738,7 +181840,7 @@
       "label": "listRegisterSessionsForDailyClose()",
       "norm_label": "listregistersessionsfordailyclose()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1227"
+      "source_location": "L1228"
     },
     {
       "community": 0,
@@ -181747,7 +181849,7 @@
       "label": "listTransactionsForDay()",
       "norm_label": "listtransactionsforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1714"
+      "source_location": "L1715"
     },
     {
       "community": 0,
@@ -181756,7 +181858,7 @@
       "label": "logicalCarryForwardSelectionCount()",
       "norm_label": "logicalcarryforwardselectioncount()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3847"
+      "source_location": "L3860"
     },
     {
       "community": 0,
@@ -181765,7 +181867,7 @@
       "label": "logicalGroupAsCarryForwardItem()",
       "norm_label": "logicalgroupascarryforwarditem()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1020"
+      "source_location": "L1021"
     },
     {
       "community": 0,
@@ -181774,7 +181876,7 @@
       "label": "markOtherDailyClosesNotCurrent()",
       "norm_label": "markotherdailyclosesnotcurrent()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4129"
+      "source_location": "L4142"
     },
     {
       "community": 0,
@@ -181783,7 +181885,7 @@
       "label": "markReportDayDirty()",
       "norm_label": "markreportdaydirty()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4236"
+      "source_location": "L4249"
     },
     {
       "community": 0,
@@ -181792,7 +181894,7 @@
       "label": "maybeRedactDailyCloseSnapshotForBroadView()",
       "norm_label": "mayberedactdailyclosesnapshotforbroadview()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2540"
+      "source_location": "L2553"
     },
     {
       "community": 0,
@@ -181801,7 +181903,7 @@
       "label": "mergeSourceCompleteness()",
       "norm_label": "mergesourcecompleteness()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L490"
+      "source_location": "L491"
     },
     {
       "community": 0,
@@ -181810,7 +181912,7 @@
       "label": "nonZeroVarianceMetadata()",
       "norm_label": "nonzerovariancemetadata()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L823"
+      "source_location": "L824"
     },
     {
       "community": 0,
@@ -181819,7 +181921,7 @@
       "label": "normalizeBroadViewMetadataLabel()",
       "norm_label": "normalizebroadviewmetadatalabel()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2451"
+      "source_location": "L2464"
     },
     {
       "community": 0,
@@ -181828,7 +181930,7 @@
       "label": "normalizeCompletedDailyCloseSnapshot()",
       "norm_label": "normalizecompleteddailyclosesnapshot()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L377"
+      "source_location": "L378"
     },
     {
       "community": 0,
@@ -181837,7 +181939,7 @@
       "label": "normalizeDailyCloseSummary()",
       "norm_label": "normalizedailyclosesummary()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L502"
+      "source_location": "L503"
     },
     {
       "community": 0,
@@ -181846,7 +181948,7 @@
       "label": "patchDailyCloseCarryForwardWorkItemMetadata()",
       "norm_label": "patchdailyclosecarryforwardworkitemmetadata()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1087"
+      "source_location": "L1088"
     },
     {
       "community": 0,
@@ -181855,7 +181957,7 @@
       "label": "posSessionIntersectsRange()",
       "norm_label": "possessionintersectsrange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1471"
+      "source_location": "L1472"
     },
     {
       "community": 0,
@@ -181864,7 +181966,7 @@
       "label": "readCappedSource()",
       "norm_label": "readcappedsource()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1690"
+      "source_location": "L1691"
     },
     {
       "community": 0,
@@ -181873,7 +181975,7 @@
       "label": "recordDailyCloseCompletedEvent()",
       "norm_label": "recorddailyclosecompletedevent()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4175"
+      "source_location": "L4188"
     },
     {
       "community": 0,
@@ -181882,7 +181984,7 @@
       "label": "recordDailyCloseCompletedReportFacts()",
       "norm_label": "recorddailyclosecompletedreportfacts()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4269"
+      "source_location": "L4282"
     },
     {
       "community": 0,
@@ -181891,7 +181993,7 @@
       "label": "redactDailyCloseItemForBroadView()",
       "norm_label": "redactdailycloseitemforbroadview()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2455"
+      "source_location": "L2468"
     },
     {
       "community": 0,
@@ -181900,7 +182002,7 @@
       "label": "redactDailyCloseOpeningContextForBroadView()",
       "norm_label": "redactdailycloseopeningcontextforbroadview()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5503"
+      "source_location": "L5521"
     },
     {
       "community": 0,
@@ -181909,7 +182011,7 @@
       "label": "redactDailyCloseReportSnapshotForBroadView()",
       "norm_label": "redactdailyclosereportsnapshotforbroadview()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2508"
+      "source_location": "L2521"
     },
     {
       "community": 0,
@@ -181918,7 +182020,7 @@
       "label": "redactDailyCloseSummaryForBroadView()",
       "norm_label": "redactdailyclosesummaryforbroadview()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2488"
+      "source_location": "L2501"
     },
     {
       "community": 0,
@@ -181927,7 +182029,7 @@
       "label": "registerMetadataLabel()",
       "norm_label": "registermetadatalabel()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L786"
+      "source_location": "L787"
     },
     {
       "community": 0,
@@ -181936,7 +182038,7 @@
       "label": "registerSessionBelongsToRange()",
       "norm_label": "registersessionbelongstorange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1454"
+      "source_location": "L1455"
     },
     {
       "community": 0,
@@ -181945,7 +182047,7 @@
       "label": "registerSessionCloseoutOperatingAt()",
       "norm_label": "registersessioncloseoutoperatingat()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L747"
+      "source_location": "L748"
     },
     {
       "community": 0,
@@ -181954,7 +182056,7 @@
       "label": "registerSessionIntersectsRange()",
       "norm_label": "registersessionintersectsrange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1444"
+      "source_location": "L1445"
     },
     {
       "community": 0,
@@ -181963,7 +182065,7 @@
       "label": "registerSessionLabel()",
       "norm_label": "registersessionlabel()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L778"
+      "source_location": "L779"
     },
     {
       "community": 0,
@@ -181972,7 +182074,7 @@
       "label": "reopenDailyCloseWithCtx()",
       "norm_label": "reopendailyclosewithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5235"
+      "source_location": "L5253"
     },
     {
       "community": 0,
@@ -181981,7 +182083,7 @@
       "label": "resolveDailyCloseCarryForwardWithCtx()",
       "norm_label": "resolvedailyclosecarryforwardwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4969"
+      "source_location": "L4987"
     },
     {
       "community": 0,
@@ -181990,7 +182092,7 @@
       "label": "resolveOperatingDateRange()",
       "norm_label": "resolveoperatingdaterange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L722"
+      "source_location": "L723"
     },
     {
       "community": 0,
@@ -181999,7 +182101,7 @@
       "label": "safeOperatingDateRange()",
       "norm_label": "safeoperatingdaterange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L694"
+      "source_location": "L695"
     },
     {
       "community": 0,
@@ -182008,7 +182110,7 @@
       "label": "snapshotReviewedItems()",
       "norm_label": "snapshotrevieweditems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2384"
+      "source_location": "L2385"
     },
     {
       "community": 0,
@@ -182017,7 +182119,7 @@
       "label": "sortDailyCloseBlockers()",
       "norm_label": "sortdailycloseblockers()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L323"
+      "source_location": "L324"
     },
     {
       "community": 0,
@@ -182026,7 +182128,7 @@
       "label": "sourceCompletenessEntry()",
       "norm_label": "sourcecompletenessentry()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L462"
+      "source_location": "L463"
     },
     {
       "community": 0,
@@ -182035,7 +182137,7 @@
       "label": "sourceIdFromCarryForwardInput()",
       "norm_label": "sourceidfromcarryforwardinput()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3907"
+      "source_location": "L3920"
     },
     {
       "community": 0,
@@ -182044,7 +182146,7 @@
       "label": "stringFromMetadata()",
       "norm_label": "stringfrommetadata()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3879"
+      "source_location": "L3892"
     },
     {
       "community": 0,
@@ -182053,7 +182155,7 @@
       "label": "toDailyCloseHistoryListItem()",
       "norm_label": "todailyclosehistorylistitem()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2575"
+      "source_location": "L2588"
     },
     {
       "community": 0,
@@ -182062,7 +182164,7 @@
       "label": "transactionPaymentSummary()",
       "norm_label": "transactionpaymentsummary()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L805"
+      "source_location": "L806"
     },
     {
       "community": 0,
@@ -182071,7 +182173,7 @@
       "label": "trimOptional()",
       "norm_label": "trimoptional()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L689"
+      "source_location": "L690"
     },
     {
       "community": 0,
@@ -182080,7 +182182,7 @@
       "label": "trustedSyncedSaleInventoryReviewUnits()",
       "norm_label": "trustedsyncedsaleinventoryreviewunits()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2176"
+      "source_location": "L2177"
     },
     {
       "community": 0,
@@ -182089,7 +182191,7 @@
       "label": "uniqueDailyCloseItems()",
       "norm_label": "uniquedailycloseitems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2168"
+      "source_location": "L2169"
     },
     {
       "community": 0,
@@ -182098,7 +182200,7 @@
       "label": "uniqueOperationalWorkItemIds()",
       "norm_label": "uniqueoperationalworkitemids()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3873"
+      "source_location": "L3886"
     },
     {
       "community": 0,
@@ -182107,7 +182209,7 @@
       "label": "uniqueSourceSubjects()",
       "norm_label": "uniquesourcesubjects()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2158"
+      "source_location": "L2159"
     },
     {
       "community": 0,
@@ -182116,7 +182218,7 @@
       "label": "validateAutomationCarryForwardWorkItems()",
       "norm_label": "validateautomationcarryforwardworkitems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3972"
+      "source_location": "L3985"
     },
     {
       "community": 0,
@@ -182125,7 +182227,7 @@
       "label": "validateCarryForwardWorkItemIds()",
       "norm_label": "validatecarryforwardworkitemids()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3793"
+      "source_location": "L3806"
     },
     {
       "community": 0,
@@ -182134,7 +182236,7 @@
       "label": "validateSelectedCarryForwardGroups()",
       "norm_label": "validateselectedcarryforwardgroups()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3821"
+      "source_location": "L3834"
     },
     {
       "community": 0,
@@ -182989,7 +183091,7 @@
       "label": "asRecord()",
       "norm_label": "asrecord()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L2432"
+      "source_location": "L2437"
     },
     {
       "community": 10,
@@ -182998,7 +183100,7 @@
       "label": "automationErrorMessage()",
       "norm_label": "automationerrormessage()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1804"
+      "source_location": "L1809"
     },
     {
       "community": 10,
@@ -183016,7 +183118,7 @@
       "label": "configuredEodAutoCompleteStoreDayContext()",
       "norm_label": "configuredeodautocompletestoredaycontext()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1617"
+      "source_location": "L1622"
     },
     {
       "community": 10,
@@ -183025,7 +183127,7 @@
       "label": "configuredOpeningOperatingDate()",
       "norm_label": "configuredopeningoperatingdate()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1577"
+      "source_location": "L1582"
     },
     {
       "community": 10,
@@ -183034,7 +183136,7 @@
       "label": "dailyManagerReportStatusForEodAutoCompleteResult()",
       "norm_label": "dailymanagerreportstatusforeodautocompleteresult()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L2106"
+      "source_location": "L2111"
     },
     {
       "community": 10,
@@ -183043,7 +183145,7 @@
       "label": "emitDailyManagerReportNotificationsForEodAutomationWithCtx()",
       "norm_label": "emitdailymanagerreportnotificationsforeodautomationwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L2127"
+      "source_location": "L2132"
     },
     {
       "community": 10,
@@ -183061,7 +183163,7 @@
       "label": "eodAutoCompletePolicyCronWindow()",
       "norm_label": "eodautocompletepolicycronwindow()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1764"
+      "source_location": "L1769"
     },
     {
       "community": 10,
@@ -183070,7 +183172,7 @@
       "label": "eodAutoCompleteTiming()",
       "norm_label": "eodautocompletetiming()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1675"
+      "source_location": "L1680"
     },
     {
       "community": 10,
@@ -183088,7 +183190,7 @@
       "label": "eodLocalCompletionWindowMinutesForPolicy()",
       "norm_label": "eodlocalcompletionwindowminutesforpolicy()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1528"
+      "source_location": "L1533"
     },
     {
       "community": 10,
@@ -183097,7 +183199,7 @@
       "label": "eodPolicyCompletionAtForStoreDay()",
       "norm_label": "eodpolicycompletionatforstoreday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1556"
+      "source_location": "L1561"
     },
     {
       "community": 10,
@@ -183169,7 +183271,7 @@
       "label": "listConfiguredAutomationPolicies()",
       "norm_label": "listconfiguredautomationpolicies()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1871"
+      "source_location": "L1876"
     },
     {
       "community": 10,
@@ -183178,7 +183280,7 @@
       "label": "localDateForPolicy()",
       "norm_label": "localdateforpolicy()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1436"
+      "source_location": "L1441"
     },
     {
       "community": 10,
@@ -183187,7 +183289,7 @@
       "label": "normalizedPolicyOffsetFromScheduleStart()",
       "norm_label": "normalizedpolicyoffsetfromschedulestart()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1515"
+      "source_location": "L1520"
     },
     {
       "community": 10,
@@ -183214,7 +183316,7 @@
       "label": "openingLocalStartMinutesForPolicy()",
       "norm_label": "openinglocalstartminutesforpolicy()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1508"
+      "source_location": "L1513"
     },
     {
       "community": 10,
@@ -183223,7 +183325,7 @@
       "label": "openingPolicyCronWindow()",
       "norm_label": "openingpolicycronwindow()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1456"
+      "source_location": "L1461"
     },
     {
       "community": 10,
@@ -183232,7 +183334,7 @@
       "label": "openingPolicyStartAtForStoreDay()",
       "norm_label": "openingpolicystartatforstoreday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1537"
+      "source_location": "L1542"
     },
     {
       "community": 10,
@@ -183241,7 +183343,7 @@
       "label": "operatingDateForPolicy()",
       "norm_label": "operatingdateforpolicy()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1427"
+      "source_location": "L1432"
     },
     {
       "community": 10,
@@ -183268,7 +183370,7 @@
       "label": "recordConfiguredAutomationFailureWithCtx()",
       "norm_label": "recordconfiguredautomationfailurewithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1808"
+      "source_location": "L1813"
     },
     {
       "community": 10,
@@ -183295,7 +183397,7 @@
       "label": "resolveConfiguredStoreScheduleContext()",
       "norm_label": "resolveconfiguredstoreschedulecontext()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1720"
+      "source_location": "L1725"
     },
     {
       "community": 10,
@@ -183313,7 +183415,7 @@
       "label": "runConfiguredDailyOperationsAutomationWithCtx()",
       "norm_label": "runconfigureddailyoperationsautomationwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1976"
+      "source_location": "L1981"
     },
     {
       "community": 10,
@@ -183322,7 +183424,7 @@
       "label": "runConfiguredPolicySafely()",
       "norm_label": "runconfiguredpolicysafely()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1848"
+      "source_location": "L1853"
     },
     {
       "community": 10,
@@ -183349,7 +183451,7 @@
       "label": "runHistoricEodAutoCloseBatchActionWithCtx()",
       "norm_label": "runhistoriceodautoclosebatchactionwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L2231"
+      "source_location": "L2236"
     },
     {
       "community": 10,
@@ -183358,7 +183460,7 @@
       "label": "runHistoricEodAutoCloseBatchWithCtx()",
       "norm_label": "runhistoriceodautoclosebatchwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1342"
+      "source_location": "L1347"
     },
     {
       "community": 10,
@@ -183376,7 +183478,7 @@
       "label": "runScheduledDailyOperationsAutomationWithCtx()",
       "norm_label": "runscheduleddailyoperationsautomationwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1907"
+      "source_location": "L1912"
     },
     {
       "community": 10,
@@ -183385,7 +183487,7 @@
       "label": "scheduleEvidenceForStoreDayContext()",
       "norm_label": "scheduleevidenceforstoredaycontext()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1656"
+      "source_location": "L1661"
     },
     {
       "community": 10,
@@ -183412,7 +183514,7 @@
       "label": "summarizeHistoricEodAutoCloseBatch()",
       "norm_label": "summarizehistoriceodautoclosebatch()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1400"
+      "source_location": "L1405"
     },
     {
       "community": 10,
@@ -210979,7 +211081,7 @@
       "label": "createCommandArgs()",
       "norm_label": "createcommandargs()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L6311"
+      "source_location": "L6335"
     },
     {
       "community": 171,
@@ -213810,6 +213912,24 @@
     {
       "community": 1800,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_staledailyclosealert_test_tsx",
+      "label": "StaleDailyCloseAlert.test.tsx",
+      "norm_label": "staledailyclosealert.test.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/StaleDailyCloseAlert.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1801,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_staledailyclosealert_tsx",
+      "label": "StaleDailyCloseAlert.tsx",
+      "norm_label": "staledailyclosealert.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/StaleDailyCloseAlert.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1802,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_walkthroughrequestnotification_test_tsx",
       "label": "WalkthroughRequestNotification.test.tsx",
       "norm_label": "walkthroughrequestnotification.test.tsx",
@@ -213817,7 +213937,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1801,
+      "community": 1803,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_weeklymanagerreport_test_tsx",
       "label": "WeeklyManagerReport.test.tsx",
@@ -213826,7 +213946,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1802,
+      "community": 1804,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_emailoperationalctastyles_ts",
       "label": "emailOperationalCtaStyles.ts",
@@ -213835,7 +213955,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1803,
+      "community": 1805,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_env_ts",
       "label": "env.ts",
@@ -213844,7 +213964,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1804,
+      "community": 1806,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_analytics_ts",
       "label": "analytics.ts",
@@ -213853,7 +213973,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1805,
+      "community": 1807,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_auth_ts",
       "label": "auth.ts",
@@ -213862,7 +213982,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1806,
+      "community": 1808,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_bannermessage_test_ts",
       "label": "bannerMessage.test.ts",
@@ -213871,30 +213991,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1807,
+      "community": 1809,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_colors_ts",
       "label": "colors.ts",
       "norm_label": "colors.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/core/routes/colors.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1808,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_core_routes_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1809,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_core_routes_landingfunnelevents_test_ts",
-      "label": "landingFunnelEvents.test.ts",
-      "norm_label": "landingfunnelevents.test.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/landingFunnelEvents.test.ts",
       "source_location": "L1"
     },
     {
@@ -214026,6 +214128,24 @@
     {
       "community": 1810,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_core_routes_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1811,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_core_routes_landingfunnelevents_test_ts",
+      "label": "landingFunnelEvents.test.ts",
+      "norm_label": "landingfunnelevents.test.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/landingFunnelEvents.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1812,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_landingfunnelevents_ts",
       "label": "landingFunnelEvents.ts",
       "norm_label": "landingfunnelevents.ts",
@@ -214033,7 +214153,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1811,
+      "community": 1813,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_organizations_ts",
       "label": "organizations.ts",
@@ -214042,7 +214162,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1812,
+      "community": 1814,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_products_ts",
       "label": "products.ts",
@@ -214051,7 +214171,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1813,
+      "community": 1815,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_storefronthidden_test_ts",
       "label": "storefrontHidden.test.ts",
@@ -214060,7 +214180,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1814,
+      "community": 1816,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_stores_ts",
       "label": "stores.ts",
@@ -214069,7 +214189,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1815,
+      "community": 1817,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_trackingevents_test_ts",
       "label": "trackingEvents.test.ts",
@@ -214078,7 +214198,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1816,
+      "community": 1818,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_walkthroughrequests_test_ts",
       "label": "walkthroughRequests.test.ts",
@@ -214087,30 +214207,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1817,
+      "community": 1819,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_bag_ts",
       "label": "bag.ts",
       "norm_label": "bag.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/bag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1818,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_guest_ts",
-      "label": "guest.ts",
-      "norm_label": "guest.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/guest.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1819,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_homepagesnapshot_test_ts",
-      "label": "homepageSnapshot.test.ts",
-      "norm_label": "homepagesnapshot.test.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/homepageSnapshot.test.ts",
       "source_location": "L1"
     },
     {
@@ -214242,6 +214344,24 @@
     {
       "community": 1820,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_guest_ts",
+      "label": "guest.ts",
+      "norm_label": "guest.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/guest.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1821,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_homepagesnapshot_test_ts",
+      "label": "homepageSnapshot.test.ts",
+      "norm_label": "homepagesnapshot.test.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/homepageSnapshot.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1822,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
@@ -214249,7 +214369,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1821,
+      "community": 1823,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_me_ts",
       "label": "me.ts",
@@ -214258,7 +214378,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1822,
+      "community": 1824,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_offers_ts",
       "label": "offers.ts",
@@ -214267,7 +214387,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1823,
+      "community": 1825,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -214276,7 +214396,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1824,
+      "community": 1826,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_paystack_ts",
       "label": "paystack.ts",
@@ -214285,7 +214405,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1825,
+      "community": 1827,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_postransaction_ts",
       "label": "posTransaction.ts",
@@ -214294,7 +214414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1826,
+      "community": 1828,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_reviews_ts",
       "label": "reviews.ts",
@@ -214303,30 +214423,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1827,
+      "community": 1829,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_rewards_ts",
       "label": "rewards.ts",
       "norm_label": "rewards.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/rewards.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1828,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/savedBag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1829,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_security_test_ts",
-      "label": "security.test.ts",
-      "norm_label": "security.test.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.test.ts",
       "source_location": "L1"
     },
     {
@@ -214458,6 +214560,24 @@
     {
       "community": 1830,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/savedBag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1831,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_security_test_ts",
+      "label": "security.test.ts",
+      "norm_label": "security.test.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1832,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_storefront_ts",
       "label": "storefront.ts",
       "norm_label": "storefront.ts",
@@ -214465,7 +214585,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1831,
+      "community": 1833,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_upsells_ts",
       "label": "upsells.ts",
@@ -214474,7 +214594,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1832,
+      "community": 1834,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_user_ts",
       "label": "user.ts",
@@ -214483,7 +214603,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1833,
+      "community": 1835,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_useroffers_ts",
       "label": "userOffers.ts",
@@ -214492,7 +214612,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1834,
+      "community": 1836,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_moneymovement_routes_index_ts",
       "label": "index.ts",
@@ -214501,7 +214621,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1835,
+      "community": 1837,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_health_test_ts",
       "label": "health.test.ts",
@@ -214510,7 +214630,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1836,
+      "community": 1838,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_ts",
       "label": "http.ts",
@@ -214519,30 +214639,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1837,
+      "community": 1839,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_intelligence_access_ts",
       "label": "access.ts",
       "norm_label": "access.ts",
       "source_file": "packages/athena-webapp/convex/intelligence/access.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1838,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_intelligence_capabilities_actions_test_ts",
-      "label": "actions.test.ts",
-      "norm_label": "actions.test.ts",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1839,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_intelligence_capabilities_insights_test_ts",
-      "label": "insights.test.ts",
-      "norm_label": "insights.test.ts",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/insights.test.ts",
       "source_location": "L1"
     },
     {
@@ -214674,6 +214776,24 @@
     {
       "community": 1840,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_intelligence_capabilities_actions_test_ts",
+      "label": "actions.test.ts",
+      "norm_label": "actions.test.ts",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1841,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_intelligence_capabilities_insights_test_ts",
+      "label": "insights.test.ts",
+      "norm_label": "insights.test.ts",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/insights.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1842,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_intelligence_lifecycle_test_ts",
       "label": "lifecycle.test.ts",
       "norm_label": "lifecycle.test.ts",
@@ -214681,7 +214801,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1841,
+      "community": 1843,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_intelligence_providers_index_ts",
       "label": "index.ts",
@@ -214690,7 +214810,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1842,
+      "community": 1844,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_intelligence_providers_providerfoundation_test_ts",
       "label": "providerFoundation.test.ts",
@@ -214699,7 +214819,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1843,
+      "community": 1845,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_intelligence_types_ts",
       "label": "types.ts",
@@ -214708,7 +214828,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1844,
+      "community": 1846,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_athenauser_test_ts",
       "label": "athenaUser.test.ts",
@@ -214717,7 +214837,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1845,
+      "community": 1847,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_auth_test_ts",
       "label": "auth.test.ts",
@@ -214726,7 +214846,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1846,
+      "community": 1848,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_categories_ts",
       "label": "categories.ts",
@@ -214735,30 +214855,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1847,
+      "community": 1849,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_colors_ts",
       "label": "colors.ts",
       "norm_label": "colors.ts",
       "source_file": "packages/athena-webapp/convex/inventory/colors.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1848,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_complimentaryproduct_ts",
-      "label": "complimentaryProduct.ts",
-      "norm_label": "complimentaryproduct.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/complimentaryProduct.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1849,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_invitecode_test_ts",
-      "label": "inviteCode.test.ts",
-      "norm_label": "invitecode.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/inviteCode.test.ts",
       "source_location": "L1"
     },
     {
@@ -214890,6 +214992,24 @@
     {
       "community": 1850,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_complimentaryproduct_ts",
+      "label": "complimentaryProduct.ts",
+      "norm_label": "complimentaryproduct.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/complimentaryProduct.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1851,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_invitecode_test_ts",
+      "label": "inviteCode.test.ts",
+      "norm_label": "invitecode.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/inviteCode.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1852,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_invitecode_ts",
       "label": "inviteCode.ts",
       "norm_label": "invitecode.ts",
@@ -214897,7 +215017,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1851,
+      "community": 1853,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizationmembers_test_ts",
       "label": "organizationMembers.test.ts",
@@ -214906,7 +215026,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1852,
+      "community": 1854,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizationmembers_ts",
       "label": "organizationMembers.ts",
@@ -214915,7 +215035,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1853,
+      "community": 1855,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_pos_ts",
       "label": "pos.ts",
@@ -214924,7 +215044,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1854,
+      "community": 1856,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_poscustomers_ts",
       "label": "posCustomers.ts",
@@ -214933,7 +215053,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1855,
+      "community": 1857,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posterminal_ts",
       "label": "posTerminal.ts",
@@ -214942,7 +215062,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1856,
+      "community": 1858,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productsku_test_ts",
       "label": "productSku.test.ts",
@@ -214951,30 +215071,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1857,
+      "community": 1859,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productutil_test_ts",
       "label": "productUtil.test.ts",
       "norm_label": "productutil.test.ts",
       "source_file": "packages/athena-webapp/convex/inventory/productUtil.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1858,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_promocode_test_ts",
-      "label": "promoCode.test.ts",
-      "norm_label": "promocode.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/promoCode.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1859,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
-      "label": "stockValidation.ts",
-      "norm_label": "stockvalidation.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/stockValidation.ts",
       "source_location": "L1"
     },
     {
@@ -215106,6 +215208,24 @@
     {
       "community": 1860,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_promocode_test_ts",
+      "label": "promoCode.test.ts",
+      "norm_label": "promocode.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/promoCode.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1861,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
+      "label": "stockValidation.ts",
+      "norm_label": "stockvalidation.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/stockValidation.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1862,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_storeconfigv2_test_ts",
       "label": "storeConfigV2.test.ts",
       "norm_label": "storeconfigv2.test.ts",
@@ -215113,7 +215233,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1861,
+      "community": 1863,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_subcategories_ts",
       "label": "subcategories.ts",
@@ -215122,7 +215242,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1862,
+      "community": 1864,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventoryledger_corrections_ts",
       "label": "corrections.ts",
@@ -215131,7 +215251,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1863,
+      "community": 1865,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventoryledger_deficitresolutionwork_test_ts",
       "label": "deficitResolutionWork.test.ts",
@@ -215140,7 +215260,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1864,
+      "community": 1866,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventoryledger_types_ts",
       "label": "types.ts",
@@ -215149,7 +215269,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1865,
+      "community": 1867,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_commandresultvalidators_test_ts",
       "label": "commandResultValidators.test.ts",
@@ -215158,7 +215278,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1866,
+      "community": 1868,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_test_ts",
       "label": "currency.test.ts",
@@ -215167,7 +215287,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1867,
+      "community": 1869,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_storememberaccess_test_ts",
       "label": "storeMemberAccess.test.ts",
@@ -215176,7 +215296,124 @@
       "source_location": "L1"
     },
     {
-      "community": 1868,
+      "community": 187,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 187,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 187,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 187,
+      "file_type": "code",
+      "id": "utils_formatdeliveryaddress",
+      "label": "formatDeliveryAddress()",
+      "norm_label": "formatdeliveryaddress()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 187,
+      "file_type": "code",
+      "id": "utils_getamountpaidfororder",
+      "label": "getAmountPaidForOrder()",
+      "norm_label": "getamountpaidfororder()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L191"
+    },
+    {
+      "community": 187,
+      "file_type": "code",
+      "id": "utils_getdiscountvalue",
+      "label": "getDiscountValue()",
+      "norm_label": "getdiscountvalue()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 187,
+      "file_type": "code",
+      "id": "utils_getonlineorderplacedat",
+      "label": "getOnlineOrderPlacedAt()",
+      "norm_label": "getonlineorderplacedat()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 187,
+      "file_type": "code",
+      "id": "utils_getorderamount",
+      "label": "getOrderAmount()",
+      "norm_label": "getorderamount()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 187,
+      "file_type": "code",
+      "id": "utils_getorderstate",
+      "label": "getOrderState()",
+      "norm_label": "getorderstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 187,
+      "file_type": "code",
+      "id": "utils_getpickupactionstate",
+      "label": "getPickupActionState()",
+      "norm_label": "getpickupactionstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L102"
+    },
+    {
+      "community": 187,
+      "file_type": "code",
+      "id": "utils_getpotentialpoints",
+      "label": "getPotentialPoints()",
+      "norm_label": "getpotentialpoints()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 187,
+      "file_type": "code",
+      "id": "utils_getproductdiscountvalue",
+      "label": "getProductDiscountValue()",
+      "norm_label": "getproductdiscountvalue()",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 187,
+      "file_type": "code",
+      "id": "utils_shouldshowpickupexceptionaction",
+      "label": "shouldShowPickupExceptionAction()",
+      "norm_label": "shouldshowpickupexceptionaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L116"
+    },
+    {
+      "community": 1870,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_storeinsights_ts",
       "label": "storeInsights.ts",
@@ -215185,7 +215422,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1869,
+      "community": 1871,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_userinsights_ts",
       "label": "userInsights.ts",
@@ -215194,124 +215431,7 @@
       "source_location": "L1"
     },
     {
-      "community": 187,
-      "file_type": "code",
-      "id": "backfillstoreschedules_backfillstoreschedulesfromlegacypolicywithctx",
-      "label": "backfillStoreSchedulesFromLegacyPolicyWithCtx()",
-      "norm_label": "backfillstoreschedulesfromlegacypolicywithctx()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L324"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "backfillstoreschedules_buildbackfillrow",
-      "label": "buildBackfillRow()",
-      "norm_label": "buildbackfillrow()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L187"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "backfillstoreschedules_buildcandidateweeklywindows",
-      "label": "buildCandidateWeeklyWindows()",
-      "norm_label": "buildcandidateweeklywindows()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L163"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "backfillstoreschedules_compatibilitymetadata",
-      "label": "compatibilityMetadata()",
-      "norm_label": "compatibilitymetadata()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L133"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "backfillstoreschedules_compatibilityonlyrow",
-      "label": "compatibilityOnlyRow()",
-      "norm_label": "compatibilityonlyrow()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L174"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "backfillstoreschedules_findexistingscheduletoskip",
-      "label": "findExistingScheduleToSkip()",
-      "norm_label": "findexistingscheduletoskip()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L114"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "backfillstoreschedules_firstpolicy",
-      "label": "firstPolicy()",
-      "norm_label": "firstpolicy()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "backfillstoreschedules_isvalidminute",
-      "label": "isValidMinute()",
-      "norm_label": "isvalidminute()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "backfillstoreschedules_listpoliciesforstoreaction",
-      "label": "listPoliciesForStoreAction()",
-      "norm_label": "listpoliciesforstoreaction()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L81"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "backfillstoreschedules_listschedulesforstorebystatus",
-      "label": "listSchedulesForStoreByStatus()",
-      "norm_label": "listschedulesforstorebystatus()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L99"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "backfillstoreschedules_normalizelimit",
-      "label": "normalizeLimit()",
-      "norm_label": "normalizelimit()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "backfillstoreschedules_trustedtimezoneforstore",
-      "label": "trustedTimezoneForStore()",
-      "norm_label": "trustedtimezoneforstore()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L126"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_migrations_backfillstoreschedules_ts",
-      "label": "backfillStoreSchedules.ts",
-      "norm_label": "backfillstoreschedules.ts",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1870,
+      "community": 1872,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_marketing_landingfunnelevents_test_ts",
       "label": "landingFunnelEvents.test.ts",
@@ -215320,7 +215440,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1871,
+      "community": 1873,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_marketing_landingfunnelretention_test_ts",
       "label": "landingFunnelRetention.test.ts",
@@ -215329,7 +215449,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1872,
+      "community": 1874,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_marketing_walkthroughconfig_test_ts",
       "label": "walkthroughConfig.test.ts",
@@ -215338,7 +215458,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1873,
+      "community": 1875,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_marketing_walkthroughrequestretention_test_ts",
       "label": "walkthroughRequestRetention.test.ts",
@@ -215347,7 +215467,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1874,
+      "community": 1876,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_marketing_walkthroughrequests_test_ts",
       "label": "walkthroughRequests.test.ts",
@@ -215356,7 +215476,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1875,
+      "community": 1877,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_migrateamountstopesewas_ts",
       "label": "migrateAmountsToPesewas.ts",
@@ -215365,7 +215485,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1876,
+      "community": 1878,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_client_test_ts",
       "label": "client.test.ts",
@@ -215374,7 +215494,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1877,
+      "community": 1879,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_config_test_ts",
       "label": "config.test.ts",
@@ -215383,7 +215503,124 @@
       "source_location": "L1"
     },
     {
-      "community": 1878,
+      "community": 188,
+      "file_type": "code",
+      "id": "backfillstoreschedules_backfillstoreschedulesfromlegacypolicywithctx",
+      "label": "backfillStoreSchedulesFromLegacyPolicyWithCtx()",
+      "norm_label": "backfillstoreschedulesfromlegacypolicywithctx()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L324"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "backfillstoreschedules_buildbackfillrow",
+      "label": "buildBackfillRow()",
+      "norm_label": "buildbackfillrow()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L187"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "backfillstoreschedules_buildcandidateweeklywindows",
+      "label": "buildCandidateWeeklyWindows()",
+      "norm_label": "buildcandidateweeklywindows()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L163"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "backfillstoreschedules_compatibilitymetadata",
+      "label": "compatibilityMetadata()",
+      "norm_label": "compatibilitymetadata()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L133"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "backfillstoreschedules_compatibilityonlyrow",
+      "label": "compatibilityOnlyRow()",
+      "norm_label": "compatibilityonlyrow()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L174"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "backfillstoreschedules_findexistingscheduletoskip",
+      "label": "findExistingScheduleToSkip()",
+      "norm_label": "findexistingscheduletoskip()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L114"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "backfillstoreschedules_firstpolicy",
+      "label": "firstPolicy()",
+      "norm_label": "firstpolicy()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "backfillstoreschedules_isvalidminute",
+      "label": "isValidMinute()",
+      "norm_label": "isvalidminute()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "backfillstoreschedules_listpoliciesforstoreaction",
+      "label": "listPoliciesForStoreAction()",
+      "norm_label": "listpoliciesforstoreaction()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L81"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "backfillstoreschedules_listschedulesforstorebystatus",
+      "label": "listSchedulesForStoreByStatus()",
+      "norm_label": "listschedulesforstorebystatus()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L99"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "backfillstoreschedules_normalizelimit",
+      "label": "normalizeLimit()",
+      "norm_label": "normalizelimit()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "backfillstoreschedules_trustedtimezoneforstore",
+      "label": "trustedTimezoneForStore()",
+      "norm_label": "trustedtimezoneforstore()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L126"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_migrations_backfillstoreschedules_ts",
+      "label": "backfillStoreSchedules.ts",
+      "norm_label": "backfillstoreschedules.ts",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1880,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_test_ts",
       "label": "normalize.test.ts",
@@ -215392,7 +215629,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1879,
+      "community": 1881,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_types_ts",
       "label": "types.ts",
@@ -215401,124 +215638,7 @@
       "source_location": "L1"
     },
     {
-      "community": 188,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operationadmission_readdefinitions_ts",
-      "label": "readDefinitions.ts",
-      "norm_label": "readdefinitions.ts",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "readdefinitions_definecashcontrolsread",
-      "label": "defineCashControlsRead()",
-      "norm_label": "definecashcontrolsread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L50"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "readdefinitions_definedailycloseread",
-      "label": "defineDailyCloseRead()",
-      "norm_label": "definedailycloseread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "readdefinitions_definedailyoperationsread",
-      "label": "defineDailyOperationsRead()",
-      "norm_label": "definedailyoperationsread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "readdefinitions_defineinventorycatalogread",
-      "label": "defineInventoryCatalogRead()",
-      "norm_label": "defineinventorycatalogread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "readdefinitions_defineinventorycostoverlayread",
-      "label": "defineInventoryCostOverlayRead()",
-      "norm_label": "defineinventorycostoverlayread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L639"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "readdefinitions_defineonlineordersread",
-      "label": "defineOnlineOrdersRead()",
-      "norm_label": "defineonlineordersread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L84"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "readdefinitions_defineoperationalworkread",
-      "label": "defineOperationalWorkRead()",
-      "norm_label": "defineoperationalworkread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "readdefinitions_defineorganizationread",
-      "label": "defineOrganizationRead()",
-      "norm_label": "defineorganizationread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L94"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "readdefinitions_defineposread",
-      "label": "definePosRead()",
-      "norm_label": "defineposread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "readdefinitions_definereadoperation",
-      "label": "defineReadOperation()",
-      "norm_label": "definereadoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "readdefinitions_definestockadjustmentsread",
-      "label": "defineStockAdjustmentsRead()",
-      "norm_label": "definestockadjustmentsread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L60"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "readdefinitions_validatereadoperationdefinition",
-      "label": "validateReadOperationDefinition()",
-      "norm_label": "validatereadoperationdefinition()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L781"
-    },
-    {
-      "community": 1880,
+      "community": 1882,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_notifications_deliverypolicy_test_ts",
       "label": "deliveryPolicy.test.ts",
@@ -215527,7 +215647,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1881,
+      "community": 1883,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_notifications_seed_ts",
       "label": "seed.ts",
@@ -215536,7 +215656,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1882,
+      "community": 1884,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_actionadmission_test_ts",
       "label": "actionAdmission.test.ts",
@@ -215545,7 +215665,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1883,
+      "community": 1885,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_adapters_test_ts",
       "label": "adapters.test.ts",
@@ -215554,7 +215674,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1884,
+      "community": 1886,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_capabilities_ts",
       "label": "capabilities.ts",
@@ -215563,7 +215683,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1885,
+      "community": 1887,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_definitions_test_ts",
       "label": "definitions.test.ts",
@@ -215572,7 +215692,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1886,
+      "community": 1888,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_migrationinventory_test_ts",
       "label": "migrationInventory.test.ts",
@@ -215581,7 +215701,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1887,
+      "community": 1889,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_migrationinventory_ts",
       "label": "migrationInventory.ts",
@@ -215590,7 +215710,124 @@
       "source_location": "L1"
     },
     {
-      "community": 1888,
+      "community": 189,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operationadmission_readdefinitions_ts",
+      "label": "readDefinitions.ts",
+      "norm_label": "readdefinitions.ts",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "readdefinitions_definecashcontrolsread",
+      "label": "defineCashControlsRead()",
+      "norm_label": "definecashcontrolsread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "readdefinitions_definedailycloseread",
+      "label": "defineDailyCloseRead()",
+      "norm_label": "definedailycloseread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "readdefinitions_definedailyoperationsread",
+      "label": "defineDailyOperationsRead()",
+      "norm_label": "definedailyoperationsread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "readdefinitions_defineinventorycatalogread",
+      "label": "defineInventoryCatalogRead()",
+      "norm_label": "defineinventorycatalogread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "readdefinitions_defineinventorycostoverlayread",
+      "label": "defineInventoryCostOverlayRead()",
+      "norm_label": "defineinventorycostoverlayread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L639"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "readdefinitions_defineonlineordersread",
+      "label": "defineOnlineOrdersRead()",
+      "norm_label": "defineonlineordersread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "readdefinitions_defineoperationalworkread",
+      "label": "defineOperationalWorkRead()",
+      "norm_label": "defineoperationalworkread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "readdefinitions_defineorganizationread",
+      "label": "defineOrganizationRead()",
+      "norm_label": "defineorganizationread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L94"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "readdefinitions_defineposread",
+      "label": "definePosRead()",
+      "norm_label": "defineposread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "readdefinitions_definereadoperation",
+      "label": "defineReadOperation()",
+      "norm_label": "definereadoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "readdefinitions_definestockadjustmentsread",
+      "label": "defineStockAdjustmentsRead()",
+      "norm_label": "definestockadjustmentsread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L60"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "readdefinitions_validatereadoperationdefinition",
+      "label": "validateReadOperationDefinition()",
+      "norm_label": "validatereadoperationdefinition()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L781"
+    },
+    {
+      "community": 1890,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_publicmutation_test_ts",
       "label": "publicMutation.test.ts",
@@ -215599,7 +215836,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1889,
+      "community": 1891,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_publicquery_test_ts",
       "label": "publicQuery.test.ts",
@@ -215608,124 +215845,7 @@
       "source_location": "L1"
     },
     {
-      "community": 189,
-      "file_type": "code",
-      "id": "frozenmetricauthority_closecandidateoperatingrange",
-      "label": "closeCandidateOperatingRange()",
-      "norm_label": "closecandidateoperatingrange()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L199"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "frozenmetricauthority_emptyclosesummary",
-      "label": "emptyCloseSummary()",
-      "norm_label": "emptyclosesummary()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "frozenmetricauthority_exactstatuses",
-      "label": "exactStatuses()",
-      "norm_label": "exactstatuses()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "frozenmetricauthority_finitenumber",
-      "label": "finiteNumber()",
-      "norm_label": "finitenumber()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L91"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "frozenmetricauthority_frozenfinancialsourcecounts",
-      "label": "frozenFinancialSourceCounts()",
-      "norm_label": "frozenfinancialsourcecounts()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L133"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "frozenmetricauthority_frozenweekmetricfordate",
-      "label": "frozenWeekMetricForDate()",
-      "norm_label": "frozenweekmetricfordate()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L481"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "frozenmetricauthority_matchesrequestedoperatingrange",
-      "label": "matchesRequestedOperatingRange()",
-      "norm_label": "matchesrequestedoperatingrange()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "frozenmetricauthority_normalizefrozenpaymenttotals",
-      "label": "normalizeFrozenPaymentTotals()",
-      "norm_label": "normalizefrozenpaymenttotals()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L241"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "frozenmetricauthority_recordvalue",
-      "label": "recordValue()",
-      "norm_label": "recordvalue()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "frozenmetricauthority_resolvefrozendailycloseauthority",
-      "label": "resolveFrozenDailyCloseAuthority()",
-      "norm_label": "resolvefrozendailycloseauthority()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L393"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "frozenmetricauthority_samedailycloseid",
-      "label": "sameDailyCloseId()",
-      "norm_label": "samedailycloseid()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L386"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "frozenmetricauthority_usablefrozenweeksummary",
-      "label": "usableFrozenWeekSummary()",
-      "norm_label": "usablefrozenweeksummary()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L273"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_dailyoperations_frozenmetricauthority_ts",
-      "label": "frozenMetricAuthority.ts",
-      "norm_label": "frozenmetricauthority.ts",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1890,
+      "community": 1892,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_readdefinitions_test_ts",
       "label": "readDefinitions.test.ts",
@@ -215734,7 +215854,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1891,
+      "community": 1893,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_types_ts",
       "label": "types.ts",
@@ -215743,7 +215863,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1892,
+      "community": 1894,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequests_shareddemo_test_ts",
       "label": "approvalRequests.sharedDemo.test.ts",
@@ -215752,7 +215872,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1893,
+      "community": 1895,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_customerprofiles_test_ts",
       "label": "customerProfiles.test.ts",
@@ -215761,7 +215881,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1894,
+      "community": 1896,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_dailyclose_adjustmentreports_test_ts",
       "label": "adjustmentReports.test.ts",
@@ -215770,7 +215890,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1895,
+      "community": 1897,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_dailyclose_approval_test_ts",
       "label": "approval.test.ts",
@@ -215779,7 +215899,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1896,
+      "community": 1898,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_dailyclose_automationpolicy_test_ts",
       "label": "automationPolicy.test.ts",
@@ -215788,30 +215908,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1897,
+      "community": 1899,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_helpers_eventbuilders_test_ts",
       "label": "eventBuilders.test.ts",
       "norm_label": "eventbuilders.test.ts",
       "source_file": "packages/athena-webapp/convex/operations/helpers/eventBuilders.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1898,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_posterminalhealthalertemail_ts",
-      "label": "posTerminalHealthAlertEmail.ts",
-      "norm_label": "posterminalhealthalertemail.ts",
-      "source_file": "packages/athena-webapp/convex/operations/posTerminalHealthAlertEmail.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1899,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_registersessionauthorityrevision_test_ts",
-      "label": "registerSessionAuthorityRevision.test.ts",
-      "norm_label": "registersessionauthorityrevision.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionAuthorityRevision.test.ts",
       "source_location": "L1"
     },
     {
@@ -216186,122 +216288,140 @@
     {
       "community": 190,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildctx",
-      "label": "buildCtx()",
-      "norm_label": "buildctx()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L956"
+      "id": "frozenmetricauthority_closecandidateoperatingrange",
+      "label": "closeCandidateOperatingRange()",
+      "norm_label": "closecandidateoperatingrange()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L199"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildinventorymovement",
-      "label": "buildInventoryMovement()",
-      "norm_label": "buildinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1109"
+      "id": "frozenmetricauthority_emptyclosesummary",
+      "label": "emptyCloseSummary()",
+      "norm_label": "emptyclosesummary()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L62"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildmapping",
-      "label": "buildMapping()",
-      "norm_label": "buildmapping()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1213"
+      "id": "frozenmetricauthority_exactstatuses",
+      "label": "exactStatuses()",
+      "norm_label": "exactstatuses()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L96"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildproductsku",
-      "label": "buildProductSku()",
-      "norm_label": "buildproductsku()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1130"
+      "id": "frozenmetricauthority_finitenumber",
+      "label": "finiteNumber()",
+      "norm_label": "finitenumber()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L91"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1169"
+      "id": "frozenmetricauthority_frozenfinancialsourcecounts",
+      "label": "frozenFinancialSourceCounts()",
+      "norm_label": "frozenfinancialsourcecounts()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L133"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildstaffprofile",
-      "label": "buildStaffProfile()",
-      "norm_label": "buildstaffprofile()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1065"
+      "id": "frozenmetricauthority_frozenweekmetricfordate",
+      "label": "frozenWeekMetricForDate()",
+      "norm_label": "frozenweekmetricfordate()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L481"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildstore",
-      "label": "buildStore()",
-      "norm_label": "buildstore()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1052"
+      "id": "frozenmetricauthority_matchesrequestedoperatingrange",
+      "label": "matchesRequestedOperatingRange()",
+      "norm_label": "matchesrequestedoperatingrange()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L102"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildterminal",
-      "label": "buildTerminal()",
-      "norm_label": "buildterminal()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1149"
+      "id": "frozenmetricauthority_normalizefrozenpaymenttotals",
+      "label": "normalizeFrozenPaymentTotals()",
+      "norm_label": "normalizefrozenpaymenttotals()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L241"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildtransaction",
-      "label": "buildTransaction()",
-      "norm_label": "buildtransaction()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1189"
+      "id": "frozenmetricauthority_recordvalue",
+      "label": "recordValue()",
+      "norm_label": "recordvalue()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L85"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildworkitem",
-      "label": "buildWorkItem()",
-      "norm_label": "buildworkitem()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1079"
+      "id": "frozenmetricauthority_resolvefrozendailycloseauthority",
+      "label": "resolveFrozenDailyCloseAuthority()",
+      "norm_label": "resolvefrozendailycloseauthority()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L393"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_defaultargs",
-      "label": "defaultArgs()",
-      "norm_label": "defaultargs()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L909"
+      "id": "frozenmetricauthority_samedailycloseid",
+      "label": "sameDailyCloseId()",
+      "norm_label": "samedailycloseid()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L386"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_expectrejectedcontext",
-      "label": "expectRejectedContext()",
-      "norm_label": "expectrejectedcontext()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L891"
+      "id": "frozenmetricauthority_usablefrozenweeksummary",
+      "label": "usableFrozenWeekSummary()",
+      "norm_label": "usablefrozenweeksummary()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L273"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_openworkinventoryreviews_test_ts",
-      "label": "openWorkInventoryReviews.test.ts",
-      "norm_label": "openworkinventoryreviews.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "id": "packages_athena_webapp_convex_operations_dailyoperations_frozenmetricauthority_ts",
+      "label": "frozenMetricAuthority.ts",
+      "norm_label": "frozenmetricauthority.ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
       "source_location": "L1"
     },
     {
       "community": 1900,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_posterminalhealthalertemail_ts",
+      "label": "posTerminalHealthAlertEmail.ts",
+      "norm_label": "posterminalhealthalertemail.ts",
+      "source_file": "packages/athena-webapp/convex/operations/posTerminalHealthAlertEmail.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1901,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_registersessionauthorityrevision_test_ts",
+      "label": "registerSessionAuthorityRevision.test.ts",
+      "norm_label": "registersessionauthorityrevision.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionAuthorityRevision.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1902,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessioncloseoutgate_test_ts",
       "label": "registerSessionCloseoutGate.test.ts",
@@ -216310,7 +216430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1901,
+      "community": 1903,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_emailotp_test_ts",
       "label": "EmailOTP.test.ts",
@@ -216319,7 +216439,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1902,
+      "community": 1904,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_apploginemailallowlist_test_ts",
       "label": "appLoginEmailAllowlist.test.ts",
@@ -216328,7 +216448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1903,
+      "community": 1905,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_platform_capabilitycatalog_test_ts",
       "label": "capabilityCatalog.test.ts",
@@ -216337,7 +216457,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1904,
+      "community": 1906,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_registerlifecycleauthority_test_ts",
       "label": "registerLifecycleAuthority.test.ts",
@@ -216346,7 +216466,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1905,
+      "community": 1907,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_correcttransactioncustomer_test_ts",
       "label": "correctTransactionCustomer.test.ts",
@@ -216355,7 +216475,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1906,
+      "community": 1908,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_corrections_correctionevents_test_ts",
       "label": "correctionEvents.test.ts",
@@ -216364,7 +216484,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1907,
+      "community": 1909,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_corrections_correctionpolicy_test_ts",
       "label": "correctionPolicy.test.ts",
@@ -216373,7 +216493,124 @@
       "source_location": "L1"
     },
     {
-      "community": 1908,
+      "community": 191,
+      "file_type": "code",
+      "id": "openworkinventoryreviews_test_buildctx",
+      "label": "buildCtx()",
+      "norm_label": "buildctx()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L956"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "openworkinventoryreviews_test_buildinventorymovement",
+      "label": "buildInventoryMovement()",
+      "norm_label": "buildinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1109"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "openworkinventoryreviews_test_buildmapping",
+      "label": "buildMapping()",
+      "norm_label": "buildmapping()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1213"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "openworkinventoryreviews_test_buildproductsku",
+      "label": "buildProductSku()",
+      "norm_label": "buildproductsku()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1130"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "openworkinventoryreviews_test_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1169"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "openworkinventoryreviews_test_buildstaffprofile",
+      "label": "buildStaffProfile()",
+      "norm_label": "buildstaffprofile()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1065"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "openworkinventoryreviews_test_buildstore",
+      "label": "buildStore()",
+      "norm_label": "buildstore()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1052"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "openworkinventoryreviews_test_buildterminal",
+      "label": "buildTerminal()",
+      "norm_label": "buildterminal()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1149"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "openworkinventoryreviews_test_buildtransaction",
+      "label": "buildTransaction()",
+      "norm_label": "buildtransaction()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1189"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "openworkinventoryreviews_test_buildworkitem",
+      "label": "buildWorkItem()",
+      "norm_label": "buildworkitem()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1079"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "openworkinventoryreviews_test_defaultargs",
+      "label": "defaultArgs()",
+      "norm_label": "defaultargs()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L909"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "openworkinventoryreviews_test_expectrejectedcontext",
+      "label": "expectRejectedContext()",
+      "norm_label": "expectrejectedcontext()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L891"
+    },
+    {
+      "community": 191,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_openworkinventoryreviews_test_ts",
+      "label": "openWorkInventoryReviews.test.ts",
+      "norm_label": "openworkinventoryreviews.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1910,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_dto_ts",
       "label": "dto.ts",
@@ -216382,7 +216619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1909,
+      "community": 1911,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_getregisterstate_test_ts",
       "label": "getRegisterState.test.ts",
@@ -216391,124 +216628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 191,
-      "file_type": "code",
-      "id": "assigncustomer_createcustomer",
-      "label": "createCustomer()",
-      "norm_label": "createcustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L132"
-    },
-    {
-      "community": 191,
-      "file_type": "code",
-      "id": "assigncustomer_fullnamefromparts",
-      "label": "fullNameFromParts()",
-      "norm_label": "fullnamefromparts()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 191,
-      "file_type": "code",
-      "id": "assigncustomer_guestresult",
-      "label": "guestResult()",
-      "norm_label": "guestresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L111"
-    },
-    {
-      "community": 191,
-      "file_type": "code",
-      "id": "assigncustomer_linktoguest",
-      "label": "linkToGuest()",
-      "norm_label": "linktoguest()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L348"
-    },
-    {
-      "community": 191,
-      "file_type": "code",
-      "id": "assigncustomer_linktostorefrontuser",
-      "label": "linkToStoreFrontUser()",
-      "norm_label": "linktostorefrontuser()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L290"
-    },
-    {
-      "community": 191,
-      "file_type": "code",
-      "id": "assigncustomer_poscustomerresult",
-      "label": "posCustomerResult()",
-      "norm_label": "poscustomerresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 191,
-      "file_type": "code",
-      "id": "assigncustomer_resolveguestmatch",
-      "label": "resolveGuestMatch()",
-      "norm_label": "resolveguestmatch()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L478"
-    },
-    {
-      "community": 191,
-      "file_type": "code",
-      "id": "assigncustomer_resolveposcustomerselection",
-      "label": "resolvePosCustomerSelection()",
-      "norm_label": "resolveposcustomerselection()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L267"
-    },
-    {
-      "community": 191,
-      "file_type": "code",
-      "id": "assigncustomer_resolvestorefrontusermatch",
-      "label": "resolveStoreFrontUserMatch()",
-      "norm_label": "resolvestorefrontusermatch()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L384"
-    },
-    {
-      "community": 191,
-      "file_type": "code",
-      "id": "assigncustomer_storefrontresult",
-      "label": "storefrontResult()",
-      "norm_label": "storefrontresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 191,
-      "file_type": "code",
-      "id": "assigncustomer_updatecustomer",
-      "label": "updateCustomer()",
-      "norm_label": "updatecustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L220"
-    },
-    {
-      "community": 191,
-      "file_type": "code",
-      "id": "assigncustomer_updatecustomerstats",
-      "label": "updateCustomerStats()",
-      "norm_label": "updatecustomerstats()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L251"
-    },
-    {
-      "community": 191,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_ts",
-      "label": "assignCustomer.ts",
-      "norm_label": "assigncustomer.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1910,
+      "community": 1912,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_possessiontracing_test_ts",
       "label": "posSessionTracing.test.ts",
@@ -216517,7 +216637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1911,
+      "community": 1913,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_searchcatalog_test_ts",
       "label": "searchCatalog.test.ts",
@@ -216526,7 +216646,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1912,
+      "community": 1914,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_localsyncreportingtypes_ts",
       "label": "localSyncReportingTypes.ts",
@@ -216535,7 +216655,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1913,
+      "community": 1915,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_registermappingauthorityrevision_test_ts",
       "label": "registerMappingAuthorityRevision.test.ts",
@@ -216544,7 +216664,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1914,
+      "community": 1916,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_registersessioncloseoutholds_test_ts",
       "label": "registerSessionCloseoutHolds.test.ts",
@@ -216553,7 +216673,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1915,
+      "community": 1917,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_registersessionsyncreview_classify_test_ts",
       "label": "registerSessionSyncReview.classify.test.ts",
@@ -216562,7 +216682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1916,
+      "community": 1918,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_types_ts",
       "label": "types.ts",
@@ -216571,7 +216691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1917,
+      "community": 1919,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminaloperationalstate_facts_ts",
       "label": "facts.ts",
@@ -216580,7 +216700,124 @@
       "source_location": "L1"
     },
     {
-      "community": 1918,
+      "community": 192,
+      "file_type": "code",
+      "id": "assigncustomer_createcustomer",
+      "label": "createCustomer()",
+      "norm_label": "createcustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L132"
+    },
+    {
+      "community": 192,
+      "file_type": "code",
+      "id": "assigncustomer_fullnamefromparts",
+      "label": "fullNameFromParts()",
+      "norm_label": "fullnamefromparts()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 192,
+      "file_type": "code",
+      "id": "assigncustomer_guestresult",
+      "label": "guestResult()",
+      "norm_label": "guestresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L111"
+    },
+    {
+      "community": 192,
+      "file_type": "code",
+      "id": "assigncustomer_linktoguest",
+      "label": "linkToGuest()",
+      "norm_label": "linktoguest()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L348"
+    },
+    {
+      "community": 192,
+      "file_type": "code",
+      "id": "assigncustomer_linktostorefrontuser",
+      "label": "linkToStoreFrontUser()",
+      "norm_label": "linktostorefrontuser()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L290"
+    },
+    {
+      "community": 192,
+      "file_type": "code",
+      "id": "assigncustomer_poscustomerresult",
+      "label": "posCustomerResult()",
+      "norm_label": "poscustomerresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 192,
+      "file_type": "code",
+      "id": "assigncustomer_resolveguestmatch",
+      "label": "resolveGuestMatch()",
+      "norm_label": "resolveguestmatch()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L478"
+    },
+    {
+      "community": 192,
+      "file_type": "code",
+      "id": "assigncustomer_resolveposcustomerselection",
+      "label": "resolvePosCustomerSelection()",
+      "norm_label": "resolveposcustomerselection()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L267"
+    },
+    {
+      "community": 192,
+      "file_type": "code",
+      "id": "assigncustomer_resolvestorefrontusermatch",
+      "label": "resolveStoreFrontUserMatch()",
+      "norm_label": "resolvestorefrontusermatch()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L384"
+    },
+    {
+      "community": 192,
+      "file_type": "code",
+      "id": "assigncustomer_storefrontresult",
+      "label": "storefrontResult()",
+      "norm_label": "storefrontresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 192,
+      "file_type": "code",
+      "id": "assigncustomer_updatecustomer",
+      "label": "updateCustomer()",
+      "norm_label": "updatecustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L220"
+    },
+    {
+      "community": 192,
+      "file_type": "code",
+      "id": "assigncustomer_updatecustomerstats",
+      "label": "updateCustomerStats()",
+      "norm_label": "updatecustomerstats()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L251"
+    },
+    {
+      "community": 192,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_ts",
+      "label": "assignCustomer.ts",
+      "norm_label": "assigncustomer.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1920,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminaloperationalstate_types_ts",
       "label": "types.ts",
@@ -216589,7 +216826,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1919,
+      "community": 1921,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_types_ts",
       "label": "types.ts",
@@ -216598,124 +216835,7 @@
       "source_location": "L1"
     },
     {
-      "community": 192,
-      "file_type": "code",
-      "id": "catalogrepository_findactivependingcheckoutlookupaliasbycode",
-      "label": "findActivePendingCheckoutLookupAliasByCode()",
-      "norm_label": "findactivependingcheckoutlookupaliasbycode()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L97"
-    },
-    {
-      "community": 192,
-      "file_type": "code",
-      "id": "catalogrepository_findactiveprovisionalimportskuforstoresku",
-      "label": "findActiveProvisionalImportSkuForStoreSku()",
-      "norm_label": "findactiveprovisionalimportskuforstoresku()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L120"
-    },
-    {
-      "community": 192,
-      "file_type": "code",
-      "id": "catalogrepository_findstoreskubybarcode",
-      "label": "findStoreSkuByBarcode()",
-      "norm_label": "findstoreskubybarcode()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 192,
-      "file_type": "code",
-      "id": "catalogrepository_findstoreskubysku",
-      "label": "findStoreSkuBySku()",
-      "norm_label": "findstoreskubysku()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 192,
-      "file_type": "code",
-      "id": "catalogrepository_getcategorybyid",
-      "label": "getCategoryById()",
-      "norm_label": "getcategorybyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 192,
-      "file_type": "code",
-      "id": "catalogrepository_getcolorbyid",
-      "label": "getColorById()",
-      "norm_label": "getcolorbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 192,
-      "file_type": "code",
-      "id": "catalogrepository_getproductbyid",
-      "label": "getProductById()",
-      "norm_label": "getproductbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 192,
-      "file_type": "code",
-      "id": "catalogrepository_isconvexproductid",
-      "label": "isConvexProductId()",
-      "norm_label": "isconvexproductid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 192,
-      "file_type": "code",
-      "id": "catalogrepository_listmatchingstoreskus",
-      "label": "listMatchingStoreSkus()",
-      "norm_label": "listmatchingstoreskus()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L140"
-    },
-    {
-      "community": 192,
-      "file_type": "code",
-      "id": "catalogrepository_listproductskusbyproductid",
-      "label": "listProductSkusByProductId()",
-      "norm_label": "listproductskusbyproductid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 192,
-      "file_type": "code",
-      "id": "catalogrepository_normalizelookupcode",
-      "label": "normalizeLookupCode()",
-      "norm_label": "normalizelookupcode()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L92"
-    },
-    {
-      "community": 192,
-      "file_type": "code",
-      "id": "catalogrepository_readallqueryresults",
-      "label": "readAllQueryResults()",
-      "norm_label": "readallqueryresults()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 192,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_catalogrepository_ts",
-      "label": "catalogRepository.ts",
-      "norm_label": "catalogrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1920,
+      "community": 1922,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminalruntime_terminalhealthalerts_test_ts",
       "label": "terminalHealthAlerts.test.ts",
@@ -216724,7 +216844,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1921,
+      "community": 1923,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_terminalsyncevidence_ts",
       "label": "terminalSyncEvidence.ts",
@@ -216733,7 +216853,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1922,
+      "community": 1924,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_domain_types_ts",
       "label": "types.ts",
@@ -216742,7 +216862,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1923,
+      "community": 1925,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registerlifecycleauthorityrepository_test_ts",
       "label": "registerLifecycleAuthorityRepository.test.ts",
@@ -216751,7 +216871,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1924,
+      "community": 1926,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registerlifecycleauthoritystatusrepository_test_ts",
       "label": "registerLifecycleAuthorityStatusRepository.test.ts",
@@ -216760,7 +216880,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1925,
+      "community": 1927,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_transactionrepository_test_ts",
       "label": "transactionRepository.test.ts",
@@ -216769,7 +216889,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1926,
+      "community": 1928,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_register_ts",
       "label": "register.ts",
@@ -216778,7 +216898,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1927,
+      "community": 1929,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_application_posruntimeadapter_test_ts",
       "label": "posRuntimeAdapter.test.ts",
@@ -216787,7 +216907,124 @@
       "source_location": "L1"
     },
     {
-      "community": 1928,
+      "community": 193,
+      "file_type": "code",
+      "id": "catalogrepository_findactivependingcheckoutlookupaliasbycode",
+      "label": "findActivePendingCheckoutLookupAliasByCode()",
+      "norm_label": "findactivependingcheckoutlookupaliasbycode()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L97"
+    },
+    {
+      "community": 193,
+      "file_type": "code",
+      "id": "catalogrepository_findactiveprovisionalimportskuforstoresku",
+      "label": "findActiveProvisionalImportSkuForStoreSku()",
+      "norm_label": "findactiveprovisionalimportskuforstoresku()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L120"
+    },
+    {
+      "community": 193,
+      "file_type": "code",
+      "id": "catalogrepository_findstoreskubybarcode",
+      "label": "findStoreSkuByBarcode()",
+      "norm_label": "findstoreskubybarcode()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 193,
+      "file_type": "code",
+      "id": "catalogrepository_findstoreskubysku",
+      "label": "findStoreSkuBySku()",
+      "norm_label": "findstoreskubysku()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 193,
+      "file_type": "code",
+      "id": "catalogrepository_getcategorybyid",
+      "label": "getCategoryById()",
+      "norm_label": "getcategorybyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 193,
+      "file_type": "code",
+      "id": "catalogrepository_getcolorbyid",
+      "label": "getColorById()",
+      "norm_label": "getcolorbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 193,
+      "file_type": "code",
+      "id": "catalogrepository_getproductbyid",
+      "label": "getProductById()",
+      "norm_label": "getproductbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 193,
+      "file_type": "code",
+      "id": "catalogrepository_isconvexproductid",
+      "label": "isConvexProductId()",
+      "norm_label": "isconvexproductid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 193,
+      "file_type": "code",
+      "id": "catalogrepository_listmatchingstoreskus",
+      "label": "listMatchingStoreSkus()",
+      "norm_label": "listmatchingstoreskus()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L140"
+    },
+    {
+      "community": 193,
+      "file_type": "code",
+      "id": "catalogrepository_listproductskusbyproductid",
+      "label": "listProductSkusByProductId()",
+      "norm_label": "listproductskusbyproductid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 193,
+      "file_type": "code",
+      "id": "catalogrepository_normalizelookupcode",
+      "label": "normalizeLookupCode()",
+      "norm_label": "normalizelookupcode()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 193,
+      "file_type": "code",
+      "id": "catalogrepository_readallqueryresults",
+      "label": "readAllQueryResults()",
+      "norm_label": "readallqueryresults()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 193,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_catalogrepository_ts",
+      "label": "catalogRepository.ts",
+      "norm_label": "catalogrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1930,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_application_types_test_ts",
       "label": "types.test.ts",
@@ -216796,7 +217033,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1929,
+      "community": 1931,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_infrastructure_transport_remoteassisttransportprovider_test_ts",
       "label": "RemoteAssistTransportProvider.test.ts",
@@ -216805,124 +217042,7 @@
       "source_location": "L1"
     },
     {
-      "community": 193,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_skumovementrange_test_ts",
-      "label": "skuMovementRange.test.ts",
-      "norm_label": "skumovementrange.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 193,
-      "file_type": "code",
-      "id": "skumovementrange_test_admitone",
-      "label": "admitOne()",
-      "norm_label": "admitone()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L352"
-    },
-    {
-      "community": 193,
-      "file_type": "code",
-      "id": "skumovementrange_test_allow",
-      "label": "allow()",
-      "norm_label": "allow()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L113"
-    },
-    {
-      "community": 193,
-      "file_type": "code",
-      "id": "skumovementrange_test_certifyday",
-      "label": "certifyDay()",
-      "norm_label": "certifyday()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L238"
-    },
-    {
-      "community": 193,
-      "file_type": "code",
-      "id": "skumovementrange_test_dailyfor",
-      "label": "dailyFor()",
-      "norm_label": "dailyfor()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L656"
-    },
-    {
-      "community": 193,
-      "file_type": "code",
-      "id": "skumovementrange_test_drive",
-      "label": "drive()",
-      "norm_label": "drive()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L322"
-    },
-    {
-      "community": 193,
-      "file_type": "code",
-      "id": "skumovementrange_test_ensure",
-      "label": "ensure()",
-      "norm_label": "ensure()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L283"
-    },
-    {
-      "community": 193,
-      "file_type": "code",
-      "id": "skumovementrange_test_handlerof",
-      "label": "handlerOf()",
-      "norm_label": "handlerof()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L108"
-    },
-    {
-      "community": 193,
-      "file_type": "code",
-      "id": "skumovementrange_test_headerbykey",
-      "label": "headerByKey()",
-      "norm_label": "headerbykey()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L304"
-    },
-    {
-      "community": 193,
-      "file_type": "code",
-      "id": "skumovementrange_test_seedskus",
-      "label": "seedSkus()",
-      "norm_label": "seedskus()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L162"
-    },
-    {
-      "community": 193,
-      "file_type": "code",
-      "id": "skumovementrange_test_seedstore",
-      "label": "seedStore()",
-      "norm_label": "seedstore()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L140"
-    },
-    {
-      "community": 193,
-      "file_type": "code",
-      "id": "skumovementrange_test_step",
-      "label": "step()",
-      "norm_label": "step()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L955"
-    },
-    {
-      "community": 193,
-      "file_type": "code",
-      "id": "skumovementrange_test_twodayfixture",
-      "label": "twoDayFixture()",
-      "norm_label": "twodayfixture()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L939"
-    },
-    {
-      "community": 1930,
+      "community": 1932,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schema_ts",
       "label": "schema.ts",
@@ -216931,7 +217051,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1931,
+      "community": 1933,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_automation_ts",
       "label": "automation.ts",
@@ -216940,7 +217060,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1932,
+      "community": 1934,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_contexttracking_ts",
       "label": "contextTracking.ts",
@@ -216949,7 +217069,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1933,
+      "community": 1935,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_customermessaging_customermessagedelivery_ts",
       "label": "customerMessageDelivery.ts",
@@ -216958,7 +217078,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1934,
+      "community": 1936,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_customermessaging_index_ts",
       "label": "index.ts",
@@ -216967,7 +217087,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1935,
+      "community": 1937,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_customermessaging_receiptsharetoken_ts",
       "label": "receiptShareToken.ts",
@@ -216976,7 +217096,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1936,
+      "community": 1938,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_intelligence_ts",
       "label": "intelligence.ts",
@@ -216985,7 +217105,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1937,
+      "community": 1939,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_appverificationcode_ts",
       "label": "appVerificationCode.ts",
@@ -216994,7 +217114,124 @@
       "source_location": "L1"
     },
     {
-      "community": 1938,
+      "community": 194,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_reports_skumovementrange_test_ts",
+      "label": "skuMovementRange.test.ts",
+      "norm_label": "skumovementrange.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 194,
+      "file_type": "code",
+      "id": "skumovementrange_test_admitone",
+      "label": "admitOne()",
+      "norm_label": "admitone()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L352"
+    },
+    {
+      "community": 194,
+      "file_type": "code",
+      "id": "skumovementrange_test_allow",
+      "label": "allow()",
+      "norm_label": "allow()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L113"
+    },
+    {
+      "community": 194,
+      "file_type": "code",
+      "id": "skumovementrange_test_certifyday",
+      "label": "certifyDay()",
+      "norm_label": "certifyday()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L238"
+    },
+    {
+      "community": 194,
+      "file_type": "code",
+      "id": "skumovementrange_test_dailyfor",
+      "label": "dailyFor()",
+      "norm_label": "dailyfor()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L656"
+    },
+    {
+      "community": 194,
+      "file_type": "code",
+      "id": "skumovementrange_test_drive",
+      "label": "drive()",
+      "norm_label": "drive()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L322"
+    },
+    {
+      "community": 194,
+      "file_type": "code",
+      "id": "skumovementrange_test_ensure",
+      "label": "ensure()",
+      "norm_label": "ensure()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L283"
+    },
+    {
+      "community": 194,
+      "file_type": "code",
+      "id": "skumovementrange_test_handlerof",
+      "label": "handlerOf()",
+      "norm_label": "handlerof()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L108"
+    },
+    {
+      "community": 194,
+      "file_type": "code",
+      "id": "skumovementrange_test_headerbykey",
+      "label": "headerByKey()",
+      "norm_label": "headerbykey()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L304"
+    },
+    {
+      "community": 194,
+      "file_type": "code",
+      "id": "skumovementrange_test_seedskus",
+      "label": "seedSkus()",
+      "norm_label": "seedskus()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L162"
+    },
+    {
+      "community": 194,
+      "file_type": "code",
+      "id": "skumovementrange_test_seedstore",
+      "label": "seedStore()",
+      "norm_label": "seedstore()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L140"
+    },
+    {
+      "community": 194,
+      "file_type": "code",
+      "id": "skumovementrange_test_step",
+      "label": "step()",
+      "norm_label": "step()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L955"
+    },
+    {
+      "community": 194,
+      "file_type": "code",
+      "id": "skumovementrange_test_twodayfixture",
+      "label": "twoDayFixture()",
+      "norm_label": "twodayfixture()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L939"
+    },
+    {
+      "community": 1940,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -217003,7 +217240,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1939,
+      "community": 1941,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -217012,124 +217249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 194,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productview_tsx",
-      "label": "ProductView.tsx",
-      "norm_label": "productview.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 194,
-      "file_type": "code",
-      "id": "productview_archivedproductnestedorigin",
-      "label": "archivedProductNestedOrigin()",
-      "norm_label": "archivedproductnestedorigin()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L107"
-    },
-    {
-      "community": 194,
-      "file_type": "code",
-      "id": "productview_buildvariantskumoneypayload",
-      "label": "buildVariantSkuMoneyPayload()",
-      "norm_label": "buildvariantskumoneypayload()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L67"
-    },
-    {
-      "community": 194,
-      "file_type": "code",
-      "id": "productview_createvariantsku",
-      "label": "createVariantSku()",
-      "norm_label": "createvariantsku()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L346"
-    },
-    {
-      "community": 194,
-      "file_type": "code",
-      "id": "productview_decodeoriginvalue",
-      "label": "decodeOriginValue()",
-      "norm_label": "decodeoriginvalue()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L93"
-    },
-    {
-      "community": 194,
-      "file_type": "code",
-      "id": "productview_deleteactiveproduct",
-      "label": "deleteActiveProduct()",
-      "norm_label": "deleteactiveproduct()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L177"
-    },
-    {
-      "community": 194,
-      "file_type": "code",
-      "id": "productview_getarchivedproductredirect",
-      "label": "getArchivedProductRedirect()",
-      "norm_label": "getarchivedproductredirect()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L74"
-    },
-    {
-      "community": 194,
-      "file_type": "code",
-      "id": "productview_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L506"
-    },
-    {
-      "community": 194,
-      "file_type": "code",
-      "id": "productview_modifyproduct",
-      "label": "modifyProduct()",
-      "norm_label": "modifyproduct()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L271"
-    },
-    {
-      "community": 194,
-      "file_type": "code",
-      "id": "productview_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L490"
-    },
-    {
-      "community": 194,
-      "file_type": "code",
-      "id": "productview_resolvelegacytaxonomysavegate",
-      "label": "resolveLegacyTaxonomySaveGate()",
-      "norm_label": "resolvelegacytaxonomysavegate()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L40"
-    },
-    {
-      "community": 194,
-      "file_type": "code",
-      "id": "productview_saveproduct",
-      "label": "saveProduct()",
-      "norm_label": "saveproduct()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L217"
-    },
-    {
-      "community": 194,
-      "file_type": "code",
-      "id": "productview_updatevariantsku",
-      "label": "updateVariantSku()",
-      "norm_label": "updatevariantsku()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L404"
-    },
-    {
-      "community": 1940,
+      "community": 1942,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -217138,7 +217258,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1941,
+      "community": 1943,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_catalogsummary_ts",
       "label": "catalogSummary.ts",
@@ -217147,7 +217267,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1942,
+      "community": 1944,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_category_ts",
       "label": "category.ts",
@@ -217156,7 +217276,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1943,
+      "community": 1945,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_color_ts",
       "label": "color.ts",
@@ -217165,7 +217285,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1944,
+      "community": 1946,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
@@ -217174,7 +217294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1945,
+      "community": 1947,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -217183,7 +217303,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1946,
+      "community": 1948,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_index_ts",
       "label": "index.ts",
@@ -217192,7 +217312,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1947,
+      "community": 1949,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_inventoryhold_ts",
       "label": "inventoryHold.ts",
@@ -217201,7 +217321,124 @@
       "source_location": "L1"
     },
     {
-      "community": 1948,
+      "community": 195,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_productview_tsx",
+      "label": "ProductView.tsx",
+      "norm_label": "productview.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 195,
+      "file_type": "code",
+      "id": "productview_archivedproductnestedorigin",
+      "label": "archivedProductNestedOrigin()",
+      "norm_label": "archivedproductnestedorigin()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L107"
+    },
+    {
+      "community": 195,
+      "file_type": "code",
+      "id": "productview_buildvariantskumoneypayload",
+      "label": "buildVariantSkuMoneyPayload()",
+      "norm_label": "buildvariantskumoneypayload()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L67"
+    },
+    {
+      "community": 195,
+      "file_type": "code",
+      "id": "productview_createvariantsku",
+      "label": "createVariantSku()",
+      "norm_label": "createvariantsku()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L346"
+    },
+    {
+      "community": 195,
+      "file_type": "code",
+      "id": "productview_decodeoriginvalue",
+      "label": "decodeOriginValue()",
+      "norm_label": "decodeoriginvalue()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L93"
+    },
+    {
+      "community": 195,
+      "file_type": "code",
+      "id": "productview_deleteactiveproduct",
+      "label": "deleteActiveProduct()",
+      "norm_label": "deleteactiveproduct()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L177"
+    },
+    {
+      "community": 195,
+      "file_type": "code",
+      "id": "productview_getarchivedproductredirect",
+      "label": "getArchivedProductRedirect()",
+      "norm_label": "getarchivedproductredirect()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L74"
+    },
+    {
+      "community": 195,
+      "file_type": "code",
+      "id": "productview_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L506"
+    },
+    {
+      "community": 195,
+      "file_type": "code",
+      "id": "productview_modifyproduct",
+      "label": "modifyProduct()",
+      "norm_label": "modifyproduct()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L271"
+    },
+    {
+      "community": 195,
+      "file_type": "code",
+      "id": "productview_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L490"
+    },
+    {
+      "community": 195,
+      "file_type": "code",
+      "id": "productview_resolvelegacytaxonomysavegate",
+      "label": "resolveLegacyTaxonomySaveGate()",
+      "norm_label": "resolvelegacytaxonomysavegate()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L40"
+    },
+    {
+      "community": 195,
+      "file_type": "code",
+      "id": "productview_saveproduct",
+      "label": "saveProduct()",
+      "norm_label": "saveproduct()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L217"
+    },
+    {
+      "community": 195,
+      "file_type": "code",
+      "id": "productview_updatevariantsku",
+      "label": "updateVariantSku()",
+      "norm_label": "updatevariantsku()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L404"
+    },
+    {
+      "community": 1950,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_inventoryimportcostoverlaybulkdecisionrequest_ts",
       "label": "inventoryImportCostOverlayBulkDecisionRequest.ts",
@@ -217210,7 +217447,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1949,
+      "community": 1951,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_inventoryimportcostoverlayrow_ts",
       "label": "inventoryImportCostOverlayRow.ts",
@@ -217219,124 +217456,7 @@
       "source_location": "L1"
     },
     {
-      "community": 195,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 195,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 195,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 195,
-      "file_type": "code",
-      "id": "utils_formatdeliveryaddress",
-      "label": "formatDeliveryAddress()",
-      "norm_label": "formatdeliveryaddress()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 195,
-      "file_type": "code",
-      "id": "utils_getamountpaidfororder",
-      "label": "getAmountPaidForOrder()",
-      "norm_label": "getamountpaidfororder()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L191"
-    },
-    {
-      "community": 195,
-      "file_type": "code",
-      "id": "utils_getdiscountvalue",
-      "label": "getDiscountValue()",
-      "norm_label": "getdiscountvalue()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 195,
-      "file_type": "code",
-      "id": "utils_getonlineorderplacedat",
-      "label": "getOnlineOrderPlacedAt()",
-      "norm_label": "getonlineorderplacedat()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 195,
-      "file_type": "code",
-      "id": "utils_getorderamount",
-      "label": "getOrderAmount()",
-      "norm_label": "getorderamount()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 195,
-      "file_type": "code",
-      "id": "utils_getorderstate",
-      "label": "getOrderState()",
-      "norm_label": "getorderstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 195,
-      "file_type": "code",
-      "id": "utils_getpickupactionstate",
-      "label": "getPickupActionState()",
-      "norm_label": "getpickupactionstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 195,
-      "file_type": "code",
-      "id": "utils_getpotentialpoints",
-      "label": "getPotentialPoints()",
-      "norm_label": "getpotentialpoints()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 195,
-      "file_type": "code",
-      "id": "utils_getproductdiscountvalue",
-      "label": "getProductDiscountValue()",
-      "norm_label": "getproductdiscountvalue()",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 195,
-      "file_type": "code",
-      "id": "utils_shouldshowpickupexceptionaction",
-      "label": "shouldShowPickupExceptionAction()",
-      "norm_label": "shouldshowpickupexceptionaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 1950,
+      "community": 1952,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_inventoryimportcostoverlayrun_ts",
       "label": "inventoryImportCostOverlayRun.ts",
@@ -217345,7 +217465,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1951,
+      "community": 1953,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_inventoryimportprovisionalsku_ts",
       "label": "inventoryImportProvisionalSku.ts",
@@ -217354,7 +217474,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1952,
+      "community": 1954,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_inventoryimportreviewversion_ts",
       "label": "inventoryImportReviewVersion.ts",
@@ -217363,7 +217483,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1953,
+      "community": 1955,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_inventoryimportreviewversionpayloadchunk_ts",
       "label": "inventoryImportReviewVersionPayloadChunk.ts",
@@ -217372,7 +217492,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1954,
+      "community": 1956,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_inventoryimportreviewversionpayloadupload_ts",
       "label": "inventoryImportReviewVersionPayloadUpload.ts",
@@ -217381,7 +217501,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1955,
+      "community": 1957,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_invitecode_ts",
       "label": "inviteCode.ts",
@@ -217390,7 +217510,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1956,
+      "community": 1958,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organization_ts",
       "label": "organization.ts",
@@ -217399,30 +217519,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1957,
+      "community": 1959,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organizationmember_ts",
       "label": "organizationMember.ts",
       "norm_label": "organizationmember.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/organizationMember.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1958,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_posregistercatalogrevision_ts",
-      "label": "posRegisterCatalogRevision.ts",
-      "norm_label": "posregistercatalogrevision.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/posRegisterCatalogRevision.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1959,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_product_ts",
-      "label": "product.ts",
-      "norm_label": "product.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/product.ts",
       "source_location": "L1"
     },
     {
@@ -217545,6 +217647,24 @@
     {
       "community": 1960,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_posregistercatalogrevision_ts",
+      "label": "posRegisterCatalogRevision.ts",
+      "norm_label": "posregistercatalogrevision.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/posRegisterCatalogRevision.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1961,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_product_ts",
+      "label": "product.ts",
+      "norm_label": "product.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/product.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1962,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_productskusearch_ts",
       "label": "productSkuSearch.ts",
       "norm_label": "productskusearch.ts",
@@ -217552,7 +217672,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1961,
+      "community": 1963,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_promocode_ts",
       "label": "promoCode.ts",
@@ -217561,7 +217681,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1962,
+      "community": 1964,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_redeemedpromocode_ts",
       "label": "redeemedPromoCode.ts",
@@ -217570,7 +217690,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1963,
+      "community": 1965,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_store_ts",
       "label": "store.ts",
@@ -217579,7 +217699,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1964,
+      "community": 1966,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_storeschedule_ts",
       "label": "storeSchedule.ts",
@@ -217588,7 +217708,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1965,
+      "community": 1967,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_storetimezone_ts",
       "label": "storeTimezone.ts",
@@ -217597,7 +217717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1966,
+      "community": 1968,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_subcategory_ts",
       "label": "subcategory.ts",
@@ -217606,30 +217726,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1967,
+      "community": 1969,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventoryledger_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventoryLedger/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1968,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_marketing_landingfunnelevent_ts",
-      "label": "landingFunnelEvent.ts",
-      "norm_label": "landingfunnelevent.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/marketing/landingFunnelEvent.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1969,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_marketing_walkthroughrequest_ts",
-      "label": "walkthroughRequest.ts",
-      "norm_label": "walkthroughrequest.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/marketing/walkthroughRequest.ts",
       "source_location": "L1"
     },
     {
@@ -217752,6 +217854,24 @@
     {
       "community": 1970,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_marketing_landingfunnelevent_ts",
+      "label": "landingFunnelEvent.ts",
+      "norm_label": "landingfunnelevent.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/marketing/landingFunnelEvent.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1971,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_marketing_walkthroughrequest_ts",
+      "label": "walkthroughRequest.ts",
+      "norm_label": "walkthroughrequest.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/marketing/walkthroughRequest.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1972,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_migrations_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
@@ -217759,7 +217879,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1971,
+      "community": 1973,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_notifications_ts",
       "label": "notifications.ts",
@@ -217768,7 +217888,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1972,
+      "community": 1974,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_index_ts",
       "label": "index.ts",
@@ -217777,7 +217897,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1973,
+      "community": 1975,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtrace_ts",
       "label": "workflowTrace.ts",
@@ -217786,7 +217906,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1974,
+      "community": 1976,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtraceevent_ts",
       "label": "workflowTraceEvent.ts",
@@ -217795,7 +217915,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1975,
+      "community": 1977,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_observability_workflowtracelookup_ts",
       "label": "workflowTraceLookup.ts",
@@ -217804,7 +217924,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1976,
+      "community": 1978,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_approvalrequest_ts",
       "label": "approvalRequest.ts",
@@ -217813,30 +217933,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1977,
+      "community": 1979,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_customerprofile_ts",
       "label": "customerProfile.ts",
       "norm_label": "customerprofile.ts",
       "source_file": "packages/athena-webapp/convex/schemas/operations/customerProfile.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1978,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_dailyclose_ts",
-      "label": "dailyClose.ts",
-      "norm_label": "dailyclose.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/dailyClose.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1979,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_dailyopening_ts",
-      "label": "dailyOpening.ts",
-      "norm_label": "dailyopening.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/dailyOpening.ts",
       "source_location": "L1"
     },
     {
@@ -217959,6 +218061,24 @@
     {
       "community": 1980,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_dailyclose_ts",
+      "label": "dailyClose.ts",
+      "norm_label": "dailyclose.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/dailyClose.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1981,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_dailyopening_ts",
+      "label": "dailyOpening.ts",
+      "norm_label": "dailyopening.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/dailyOpening.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1982,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
@@ -217966,7 +218086,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1981,
+      "community": 1983,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_inventorymovement_ts",
       "label": "inventoryMovement.ts",
@@ -217975,7 +218095,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1982,
+      "community": 1984,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_managerelevation_ts",
       "label": "managerElevation.ts",
@@ -217984,7 +218104,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1983,
+      "community": 1985,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalevent_ts",
       "label": "operationalEvent.ts",
@@ -217993,7 +218113,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1984,
+      "community": 1986,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_operationalworkitem_ts",
       "label": "operationalWorkItem.ts",
@@ -218002,7 +218122,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1985,
+      "community": 1987,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_oversizedoperationalworkrepair_ts",
       "label": "oversizedOperationalWorkRepair.ts",
@@ -218011,7 +218131,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1986,
+      "community": 1988,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_paymentallocation_ts",
       "label": "paymentAllocation.ts",
@@ -218020,30 +218140,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1987,
+      "community": 1989,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_registersession_ts",
       "label": "registerSession.ts",
       "norm_label": "registersession.ts",
       "source_file": "packages/athena-webapp/convex/schemas/operations/registerSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1988,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_skuactivityevent_ts",
-      "label": "skuActivityEvent.ts",
-      "norm_label": "skuactivityevent.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/skuActivityEvent.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1989,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_operations_staffcredential_ts",
-      "label": "staffCredential.ts",
-      "norm_label": "staffcredential.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/operations/staffCredential.ts",
       "source_location": "L1"
     },
     {
@@ -218166,6 +218268,24 @@
     {
       "community": 1990,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_skuactivityevent_ts",
+      "label": "skuActivityEvent.ts",
+      "norm_label": "skuactivityevent.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/skuActivityEvent.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1991,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_operations_staffcredential_ts",
+      "label": "staffCredential.ts",
+      "norm_label": "staffcredential.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/operations/staffCredential.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1992,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffprofile_ts",
       "label": "staffProfile.ts",
       "norm_label": "staffprofile.ts",
@@ -218173,7 +218293,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1991,
+      "community": 1993,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_operations_staffroleassignment_ts",
       "label": "staffRoleAssignment.ts",
@@ -218182,7 +218302,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1992,
+      "community": 1994,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_payments_mtncollections_ts",
       "label": "mtnCollections.ts",
@@ -218191,7 +218311,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1993,
+      "community": 1995,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_customer_ts",
       "label": "customer.ts",
@@ -218200,7 +218320,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1994,
+      "community": 1996,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesession_ts",
       "label": "expenseSession.ts",
@@ -218209,7 +218329,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1995,
+      "community": 1997,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesessionitem_ts",
       "label": "expenseSessionItem.ts",
@@ -218218,7 +218338,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1996,
+      "community": 1998,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransaction_ts",
       "label": "expenseTransaction.ts",
@@ -218227,30 +218347,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1997,
+      "community": 1999,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransactionitem_ts",
       "label": "expenseTransactionItem.ts",
       "norm_label": "expensetransactionitem.ts",
       "source_file": "packages/athena-webapp/convex/schemas/pos/expenseTransactionItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1998,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1999,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_posamountmigrationrun_ts",
-      "label": "posAmountMigrationRun.ts",
-      "norm_label": "posamountmigrationrun.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/posAmountMigrationRun.ts",
       "source_location": "L1"
     },
     {
@@ -219543,6 +219645,24 @@
     {
       "community": 2000,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2001,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_posamountmigrationrun_ts",
+      "label": "posAmountMigrationRun.ts",
+      "norm_label": "posamountmigrationrun.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/posAmountMigrationRun.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2002,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posclientevent_ts",
       "label": "posClientEvent.ts",
       "norm_label": "posclientevent.ts",
@@ -219550,7 +219670,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2001,
+      "community": 2003,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_poslifecyclejournal_ts",
       "label": "posLifecycleJournal.ts",
@@ -219559,7 +219679,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2002,
+      "community": 2004,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_poslocalstaffproof_ts",
       "label": "posLocalStaffProof.ts",
@@ -219568,7 +219688,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2003,
+      "community": 2005,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_poslocalsyncconflict_ts",
       "label": "posLocalSyncConflict.ts",
@@ -219577,7 +219697,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2004,
+      "community": 2006,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_poslocalsynccursor_ts",
       "label": "posLocalSyncCursor.ts",
@@ -219586,7 +219706,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2005,
+      "community": 2007,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_poslocalsyncevent_ts",
       "label": "posLocalSyncEvent.ts",
@@ -219595,7 +219715,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2006,
+      "community": 2008,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_poslocalsyncmapping_ts",
       "label": "posLocalSyncMapping.ts",
@@ -219604,30 +219724,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2007,
+      "community": 2009,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_pospendingcheckoutitem_ts",
       "label": "posPendingCheckoutItem.ts",
       "norm_label": "pospendingcheckoutitem.ts",
       "source_file": "packages/athena-webapp/convex/schemas/pos/posPendingCheckoutItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2008,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_pospendingcheckoutlookupalias_ts",
-      "label": "posPendingCheckoutLookupAlias.ts",
-      "norm_label": "pospendingcheckoutlookupalias.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/posPendingCheckoutLookupAlias.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2009,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_posrecoverycredential_ts",
-      "label": "posRecoveryCredential.ts",
-      "norm_label": "posrecoverycredential.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/posRecoveryCredential.ts",
       "source_location": "L1"
     },
     {
@@ -219750,6 +219852,24 @@
     {
       "community": 2010,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_pospendingcheckoutlookupalias_ts",
+      "label": "posPendingCheckoutLookupAlias.ts",
+      "norm_label": "pospendingcheckoutlookupalias.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/posPendingCheckoutLookupAlias.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2011,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_posrecoverycredential_ts",
+      "label": "posRecoveryCredential.ts",
+      "norm_label": "posrecoverycredential.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/posRecoveryCredential.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2012,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posregisterauthorityreplicationstatus_ts",
       "label": "posRegisterAuthorityReplicationStatus.ts",
       "norm_label": "posregisterauthorityreplicationstatus.ts",
@@ -219757,7 +219877,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2011,
+      "community": 2013,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posregistermappingauthority_ts",
       "label": "posRegisterMappingAuthority.ts",
@@ -219766,7 +219886,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2012,
+      "community": 2014,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posregistersessionactivity_ts",
       "label": "posRegisterSessionActivity.ts",
@@ -219775,7 +219895,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2013,
+      "community": 2015,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posregistersessionactivitycheckpoint_ts",
       "label": "posRegisterSessionActivityCheckpoint.ts",
@@ -219784,7 +219904,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2014,
+      "community": 2016,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possession_ts",
       "label": "posSession.ts",
@@ -219793,7 +219913,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2015,
+      "community": 2017,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possessionitem_ts",
       "label": "posSessionItem.ts",
@@ -219802,7 +219922,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2016,
+      "community": 2018,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posterminal_test_ts",
       "label": "posTerminal.test.ts",
@@ -219811,30 +219931,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2017,
+      "community": 2019,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posterminal_ts",
       "label": "posTerminal.ts",
       "norm_label": "posterminal.ts",
       "source_file": "packages/athena-webapp/convex/schemas/pos/posTerminal.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2018,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_posterminalrecovery_ts",
-      "label": "posTerminalRecovery.ts",
-      "norm_label": "posterminalrecovery.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/posTerminalRecovery.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2019,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_posterminalruntimestatus_ts",
-      "label": "posTerminalRuntimeStatus.ts",
-      "norm_label": "posterminalruntimestatus.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/posTerminalRuntimeStatus.ts",
       "source_location": "L1"
     },
     {
@@ -219957,6 +220059,24 @@
     {
       "community": 2020,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_posterminalrecovery_ts",
+      "label": "posTerminalRecovery.ts",
+      "norm_label": "posterminalrecovery.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/posTerminalRecovery.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2021,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_posterminalruntimestatus_ts",
+      "label": "posTerminalRuntimeStatus.ts",
+      "norm_label": "posterminalruntimestatus.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/posTerminalRuntimeStatus.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2022,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransaction_ts",
       "label": "posTransaction.ts",
       "norm_label": "postransaction.ts",
@@ -219964,7 +220084,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2021,
+      "community": 2023,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransactionadjustment_ts",
       "label": "posTransactionAdjustment.ts",
@@ -219973,7 +220093,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2022,
+      "community": 2024,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransactionadjustmentline_ts",
       "label": "posTransactionAdjustmentLine.ts",
@@ -219982,7 +220102,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2023,
+      "community": 2025,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransactionitem_ts",
       "label": "posTransactionItem.ts",
@@ -219991,7 +220111,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2024,
+      "community": 2026,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransactionserviceline_test_ts",
       "label": "posTransactionServiceLine.test.ts",
@@ -220000,7 +220120,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2025,
+      "community": 2027,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransactionserviceline_ts",
       "label": "posTransactionServiceLine.ts",
@@ -220009,7 +220129,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2026,
+      "community": 2028,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_remoteassist_index_ts",
       "label": "index.ts",
@@ -220018,30 +220138,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2027,
+      "community": 2029,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_remoteassist_remoteassistclient_ts",
       "label": "remoteAssistClient.ts",
       "norm_label": "remoteassistclient.ts",
       "source_file": "packages/athena-webapp/convex/schemas/remoteAssist/remoteAssistClient.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2028,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_remoteassist_remoteassistsession_ts",
-      "label": "remoteAssistSession.ts",
-      "norm_label": "remoteassistsession.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/remoteAssist/remoteAssistSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2029,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_reports_derived_ts",
-      "label": "derived.ts",
-      "norm_label": "derived.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/reports/derived.ts",
       "source_location": "L1"
     },
     {
@@ -220164,6 +220266,24 @@
     {
       "community": 2030,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_remoteassist_remoteassistsession_ts",
+      "label": "remoteAssistSession.ts",
+      "norm_label": "remoteassistsession.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/remoteAssist/remoteAssistSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2031,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_reports_derived_ts",
+      "label": "derived.ts",
+      "norm_label": "derived.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/reports/derived.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2032,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_reports_facts_ts",
       "label": "facts.ts",
       "norm_label": "facts.ts",
@@ -220171,7 +220291,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2031,
+      "community": 2033,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_reports_index_ts",
       "label": "index.ts",
@@ -220180,7 +220300,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2032,
+      "community": 2034,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_reports_verificationruns_ts",
       "label": "verificationRuns.ts",
@@ -220189,7 +220309,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2033,
+      "community": 2035,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_index_ts",
       "label": "index.ts",
@@ -220198,7 +220318,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2034,
+      "community": 2036,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_serviceappointment_ts",
       "label": "serviceAppointment.ts",
@@ -220207,7 +220327,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2035,
+      "community": 2037,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecase_ts",
       "label": "serviceCase.ts",
@@ -220216,7 +220336,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2036,
+      "community": 2038,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecaselineitem_ts",
       "label": "serviceCaseLineItem.ts",
@@ -220225,30 +220345,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2037,
+      "community": 2039,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_serviceops_servicecatalog_ts",
       "label": "serviceCatalog.ts",
       "norm_label": "servicecatalog.ts",
       "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceCatalog.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2038,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_serviceops_serviceinventoryusage_ts",
-      "label": "serviceInventoryUsage.ts",
-      "norm_label": "serviceinventoryusage.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceInventoryUsage.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2039,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_shareddemo_ts",
-      "label": "sharedDemo.ts",
-      "norm_label": "shareddemo.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/sharedDemo.ts",
       "source_location": "L1"
     },
     {
@@ -220371,6 +220473,24 @@
     {
       "community": 2040,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_serviceops_serviceinventoryusage_ts",
+      "label": "serviceInventoryUsage.ts",
+      "norm_label": "serviceinventoryusage.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/serviceOps/serviceInventoryUsage.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2041,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_shareddemo_ts",
+      "label": "sharedDemo.ts",
+      "norm_label": "shareddemo.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/sharedDemo.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2042,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_staffmessages_ts",
       "label": "staffMessages.ts",
       "norm_label": "staffmessages.ts",
@@ -220378,7 +220498,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2041,
+      "community": 2043,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_cyclecountdraft_ts",
       "label": "cycleCountDraft.ts",
@@ -220387,7 +220507,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2042,
+      "community": 2044,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_index_ts",
       "label": "index.ts",
@@ -220396,7 +220516,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2043,
+      "community": 2045,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorder_ts",
       "label": "purchaseOrder.ts",
@@ -220405,7 +220525,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2044,
+      "community": 2046,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_purchaseorderlineitem_ts",
       "label": "purchaseOrderLineItem.ts",
@@ -220414,7 +220534,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2045,
+      "community": 2047,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_receivingbatch_ts",
       "label": "receivingBatch.ts",
@@ -220423,7 +220543,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2046,
+      "community": 2048,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_stockadjustmentbatch_ts",
       "label": "stockAdjustmentBatch.ts",
@@ -220432,30 +220552,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2047,
+      "community": 2049,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_stockops_vendor_ts",
       "label": "vendor.ts",
       "norm_label": "vendor.ts",
       "source_file": "packages/athena-webapp/convex/schemas/stockOps/vendor.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2048,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_analytics_ts",
-      "label": "analytics.ts",
-      "norm_label": "analytics.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/analytics.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2049,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_bag_ts",
-      "label": "bag.ts",
-      "norm_label": "bag.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/bag.ts",
       "source_location": "L1"
     },
     {
@@ -220578,6 +220680,24 @@
     {
       "community": 2050,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_analytics_ts",
+      "label": "analytics.ts",
+      "norm_label": "analytics.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/analytics.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2051,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_bag_ts",
+      "label": "bag.ts",
+      "norm_label": "bag.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/bag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2052,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bagitem_ts",
       "label": "bagItem.ts",
       "norm_label": "bagitem.ts",
@@ -220585,7 +220705,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2051,
+      "community": 2053,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
       "label": "checkoutSession.ts",
@@ -220594,7 +220714,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2052,
+      "community": 2054,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsessionitem_ts",
       "label": "checkoutSessionItem.ts",
@@ -220603,7 +220723,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2053,
+      "community": 2055,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
       "label": "guest.ts",
@@ -220612,7 +220732,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2054,
+      "community": 2056,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
       "label": "index.ts",
@@ -220621,7 +220741,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2055,
+      "community": 2057,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
       "label": "offer.ts",
@@ -220630,7 +220750,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2056,
+      "community": 2058,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -220639,30 +220759,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2057,
+      "community": 2059,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
       "norm_label": "onlineorderitem.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/onlineOrder/onlineOrderItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2058,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_review_ts",
-      "label": "review.ts",
-      "norm_label": "review.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/review.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2059,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_rewards_ts",
-      "label": "rewards.ts",
-      "norm_label": "rewards.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/rewards.ts",
       "source_location": "L1"
     },
     {
@@ -220785,6 +220887,24 @@
     {
       "community": 2060,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_review_ts",
+      "label": "review.ts",
+      "norm_label": "review.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/review.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2061,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_rewards_ts",
+      "label": "rewards.ts",
+      "norm_label": "rewards.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/rewards.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2062,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
       "label": "savedBag.ts",
       "norm_label": "savedbag.ts",
@@ -220792,7 +220912,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2061,
+      "community": 2063,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -220801,7 +220921,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2062,
+      "community": 2064,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontsession_ts",
       "label": "storeFrontSession.ts",
@@ -220810,7 +220930,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2063,
+      "community": 2065,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
       "label": "storeFrontUser.ts",
@@ -220819,7 +220939,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2064,
+      "community": 2066,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
       "label": "storeFrontVerificationCode.ts",
@@ -220828,7 +220948,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2065,
+      "community": 2067,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -220837,7 +220957,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2066,
+      "community": 2068,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_services_orderemailservice_test_ts",
       "label": "orderEmailService.test.ts",
@@ -220846,30 +220966,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2067,
+      "community": 2069,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_authboundary_test_ts",
       "label": "authBoundary.test.ts",
       "norm_label": "authboundary.test.ts",
       "source_file": "packages/athena-webapp/convex/sharedDemo/authBoundary.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2068,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_shareddemo_config_test_ts",
-      "label": "config.test.ts",
-      "norm_label": "config.test.ts",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/config.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2069,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_shareddemo_domainrestore_test_ts",
-      "label": "domainRestore.test.ts",
-      "norm_label": "domainrestore.test.ts",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.test.ts",
       "source_location": "L1"
     },
     {
@@ -220992,6 +221094,24 @@
     {
       "community": 2070,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_shareddemo_config_test_ts",
+      "label": "config.test.ts",
+      "norm_label": "config.test.ts",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/config.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2071,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_shareddemo_domainrestore_test_ts",
+      "label": "domainRestore.test.ts",
+      "norm_label": "domainrestore.test.ts",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2072,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_foundation_test_ts",
       "label": "foundation.test.ts",
       "norm_label": "foundation.test.ts",
@@ -220999,7 +221119,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2071,
+      "community": 2073,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_openingbaseline_test_ts",
       "label": "openingBaseline.test.ts",
@@ -221008,7 +221128,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2072,
+      "community": 2074,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_policy_test_ts",
       "label": "policy.test.ts",
@@ -221017,7 +221137,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2073,
+      "community": 2075,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_public_test_ts",
       "label": "public.test.ts",
@@ -221026,7 +221146,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2074,
+      "community": 2076,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_serviceeffectboundarycoverage_test_ts",
       "label": "serviceEffectBoundaryCoverage.test.ts",
@@ -221035,7 +221155,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2075,
+      "community": 2077,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bag_ts",
       "label": "bag.ts",
@@ -221044,7 +221164,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2076,
+      "community": 2078,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -221053,30 +221173,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2077,
+      "community": 2079,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customer_ts",
       "label": "customer.ts",
       "norm_label": "customer.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/customer.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2078,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_guest_ts",
-      "label": "guest.ts",
-      "norm_label": "guest.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/guest.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2079,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_offers_test_ts",
-      "label": "offers.test.ts",
-      "norm_label": "offers.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.test.ts",
       "source_location": "L1"
     },
     {
@@ -221190,6 +221292,24 @@
     {
       "community": 2080,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_guest_ts",
+      "label": "guest.ts",
+      "norm_label": "guest.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/guest.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2081,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_offers_test_ts",
+      "label": "offers.test.ts",
+      "norm_label": "offers.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2082,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
       "label": "onlineOrderUtilFns.ts",
       "norm_label": "onlineorderutilfns.ts",
@@ -221197,7 +221317,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2081,
+      "community": 2083,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_orderoperations_test_ts",
       "label": "orderOperations.test.ts",
@@ -221206,7 +221326,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2082,
+      "community": 2084,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_paystackactions_ts",
       "label": "paystackActions.ts",
@@ -221215,7 +221335,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2083,
+      "community": 2085,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -221224,7 +221344,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2084,
+      "community": 2086,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -221233,7 +221353,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2085,
+      "community": 2087,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_userstoreactivity_test_ts",
       "label": "userStoreActivity.test.ts",
@@ -221242,7 +221362,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2086,
+      "community": 2088,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_users_ts",
       "label": "users.ts",
@@ -221251,30 +221371,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2087,
+      "community": 2089,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storetime_storetimeauthority_test_ts",
       "label": "storeTimeAuthority.test.ts",
       "norm_label": "storetimeauthority.test.ts",
       "source_file": "packages/athena-webapp/convex/storeTime/storeTimeAuthority.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2088,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_types_payment_ts",
-      "label": "payment.ts",
-      "norm_label": "payment.ts",
-      "source_file": "packages/athena-webapp/convex/types/payment.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2089,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_utils_test_ts",
-      "label": "utils.test.ts",
-      "norm_label": "utils.test.ts",
-      "source_file": "packages/athena-webapp/convex/utils.test.ts",
       "source_location": "L1"
     },
     {
@@ -221388,6 +221490,24 @@
     {
       "community": 2090,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_types_payment_ts",
+      "label": "payment.ts",
+      "norm_label": "payment.ts",
+      "source_file": "packages/athena-webapp/convex/types/payment.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2091,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_utils_test_ts",
+      "label": "utils.test.ts",
+      "norm_label": "utils.test.ts",
+      "source_file": "packages/athena-webapp/convex/utils.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2092,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_test_ts",
       "label": "posSession.test.ts",
       "norm_label": "possession.test.ts",
@@ -221395,7 +221515,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2091,
+      "community": 2093,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_purchaseorder_test_ts",
       "label": "purchaseOrder.test.ts",
@@ -221404,7 +221524,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2092,
+      "community": 2094,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_registersession_test_ts",
       "label": "registerSession.test.ts",
@@ -221413,7 +221533,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2093,
+      "community": 2095,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_servicecase_test_ts",
       "label": "serviceCase.test.ts",
@@ -221422,7 +221542,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2094,
+      "community": 2096,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_presentation_test_ts",
       "label": "presentation.test.ts",
@@ -221431,7 +221551,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2095,
+      "community": 2097,
       "file_type": "code",
       "id": "packages_athena_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -221440,7 +221560,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2096,
+      "community": 2098,
       "file_type": "code",
       "id": "packages_athena_webapp_index_ts",
       "label": "index.ts",
@@ -221449,30 +221569,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2097,
+      "community": 2099,
       "file_type": "code",
       "id": "packages_athena_webapp_playwright_config_ts",
       "label": "playwright.config.ts",
       "norm_label": "playwright.config.ts",
       "source_file": "packages/athena-webapp/playwright.config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2098,
-      "file_type": "code",
-      "id": "packages_athena_webapp_playwright_prod_config_ts",
-      "label": "playwright.prod.config.ts",
-      "norm_label": "playwright.prod.config.ts",
-      "source_file": "packages/athena-webapp/playwright.prod.config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2099,
-      "file_type": "code",
-      "id": "packages_athena_webapp_postcss_config_js",
-      "label": "postcss.config.js",
-      "norm_label": "postcss.config.js",
-      "source_file": "packages/athena-webapp/postcss.config.js",
       "source_location": "L1"
     },
     {
@@ -221955,6 +222057,24 @@
     {
       "community": 2100,
       "file_type": "code",
+      "id": "packages_athena_webapp_playwright_prod_config_ts",
+      "label": "playwright.prod.config.ts",
+      "norm_label": "playwright.prod.config.ts",
+      "source_file": "packages/athena-webapp/playwright.prod.config.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2101,
+      "file_type": "code",
+      "id": "packages_athena_webapp_postcss_config_js",
+      "label": "postcss.config.js",
+      "norm_label": "postcss.config.js",
+      "source_file": "packages/athena-webapp/postcss.config.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 2102,
+      "file_type": "code",
       "id": "packages_athena_webapp_shared_approvalpolicy_ts",
       "label": "approvalPolicy.ts",
       "norm_label": "approvalpolicy.ts",
@@ -221962,7 +222082,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2101,
+      "community": 2103,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_auth_ts",
       "label": "auth.ts",
@@ -221971,7 +222091,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2102,
+      "community": 2104,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_commandresult_test_ts",
       "label": "commandResult.test.ts",
@@ -221980,7 +222100,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2103,
+      "community": 2105,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_currencyformatter_test_ts",
       "label": "currencyFormatter.test.ts",
@@ -221989,7 +222109,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2104,
+      "community": 2106,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_homepageranking_test_ts",
       "label": "homepageRanking.test.ts",
@@ -221998,7 +222118,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2105,
+      "community": 2107,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_intelligence_contextbundletypes_ts",
       "label": "contextBundleTypes.ts",
@@ -222007,7 +222127,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2106,
+      "community": 2108,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_intelligence_contexteventtypes_ts",
       "label": "contextEventTypes.ts",
@@ -222016,30 +222136,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2107,
+      "community": 2109,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_intelligence_contexttracking_test_ts",
       "label": "contextTracking.test.ts",
       "norm_label": "contexttracking.test.ts",
       "source_file": "packages/athena-webapp/shared/intelligence/contextTracking.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2108,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_intelligence_contexttypes_ts",
-      "label": "contextTypes.ts",
-      "norm_label": "contexttypes.ts",
-      "source_file": "packages/athena-webapp/shared/intelligence/contextTypes.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2109,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_intelligence_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/shared/intelligence/index.ts",
       "source_location": "L1"
     },
     {
@@ -222153,6 +222255,24 @@
     {
       "community": 2110,
       "file_type": "code",
+      "id": "packages_athena_webapp_shared_intelligence_contexttypes_ts",
+      "label": "contextTypes.ts",
+      "norm_label": "contexttypes.ts",
+      "source_file": "packages/athena-webapp/shared/intelligence/contextTypes.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2111,
+      "file_type": "code",
+      "id": "packages_athena_webapp_shared_intelligence_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/shared/intelligence/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2112,
+      "file_type": "code",
       "id": "packages_athena_webapp_shared_intelligence_providertypes_ts",
       "label": "providerTypes.ts",
       "norm_label": "providertypes.ts",
@@ -222160,7 +222280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2111,
+      "community": 2113,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_inventoryimportreviewpayload_test_ts",
       "label": "inventoryImportReviewPayload.test.ts",
@@ -222169,7 +222289,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2112,
+      "community": 2114,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_inventoryimportsource_test_ts",
       "label": "inventoryImportSource.test.ts",
@@ -222178,7 +222298,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2113,
+      "community": 2115,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_pos_terminalruntimematerial_test_ts",
       "label": "terminalRuntimeMaterial.test.ts",
@@ -222187,7 +222307,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2114,
+      "community": 2116,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_posregistersessionactivitycontract_test_ts",
       "label": "posRegisterSessionActivityContract.test.ts",
@@ -222196,7 +222316,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2115,
+      "community": 2117,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_productdisplayname_test_ts",
       "label": "productDisplayName.test.ts",
@@ -222205,7 +222325,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2116,
+      "community": 2118,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_registersessionlifecyclepolicy_test_ts",
       "label": "registerSessionLifecyclePolicy.test.ts",
@@ -222214,30 +222334,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2117,
+      "community": 2119,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_registersessionstatus_test_ts",
       "label": "registerSessionStatus.test.ts",
       "norm_label": "registersessionstatus.test.ts",
       "source_file": "packages/athena-webapp/shared/registerSessionStatus.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2118,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_shareddemoregistererror_test_ts",
-      "label": "sharedDemoRegisterError.test.ts",
-      "norm_label": "shareddemoregistererror.test.ts",
-      "source_file": "packages/athena-webapp/shared/sharedDemoRegisterError.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2119,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_staffdisplayname_test_ts",
-      "label": "staffDisplayName.test.ts",
-      "norm_label": "staffdisplayname.test.ts",
-      "source_file": "packages/athena-webapp/shared/staffDisplayName.test.ts",
       "source_location": "L1"
     },
     {
@@ -222351,6 +222453,24 @@
     {
       "community": 2120,
       "file_type": "code",
+      "id": "packages_athena_webapp_shared_shareddemoregistererror_test_ts",
+      "label": "sharedDemoRegisterError.test.ts",
+      "norm_label": "shareddemoregistererror.test.ts",
+      "source_file": "packages/athena-webapp/shared/sharedDemoRegisterError.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2121,
+      "file_type": "code",
+      "id": "packages_athena_webapp_shared_staffdisplayname_test_ts",
+      "label": "staffDisplayName.test.ts",
+      "norm_label": "staffdisplayname.test.ts",
+      "source_file": "packages/athena-webapp/shared/staffDisplayName.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2122,
+      "file_type": "code",
       "id": "packages_athena_webapp_shared_storefrontvisibility_test_ts",
       "label": "storefrontVisibility.test.ts",
       "norm_label": "storefrontvisibility.test.ts",
@@ -222358,7 +222478,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2121,
+      "community": 2123,
       "file_type": "code",
       "id": "packages_athena_webapp_src_approuter_ts",
       "label": "appRouter.ts",
@@ -222367,7 +222487,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2122,
+      "community": 2124,
       "file_type": "code",
       "id": "packages_athena_webapp_src_auth_convexauthurl_test_ts",
       "label": "convexAuthUrl.test.ts",
@@ -222376,7 +222496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2123,
+      "community": 2125,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_genericcombobox_tsx",
       "label": "GenericComboBox.tsx",
@@ -222385,7 +222505,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2124,
+      "community": 2126,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_navbar_test_tsx",
       "label": "Navbar.test.tsx",
@@ -222394,7 +222514,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2125,
+      "community": 2127,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_navbar_tsx",
       "label": "Navbar.tsx",
@@ -222403,7 +222523,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2126,
+      "community": 2128,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationview_test_tsx",
       "label": "OrganizationView.test.tsx",
@@ -222412,30 +222532,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2127,
+      "community": 2129,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_protectedroute_test_tsx",
       "label": "ProtectedRoute.test.tsx",
       "norm_label": "protectedroute.test.tsx",
       "source_file": "packages/athena-webapp/src/components/ProtectedRoute.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2128,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_storeaccordion_tsx",
-      "label": "StoreAccordion.tsx",
-      "norm_label": "storeaccordion.tsx",
-      "source_file": "packages/athena-webapp/src/components/StoreAccordion.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2129,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_storeview_test_tsx",
-      "label": "StoreView.test.tsx",
-      "norm_label": "storeview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/StoreView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -222549,6 +222651,24 @@
     {
       "community": 2130,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_storeaccordion_tsx",
+      "label": "StoreAccordion.tsx",
+      "norm_label": "storeaccordion.tsx",
+      "source_file": "packages/athena-webapp/src/components/StoreAccordion.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2131,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_storeview_test_tsx",
+      "label": "StoreView.test.tsx",
+      "norm_label": "storeview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/StoreView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2132,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesaccordion_tsx",
       "label": "StoresAccordion.tsx",
       "norm_label": "storesaccordion.tsx",
@@ -222556,7 +222676,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2131,
+      "community": 2133,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_themetoggle_tsx",
       "label": "ThemeToggle.tsx",
@@ -222565,7 +222685,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2132,
+      "community": 2134,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_view_test_tsx",
       "label": "View.test.tsx",
@@ -222574,7 +222694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2133,
+      "community": 2135,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributestable_test_ts",
       "label": "AttributesTable.test.ts",
@@ -222583,7 +222703,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2134,
+      "community": 2136,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_defaultattributestogglegroup_tsx",
       "label": "DefaultAttributesToggleGroup.tsx",
@@ -222592,7 +222712,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2135,
+      "community": 2137,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -222601,7 +222721,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2136,
+      "community": 2138,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributesview_tsx",
       "label": "ProductAttributesView.tsx",
@@ -222610,30 +222730,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2137,
+      "community": 2139,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productcategorization_test_ts",
       "label": "ProductCategorization.test.ts",
       "norm_label": "productcategorization.test.ts",
       "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2138,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productstock_test_ts",
-      "label": "ProductStock.test.ts",
-      "norm_label": "productstock.test.ts",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2139,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productview_test_tsx",
-      "label": "ProductView.test.tsx",
-      "norm_label": "productview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -222747,6 +222849,24 @@
     {
       "community": 2140,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_productstock_test_ts",
+      "label": "ProductStock.test.ts",
+      "norm_label": "productstock.test.ts",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2141,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_productview_test_tsx",
+      "label": "ProductView.test.tsx",
+      "norm_label": "productview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2142,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesview_test_tsx",
       "label": "CopyImagesView.test.tsx",
       "norm_label": "copyimagesview.test.tsx",
@@ -222754,7 +222874,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2141,
+      "community": 2143,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
       "label": "constants.ts",
@@ -222763,7 +222883,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2142,
+      "community": 2144,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -222772,7 +222892,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2143,
+      "community": 2145,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -222781,7 +222901,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2144,
+      "community": 2146,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -222790,7 +222910,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2145,
+      "community": 2147,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_types_ts",
       "label": "types.ts",
@@ -222799,7 +222919,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2146,
+      "community": 2148,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsview_test_tsx",
       "label": "AnalyticsView.test.tsx",
@@ -222808,30 +222928,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2147,
+      "community": 2149,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_conversionfunnelchart_tsx",
       "label": "ConversionFunnelChart.tsx",
       "norm_label": "conversionfunnelchart.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/ConversionFunnelChart.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2148,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_revenuechart_tsx",
-      "label": "RevenueChart.tsx",
-      "norm_label": "revenuechart.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/RevenueChart.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2149,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
-      "label": "analytics-columns.tsx",
-      "norm_label": "analytics-columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/analytics-columns.tsx",
       "source_location": "L1"
     },
     {
@@ -222945,6 +223047,24 @@
     {
       "community": 2150,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_revenuechart_tsx",
+      "label": "RevenueChart.tsx",
+      "norm_label": "revenuechart.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/RevenueChart.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2151,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
+      "label": "analytics-columns.tsx",
+      "norm_label": "analytics-columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/analytics-columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2152,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -222952,7 +223072,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2151,
+      "community": 2153,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -222961,7 +223081,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2152,
+      "community": 2154,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -222970,7 +223090,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2153,
+      "community": 2155,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -222979,7 +223099,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2154,
+      "community": 2156,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -222988,7 +223108,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2155,
+      "community": 2157,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -222997,7 +223117,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2156,
+      "community": 2158,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -223006,30 +223126,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2157,
+      "community": 2159,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2158,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2159,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/columns.tsx",
       "source_location": "L1"
     },
     {
@@ -223143,6 +223245,24 @@
     {
       "community": 2160,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2161,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2162,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -223150,7 +223270,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2161,
+      "community": 2163,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -223159,7 +223279,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2162,
+      "community": 2164,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_chart_tsx",
       "label": "chart.tsx",
@@ -223168,7 +223288,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2163,
+      "community": 2165,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -223177,7 +223297,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2164,
+      "community": 2166,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -223186,7 +223306,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2165,
+      "community": 2167,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -223195,7 +223315,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2166,
+      "community": 2168,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_columns_tsx",
       "label": "columns.tsx",
@@ -223204,30 +223324,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2167,
+      "community": 2169,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
       "source_file": "packages/athena-webapp/src/components/analytics/table/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2168,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2169,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -223341,6 +223443,24 @@
     {
       "community": 2170,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2171,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2172,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -223348,7 +223468,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2171,
+      "community": 2173,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_ts",
       "label": "data.ts",
@@ -223357,7 +223477,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2172,
+      "community": 2174,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -223366,7 +223486,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2173,
+      "community": 2175,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -223375,7 +223495,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2174,
+      "community": 2176,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -223384,7 +223504,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2175,
+      "community": 2177,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_columns_tsx",
       "label": "columns.tsx",
@@ -223393,7 +223513,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2176,
+      "community": 2178,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -223402,30 +223522,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2177,
+      "community": 2179,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2178,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2179,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -223539,6 +223641,24 @@
     {
       "community": 2180,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2181,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2182,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_settings_appsettingsview_test_tsx",
       "label": "AppSettingsView.test.tsx",
       "norm_label": "appsettingsview.test.tsx",
@@ -223546,7 +223666,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2181,
+      "community": 2183,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_sidebar_test_tsx",
       "label": "app-sidebar.test.tsx",
@@ -223555,7 +223675,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2182,
+      "community": 2184,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_assetscolumns_tsx",
       "label": "assetsColumns.tsx",
@@ -223564,7 +223684,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2183,
+      "community": 2185,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_constants_ts",
       "label": "constants.ts",
@@ -223573,7 +223693,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2184,
+      "community": 2186,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -223582,7 +223702,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2185,
+      "community": 2187,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -223591,7 +223711,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2186,
+      "community": 2188,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -223600,30 +223720,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2187,
+      "community": 2189,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_ts",
       "label": "data.ts",
       "norm_label": "data.ts",
       "source_file": "packages/athena-webapp/src/components/assets/assets-table/data.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2188,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_test_tsx",
-      "label": "DefaultCatchBoundary.test.tsx",
-      "norm_label": "defaultcatchboundary.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/DefaultCatchBoundary.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2189,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_tsx",
-      "label": "DefaultCatchBoundary.tsx",
-      "norm_label": "defaultcatchboundary.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/DefaultCatchBoundary.tsx",
       "source_location": "L1"
     },
     {
@@ -223737,6 +223839,24 @@
     {
       "community": 2190,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_test_tsx",
+      "label": "DefaultCatchBoundary.test.tsx",
+      "norm_label": "defaultcatchboundary.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/DefaultCatchBoundary.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2191,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_tsx",
+      "label": "DefaultCatchBoundary.tsx",
+      "norm_label": "defaultcatchboundary.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/DefaultCatchBoundary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2192,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_test_tsx",
       "label": "LoginForm.test.tsx",
       "norm_label": "loginform.test.tsx",
@@ -223744,7 +223864,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2191,
+      "community": 2193,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_posrecoverycodeform_test_tsx",
       "label": "PosRecoveryCodeForm.test.tsx",
@@ -223753,7 +223873,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2192,
+      "community": 2194,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -223762,7 +223882,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2193,
+      "community": 2195,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -223771,7 +223891,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2194,
+      "community": 2196,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -223780,7 +223900,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2195,
+      "community": 2197,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -223789,7 +223909,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2196,
+      "community": 2198,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -223798,30 +223918,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2197,
+      "community": 2199,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
       "source_file": "packages/athena-webapp/src/components/base/table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2198,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/base/table/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
@@ -224295,6 +224397,24 @@
     {
       "community": 2200,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_table_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/base/table/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2201,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2202,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -224302,7 +224422,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2201,
+      "community": 2203,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_test_tsx",
       "label": "data-table.test.tsx",
@@ -224311,7 +224431,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2202,
+      "community": 2204,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -224320,7 +224440,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2203,
+      "community": 2205,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
       "label": "BulkOperationsPage.tsx",
@@ -224329,7 +224449,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2204,
+      "community": 2206,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_auth_test_tsx",
       "label": "CashControlsDashboard.auth.test.tsx",
@@ -224338,7 +224458,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2205,
+      "community": 2207,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsdashboard_test_tsx",
       "label": "CashControlsDashboard.test.tsx",
@@ -224347,7 +224467,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2206,
+      "community": 2208,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_cashcontrolsworkspaceheader_tsx",
       "label": "CashControlsWorkspaceHeader.tsx",
@@ -224356,30 +224476,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2207,
+      "community": 2209,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_auth_test_tsx",
       "label": "RegisterSessionView.auth.test.tsx",
       "norm_label": "registersessionview.auth.test.tsx",
       "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.auth.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2208,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_test_tsx",
-      "label": "RegisterSessionView.test.tsx",
-      "norm_label": "registersessionview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2209,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_registersessionsview_test_tsx",
-      "label": "RegisterSessionsView.test.tsx",
-      "norm_label": "registersessionsview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -224493,6 +224595,24 @@
     {
       "community": 2210,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cash_controls_registersessionview_test_tsx",
+      "label": "RegisterSessionView.test.tsx",
+      "norm_label": "registersessionview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2211,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cash_controls_registersessionsview_test_tsx",
+      "label": "RegisterSessionsView.test.tsx",
+      "norm_label": "registersessionsview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2212,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_formatreviewreason_test_ts",
       "label": "formatReviewReason.test.ts",
       "norm_label": "formatreviewreason.test.ts",
@@ -224500,7 +224620,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2211,
+      "community": 2213,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessiontimestamps_test_ts",
       "label": "registerSessionTimestamps.test.ts",
@@ -224509,7 +224629,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2212,
+      "community": 2214,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_columns_tsx",
       "label": "columns.tsx",
@@ -224518,7 +224638,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2213,
+      "community": 2215,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -224527,7 +224647,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2214,
+      "community": 2216,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -224536,7 +224656,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2215,
+      "community": 2217,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_animateddatastate_test_tsx",
       "label": "AnimatedDataState.test.tsx",
@@ -224545,7 +224665,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2216,
+      "community": 2218,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_listpagination_test_tsx",
       "label": "ListPagination.test.tsx",
@@ -224554,30 +224674,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2217,
+      "community": 2219,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_listpagination_tsx",
       "label": "ListPagination.tsx",
       "norm_label": "listpagination.tsx",
       "source_file": "packages/athena-webapp/src/components/common/ListPagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2218,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_common_pageheader_test_tsx",
-      "label": "PageHeader.test.tsx",
-      "norm_label": "pageheader.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/common/PageHeader.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2219,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_common_pagelevelheader_test_tsx",
-      "label": "PageLevelHeader.test.tsx",
-      "norm_label": "pagelevelheader.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/common/PageLevelHeader.test.tsx",
       "source_location": "L1"
     },
     {
@@ -224691,6 +224793,24 @@
     {
       "community": 2220,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_common_pageheader_test_tsx",
+      "label": "PageHeader.test.tsx",
+      "norm_label": "pageheader.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/common/PageHeader.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2221,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_common_pagelevelheader_test_tsx",
+      "label": "PageLevelHeader.test.tsx",
+      "norm_label": "pagelevelheader.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/common/PageLevelHeader.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2222,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_pagelevelheader_tsx",
       "label": "PageLevelHeader.tsx",
       "norm_label": "pagelevelheader.tsx",
@@ -224698,7 +224818,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2221,
+      "community": 2223,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
       "label": "MetricCard.tsx",
@@ -224707,7 +224827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2222,
+      "community": 2224,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_docs_docsreportview_tsx",
       "label": "DocsReportView.tsx",
@@ -224716,7 +224836,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2223,
+      "community": 2225,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
       "label": "ExpenseCompletion.tsx",
@@ -224725,7 +224845,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2224,
+      "community": 2226,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_home_test_tsx",
       "label": "Home.test.tsx",
@@ -224734,7 +224854,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2225,
+      "community": 2227,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_homepageplacementproductimage_test_ts",
       "label": "HomepagePlacementProductImage.test.ts",
@@ -224743,7 +224863,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2226,
+      "community": 2228,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookimageuploader_test_tsx",
       "label": "ShopLookImageUploader.test.tsx",
@@ -224752,30 +224872,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2227,
+      "community": 2229,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_test_tsx",
       "label": "index.test.tsx",
       "norm_label": "index.test.tsx",
       "source_file": "packages/athena-webapp/src/components/join-team/index.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2228,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_landing_story_demoday_test_ts",
-      "label": "demoDay.test.ts",
-      "norm_label": "demoday.test.ts",
-      "source_file": "packages/athena-webapp/src/components/landing/story/demoDay.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2229,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_commandapprovaldialog_test_tsx",
-      "label": "CommandApprovalDialog.test.tsx",
-      "norm_label": "commandapprovaldialog.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/CommandApprovalDialog.test.tsx",
       "source_location": "L1"
     },
     {
@@ -224889,6 +224991,24 @@
     {
       "community": 2230,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_landing_story_demoday_test_ts",
+      "label": "demoDay.test.ts",
+      "norm_label": "demoday.test.ts",
+      "source_file": "packages/athena-webapp/src/components/landing/story/demoDay.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2231,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_operations_commandapprovaldialog_test_tsx",
+      "label": "CommandApprovalDialog.test.tsx",
+      "norm_label": "commandapprovaldialog.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/CommandApprovalDialog.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2232,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_auth_test_tsx",
       "label": "OperationsQueueView.auth.test.tsx",
       "norm_label": "operationsqueueview.auth.test.tsx",
@@ -224896,7 +225016,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2231,
+      "community": 2233,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationssummarymetric_test_tsx",
       "label": "OperationsSummaryMetric.test.tsx",
@@ -224905,7 +225025,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2232,
+      "community": 2234,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_skuactivitytimeline_test_tsx",
       "label": "SkuActivityTimeline.test.tsx",
@@ -224914,7 +225034,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2233,
+      "community": 2235,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_openworkinventoryreport_test_ts",
       "label": "openWorkInventoryReport.test.ts",
@@ -224923,7 +225043,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2234,
+      "community": 2236,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_skuactivitytimelineadapter_test_ts",
       "label": "skuActivityTimelineAdapter.test.ts",
@@ -224932,7 +225052,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2235,
+      "community": 2237,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_skuactivityuntrustedsalesadapter_test_ts",
       "label": "skuActivityUntrustedSalesAdapter.test.ts",
@@ -224941,7 +225061,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2236,
+      "community": 2238,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_useapprovedcommand_test_tsx",
       "label": "useApprovedCommand.test.tsx",
@@ -224950,30 +225070,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2237,
+      "community": 2239,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_customerdetailsview_test_tsx",
       "label": "CustomerDetailsView.test.tsx",
       "norm_label": "customerdetailsview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2238,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
-      "label": "CustomerDetailsView.tsx",
-      "norm_label": "customerdetailsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2239,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orderdetailsview_test_tsx",
-      "label": "OrderDetailsView.test.tsx",
-      "norm_label": "orderdetailsview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -225078,6 +225180,24 @@
     {
       "community": 2240,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
+      "label": "CustomerDetailsView.tsx",
+      "norm_label": "customerdetailsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2241,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orderdetailsview_test_tsx",
+      "label": "OrderDetailsView.test.tsx",
+      "norm_label": "orderdetailsview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2242,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_test_tsx",
       "label": "OrderStatus.test.tsx",
       "norm_label": "orderstatus.test.tsx",
@@ -225085,7 +225205,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2241,
+      "community": 2243,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_tsx",
       "label": "OrderStatus.tsx",
@@ -225094,7 +225214,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2242,
+      "community": 2244,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -225103,7 +225223,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2243,
+      "community": 2245,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderview_test_tsx",
       "label": "OrderView.test.tsx",
@@ -225112,7 +225232,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2244,
+      "community": 2246,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersview_test_tsx",
       "label": "OrdersView.test.tsx",
@@ -225121,7 +225241,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2245,
+      "community": 2247,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_refundsview_test_tsx",
       "label": "RefundsView.test.tsx",
@@ -225130,7 +225250,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2246,
+      "community": 2248,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_returnexchangeview_test_tsx",
       "label": "ReturnExchangeView.test.tsx",
@@ -225139,30 +225259,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2247,
+      "community": 2249,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2248,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -225267,6 +225369,24 @@
     {
       "community": 2250,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2251,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2252,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -225274,7 +225394,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2251,
+      "community": 2253,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_ts",
       "label": "data.ts",
@@ -225283,7 +225403,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2252,
+      "community": 2254,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_test_tsx",
       "label": "orderColumns.test.tsx",
@@ -225292,7 +225412,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2253,
+      "community": 2255,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_refundutils_test_ts",
       "label": "refundUtils.test.ts",
@@ -225301,7 +225421,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2254,
+      "community": 2256,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_utils_test_ts",
       "label": "utils.test.ts",
@@ -225310,7 +225430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2255,
+      "community": 2257,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_constants_ts",
       "label": "constants.ts",
@@ -225319,7 +225439,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2256,
+      "community": 2258,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -225328,30 +225448,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2257,
+      "community": 2259,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2258,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2259,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -225456,6 +225558,24 @@
     {
       "community": 2260,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2261,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2262,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_ts",
       "label": "data.ts",
       "norm_label": "data.ts",
@@ -225463,7 +225583,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2261,
+      "community": 2263,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_invitecolumns_tsx",
       "label": "inviteColumns.tsx",
@@ -225472,7 +225592,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2262,
+      "community": 2264,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_constants_ts",
       "label": "constants.ts",
@@ -225481,7 +225601,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2263,
+      "community": 2265,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -225490,7 +225610,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2264,
+      "community": 2266,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -225499,7 +225619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2265,
+      "community": 2267,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -225508,7 +225628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2266,
+      "community": 2268,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -225517,30 +225637,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2267,
+      "community": 2269,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
       "label": "data.ts",
       "norm_label": "data.ts",
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2268,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_memberscolumns_tsx",
-      "label": "membersColumns.tsx",
-      "norm_label": "memberscolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/membersColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2269,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_switcher_test_tsx",
-      "label": "organization-switcher.test.tsx",
-      "norm_label": "organization-switcher.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-switcher.test.tsx",
       "source_location": "L1"
     },
     {
@@ -225645,6 +225747,24 @@
     {
       "community": 2270,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_memberscolumns_tsx",
+      "label": "membersColumns.tsx",
+      "norm_label": "memberscolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/membersColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2271,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_switcher_test_tsx",
+      "label": "organization-switcher.test.tsx",
+      "norm_label": "organization-switcher.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-switcher.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2272,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
       "label": "CashierView.tsx",
       "norm_label": "cashierview.tsx",
@@ -225652,7 +225772,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2271,
+      "community": 2273,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_posregisterview_tsx",
       "label": "POSRegisterView.tsx",
@@ -225661,7 +225781,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2272,
+      "community": 2274,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_paymentview_test_tsx",
       "label": "PaymentView.test.tsx",
@@ -225670,7 +225790,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2273,
+      "community": 2275,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pointofsaleview_test_tsx",
       "label": "PointOfSaleView.test.tsx",
@@ -225679,7 +225799,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2274,
+      "community": 2276,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productlookup_tsx",
       "label": "ProductLookup.tsx",
@@ -225688,7 +225808,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2275,
+      "community": 2277,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_registeractions_tsx",
       "label": "RegisterActions.tsx",
@@ -225697,7 +225817,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2276,
+      "community": 2278,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_test_tsx",
       "label": "SessionManager.test.tsx",
@@ -225706,30 +225826,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2277,
+      "community": 2279,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_tsx",
       "label": "SessionManager.tsx",
       "norm_label": "sessionmanager.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2278,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_totalsdisplay_test_tsx",
-      "label": "TotalsDisplay.test.tsx",
-      "norm_label": "totalsdisplay.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2279,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
-      "label": "TotalsDisplay.tsx",
-      "norm_label": "totalsdisplay.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.tsx",
       "source_location": "L1"
     },
     {
@@ -225834,6 +225936,24 @@
     {
       "community": 2280,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_totalsdisplay_test_tsx",
+      "label": "TotalsDisplay.test.tsx",
+      "norm_label": "totalsdisplay.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2281,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
+      "label": "TotalsDisplay.tsx",
+      "norm_label": "totalsdisplay.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2282,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_test_tsx",
       "label": "ExpenseReportView.test.tsx",
       "norm_label": "expensereportview.test.tsx",
@@ -225841,7 +225961,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2281,
+      "community": 2283,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_test_ts",
       "label": "ExpenseReportsView.test.ts",
@@ -225850,7 +225970,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2282,
+      "community": 2284,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_test_tsx",
       "label": "ExpenseReportsView.test.tsx",
@@ -225859,7 +225979,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2283,
+      "community": 2285,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportcolumns_tsx",
       "label": "expenseReportColumns.tsx",
@@ -225868,7 +225988,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2284,
+      "community": 2286,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_receipt_posreceiptsharecontrol_test_tsx",
       "label": "PosReceiptShareControl.test.tsx",
@@ -225877,7 +225997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2285,
+      "community": 2287,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_posregisteropeningguard_test_tsx",
       "label": "POSRegisterOpeningGuard.test.tsx",
@@ -225886,7 +226006,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2286,
+      "community": 2288,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registeractionbar_test_tsx",
       "label": "RegisterActionBar.test.tsx",
@@ -225895,30 +226015,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2287,
+      "community": 2289,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registeractionbar_tsx",
       "label": "RegisterActionBar.tsx",
       "norm_label": "registeractionbar.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/register/RegisterActionBar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2288,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_registercheckoutpanel_test_tsx",
-      "label": "RegisterCheckoutPanel.test.tsx",
-      "norm_label": "registercheckoutpanel.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCheckoutPanel.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2289,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_test_tsx",
-      "label": "HeldSessionsList.test.tsx",
-      "norm_label": "heldsessionslist.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.test.tsx",
       "source_location": "L1"
     },
     {
@@ -226023,6 +226125,24 @@
     {
       "community": 2290,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_register_registercheckoutpanel_test_tsx",
+      "label": "RegisterCheckoutPanel.test.tsx",
+      "norm_label": "registercheckoutpanel.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCheckoutPanel.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2291,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_test_tsx",
+      "label": "HeldSessionsList.test.tsx",
+      "norm_label": "heldsessionslist.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2292,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessions_possessionsview_test_tsx",
       "label": "POSSessionsView.test.tsx",
       "norm_label": "possessionsview.test.tsx",
@@ -226030,7 +226150,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2291,
+      "community": 2293,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessions_possessioncolumns_tsx",
       "label": "posSessionColumns.tsx",
@@ -226039,7 +226159,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2292,
+      "community": 2294,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_terminals_posterminaldetailview_test_tsx",
       "label": "POSTerminalDetailView.test.tsx",
@@ -226048,7 +226168,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2293,
+      "community": 2295,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_terminals_terminalhealthpresentation_test_ts",
       "label": "terminalHealthPresentation.test.ts",
@@ -226057,7 +226177,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2294,
+      "community": 2296,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_terminals_terminalhealthtypes_ts",
       "label": "terminalHealthTypes.ts",
@@ -226066,7 +226186,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2295,
+      "community": 2297,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_test_tsx",
       "label": "TransactionsView.test.tsx",
@@ -226075,7 +226195,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2296,
+      "community": 2298,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_types_ts",
       "label": "types.ts",
@@ -226084,30 +226204,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2297,
+      "community": 2299,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_receivingview_test_tsx",
       "label": "ReceivingView.test.tsx",
       "norm_label": "receivingview.test.tsx",
       "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2298,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
-      "label": "AnalyticsInsights.tsx",
-      "norm_label": "analyticsinsights.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/AnalyticsInsights.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2299,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_attributesview_tsx",
-      "label": "AttributesView.tsx",
-      "norm_label": "attributesview.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/AttributesView.tsx",
       "source_location": "L1"
     },
     {
@@ -226563,6 +226665,24 @@
     {
       "community": 2300,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
+      "label": "AnalyticsInsights.tsx",
+      "norm_label": "analyticsinsights.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/AnalyticsInsights.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2301,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_attributesview_tsx",
+      "label": "AttributesView.tsx",
+      "norm_label": "attributesview.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/AttributesView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2302,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_detailsview_tsx",
       "label": "DetailsView.tsx",
       "norm_label": "detailsview.tsx",
@@ -226570,7 +226690,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2301,
+      "community": 2303,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_imagesview_test_tsx",
       "label": "ImagesView.test.tsx",
@@ -226579,7 +226699,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2302,
+      "community": 2304,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productdetailview_test_tsx",
       "label": "ProductDetailView.test.tsx",
@@ -226588,7 +226708,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2303,
+      "community": 2305,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productoperationaltimeline_test_tsx",
       "label": "ProductOperationalTimeline.test.tsx",
@@ -226597,7 +226717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2304,
+      "community": 2306,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstockpresentation_test_ts",
       "label": "productStockPresentation.test.ts",
@@ -226606,7 +226726,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2305,
+      "community": 2307,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_archivedproducts_test_tsx",
       "label": "ArchivedProducts.test.tsx",
@@ -226615,7 +226735,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2306,
+      "community": 2308,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsubcategorytogglegroup_tsx",
       "label": "ProductSubcategoryToggleGroup.tsx",
@@ -226624,30 +226744,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2307,
+      "community": 2309,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productslistview_test_ts",
       "label": "ProductsListView.test.ts",
       "norm_label": "productslistview.test.ts",
       "source_file": "packages/athena-webapp/src/components/products/ProductsListView.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2308,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_productslistview_test_tsx",
-      "label": "ProductsListView.test.tsx",
-      "norm_label": "productslistview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/ProductsListView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_storeproducts_tsx",
-      "label": "StoreProducts.tsx",
-      "norm_label": "storeproducts.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/StoreProducts.tsx",
       "source_location": "L1"
     },
     {
@@ -226752,6 +226854,24 @@
     {
       "community": 2310,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_productslistview_test_tsx",
+      "label": "ProductsListView.test.tsx",
+      "norm_label": "productslistview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/ProductsListView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2311,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_storeproducts_tsx",
+      "label": "StoreProducts.tsx",
+      "norm_label": "storeproducts.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/StoreProducts.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2312,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_unresolvedproducts_test_tsx",
       "label": "UnresolvedProducts.test.tsx",
       "norm_label": "unresolvedproducts.test.tsx",
@@ -226759,7 +226879,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2311,
+      "community": 2313,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_unresolvedproducts_tsx",
       "label": "UnresolvedProducts.tsx",
@@ -226768,7 +226888,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2312,
+      "community": 2314,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproducts_tsx",
       "label": "ComplimentaryProducts.tsx",
@@ -226777,7 +226897,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2313,
+      "community": 2315,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductscolumn_tsx",
       "label": "complimentaryProductsColumn.tsx",
@@ -226786,7 +226906,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2314,
+      "community": 2316,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -226795,7 +226915,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2315,
+      "community": 2317,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -226804,7 +226924,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2316,
+      "community": 2318,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_test_tsx",
       "label": "data-table-toolbar.test.tsx",
@@ -226813,30 +226933,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2317,
+      "community": 2319,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2318,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_test_tsx",
-      "label": "data-table.test.tsx",
-      "norm_label": "data-table.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2319,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data.ts",
       "source_location": "L1"
     },
     {
@@ -226941,6 +227043,24 @@
     {
       "community": 2320,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_test_tsx",
+      "label": "data-table.test.tsx",
+      "norm_label": "data-table.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2321,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2322,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_productcolumns_tsx",
       "label": "productColumns.tsx",
       "norm_label": "productcolumns.tsx",
@@ -226948,7 +227068,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2321,
+      "community": 2323,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_test_tsx",
       "label": "PromoCodeHeader.test.tsx",
@@ -226957,7 +227077,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2322,
+      "community": 2324,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodes_tsx",
       "label": "PromoCodes.tsx",
@@ -226966,7 +227086,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2323,
+      "community": 2325,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_analytics_promocodeanalytics_tsx",
       "label": "PromoCodeAnalytics.tsx",
@@ -226975,7 +227095,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2324,
+      "community": 2326,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_captured_emails_columns_tsx",
       "label": "captured-emails-columns.tsx",
@@ -226984,7 +227104,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2325,
+      "community": 2327,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_test_ts",
       "label": "promoCodeMoney.test.ts",
@@ -226993,7 +227113,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2326,
+      "community": 2328,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -227002,30 +227122,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2327,
+      "community": 2329,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2328,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2329,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
@@ -227130,6 +227232,24 @@
     {
       "community": 2330,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2331,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2332,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -227137,7 +227257,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2331,
+      "community": 2333,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_columns_tsx",
       "label": "columns.tsx",
@@ -227146,7 +227266,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2332,
+      "community": 2334,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_constants_ts",
       "label": "constants.ts",
@@ -227155,7 +227275,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2333,
+      "community": 2335,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -227164,7 +227284,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2334,
+      "community": 2336,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -227173,7 +227293,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2335,
+      "community": 2337,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -227182,7 +227302,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2336,
+      "community": 2338,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_ts",
       "label": "data.ts",
@@ -227191,30 +227311,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2337,
+      "community": 2339,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
       "source_file": "packages/athena-webapp/src/components/promo-codes/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2338,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_welcome_offer_card_tsx",
-      "label": "welcome-offer-card.tsx",
-      "norm_label": "welcome-offer-card.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/welcome-offer-card.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2339,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_remote_assist_posremoteassistruntimehost_test_tsx",
-      "label": "PosRemoteAssistRuntimeHost.test.tsx",
-      "norm_label": "posremoteassistruntimehost.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/remote-assist/PosRemoteAssistRuntimeHost.test.tsx",
       "source_location": "L1"
     },
     {
@@ -227319,6 +227421,24 @@
     {
       "community": 2340,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_welcome_offer_card_tsx",
+      "label": "welcome-offer-card.tsx",
+      "norm_label": "welcome-offer-card.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/welcome-offer-card.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2341,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_remote_assist_posremoteassistruntimehost_test_tsx",
+      "label": "PosRemoteAssistRuntimeHost.test.tsx",
+      "norm_label": "posremoteassistruntimehost.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/remote-assist/PosRemoteAssistRuntimeHost.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2342,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_remote_assist_remoteassistliveviewer_test_tsx",
       "label": "RemoteAssistLiveViewer.test.tsx",
       "norm_label": "remoteassistliveviewer.test.tsx",
@@ -227326,7 +227446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2341,
+      "community": 2343,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_remote_assist_remoteassistruntimeshell_test_tsx",
       "label": "RemoteAssistRuntimeShell.test.tsx",
@@ -227335,7 +227455,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2342,
+      "community": 2344,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_remote_assist_remoteassistsupportconsole_tsx",
       "label": "RemoteAssistSupportConsole.tsx",
@@ -227344,7 +227464,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2343,
+      "community": 2345,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_remote_assist_index_ts",
       "label": "index.ts",
@@ -227353,7 +227473,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2344,
+      "community": 2346,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportcalendar_test_tsx",
       "label": "ReportCalendar.test.tsx",
@@ -227362,7 +227482,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2345,
+      "community": 2347,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportcustomrangepanel_test_tsx",
       "label": "ReportCustomRangePanel.test.tsx",
@@ -227371,7 +227491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2346,
+      "community": 2348,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportdaterangefield_test_tsx",
       "label": "ReportDateRangeField.test.tsx",
@@ -227380,30 +227500,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2347,
+      "community": 2349,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportsegmentedtabs_test_tsx",
       "label": "ReportSegmentedTabs.test.tsx",
       "norm_label": "reportsegmentedtabs.test.tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportSegmentedTabs.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2348,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reports_reportsegmentedtabs_tsx",
-      "label": "ReportSegmentedTabs.tsx",
-      "norm_label": "reportsegmentedtabs.tsx",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportSegmentedTabs.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2349,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reports_reportskumixchart_test_tsx",
-      "label": "ReportSkuMixChart.test.tsx",
-      "norm_label": "reportskumixchart.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportSkuMixChart.test.tsx",
       "source_location": "L1"
     },
     {
@@ -227508,6 +227610,24 @@
     {
       "community": 2350,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_reports_reportsegmentedtabs_tsx",
+      "label": "ReportSegmentedTabs.tsx",
+      "norm_label": "reportsegmentedtabs.tsx",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportSegmentedTabs.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2351,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_reports_reportskumixchart_test_tsx",
+      "label": "ReportSkuMixChart.test.tsx",
+      "norm_label": "reportskumixchart.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportSkuMixChart.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2352,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportformat_test_ts",
       "label": "reportFormat.test.ts",
       "norm_label": "reportformat.test.ts",
@@ -227515,7 +227635,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2351,
+      "community": 2353,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportperiodkeys_test_ts",
       "label": "reportPeriodKeys.test.ts",
@@ -227524,7 +227644,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2352,
+      "community": 2354,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportroutesearch_test_ts",
       "label": "reportRouteSearch.test.ts",
@@ -227533,7 +227653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2353,
+      "community": 2355,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_ratingstars_tsx",
       "label": "RatingStars.tsx",
@@ -227542,7 +227662,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2354,
+      "community": 2356,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
       "label": "ReviewCard.tsx",
@@ -227551,7 +227671,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2355,
+      "community": 2357,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewmetadata_tsx",
       "label": "ReviewMetadata.tsx",
@@ -227560,7 +227680,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2356,
+      "community": 2358,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeform_tsx",
       "label": "ServiceIntakeForm.tsx",
@@ -227569,30 +227689,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2357,
+      "community": 2359,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemoexperience_test_tsx",
       "label": "SharedDemoExperience.test.tsx",
       "norm_label": "shareddemoexperience.test.tsx",
       "source_file": "packages/athena-webapp/src/components/shared-demo/SharedDemoExperience.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2358,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_shared_demo_shareddemorestoreoverlay_test_tsx",
-      "label": "SharedDemoRestoreOverlay.test.tsx",
-      "norm_label": "shareddemorestoreoverlay.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/SharedDemoRestoreOverlay.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2359,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_shared_demo_shareddemolocalbootstrap_test_ts",
-      "label": "sharedDemoLocalBootstrap.test.ts",
-      "norm_label": "shareddemolocalbootstrap.test.ts",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLocalBootstrap.test.ts",
       "source_location": "L1"
     },
     {
@@ -227697,6 +227799,24 @@
     {
       "community": 2360,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_shared_demo_shareddemorestoreoverlay_test_tsx",
+      "label": "SharedDemoRestoreOverlay.test.tsx",
+      "norm_label": "shareddemorestoreoverlay.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/SharedDemoRestoreOverlay.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2361,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_shared_demo_shareddemolocalbootstrap_test_ts",
+      "label": "sharedDemoLocalBootstrap.test.ts",
+      "norm_label": "shareddemolocalbootstrap.test.ts",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLocalBootstrap.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2362,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemorestoreoverlay_test_ts",
       "label": "sharedDemoRestoreOverlay.test.ts",
       "norm_label": "shareddemorestoreoverlay.test.ts",
@@ -227704,7 +227824,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2361,
+      "community": 2363,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemorestoreoverlay_tsx",
       "label": "sharedDemoRestoreOverlay.tsx",
@@ -227713,7 +227833,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2362,
+      "community": 2364,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_index_tsx",
       "label": "index.tsx",
@@ -227722,7 +227842,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2363,
+      "community": 2365,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_auth_staffauthenticationdialog_test_tsx",
       "label": "StaffAuthenticationDialog.test.tsx",
@@ -227731,7 +227851,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2364,
+      "community": 2366,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_auth_staffpininput_tsx",
       "label": "StaffPinInput.tsx",
@@ -227740,7 +227860,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2365,
+      "community": 2367,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfound_test_tsx",
       "label": "NotFound.test.tsx",
@@ -227749,7 +227869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2366,
+      "community": 2368,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_stock_ops_skusearchfilterbar_tsx",
       "label": "SkuSearchFilterBar.tsx",
@@ -227758,30 +227878,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2367,
+      "community": 2369,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_test_ts",
       "label": "FeesView.test.ts",
       "norm_label": "feesview.test.ts",
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2368,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_fulfillmentview_test_tsx",
-      "label": "FulfillmentView.test.tsx",
-      "norm_label": "fulfillmentview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2369,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_test_tsx",
-      "label": "MaintenanceView.test.tsx",
-      "norm_label": "maintenanceview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.test.tsx",
       "source_location": "L1"
     },
     {
@@ -227886,6 +227988,24 @@
     {
       "community": 2370,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_fulfillmentview_test_tsx",
+      "label": "FulfillmentView.test.tsx",
+      "norm_label": "fulfillmentview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2371,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_test_tsx",
+      "label": "MaintenanceView.test.tsx",
+      "norm_label": "maintenanceview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2372,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_test_tsx",
       "label": "MtnMomoView.test.tsx",
       "norm_label": "mtnmomoview.test.tsx",
@@ -227893,7 +228013,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2371,
+      "community": 2373,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_test_tsx",
       "label": "useStoreConfigUpdate.test.tsx",
@@ -227902,7 +228022,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2372,
+      "community": 2374,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestorescheduleupdate_test_tsx",
       "label": "useStoreScheduleUpdate.test.tsx",
@@ -227911,7 +228031,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2373,
+      "community": 2375,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_index_tsx",
       "label": "index.tsx",
@@ -227920,7 +228040,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2374,
+      "community": 2376,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceview_test_tsx",
       "label": "WorkflowTraceView.test.tsx",
@@ -227929,7 +228049,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2375,
+      "community": 2377,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -227938,7 +228058,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2376,
+      "community": 2378,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_test_tsx",
       "label": "button.test.tsx",
@@ -227947,30 +228067,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2377,
+      "community": 2379,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
       "norm_label": "button.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/button.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2378,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
-      "label": "calendar.test.tsx",
-      "norm_label": "calendar.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/calendar.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2379,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_card_tsx",
-      "label": "card.tsx",
-      "norm_label": "card.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/card.tsx",
       "source_location": "L1"
     },
     {
@@ -228075,6 +228177,24 @@
     {
       "community": 2380,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
+      "label": "calendar.test.tsx",
+      "norm_label": "calendar.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/calendar.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2381,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_card_tsx",
+      "label": "card.tsx",
+      "norm_label": "card.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/card.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2382,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
       "norm_label": "checkbox.tsx",
@@ -228082,7 +228202,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2381,
+      "community": 2383,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_collapsible_tsx",
       "label": "collapsible.tsx",
@@ -228091,7 +228211,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2382,
+      "community": 2384,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -228100,7 +228220,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2383,
+      "community": 2385,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
@@ -228109,7 +228229,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2384,
+      "community": 2386,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
@@ -228118,7 +228238,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2385,
+      "community": 2387,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
@@ -228127,7 +228247,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2386,
+      "community": 2388,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -228136,30 +228256,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2387,
+      "community": 2389,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
       "norm_label": "icons.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/icons.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2388,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
-      "label": "input-otp.tsx",
-      "norm_label": "input-otp.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/input-otp.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2389,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_input_test_tsx",
-      "label": "input.test.tsx",
-      "norm_label": "input.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/input.test.tsx",
       "source_location": "L1"
     },
     {
@@ -228264,6 +228366,24 @@
     {
       "community": 2390,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
+      "label": "input-otp.tsx",
+      "norm_label": "input-otp.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/input-otp.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2391,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_input_test_tsx",
+      "label": "input.test.tsx",
+      "norm_label": "input.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/input.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2392,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
       "norm_label": "input.tsx",
@@ -228271,7 +228391,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2391,
+      "community": 2393,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -228280,7 +228400,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2392,
+      "community": 2394,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_panel_header_tsx",
       "label": "panel-header.tsx",
@@ -228289,7 +228409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2393,
+      "community": 2395,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -228298,7 +228418,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2394,
+      "community": 2396,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_primitives_test_tsx",
       "label": "primitives.test.tsx",
@@ -228307,7 +228427,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2395,
+      "community": 2397,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -228316,7 +228436,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2396,
+      "community": 2398,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -228325,30 +228445,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2397,
+      "community": 2399,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
       "norm_label": "select.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/select.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2398,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_separator_tsx",
-      "label": "separator.tsx",
-      "norm_label": "separator.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/separator.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2399,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
-      "label": "sheet.tsx",
-      "norm_label": "sheet.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/sheet.tsx",
       "source_location": "L1"
     },
     {
@@ -228804,6 +228906,24 @@
     {
       "community": 2400,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_separator_tsx",
+      "label": "separator.tsx",
+      "norm_label": "separator.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/separator.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2401,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
+      "label": "sheet.tsx",
+      "norm_label": "sheet.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/sheet.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2402,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_switch_tsx",
       "label": "switch.tsx",
       "norm_label": "switch.tsx",
@@ -228811,7 +228931,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2401,
+      "community": 2403,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_table_test_tsx",
       "label": "table.test.tsx",
@@ -228820,7 +228940,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2402,
+      "community": 2404,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -228829,7 +228949,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2403,
+      "community": 2405,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -228838,7 +228958,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2404,
+      "community": 2406,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -228847,7 +228967,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2405,
+      "community": 2407,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -228856,7 +228976,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2406,
+      "community": 2408,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -228865,30 +228985,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2407,
+      "community": 2409,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
       "norm_label": "tooltip.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/tooltip.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2408,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_upload_button_tsx",
-      "label": "upload-button.tsx",
-      "norm_label": "upload-button.tsx",
-      "source_file": "packages/athena-webapp/src/components/upload-button.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2409,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
-      "label": "BagView.tsx",
-      "norm_label": "bagview.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/BagView.tsx",
       "source_location": "L1"
     },
     {
@@ -228993,6 +229095,24 @@
     {
       "community": 2410,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_upload_button_tsx",
+      "label": "upload-button.tsx",
+      "norm_label": "upload-button.tsx",
+      "source_file": "packages/athena-webapp/src/components/upload-button.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2411,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
+      "label": "BagView.tsx",
+      "norm_label": "bagview.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/BagView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2412,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
@@ -229000,7 +229120,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2411,
+      "community": 2413,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
       "label": "constants.ts",
@@ -229009,7 +229129,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2412,
+      "community": 2414,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -229018,7 +229138,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2413,
+      "community": 2415,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -229027,7 +229147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2414,
+      "community": 2416,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -229036,7 +229156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2415,
+      "community": 2417,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
       "label": "data.ts",
@@ -229045,7 +229165,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2416,
+      "community": 2418,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
       "label": "bag-columns.tsx",
@@ -229054,30 +229174,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2417,
+      "community": 2419,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
       "label": "bags-table.tsx",
       "norm_label": "bags-table.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bags-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2418,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2419,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
@@ -229182,6 +229284,24 @@
     {
       "community": 2420,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2421,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2422,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -229189,7 +229309,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2421,
+      "community": 2423,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -229198,7 +229318,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2422,
+      "community": 2424,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -229207,7 +229327,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2423,
+      "community": 2425,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
       "label": "LinkedAccounts.tsx",
@@ -229216,7 +229336,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2424,
+      "community": 2426,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
       "label": "TimelineEventCard.test.tsx",
@@ -229225,7 +229345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2425,
+      "community": 2427,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
       "label": "UserCheckoutSession.tsx",
@@ -229234,7 +229354,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2426,
+      "community": 2428,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
       "label": "index.ts",
@@ -229243,30 +229363,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2427,
+      "community": 2429,
       "file_type": "code",
       "id": "packages_athena_webapp_src_config_test_ts",
       "label": "config.test.ts",
       "norm_label": "config.test.ts",
       "source_file": "packages/athena-webapp/src/config.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2428,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_contexttracking_docsworkspacetracking_test_ts",
-      "label": "docsWorkspaceTracking.test.ts",
-      "norm_label": "docsworkspacetracking.test.ts",
-      "source_file": "packages/athena-webapp/src/contextTracking/docsWorkspaceTracking.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2429,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
-      "label": "ThemeContext.tsx",
-      "norm_label": "themecontext.tsx",
-      "source_file": "packages/athena-webapp/src/contexts/ThemeContext.tsx",
       "source_location": "L1"
     },
     {
@@ -229371,6 +229473,24 @@
     {
       "community": 2430,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_contexttracking_docsworkspacetracking_test_ts",
+      "label": "docsWorkspaceTracking.test.ts",
+      "norm_label": "docsworkspacetracking.test.ts",
+      "source_file": "packages/athena-webapp/src/contextTracking/docsWorkspaceTracking.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2431,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
+      "label": "ThemeContext.tsx",
+      "norm_label": "themecontext.tsx",
+      "source_file": "packages/athena-webapp/src/contexts/ThemeContext.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2432,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_onlineordersessionoverlay_test_ts",
       "label": "onlineOrderSessionOverlay.test.ts",
       "norm_label": "onlineordersessionoverlay.test.ts",
@@ -229378,7 +229498,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2431,
+      "community": 2433,
       "file_type": "code",
       "id": "packages_athena_webapp_src_design_system_build_config_test_ts",
       "label": "design-system-build-config.test.ts",
@@ -229387,7 +229507,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2432,
+      "community": 2434,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_pagination_persistence_test_ts",
       "label": "use-pagination-persistence.test.ts",
@@ -229396,7 +229516,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2433,
+      "community": 2435,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
@@ -229405,7 +229525,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2434,
+      "community": 2436,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useauth_test_tsx",
       "label": "useAuth.test.tsx",
@@ -229414,7 +229534,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2435,
+      "community": 2437,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_test_ts",
       "label": "useExpenseSessions.test.ts",
@@ -229423,7 +229543,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2436,
+      "community": 2438,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactivestore_test_ts",
       "label": "useGetActiveStore.test.ts",
@@ -229432,30 +229552,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2437,
+      "community": 2439,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetterminal_test_ts",
       "label": "useGetTerminal.test.ts",
       "norm_label": "usegetterminal.test.ts",
       "source_file": "packages/athena-webapp/src/hooks/useGetTerminal.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2438,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
-      "label": "useOrganizationModal.tsx",
-      "norm_label": "useorganizationmodal.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/useOrganizationModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2439,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useposproducts_test_ts",
-      "label": "usePOSProducts.test.ts",
-      "norm_label": "useposproducts.test.ts",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.test.ts",
       "source_location": "L1"
     },
     {
@@ -229551,6 +229653,24 @@
     {
       "community": 2440,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
+      "label": "useOrganizationModal.tsx",
+      "norm_label": "useorganizationmodal.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/useOrganizationModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2441,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useposproducts_test_ts",
+      "label": "usePOSProducts.test.ts",
+      "norm_label": "useposproducts.test.ts",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2442,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprotectedadminpagestate_test_tsx",
       "label": "useProtectedAdminPageState.test.tsx",
       "norm_label": "useprotectedadminpagestate.test.tsx",
@@ -229558,7 +229678,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2441,
+      "community": 2443,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useshareddemocontext_test_ts",
       "label": "useSharedDemoContext.test.ts",
@@ -229567,7 +229687,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2442,
+      "community": 2444,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usestoreoperatingclock_test_tsx",
       "label": "useStoreOperatingClock.test.tsx",
@@ -229576,7 +229696,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2443,
+      "community": 2445,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_access_capabilities_test_ts",
       "label": "capabilities.test.ts",
@@ -229585,7 +229705,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2444,
+      "community": 2446,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_messages_appmessagescontext_ts",
       "label": "AppMessagesContext.ts",
@@ -229594,7 +229714,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2445,
+      "community": 2447,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_messages_appmessagecommunicationpreferencecontext_ts",
       "label": "appMessageCommunicationPreferenceContext.ts",
@@ -229603,7 +229723,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2446,
+      "community": 2448,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_messages_index_ts",
       "label": "index.ts",
@@ -229612,30 +229732,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2447,
+      "community": 2449,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_update_appupdateactions_ts",
       "label": "appUpdateActions.ts",
       "norm_label": "appupdateactions.ts",
       "source_file": "packages/athena-webapp/src/lib/app-update/appUpdateActions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2448,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_app_update_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/src/lib/app-update/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2449,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_app_update_updatecommunicationpreferencecontext_ts",
-      "label": "updateCommunicationPreferenceContext.ts",
-      "norm_label": "updatecommunicationpreferencecontext.ts",
-      "source_file": "packages/athena-webapp/src/lib/app-update/updateCommunicationPreferenceContext.ts",
       "source_location": "L1"
     },
     {
@@ -229731,6 +229833,24 @@
     {
       "community": 2450,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_app_update_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/src/lib/app-update/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2451,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_app_update_updatecommunicationpreferencecontext_ts",
+      "label": "updateCommunicationPreferenceContext.ts",
+      "norm_label": "updatecommunicationpreferencecontext.ts",
+      "source_file": "packages/athena-webapp/src/lib/app-update/updateCommunicationPreferenceContext.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2452,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_update_updatecoordinator_test_ts",
       "label": "updateCoordinator.test.ts",
       "norm_label": "updatecoordinator.test.ts",
@@ -229738,7 +229858,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2451,
+      "community": 2453,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_aws_ts",
       "label": "aws.ts",
@@ -229747,7 +229867,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2452,
+      "community": 2454,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -229756,7 +229876,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2453,
+      "community": 2455,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -229765,7 +229885,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2454,
+      "community": 2456,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_docs_access_test_ts",
       "label": "access.test.ts",
@@ -229774,7 +229894,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2455,
+      "community": 2457,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_docs_content_test_ts",
       "label": "content.test.ts",
@@ -229783,7 +229903,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2456,
+      "community": 2458,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_docs_navigation_test_ts",
       "label": "navigation.test.ts",
@@ -229792,30 +229912,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2457,
+      "community": 2459,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_docs_parsing_test_ts",
       "label": "parsing.test.ts",
       "norm_label": "parsing.test.ts",
       "source_file": "packages/athena-webapp/src/lib/docs/parsing.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2458,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_docs_reportcontract_test_ts",
-      "label": "reportContract.test.ts",
-      "norm_label": "reportcontract.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/docs/reportContract.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2459,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_docs_scrollprogress_test_ts",
-      "label": "scrollProgress.test.ts",
-      "norm_label": "scrollprogress.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/docs/scrollProgress.test.ts",
       "source_location": "L1"
     },
     {
@@ -229911,6 +230013,24 @@
     {
       "community": 2460,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_docs_reportcontract_test_ts",
+      "label": "reportContract.test.ts",
+      "norm_label": "reportcontract.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/docs/reportContract.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2461,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_docs_scrollprogress_test_ts",
+      "label": "scrollProgress.test.ts",
+      "norm_label": "scrollprogress.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/docs/scrollProgress.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2462,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_docs_virtual_docs_index_d_ts",
       "label": "virtual-docs-index.d.ts",
       "norm_label": "virtual-docs-index.d.ts",
@@ -229918,7 +230038,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2461,
+      "community": 2463,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_operatormessages_test_ts",
       "label": "operatorMessages.test.ts",
@@ -229927,7 +230047,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2462,
+      "community": 2464,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentcommandtoast_test_ts",
       "label": "presentCommandToast.test.ts",
@@ -229936,7 +230056,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2463,
+      "community": 2465,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_test_ts",
       "label": "presentUnexpectedErrorToast.test.ts",
@@ -229945,7 +230065,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2464,
+      "community": 2466,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_test_ts",
       "label": "runCommand.test.ts",
@@ -229954,7 +230074,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2465,
+      "community": 2467,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -229963,7 +230083,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2466,
+      "community": 2468,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -229972,7 +230092,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2467,
+      "community": 2469,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_inventory_import_inventoryimportparser_test_ts",
       "label": "inventoryImportParser.test.ts",
@@ -229981,7 +230101,97 @@
       "source_location": "L1"
     },
     {
-      "community": 2468,
+      "community": 247,
+      "file_type": "code",
+      "id": "index_resolveverificationcoderecipient",
+      "label": "resolveVerificationCodeRecipient()",
+      "norm_label": "resolveverificationcoderecipient()",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "index_senddailymanagerreportemail",
+      "label": "sendDailyManagerReportEmail()",
+      "norm_label": "senddailymanagerreportemail()",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "source_location": "L373"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "index_senddiscountcodeemail",
+      "label": "sendDiscountCodeEmail()",
+      "norm_label": "senddiscountcodeemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L255"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "index_senddiscountreminderemail",
+      "label": "sendDiscountReminderEmail()",
+      "norm_label": "senddiscountreminderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L334"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "index_sendfeedbackrequestemail",
+      "label": "sendFeedbackRequestEmail()",
+      "norm_label": "sendfeedbackrequestemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "index_sendneworderemail",
+      "label": "sendNewOrderEmail()",
+      "norm_label": "sendneworderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L117"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "index_sendorderemail",
+      "label": "sendOrderEmail()",
+      "norm_label": "sendorderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "index_sendverificationcode",
+      "label": "sendVerificationCode()",
+      "norm_label": "sendverificationcode()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2470,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_marketing_landingfunnelclient_test_ts",
       "label": "landingFunnelClient.test.ts",
@@ -229990,7 +230200,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2469,
+      "community": 2471,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_marketing_walkthroughprivacy_ts",
       "label": "walkthroughPrivacy.ts",
@@ -229999,97 +230209,7 @@
       "source_location": "L1"
     },
     {
-      "community": 247,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_marketing_walkthroughconfig_ts",
-      "label": "walkthroughConfig.ts",
-      "norm_label": "walkthroughconfig.ts",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "walkthroughconfig_landingfunnelhourlylimit",
-      "label": "landingFunnelHourlyLimit()",
-      "norm_label": "landingfunnelhourlylimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "walkthroughconfig_parseboundedpositiveinteger",
-      "label": "parseBoundedPositiveInteger()",
-      "norm_label": "parseboundedpositiveinteger()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "walkthroughconfig_resolvewalkthroughallowedorigins",
-      "label": "resolveWalkthroughAllowedOrigins()",
-      "norm_label": "resolvewalkthroughallowedorigins()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughallowedorigins",
-      "label": "walkthroughAllowedOrigins()",
-      "norm_label": "walkthroughallowedorigins()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughdailyperemaillimit",
-      "label": "walkthroughDailyPerEmailLimit()",
-      "norm_label": "walkthroughdailyperemaillimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L55"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughhourlygloballimit",
-      "label": "walkthroughHourlyGlobalLimit()",
-      "norm_label": "walkthroughhourlygloballimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughhourlynotificationlimit",
-      "label": "walkthroughHourlyNotificationLimit()",
-      "norm_label": "walkthroughhourlynotificationlimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughmaxbodybytes",
-      "label": "walkthroughMaxBodyBytes()",
-      "norm_label": "walkthroughmaxbodybytes()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughprivacycontact",
-      "label": "walkthroughPrivacyContact()",
-      "norm_label": "walkthroughprivacycontact()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 2470,
+      "community": 2472,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_marketing_walkthroughrequestclient_test_ts",
       "label": "walkthroughRequestClient.test.ts",
@@ -230098,7 +230218,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2471,
+      "community": 2473,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_navigation_appentryroutes_test_ts",
       "label": "appEntryRoutes.test.ts",
@@ -230107,7 +230227,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2472,
+      "community": 2474,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_navigation_storeentryroute_test_ts",
       "label": "storeEntryRoute.test.ts",
@@ -230116,7 +230236,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2473,
+      "community": 2475,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_operations_operatingdate_test_ts",
       "label": "operatingDate.test.ts",
@@ -230125,7 +230245,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2474,
+      "community": 2476,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_dto_ts",
       "label": "dto.ts",
@@ -230134,7 +230254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2475,
+      "community": 2477,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_ports_ts",
       "label": "ports.ts",
@@ -230143,7 +230263,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2476,
+      "community": 2478,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_poslocalstoreport_ts",
       "label": "posLocalStorePort.ts",
@@ -230152,7 +230272,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2477,
+      "community": 2479,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_results_test_ts",
       "label": "results.test.ts",
@@ -230161,7 +230281,97 @@
       "source_location": "L1"
     },
     {
-      "community": 2478,
+      "community": 248,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_marketing_walkthroughconfig_ts",
+      "label": "walkthroughConfig.ts",
+      "norm_label": "walkthroughconfig.ts",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "walkthroughconfig_landingfunnelhourlylimit",
+      "label": "landingFunnelHourlyLimit()",
+      "norm_label": "landingfunnelhourlylimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "walkthroughconfig_parseboundedpositiveinteger",
+      "label": "parseBoundedPositiveInteger()",
+      "norm_label": "parseboundedpositiveinteger()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "walkthroughconfig_resolvewalkthroughallowedorigins",
+      "label": "resolveWalkthroughAllowedOrigins()",
+      "norm_label": "resolvewalkthroughallowedorigins()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughallowedorigins",
+      "label": "walkthroughAllowedOrigins()",
+      "norm_label": "walkthroughallowedorigins()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughdailyperemaillimit",
+      "label": "walkthroughDailyPerEmailLimit()",
+      "norm_label": "walkthroughdailyperemaillimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughhourlygloballimit",
+      "label": "walkthroughHourlyGlobalLimit()",
+      "norm_label": "walkthroughhourlygloballimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughhourlynotificationlimit",
+      "label": "walkthroughHourlyNotificationLimit()",
+      "norm_label": "walkthroughhourlynotificationlimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughmaxbodybytes",
+      "label": "walkthroughMaxBodyBytes()",
+      "norm_label": "walkthroughmaxbodybytes()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughprivacycontact",
+      "label": "walkthroughPrivacyContact()",
+      "norm_label": "walkthroughprivacycontact()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 2480,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_constants_ts",
       "label": "constants.ts",
@@ -230170,7 +230380,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2479,
+      "community": 2481,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
       "label": "displayAmounts.test.ts",
@@ -230179,97 +230389,7 @@
       "source_location": "L1"
     },
     {
-      "community": 248,
-      "file_type": "code",
-      "id": "definitions_costoverlaystorewriteoperation",
-      "label": "costOverlayStoreWriteOperation()",
-      "norm_label": "costoverlaystorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L569"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "definitions_cyclecountdraftstorewriteoperation",
-      "label": "cycleCountDraftStoreWriteOperation()",
-      "norm_label": "cyclecountdraftstorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L383"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "definitions_defineoperation",
-      "label": "defineOperation()",
-      "norm_label": "defineoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "definitions_inventoryimportreviewpayloadwriteoperation",
-      "label": "inventoryImportReviewPayloadWriteOperation()",
-      "norm_label": "inventoryimportreviewpayloadwriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L544"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "definitions_notificationsubscriptionrowwriteoperation",
-      "label": "notificationSubscriptionRowWriteOperation()",
-      "norm_label": "notificationsubscriptionrowwriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L629"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "definitions_orderstorewriteoperation",
-      "label": "orderStoreWriteOperation()",
-      "norm_label": "orderstorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L155"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "definitions_storewriteoperation",
-      "label": "storeWriteOperation()",
-      "norm_label": "storewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L108"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "definitions_transactionstorewriteoperation",
-      "label": "transactionStoreWriteOperation()",
-      "norm_label": "transactionstorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "definitions_validateoperationdefinition",
-      "label": "validateOperationDefinition()",
-      "norm_label": "validateoperationdefinition()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L724"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operationadmission_definitions_ts",
-      "label": "definitions.ts",
-      "norm_label": "definitions.ts",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2480,
+      "community": 2482,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_cart_test_ts",
       "label": "cart.test.ts",
@@ -230278,7 +230398,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2481,
+      "community": 2483,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_index_ts",
       "label": "index.ts",
@@ -230287,7 +230407,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2482,
+      "community": 2484,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_session_test_ts",
       "label": "session.test.ts",
@@ -230296,7 +230416,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2483,
+      "community": 2485,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_types_ts",
       "label": "types.ts",
@@ -230305,7 +230425,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2484,
+      "community": 2486,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_expensereceipt_test_ts",
       "label": "expenseReceipt.test.ts",
@@ -230314,7 +230434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2485,
+      "community": 2487,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_test_ts",
       "label": "registerGateway.test.ts",
@@ -230323,7 +230443,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2486,
+      "community": 2488,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registerlifecycleauthoritygateway_test_ts",
       "label": "registerLifecycleAuthorityGateway.test.ts",
@@ -230332,7 +230452,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2487,
+      "community": 2489,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_sessiongateway_test_ts",
       "label": "sessionGateway.test.ts",
@@ -230341,7 +230461,97 @@
       "source_location": "L1"
     },
     {
-      "community": 2488,
+      "community": 249,
+      "file_type": "code",
+      "id": "definitions_costoverlaystorewriteoperation",
+      "label": "costOverlayStoreWriteOperation()",
+      "norm_label": "costoverlaystorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L569"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "definitions_cyclecountdraftstorewriteoperation",
+      "label": "cycleCountDraftStoreWriteOperation()",
+      "norm_label": "cyclecountdraftstorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L383"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "definitions_defineoperation",
+      "label": "defineOperation()",
+      "norm_label": "defineoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "definitions_inventoryimportreviewpayloadwriteoperation",
+      "label": "inventoryImportReviewPayloadWriteOperation()",
+      "norm_label": "inventoryimportreviewpayloadwriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L544"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "definitions_notificationsubscriptionrowwriteoperation",
+      "label": "notificationSubscriptionRowWriteOperation()",
+      "norm_label": "notificationsubscriptionrowwriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L629"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "definitions_orderstorewriteoperation",
+      "label": "orderStoreWriteOperation()",
+      "norm_label": "orderstorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L155"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "definitions_storewriteoperation",
+      "label": "storeWriteOperation()",
+      "norm_label": "storewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L108"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "definitions_transactionstorewriteoperation",
+      "label": "transactionStoreWriteOperation()",
+      "norm_label": "transactionstorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "definitions_validateoperationdefinition",
+      "label": "validateOperationDefinition()",
+      "norm_label": "validateoperationdefinition()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L724"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operationadmission_definitions_ts",
+      "label": "definitions.ts",
+      "norm_label": "definitions.ts",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2490,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_drawerauthorityreconciliation_test_ts",
       "label": "drawerAuthorityReconciliation.test.ts",
@@ -230350,7 +230560,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2489,
+      "community": 2491,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_indexeddbposlocalstorageengine_test_ts",
       "label": "indexedDbPosLocalStorageEngine.test.ts",
@@ -230359,97 +230569,7 @@
       "source_location": "L1"
     },
     {
-      "community": 249,
-      "file_type": "code",
-      "id": "adjustmentreports_adjustmentappliedat",
-      "label": "adjustmentAppliedAt()",
-      "norm_label": "adjustmentappliedat()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "adjustmentreports_adjustmentsalesdelta",
-      "label": "adjustmentSalesDelta()",
-      "norm_label": "adjustmentsalesdelta()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "adjustmentreports_adjustmentsettlementamount",
-      "label": "adjustmentSettlementAmount()",
-      "norm_label": "adjustmentsettlementamount()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L143"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "adjustmentreports_adjustmenttransactionid",
-      "label": "adjustmentTransactionId()",
-      "norm_label": "adjustmenttransactionid()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L110"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "adjustmentreports_buildadjustmentpaymenttotals",
-      "label": "buildAdjustmentPaymentTotals()",
-      "norm_label": "buildadjustmentpaymenttotals()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L242"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "adjustmentreports_buildadjustmentreporttotals",
-      "label": "buildAdjustmentReportTotals()",
-      "norm_label": "buildadjustmentreporttotals()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L275"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "adjustmentreports_listappliedtransactionadjustmentsforday",
-      "label": "listAppliedTransactionAdjustmentsForDay()",
-      "norm_label": "listappliedtransactionadjustmentsforday()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L229"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "adjustmentreports_readappliedtransactionadjustmentsforday",
-      "label": "readAppliedTransactionAdjustmentsForDay()",
-      "norm_label": "readappliedtransactionadjustmentsforday()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L173"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "adjustmentreports_sourcecompletenessentry",
-      "label": "sourceCompletenessEntry()",
-      "norm_label": "sourcecompletenessentry()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L76"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_dailyclose_adjustmentreports_ts",
-      "label": "adjustmentReports.ts",
-      "norm_label": "adjustmentreports.ts",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2490,
+      "community": 2492,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localposentrycontext_test_ts",
       "label": "localPosEntryContext.test.ts",
@@ -230458,7 +230578,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2491,
+      "community": 2493,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localposreadiness_test_ts",
       "label": "localPosReadiness.test.ts",
@@ -230467,7 +230587,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2492,
+      "community": 2494,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalledgerpolicy_test_ts",
       "label": "posLocalLedgerPolicy.test.ts",
@@ -230476,7 +230596,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2493,
+      "community": 2495,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoragehealth_test_ts",
       "label": "posLocalStorageHealth.test.ts",
@@ -230485,7 +230605,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2494,
+      "community": 2496,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstorageruntime_test_ts",
       "label": "posLocalStorageRuntime.test.ts",
@@ -230494,7 +230614,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2495,
+      "community": 2497,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoreinitialization_test_ts",
       "label": "posLocalStoreInitialization.test.ts",
@@ -230503,7 +230623,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2496,
+      "community": 2498,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoremaintenance_test_ts",
       "label": "posLocalStoreMaintenance.test.ts",
@@ -230512,30 +230632,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2497,
+      "community": 2499,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoremigrations_test_ts",
       "label": "posLocalStoreMigrations.test.ts",
       "norm_label": "poslocalstoremigrations.test.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStoreMigrations.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2498,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoresnapshot_test_ts",
-      "label": "posLocalStoreSnapshot.test.ts",
-      "norm_label": "poslocalstoresnapshot.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStoreSnapshot.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2499,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registercatalogpinruntime_test_ts",
-      "label": "registerCatalogPinRuntime.test.ts",
-      "norm_label": "registercatalogpinruntime.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.test.ts",
       "source_location": "L1"
     },
     {
@@ -230892,95 +230994,113 @@
     {
       "community": 250,
       "file_type": "code",
-      "id": "inventorymovements_assertnobusinesseventconflict",
-      "label": "assertNoBusinessEventConflict()",
-      "norm_label": "assertnobusinesseventconflict()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L178"
+      "id": "adjustmentreports_adjustmentappliedat",
+      "label": "adjustmentAppliedAt()",
+      "norm_label": "adjustmentappliedat()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L101"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "inventorymovements_buildinventorymovement",
-      "label": "buildInventoryMovement()",
-      "norm_label": "buildinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L124"
+      "id": "adjustmentreports_adjustmentsalesdelta",
+      "label": "adjustmentSalesDelta()",
+      "norm_label": "adjustmentsalesdelta()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L116"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "inventorymovements_buildskuactivityforinventorymovement",
-      "label": "buildSkuActivityForInventoryMovement()",
-      "norm_label": "buildskuactivityforinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L66"
+      "id": "adjustmentreports_adjustmentsettlementamount",
+      "label": "adjustmentSettlementAmount()",
+      "norm_label": "adjustmentsettlementamount()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L143"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "inventorymovements_getskuactivitytypeformovement",
-      "label": "getSkuActivityTypeForMovement()",
-      "norm_label": "getskuactivitytypeformovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L49"
+      "id": "adjustmentreports_adjustmenttransactionid",
+      "label": "adjustmentTransactionId()",
+      "norm_label": "adjustmenttransactionid()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L110"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "inventorymovements_matchesexistingmovement",
-      "label": "matchesExistingMovement()",
-      "norm_label": "matchesexistingmovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L150"
+      "id": "adjustmentreports_buildadjustmentpaymenttotals",
+      "label": "buildAdjustmentPaymentTotals()",
+      "norm_label": "buildadjustmentpaymenttotals()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L242"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "inventorymovements_recordinventorymovementwithctx",
-      "label": "recordInventoryMovementWithCtx()",
-      "norm_label": "recordinventorymovementwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L200"
+      "id": "adjustmentreports_buildadjustmentreporttotals",
+      "label": "buildAdjustmentReportTotals()",
+      "norm_label": "buildadjustmentreporttotals()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L275"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "inventorymovements_recordinventorymovementwithdispositionwithctx",
-      "label": "recordInventoryMovementWithDispositionWithCtx()",
-      "norm_label": "recordinventorymovementwithdispositionwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L245"
+      "id": "adjustmentreports_listappliedtransactionadjustmentsforday",
+      "label": "listAppliedTransactionAdjustmentsForDay()",
+      "norm_label": "listappliedtransactionadjustmentsforday()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L229"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "inventorymovements_recordskuactivityforinventorymovementwithctx",
-      "label": "recordSkuActivityForInventoryMovementWithCtx()",
-      "norm_label": "recordskuactivityforinventorymovementwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L111"
+      "id": "adjustmentreports_readappliedtransactionadjustmentsforday",
+      "label": "readAppliedTransactionAdjustmentsForDay()",
+      "norm_label": "readappliedtransactionadjustmentsforday()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L173"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "inventorymovements_summarizeinventorymovements",
-      "label": "summarizeInventoryMovements()",
-      "norm_label": "summarizeinventorymovements()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L135"
+      "id": "adjustmentreports_sourcecompletenessentry",
+      "label": "sourceCompletenessEntry()",
+      "norm_label": "sourcecompletenessentry()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L76"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
-      "label": "inventoryMovements.ts",
-      "norm_label": "inventorymovements.ts",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "id": "packages_athena_webapp_convex_operations_dailyclose_adjustmentreports_ts",
+      "label": "adjustmentReports.ts",
+      "norm_label": "adjustmentreports.ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
       "source_location": "L1"
     },
     {
       "community": 2500,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoresnapshot_test_ts",
+      "label": "posLocalStoreSnapshot.test.ts",
+      "norm_label": "poslocalstoresnapshot.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStoreSnapshot.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2501,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registercatalogpinruntime_test_ts",
+      "label": "registerCatalogPinRuntime.test.ts",
+      "norm_label": "registercatalogpinruntime.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2502,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registerlifecycleauthorityrollout_test_ts",
       "label": "registerLifecycleAuthorityRollout.test.ts",
@@ -230989,7 +231109,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2501,
+      "community": 2503,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registersessionauthoritybootstrap_test_ts",
       "label": "registerSessionAuthorityBootstrap.test.ts",
@@ -230998,7 +231118,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2502,
+      "community": 2504,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_saleblockerpolicy_test_ts",
       "label": "saleBlockerPolicy.test.ts",
@@ -231007,7 +231127,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2503,
+      "community": 2505,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_syncgapdiagnosis_test_ts",
       "label": "syncGapDiagnosis.test.ts",
@@ -231016,7 +231136,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2504,
+      "community": 2506,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_printattempttelemetry_test_ts",
       "label": "printAttemptTelemetry.test.ts",
@@ -231025,7 +231145,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2505,
+      "community": 2507,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_runtimecounters_test_ts",
       "label": "runtimeCounters.test.ts",
@@ -231034,7 +231154,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2506,
+      "community": 2508,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_telemetrybuffer_test_ts",
       "label": "telemetryBuffer.test.ts",
@@ -231043,7 +231163,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2507,
+      "community": 2509,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearch_test_ts",
       "label": "catalogSearch.test.ts",
@@ -231052,7 +231172,97 @@
       "source_location": "L1"
     },
     {
-      "community": 2508,
+      "community": 251,
+      "file_type": "code",
+      "id": "inventorymovements_assertnobusinesseventconflict",
+      "label": "assertNoBusinessEventConflict()",
+      "norm_label": "assertnobusinesseventconflict()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L178"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "inventorymovements_buildinventorymovement",
+      "label": "buildInventoryMovement()",
+      "norm_label": "buildinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L124"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "inventorymovements_buildskuactivityforinventorymovement",
+      "label": "buildSkuActivityForInventoryMovement()",
+      "norm_label": "buildskuactivityforinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "inventorymovements_getskuactivitytypeformovement",
+      "label": "getSkuActivityTypeForMovement()",
+      "norm_label": "getskuactivitytypeformovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "inventorymovements_matchesexistingmovement",
+      "label": "matchesExistingMovement()",
+      "norm_label": "matchesexistingmovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L150"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "inventorymovements_recordinventorymovementwithctx",
+      "label": "recordInventoryMovementWithCtx()",
+      "norm_label": "recordinventorymovementwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L200"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "inventorymovements_recordinventorymovementwithdispositionwithctx",
+      "label": "recordInventoryMovementWithDispositionWithCtx()",
+      "norm_label": "recordinventorymovementwithdispositionwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L245"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "inventorymovements_recordskuactivityforinventorymovementwithctx",
+      "label": "recordSkuActivityForInventoryMovementWithCtx()",
+      "norm_label": "recordskuactivityforinventorymovementwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L111"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "inventorymovements_summarizeinventorymovements",
+      "label": "summarizeInventoryMovements()",
+      "norm_label": "summarizeinventorymovements()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
+      "label": "inventoryMovements.ts",
+      "norm_label": "inventorymovements.ts",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2510,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_catalogsearchpresentation_test_ts",
       "label": "catalogSearchPresentation.test.ts",
@@ -231061,7 +231271,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2509,
+      "community": 2511,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_registercashierpresence_test_ts",
       "label": "registerCashierPresence.test.ts",
@@ -231070,97 +231280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 251,
-      "file_type": "code",
-      "id": "operationalevents_buildoperationalevent",
-      "label": "buildOperationalEvent()",
-      "norm_label": "buildoperationalevent()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L43"
-    },
-    {
-      "community": 251,
-      "file_type": "code",
-      "id": "operationalevents_buildtracemetadata",
-      "label": "buildTraceMetadata()",
-      "norm_label": "buildtracemetadata()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 251,
-      "file_type": "code",
-      "id": "operationalevents_isrecord",
-      "label": "isRecord()",
-      "norm_label": "isrecord()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L145"
-    },
-    {
-      "community": 251,
-      "file_type": "code",
-      "id": "operationalevents_listproductoperationaltimelinewithctx",
-      "label": "listProductOperationalTimelineWithCtx()",
-      "norm_label": "listproductoperationaltimelinewithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L246"
-    },
-    {
-      "community": 251,
-      "file_type": "code",
-      "id": "operationalevents_matchesexistingevent",
-      "label": "matchesExistingEvent()",
-      "norm_label": "matchesexistingevent()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L149"
-    },
-    {
-      "community": 251,
-      "file_type": "code",
-      "id": "operationalevents_metadatadedupekeysmatch",
-      "label": "metadataDedupeKeysMatch()",
-      "norm_label": "metadatadedupekeysmatch()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L205"
-    },
-    {
-      "community": 251,
-      "file_type": "code",
-      "id": "operationalevents_normalizeoperationaleventtracefields",
-      "label": "normalizeOperationalEventTraceFields()",
-      "norm_label": "normalizeoperationaleventtracefields()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L60"
-    },
-    {
-      "community": 251,
-      "file_type": "code",
-      "id": "operationalevents_recordoperationaleventwithctx",
-      "label": "recordOperationalEventWithCtx()",
-      "norm_label": "recordoperationaleventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L215"
-    },
-    {
-      "community": 251,
-      "file_type": "code",
-      "id": "operationalevents_shouldnormalizepostrace",
-      "label": "shouldNormalizePosTrace()",
-      "norm_label": "shouldnormalizepostrace()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L118"
-    },
-    {
-      "community": 251,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
-      "label": "operationalEvents.ts",
-      "norm_label": "operationalevents.ts",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2510,
+      "community": 2512,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_registercheckoutprojection_test_ts",
       "label": "registerCheckoutProjection.test.ts",
@@ -231169,7 +231289,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2511,
+      "community": 2513,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_registeruistate_test_ts",
       "label": "registerUiState.test.ts",
@@ -231178,7 +231298,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2512,
+      "community": 2514,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregistercheckoutdraftstate_test_ts",
       "label": "useRegisterCheckoutDraftState.test.ts",
@@ -231187,7 +231307,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2513,
+      "community": 2515,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_registersessioncode_test_ts",
       "label": "registerSessionCode.test.ts",
@@ -231196,7 +231316,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2514,
+      "community": 2516,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_syncstatuspresentation_test_ts",
       "label": "syncStatusPresentation.test.ts",
@@ -231205,7 +231325,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2515,
+      "community": 2517,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_productutils_test_ts",
       "label": "productUtils.test.ts",
@@ -231214,7 +231334,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2516,
+      "community": 2518,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_remote_assist_contract_test_ts",
       "label": "contract.test.ts",
@@ -231223,7 +231343,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2517,
+      "community": 2519,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_remote_assist_guardrails_test_ts",
       "label": "guardrails.test.ts",
@@ -231232,7 +231352,97 @@
       "source_location": "L1"
     },
     {
-      "community": 2518,
+      "community": 252,
+      "file_type": "code",
+      "id": "operationalevents_buildoperationalevent",
+      "label": "buildOperationalEvent()",
+      "norm_label": "buildoperationalevent()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 252,
+      "file_type": "code",
+      "id": "operationalevents_buildtracemetadata",
+      "label": "buildTraceMetadata()",
+      "norm_label": "buildtracemetadata()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 252,
+      "file_type": "code",
+      "id": "operationalevents_isrecord",
+      "label": "isRecord()",
+      "norm_label": "isrecord()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L145"
+    },
+    {
+      "community": 252,
+      "file_type": "code",
+      "id": "operationalevents_listproductoperationaltimelinewithctx",
+      "label": "listProductOperationalTimelineWithCtx()",
+      "norm_label": "listproductoperationaltimelinewithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L246"
+    },
+    {
+      "community": 252,
+      "file_type": "code",
+      "id": "operationalevents_matchesexistingevent",
+      "label": "matchesExistingEvent()",
+      "norm_label": "matchesexistingevent()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L149"
+    },
+    {
+      "community": 252,
+      "file_type": "code",
+      "id": "operationalevents_metadatadedupekeysmatch",
+      "label": "metadataDedupeKeysMatch()",
+      "norm_label": "metadatadedupekeysmatch()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L205"
+    },
+    {
+      "community": 252,
+      "file_type": "code",
+      "id": "operationalevents_normalizeoperationaleventtracefields",
+      "label": "normalizeOperationalEventTraceFields()",
+      "norm_label": "normalizeoperationaleventtracefields()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L60"
+    },
+    {
+      "community": 252,
+      "file_type": "code",
+      "id": "operationalevents_recordoperationaleventwithctx",
+      "label": "recordOperationalEventWithCtx()",
+      "norm_label": "recordoperationaleventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L215"
+    },
+    {
+      "community": 252,
+      "file_type": "code",
+      "id": "operationalevents_shouldnormalizepostrace",
+      "label": "shouldNormalizePosTrace()",
+      "norm_label": "shouldnormalizepostrace()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L118"
+    },
+    {
+      "community": 252,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
+      "label": "operationalEvents.ts",
+      "norm_label": "operationalevents.ts",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2520,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_remote_assist_index_ts",
       "label": "index.ts",
@@ -231241,7 +231451,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2519,
+      "community": 2521,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_runtimebuildmetadata_test_ts",
       "label": "runtimeBuildMetadata.test.ts",
@@ -231250,97 +231460,7 @@
       "source_location": "L1"
     },
     {
-      "community": 252,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_amendrepairwithctx",
-      "label": "amendRepairWithCtx()",
-      "norm_label": "amendrepairwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L430"
-    },
-    {
-      "community": 252,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_createrepairwithctx",
-      "label": "createRepairWithCtx()",
-      "norm_label": "createrepairwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L160"
-    },
-    {
-      "community": 252,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_pauserepair",
-      "label": "pauseRepair()",
-      "norm_label": "pauserepair()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L231"
-    },
-    {
-      "community": 252,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_processrepairbatchwithctx",
-      "label": "processRepairBatchWithCtx()",
-      "norm_label": "processrepairbatchwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L249"
-    },
-    {
-      "community": 252,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_readcurrentgroup",
-      "label": "readCurrentGroup()",
-      "norm_label": "readcurrentgroup()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 252,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_recordrepairauditevent",
-      "label": "recordRepairAuditEvent()",
-      "norm_label": "recordrepairauditevent()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 252,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_requireevidence",
-      "label": "requireEvidence()",
-      "norm_label": "requireevidence()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 252,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_resumerepairwithctx",
-      "label": "resumeRepairWithCtx()",
-      "norm_label": "resumerepairwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L472"
-    },
-    {
-      "community": 252,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_schedulenextbatch",
-      "label": "scheduleNextBatch()",
-      "norm_label": "schedulenextbatch()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 252,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_oversizedoperationalworkrepair_ts",
-      "label": "oversizedOperationalWorkRepair.ts",
-      "norm_label": "oversizedoperationalworkrepair.ts",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2520,
+      "community": 2522,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -231349,7 +231469,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2521,
+      "community": 2523,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
@@ -231358,7 +231478,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2522,
+      "community": 2524,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -231367,7 +231487,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2523,
+      "community": 2525,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -231376,7 +231496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2524,
+      "community": 2526,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -231385,7 +231505,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2525,
+      "community": 2527,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_security_localpinverifier_test_ts",
       "label": "localPinVerifier.test.ts",
@@ -231394,7 +231514,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2526,
+      "community": 2528,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_sheetreturn_test_ts",
       "label": "sheetReturn.test.ts",
@@ -231403,7 +231523,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2527,
+      "community": 2529,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_stockops_skusearch_test_ts",
       "label": "skuSearch.test.ts",
@@ -231412,7 +231532,97 @@
       "source_location": "L1"
     },
     {
-      "community": 2528,
+      "community": 253,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_amendrepairwithctx",
+      "label": "amendRepairWithCtx()",
+      "norm_label": "amendrepairwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L430"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_createrepairwithctx",
+      "label": "createRepairWithCtx()",
+      "norm_label": "createrepairwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L160"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_pauserepair",
+      "label": "pauseRepair()",
+      "norm_label": "pauserepair()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L231"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_processrepairbatchwithctx",
+      "label": "processRepairBatchWithCtx()",
+      "norm_label": "processrepairbatchwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L249"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_readcurrentgroup",
+      "label": "readCurrentGroup()",
+      "norm_label": "readcurrentgroup()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_recordrepairauditevent",
+      "label": "recordRepairAuditEvent()",
+      "norm_label": "recordrepairauditevent()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_requireevidence",
+      "label": "requireEvidence()",
+      "norm_label": "requireevidence()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_resumerepairwithctx",
+      "label": "resumeRepairWithCtx()",
+      "norm_label": "resumerepairwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L472"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_schedulenextbatch",
+      "label": "scheduleNextBatch()",
+      "norm_label": "schedulenextbatch()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L153"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_oversizedoperationalworkrepair_ts",
+      "label": "oversizedOperationalWorkRepair.ts",
+      "norm_label": "oversizedoperationalworkrepair.ts",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2530,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
@@ -231421,7 +231631,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2529,
+      "community": 2531,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_traces_createworkflowtraceid_test_ts",
       "label": "createWorkflowTraceId.test.ts",
@@ -231430,97 +231640,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
-      "label": "registerSessionTracing.ts",
-      "norm_label": "registersessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "registersessiontracing_buildactorrefs",
-      "label": "buildActorRefs()",
-      "norm_label": "buildactorrefs()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "registersessiontracing_buildtraceevent",
-      "label": "buildTraceEvent()",
-      "norm_label": "buildtraceevent()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L196"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "registersessiontracing_buildtracerecord",
-      "label": "buildTraceRecord()",
-      "norm_label": "buildtracerecord()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L161"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "registersessiontracing_displaytraceamount",
-      "label": "displayTraceAmount()",
-      "norm_label": "displaytraceamount()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L114"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "registersessiontracing_formattransactionlabel",
-      "label": "formatTransactionLabel()",
-      "norm_label": "formattransactionlabel()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L132"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "registersessiontracing_recordregistersessiontracebesteffort",
-      "label": "recordRegisterSessionTraceBestEffort()",
-      "norm_label": "recordregistersessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L407"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "registersessiontracing_resolveoccurredat",
-      "label": "resolveOccurredAt()",
-      "norm_label": "resolveoccurredat()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L76"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "registersessiontracing_resolvestorecurrency",
-      "label": "resolveStoreCurrency()",
-      "norm_label": "resolvestorecurrency()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L146"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "registersessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L92"
-    },
-    {
-      "community": 2530,
+      "community": 2532,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -231529,7 +231649,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2531,
+      "community": 2533,
       "file_type": "code",
       "id": "packages_athena_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -231538,7 +231658,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2532,
+      "community": 2534,
       "file_type": "code",
       "id": "packages_athena_webapp_src_offline_posappshellreadiness_test_ts",
       "label": "posAppShellReadiness.test.ts",
@@ -231547,7 +231667,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2533,
+      "community": 2535,
       "file_type": "code",
       "id": "packages_athena_webapp_src_offline_posappshellroutes_test_ts",
       "label": "posAppShellRoutes.test.ts",
@@ -231556,7 +231676,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2534,
+      "community": 2536,
       "file_type": "code",
       "id": "packages_athena_webapp_src_offline_posofflinereadiness_test_ts",
       "label": "posOfflineReadiness.test.ts",
@@ -231565,7 +231685,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2535,
+      "community": 2537,
       "file_type": "code",
       "id": "packages_athena_webapp_src_offline_registerposappshellserviceworker_test_ts",
       "label": "registerPosAppShellServiceWorker.test.ts",
@@ -231574,7 +231694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2536,
+      "community": 2538,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -231583,7 +231703,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2537,
+      "community": 2539,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_app_entry_route_tsx",
       "label": "-app-entry-route.tsx",
@@ -231592,7 +231712,97 @@
       "source_location": "L1"
     },
     {
-      "community": 2538,
+      "community": 254,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
+      "label": "registerSessionTracing.ts",
+      "norm_label": "registersessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "registersessiontracing_buildactorrefs",
+      "label": "buildActorRefs()",
+      "norm_label": "buildactorrefs()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "registersessiontracing_buildtraceevent",
+      "label": "buildTraceEvent()",
+      "norm_label": "buildtraceevent()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L196"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "registersessiontracing_buildtracerecord",
+      "label": "buildTraceRecord()",
+      "norm_label": "buildtracerecord()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L161"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "registersessiontracing_displaytraceamount",
+      "label": "displayTraceAmount()",
+      "norm_label": "displaytraceamount()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L114"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "registersessiontracing_formattransactionlabel",
+      "label": "formatTransactionLabel()",
+      "norm_label": "formattransactionlabel()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L132"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "registersessiontracing_recordregistersessiontracebesteffort",
+      "label": "recordRegisterSessionTraceBestEffort()",
+      "norm_label": "recordregistersessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L407"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "registersessiontracing_resolveoccurredat",
+      "label": "resolveOccurredAt()",
+      "norm_label": "resolveoccurredat()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "registersessiontracing_resolvestorecurrency",
+      "label": "resolveStoreCurrency()",
+      "norm_label": "resolvestorecurrency()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L146"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "registersessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 2540,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_privacy_page_tsx",
       "label": "-privacy-page.tsx",
@@ -231601,7 +231811,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2539,
+      "community": 2541,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_root_page_search_ts",
       "label": "-root-page-search.ts",
@@ -231610,97 +231820,7 @@
       "source_location": "L1"
     },
     {
-      "community": 254,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_classifyfinalizedlineagerepairconflicts",
-      "label": "classifyFinalizedLineageRepairConflicts()",
-      "norm_label": "classifyfinalizedlineagerepairconflicts()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L222"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_classifyrepaircandidate",
-      "label": "classifyRepairCandidate()",
-      "norm_label": "classifyrepaircandidate()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L164"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_countrepairablefinalizedlineagelines",
-      "label": "countRepairableFinalizedLineageLines()",
-      "norm_label": "countrepairablefinalizedlineagelines()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L284"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_getprovisionalimportsku",
-      "label": "getProvisionalImportSku()",
-      "norm_label": "getprovisionalimportsku()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L318"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_isclosedregisterrepairreplayconflict",
-      "label": "isClosedRegisterRepairReplayConflict()",
-      "norm_label": "isclosedregisterrepairreplayconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L273"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_isfinalizedlineagerepairconflict",
-      "label": "isFinalizedLineageRepairConflict()",
-      "norm_label": "isfinalizedlineagerepairconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L258"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_isprovisionalrowchangedconflict",
-      "label": "isProvisionalRowChangedConflict()",
-      "norm_label": "isprovisionalrowchangedconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L265"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_recordfinalizedlineagerepairevent",
-      "label": "recordFinalizedLineageRepairEvent()",
-      "norm_label": "recordfinalizedlineagerepairevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L358"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_skipped",
-      "label": "skipped()",
-      "norm_label": "skipped()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L346"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sync_finalizedlineageremediation_ts",
-      "label": "finalizedLineageRemediation.ts",
-      "norm_label": "finalizedlineageremediation.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2540,
+      "community": 2542,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_shared_demo_entry_tsx",
       "label": "-shared-demo-entry.tsx",
@@ -231709,7 +231829,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2541,
+      "community": 2543,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_walkthrough_page_tsx",
       "label": "-walkthrough-page.tsx",
@@ -231718,7 +231838,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2542,
+      "community": 2544,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_root_test_ts",
       "label": "__root.test.ts",
@@ -231727,7 +231847,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2543,
+      "community": 2545,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
       "label": "index.tsx",
@@ -231736,7 +231856,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2544,
+      "community": 2546,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
       "label": "index.tsx",
@@ -231745,7 +231865,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2545,
+      "community": 2547,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
       "label": "index.tsx",
@@ -231754,7 +231874,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2546,
+      "community": 2548,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
       "label": "$storeUrlSlug.tsx",
@@ -231763,7 +231883,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2547,
+      "community": 2549,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_app_settings_tsx",
       "label": "app-settings.tsx",
@@ -231772,7 +231892,97 @@
       "source_location": "L1"
     },
     {
-      "community": 2548,
+      "community": 255,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_classifyfinalizedlineagerepairconflicts",
+      "label": "classifyFinalizedLineageRepairConflicts()",
+      "norm_label": "classifyfinalizedlineagerepairconflicts()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L222"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_classifyrepaircandidate",
+      "label": "classifyRepairCandidate()",
+      "norm_label": "classifyrepaircandidate()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L164"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_countrepairablefinalizedlineagelines",
+      "label": "countRepairableFinalizedLineageLines()",
+      "norm_label": "countrepairablefinalizedlineagelines()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L284"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_getprovisionalimportsku",
+      "label": "getProvisionalImportSku()",
+      "norm_label": "getprovisionalimportsku()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L318"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_isclosedregisterrepairreplayconflict",
+      "label": "isClosedRegisterRepairReplayConflict()",
+      "norm_label": "isclosedregisterrepairreplayconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L273"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_isfinalizedlineagerepairconflict",
+      "label": "isFinalizedLineageRepairConflict()",
+      "norm_label": "isfinalizedlineagerepairconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L258"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_isprovisionalrowchangedconflict",
+      "label": "isProvisionalRowChangedConflict()",
+      "norm_label": "isprovisionalrowchangedconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L265"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_recordfinalizedlineagerepairevent",
+      "label": "recordFinalizedLineageRepairEvent()",
+      "norm_label": "recordfinalizedlineagerepairevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L358"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_skipped",
+      "label": "skipped()",
+      "norm_label": "skipped()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L346"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_sync_finalizedlineageremediation_ts",
+      "label": "finalizedLineageRemediation.ts",
+      "norm_label": "finalizedlineageremediation.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2550,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
       "label": "assets.index.tsx",
@@ -231781,7 +231991,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2549,
+      "community": 2551,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
       "label": "bags.$bagId.tsx",
@@ -231790,97 +232000,7 @@
       "source_location": "L1"
     },
     {
-      "community": 255,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_terminalrecoveryrepository_ts",
-      "label": "terminalRecoveryRepository.ts",
-      "norm_label": "terminalrecoveryrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_createterminalrecoverycommandreadrepository",
-      "label": "createTerminalRecoveryCommandReadRepository()",
-      "norm_label": "createterminalrecoverycommandreadrepository()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_createterminalrecoverycommandrepository",
-      "label": "createTerminalRecoveryCommandRepository()",
-      "norm_label": "createterminalrecoverycommandrepository()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L127"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_deduperecoverycommandsbyid",
-      "label": "dedupeRecoveryCommandsById()",
-      "norm_label": "deduperecoverycommandsbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_deduperecoveryconflictsbyid",
-      "label": "dedupeRecoveryConflictsById()",
-      "norm_label": "deduperecoveryconflictsbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L193"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_getterminalrecoverysourceevent",
-      "label": "getTerminalRecoverySourceEvent()",
-      "norm_label": "getterminalrecoverysourceevent()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L222"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_iscurrentterminalrecoveryconflict",
-      "label": "isCurrentTerminalRecoveryConflict()",
-      "norm_label": "iscurrentterminalrecoveryconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L206"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsforrepair",
-      "label": "listTerminalRecoveryConflictsForRepair()",
-      "norm_label": "listterminalrecoveryconflictsforrepair()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L141"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsources",
-      "label": "listTerminalRecoveryConflictSources()",
-      "norm_label": "listterminalrecoveryconflictsources()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L162"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_patchterminalrecoveryconflict",
-      "label": "patchTerminalRecoveryConflict()",
-      "norm_label": "patchterminalrecoveryconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L241"
-    },
-    {
-      "community": 2550,
+      "community": 2552,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
       "label": "bags.index.tsx",
@@ -231889,7 +232009,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2551,
+      "community": 2553,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
       "label": "index.tsx",
@@ -231898,7 +232018,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2552,
+      "community": 2554,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
       "label": "checkout-sessions.index.tsx",
@@ -231907,7 +232027,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2553,
+      "community": 2555,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
       "label": "configuration.index.tsx",
@@ -231916,7 +232036,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2554,
+      "community": 2556,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
       "label": "dashboard.index.tsx",
@@ -231925,7 +232045,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2555,
+      "community": 2557,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
       "label": "home.tsx",
@@ -231934,7 +232054,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2556,
+      "community": 2558,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
       "label": "logs.$logId.tsx",
@@ -231943,7 +232063,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2557,
+      "community": 2559,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
       "label": "logs.index.tsx",
@@ -231952,7 +232072,97 @@
       "source_location": "L1"
     },
     {
-      "community": 2558,
+      "community": 256,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_terminalrecoveryrepository_ts",
+      "label": "terminalRecoveryRepository.ts",
+      "norm_label": "terminalrecoveryrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_createterminalrecoverycommandreadrepository",
+      "label": "createTerminalRecoveryCommandReadRepository()",
+      "norm_label": "createterminalrecoverycommandreadrepository()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_createterminalrecoverycommandrepository",
+      "label": "createTerminalRecoveryCommandRepository()",
+      "norm_label": "createterminalrecoverycommandrepository()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L127"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_deduperecoverycommandsbyid",
+      "label": "dedupeRecoveryCommandsById()",
+      "norm_label": "deduperecoverycommandsbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L116"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_deduperecoveryconflictsbyid",
+      "label": "dedupeRecoveryConflictsById()",
+      "norm_label": "deduperecoveryconflictsbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L193"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_getterminalrecoverysourceevent",
+      "label": "getTerminalRecoverySourceEvent()",
+      "norm_label": "getterminalrecoverysourceevent()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L222"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_iscurrentterminalrecoveryconflict",
+      "label": "isCurrentTerminalRecoveryConflict()",
+      "norm_label": "iscurrentterminalrecoveryconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L206"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsforrepair",
+      "label": "listTerminalRecoveryConflictsForRepair()",
+      "norm_label": "listterminalrecoveryconflictsforrepair()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L141"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsources",
+      "label": "listTerminalRecoveryConflictSources()",
+      "norm_label": "listterminalrecoveryconflictsources()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L162"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_patchterminalrecoveryconflict",
+      "label": "patchTerminalRecoveryConflict()",
+      "norm_label": "patchterminalrecoveryconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L241"
+    },
+    {
+      "community": 2560,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
       "label": "members.index.tsx",
@@ -231961,7 +232171,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2559,
+      "community": 2561,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_test_ts",
       "label": "index.test.ts",
@@ -231970,97 +232180,7 @@
       "source_location": "L1"
     },
     {
-      "community": 256,
-      "file_type": "code",
-      "id": "contract_test_day",
-      "label": "day()",
-      "norm_label": "day()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L1308"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "contract_test_fieldsof",
-      "label": "fieldsOf()",
-      "norm_label": "fieldsof()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L86"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "contract_test_headerfor",
-      "label": "headerFor()",
-      "norm_label": "headerfor()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L972"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "contract_test_inclusivedays",
-      "label": "inclusiveDays()",
-      "norm_label": "inclusivedays()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L1216"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "contract_test_movementidentityargs",
-      "label": "movementIdentityArgs()",
-      "norm_label": "movementidentityargs()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L602"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "contract_test_probe",
-      "label": "probe()",
-      "norm_label": "probe()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L1312"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "contract_test_seedproductsku",
-      "label": "seedProductSku()",
-      "norm_label": "seedproductsku()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L561"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "contract_test_seedstore",
-      "label": "seedStore()",
-      "norm_label": "seedstore()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L542"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "contract_test_unionliterals",
-      "label": "unionLiterals()",
-      "norm_label": "unionliterals()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L92"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_contract_test_ts",
-      "label": "contract.test.ts",
-      "norm_label": "contract.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2560,
+      "community": 2562,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_inventory_import_cost_overlay_search_ts",
       "label": "-cost-overlay-search.ts",
@@ -232069,7 +232189,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2561,
+      "community": 2563,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_inventory_import_cost_overlay_test_ts",
       "label": "cost-overlay.test.ts",
@@ -232078,7 +232198,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2562,
+      "community": 2564,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_inventory_import_cost_overlay_tsx",
       "label": "cost-overlay.tsx",
@@ -232087,7 +232207,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2563,
+      "community": 2565,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_inventory_import_review_tsx",
       "label": "review.tsx",
@@ -232096,7 +232216,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2564,
+      "community": 2566,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_inventory_import_test_tsx",
       "label": "inventory-import.test.tsx",
@@ -232105,7 +232225,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2565,
+      "community": 2567,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_inventory_import_tsx",
       "label": "inventory-import.tsx",
@@ -232114,7 +232234,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2566,
+      "community": 2568,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_sku_activity_test_tsx",
       "label": "sku-activity.test.tsx",
@@ -232123,7 +232243,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2567,
+      "community": 2569,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
       "label": "index.tsx",
@@ -232132,7 +232252,97 @@
       "source_location": "L1"
     },
     {
-      "community": 2568,
+      "community": 257,
+      "file_type": "code",
+      "id": "contract_test_day",
+      "label": "day()",
+      "norm_label": "day()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L1308"
+    },
+    {
+      "community": 257,
+      "file_type": "code",
+      "id": "contract_test_fieldsof",
+      "label": "fieldsOf()",
+      "norm_label": "fieldsof()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L86"
+    },
+    {
+      "community": 257,
+      "file_type": "code",
+      "id": "contract_test_headerfor",
+      "label": "headerFor()",
+      "norm_label": "headerfor()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L972"
+    },
+    {
+      "community": 257,
+      "file_type": "code",
+      "id": "contract_test_inclusivedays",
+      "label": "inclusiveDays()",
+      "norm_label": "inclusivedays()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L1216"
+    },
+    {
+      "community": 257,
+      "file_type": "code",
+      "id": "contract_test_movementidentityargs",
+      "label": "movementIdentityArgs()",
+      "norm_label": "movementidentityargs()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L602"
+    },
+    {
+      "community": 257,
+      "file_type": "code",
+      "id": "contract_test_probe",
+      "label": "probe()",
+      "norm_label": "probe()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L1312"
+    },
+    {
+      "community": 257,
+      "file_type": "code",
+      "id": "contract_test_seedproductsku",
+      "label": "seedProductSku()",
+      "norm_label": "seedproductsku()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L561"
+    },
+    {
+      "community": 257,
+      "file_type": "code",
+      "id": "contract_test_seedstore",
+      "label": "seedStore()",
+      "norm_label": "seedstore()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L542"
+    },
+    {
+      "community": 257,
+      "file_type": "code",
+      "id": "contract_test_unionliterals",
+      "label": "unionLiterals()",
+      "norm_label": "unionliterals()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 257,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_reports_contract_test_ts",
+      "label": "contract.test.ts",
+      "norm_label": "contract.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2570,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
       "label": "all.index.tsx",
@@ -232141,7 +232351,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2569,
+      "community": 2571,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
       "label": "cancelled.index.tsx",
@@ -232150,97 +232360,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
-      "file_type": "code",
-      "id": "customrange_aggregateskudays",
-      "label": "aggregateSkuDays()",
-      "norm_label": "aggregateskudays()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L217"
-    },
-    {
-      "community": 257,
-      "file_type": "code",
-      "id": "customrange_computerange",
-      "label": "computeRange()",
-      "norm_label": "computerange()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L253"
-    },
-    {
-      "community": 257,
-      "file_type": "code",
-      "id": "customrange_computerequestkey",
-      "label": "computeRequestKey()",
-      "norm_label": "computerequestkey()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L84"
-    },
-    {
-      "community": 257,
-      "file_type": "code",
-      "id": "customrange_inclusivedayspan",
-      "label": "inclusiveDaySpan()",
-      "norm_label": "inclusivedayspan()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 257,
-      "file_type": "code",
-      "id": "customrange_isvalidoperatingdate",
-      "label": "isValidOperatingDate()",
-      "norm_label": "isvalidoperatingdate()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 257,
-      "file_type": "code",
-      "id": "customrange_requestrangecore",
-      "label": "requestRangeCore()",
-      "norm_label": "requestrangecore()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L112"
-    },
-    {
-      "community": 257,
-      "file_type": "code",
-      "id": "customrange_sumdays",
-      "label": "sumDays()",
-      "norm_label": "sumdays()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L189"
-    },
-    {
-      "community": 257,
-      "file_type": "code",
-      "id": "customrange_utcmillisforlabel",
-      "label": "utcMillisForLabel()",
-      "norm_label": "utcmillisforlabel()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 257,
-      "file_type": "code",
-      "id": "customrange_validaterangeargs",
-      "label": "validateRangeArgs()",
-      "norm_label": "validaterangeargs()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 257,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_customrange_ts",
-      "label": "customRange.ts",
-      "norm_label": "customrange.ts",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2570,
+      "community": 2572,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
       "label": "completed.index.tsx",
@@ -232249,7 +232369,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2571,
+      "community": 2573,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
       "label": "index.tsx",
@@ -232258,7 +232378,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2572,
+      "community": 2574,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
       "label": "open.index.tsx",
@@ -232267,7 +232387,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2573,
+      "community": 2575,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
       "label": "out-for-delivery.index.tsx",
@@ -232276,7 +232396,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2574,
+      "community": 2576,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
       "label": "ready.index.tsx",
@@ -232285,7 +232405,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2575,
+      "community": 2577,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
       "label": "refunded.index.tsx",
@@ -232294,7 +232414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2576,
+      "community": 2578,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
       "label": "$reportId.tsx",
@@ -232303,7 +232423,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2577,
+      "community": 2579,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
       "label": "expense-reports.index.tsx",
@@ -232312,7 +232432,97 @@
       "source_location": "L1"
     },
     {
-      "community": 2578,
+      "community": 258,
+      "file_type": "code",
+      "id": "customrange_aggregateskudays",
+      "label": "aggregateSkuDays()",
+      "norm_label": "aggregateskudays()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L217"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "customrange_computerange",
+      "label": "computeRange()",
+      "norm_label": "computerange()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L253"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "customrange_computerequestkey",
+      "label": "computeRequestKey()",
+      "norm_label": "computerequestkey()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "customrange_inclusivedayspan",
+      "label": "inclusiveDaySpan()",
+      "norm_label": "inclusivedayspan()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "customrange_isvalidoperatingdate",
+      "label": "isValidOperatingDate()",
+      "norm_label": "isvalidoperatingdate()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "customrange_requestrangecore",
+      "label": "requestRangeCore()",
+      "norm_label": "requestrangecore()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L112"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "customrange_sumdays",
+      "label": "sumDays()",
+      "norm_label": "sumdays()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L189"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "customrange_utcmillisforlabel",
+      "label": "utcMillisForLabel()",
+      "norm_label": "utcmillisforlabel()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "customrange_validaterangeargs",
+      "label": "validateRangeArgs()",
+      "norm_label": "validaterangeargs()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_reports_customrange_ts",
+      "label": "customRange.ts",
+      "norm_label": "customrange.ts",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2580,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_test_tsx",
       "label": "expense.index.test.tsx",
@@ -232321,7 +232531,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2579,
+      "community": 2581,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
       "label": "register.index.tsx",
@@ -232330,97 +232540,7 @@
       "source_location": "L1"
     },
     {
-      "community": 258,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_rangesnapshotlifecycle_test_ts",
-      "label": "rangeSnapshotLifecycle.test.ts",
-      "norm_label": "rangesnapshotlifecycle.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_allow",
-      "label": "allow()",
-      "norm_label": "allow()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L53"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_certifyday",
-      "label": "certifyDay()",
-      "norm_label": "certifyday()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L109"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_consume",
-      "label": "consume()",
-      "norm_label": "consume()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L296"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_drive",
-      "label": "drive()",
-      "norm_label": "drive()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L247"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_ensuresynthetic",
-      "label": "ensureSynthetic()",
-      "norm_label": "ensuresynthetic()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L208"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_headerbykey",
-      "label": "headerByKey()",
-      "norm_label": "headerbykey()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L230"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_insertkindedheader",
-      "label": "insertKindedHeader()",
-      "norm_label": "insertkindedheader()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L612"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_seedstore",
-      "label": "seedStore()",
-      "norm_label": "seedstore()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_synthetickind",
-      "label": "syntheticKind()",
-      "norm_label": "synthetickind()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L150"
-    },
-    {
-      "community": 2580,
+      "community": 2582,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_sessions_index_tsx",
       "label": "sessions.index.tsx",
@@ -232429,7 +232549,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2581,
+      "community": 2583,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_terminals_terminalid_tsx",
       "label": "$terminalId.tsx",
@@ -232438,7 +232558,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2582,
+      "community": 2584,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_terminals_index_tsx",
       "label": "terminals.index.tsx",
@@ -232447,7 +232567,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2583,
+      "community": 2585,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
       "label": "$transactionId.tsx",
@@ -232456,7 +232576,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2584,
+      "community": 2586,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
       "label": "transactions.index.tsx",
@@ -232465,7 +232585,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2585,
+      "community": 2587,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_test_ts",
       "label": "procurement.index.test.ts",
@@ -232474,7 +232594,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2586,
+      "community": 2588,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
       "label": "edit.tsx",
@@ -232483,7 +232603,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2587,
+      "community": 2589,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
       "label": "index.tsx",
@@ -232492,7 +232612,97 @@
       "source_location": "L1"
     },
     {
-      "community": 2588,
+      "community": 259,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_reports_rangesnapshotlifecycle_test_ts",
+      "label": "rangeSnapshotLifecycle.test.ts",
+      "norm_label": "rangesnapshotlifecycle.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_allow",
+      "label": "allow()",
+      "norm_label": "allow()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_certifyday",
+      "label": "certifyDay()",
+      "norm_label": "certifyday()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L109"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_consume",
+      "label": "consume()",
+      "norm_label": "consume()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L296"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_drive",
+      "label": "drive()",
+      "norm_label": "drive()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L247"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_ensuresynthetic",
+      "label": "ensureSynthetic()",
+      "norm_label": "ensuresynthetic()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L208"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_headerbykey",
+      "label": "headerByKey()",
+      "norm_label": "headerbykey()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L230"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_insertkindedheader",
+      "label": "insertKindedHeader()",
+      "norm_label": "insertkindedheader()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L612"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_seedstore",
+      "label": "seedStore()",
+      "norm_label": "seedstore()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_synthetickind",
+      "label": "syntheticKind()",
+      "norm_label": "synthetickind()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L150"
+    },
+    {
+      "community": 2590,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_archived_tsx",
       "label": "archived.tsx",
@@ -232501,7 +232711,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2589,
+      "community": 2591,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
       "label": "new.tsx",
@@ -232510,97 +232720,7 @@
       "source_location": "L1"
     },
     {
-      "community": 259,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_verificationclassify_ts",
-      "label": "verificationClassify.ts",
-      "norm_label": "verificationclassify.ts",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "verificationclassify_buildclassification",
-      "label": "buildClassification()",
-      "norm_label": "buildclassification()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L448"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "verificationclassify_classifydayresult",
-      "label": "classifyDayResult()",
-      "norm_label": "classifydayresult()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L481"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "verificationclassify_classifyweekresult",
-      "label": "classifyWeekResult()",
-      "norm_label": "classifyweekresult()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L562"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "verificationclassify_confirmsclean",
-      "label": "confirmsClean()",
-      "norm_label": "confirmsclean()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L681"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "verificationclassify_explainmetricdifference",
-      "label": "explainMetricDifference()",
-      "norm_label": "explainmetricdifference()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L378"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "verificationclassify_fingerprintdifferences",
-      "label": "fingerprintDifferences()",
-      "norm_label": "fingerprintdifferences()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L354"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "verificationclassify_initialstreakstate",
-      "label": "initialStreakState()",
-      "norm_label": "initialstreakstate()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L658"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "verificationclassify_nextstreakstate",
-      "label": "nextStreakState()",
-      "norm_label": "nextstreakstate()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L707"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "verificationclassify_partitiondifferences",
-      "label": "partitionDifferences()",
-      "norm_label": "partitiondifferences()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L434"
-    },
-    {
-      "community": 2590,
+      "community": 2592,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
       "label": "new.tsx",
@@ -232609,7 +232729,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2591,
+      "community": 2593,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
       "label": "unresolved.tsx",
@@ -232618,7 +232738,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2592,
+      "community": 2594,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
       "label": "$promoCodeSlug.tsx",
@@ -232627,7 +232747,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2593,
+      "community": 2595,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
       "label": "index.tsx",
@@ -232636,7 +232756,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2594,
+      "community": 2596,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
       "label": "new.tsx",
@@ -232645,7 +232765,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2595,
+      "community": 2597,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_items_productskuid_test_ts",
       "label": "$productSkuId.test.ts",
@@ -232654,7 +232774,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2596,
+      "community": 2598,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_items_index_test_ts",
       "label": "index.test.ts",
@@ -232663,30 +232783,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2597,
+      "community": 2599,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_items_tsx",
       "label": "items.tsx",
       "norm_label": "items.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports/items.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2598,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_weekly_test_ts",
-      "label": "weekly.test.ts",
-      "norm_label": "weekly.test.ts",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports/weekly.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2599,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_tsx",
-      "label": "reports.tsx",
-      "norm_label": "reports.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports.tsx",
       "source_location": "L1"
     },
     {
@@ -233034,95 +233136,113 @@
     {
       "community": 260,
       "file_type": "code",
-      "id": "index_resolveverificationcoderecipient",
-      "label": "resolveVerificationCodeRecipient()",
-      "norm_label": "resolveverificationcoderecipient()",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "index_senddailymanagerreportemail",
-      "label": "sendDailyManagerReportEmail()",
-      "norm_label": "senddailymanagerreportemail()",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
-      "source_location": "L373"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "index_senddiscountcodeemail",
-      "label": "sendDiscountCodeEmail()",
-      "norm_label": "senddiscountcodeemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L255"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "index_senddiscountreminderemail",
-      "label": "sendDiscountReminderEmail()",
-      "norm_label": "senddiscountreminderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L334"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "index_sendfeedbackrequestemail",
-      "label": "sendFeedbackRequestEmail()",
-      "norm_label": "sendfeedbackrequestemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L167"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "index_sendneworderemail",
-      "label": "sendNewOrderEmail()",
-      "norm_label": "sendneworderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L117"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "index_sendorderemail",
-      "label": "sendOrderEmail()",
-      "norm_label": "sendorderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "index_sendverificationcode",
-      "label": "sendVerificationCode()",
-      "norm_label": "sendverificationcode()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "id": "packages_athena_webapp_convex_reports_verificationclassify_ts",
+      "label": "verificationClassify.ts",
+      "norm_label": "verificationclassify.ts",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
       "source_location": "L1"
     },
     {
       "community": 260,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L1"
+      "id": "verificationclassify_buildclassification",
+      "label": "buildClassification()",
+      "norm_label": "buildclassification()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L448"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "verificationclassify_classifydayresult",
+      "label": "classifyDayResult()",
+      "norm_label": "classifydayresult()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L481"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "verificationclassify_classifyweekresult",
+      "label": "classifyWeekResult()",
+      "norm_label": "classifyweekresult()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L562"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "verificationclassify_confirmsclean",
+      "label": "confirmsClean()",
+      "norm_label": "confirmsclean()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L681"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "verificationclassify_explainmetricdifference",
+      "label": "explainMetricDifference()",
+      "norm_label": "explainmetricdifference()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L378"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "verificationclassify_fingerprintdifferences",
+      "label": "fingerprintDifferences()",
+      "norm_label": "fingerprintdifferences()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L354"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "verificationclassify_initialstreakstate",
+      "label": "initialStreakState()",
+      "norm_label": "initialstreakstate()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L658"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "verificationclassify_nextstreakstate",
+      "label": "nextStreakState()",
+      "norm_label": "nextstreakstate()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L707"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "verificationclassify_partitiondifferences",
+      "label": "partitionDifferences()",
+      "norm_label": "partitiondifferences()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L434"
     },
     {
       "community": 2600,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_weekly_test_ts",
+      "label": "weekly.test.ts",
+      "norm_label": "weekly.test.ts",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports/weekly.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2601,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_tsx",
+      "label": "reports.tsx",
+      "norm_label": "reports.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2602,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
       "label": "index.tsx",
@@ -233131,7 +233251,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2601,
+      "community": 2603,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
       "label": "new.index.tsx",
@@ -233140,7 +233260,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2602,
+      "community": 2604,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_active_cases_index_tsx",
       "label": "active-cases.index.tsx",
@@ -233149,7 +233269,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2603,
+      "community": 2605,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_appointments_index_tsx",
       "label": "appointments.index.tsx",
@@ -233158,7 +233278,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2604,
+      "community": 2606,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_catalog_management_index_tsx",
       "label": "catalog-management.index.tsx",
@@ -233167,7 +233287,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2605,
+      "community": 2607,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_index_tsx",
       "label": "index.tsx",
@@ -233176,7 +233296,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2606,
+      "community": 2608,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_intake_index_tsx",
       "label": "intake.index.tsx",
@@ -233185,30 +233305,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2607,
+      "community": 2609,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_test_tsx",
       "label": "$traceId.test.tsx",
       "norm_label": "$traceid.test.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/traces/$traceId.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2608,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
-      "label": "users.$userId.tsx",
-      "norm_label": "users.$userid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/users.$userId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2609,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/index.tsx",
       "source_location": "L1"
     },
     {
@@ -233304,6 +233406,24 @@
     {
       "community": 2610,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
+      "label": "users.$userId.tsx",
+      "norm_label": "users.$userid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/users.$userId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2611,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2612,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_shell_test_tsx",
       "label": "_authed-shell.test.tsx",
       "norm_label": "_authed-shell.test.tsx",
@@ -233311,7 +233431,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2611,
+      "community": 2613,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_test_tsx",
       "label": "_authed.test.tsx",
@@ -233320,7 +233440,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2612,
+      "community": 2614,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_app_route_test_tsx",
       "label": "app.route.test.tsx",
@@ -233329,7 +233449,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2613,
+      "community": 2615,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_app_test_tsx",
       "label": "app.test.tsx",
@@ -233338,7 +233458,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2614,
+      "community": 2616,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_app_tsx",
       "label": "app.tsx",
@@ -233347,7 +233467,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2615,
+      "community": 2617,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_demo_test_tsx",
       "label": "demo.test.tsx",
@@ -233356,7 +233476,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2616,
+      "community": 2618,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_demo_tsx",
       "label": "demo.tsx",
@@ -233365,30 +233485,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2617,
+      "community": 2619,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_docs_index_tsx",
       "label": "docs.index.tsx",
       "norm_label": "docs.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/docs.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2618,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_docs_reports_slug_tsx",
-      "label": "docs.reports.$slug.tsx",
-      "norm_label": "docs.reports.$slug.tsx",
-      "source_file": "packages/athena-webapp/src/routes/docs.reports.$slug.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2619,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_docs_solutions_category_slug_test_tsx",
-      "label": "docs.solutions.$category.$slug.test.tsx",
-      "norm_label": "docs.solutions.$category.$slug.test.tsx",
-      "source_file": "packages/athena-webapp/src/routes/docs.solutions.$category.$slug.test.tsx",
       "source_location": "L1"
     },
     {
@@ -233484,6 +233586,24 @@
     {
       "community": 2620,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_docs_reports_slug_tsx",
+      "label": "docs.reports.$slug.tsx",
+      "norm_label": "docs.reports.$slug.tsx",
+      "source_file": "packages/athena-webapp/src/routes/docs.reports.$slug.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2621,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_docs_solutions_category_slug_test_tsx",
+      "label": "docs.solutions.$category.$slug.test.tsx",
+      "norm_label": "docs.solutions.$category.$slug.test.tsx",
+      "source_file": "packages/athena-webapp/src/routes/docs.solutions.$category.$slug.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2622,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_docs_tsx",
       "label": "docs.tsx",
       "norm_label": "docs.tsx",
@@ -233491,7 +233611,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2621,
+      "community": 2623,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_test_tsx",
       "label": "index.test.tsx",
@@ -233500,7 +233620,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2622,
+      "community": 2624,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -233509,7 +233629,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2623,
+      "community": 2625,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
       "label": "join-team.index.tsx",
@@ -233518,7 +233638,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2624,
+      "community": 2626,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_landing_tsx",
       "label": "landing.tsx",
@@ -233527,7 +233647,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2625,
+      "community": 2627,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_test_tsx",
       "label": "_layout.index.test.tsx",
@@ -233536,7 +233656,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2626,
+      "community": 2628,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
       "label": "_layout.index.tsx",
@@ -233545,30 +233665,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2627,
+      "community": 2629,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_tsx",
       "label": "_layout.tsx",
       "norm_label": "_layout.tsx",
       "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2628,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_privacy_test_tsx",
-      "label": "privacy.test.tsx",
-      "norm_label": "privacy.test.tsx",
-      "source_file": "packages/athena-webapp/src/routes/privacy.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2629,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_privacy_tsx",
-      "label": "privacy.tsx",
-      "norm_label": "privacy.tsx",
-      "source_file": "packages/athena-webapp/src/routes/privacy.tsx",
       "source_location": "L1"
     },
     {
@@ -233664,6 +233766,24 @@
     {
       "community": 2630,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_privacy_test_tsx",
+      "label": "privacy.test.tsx",
+      "norm_label": "privacy.test.tsx",
+      "source_file": "packages/athena-webapp/src/routes/privacy.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2631,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_privacy_tsx",
+      "label": "privacy.tsx",
+      "norm_label": "privacy.tsx",
+      "source_file": "packages/athena-webapp/src/routes/privacy.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2632,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_register_interest_tsx",
       "label": "register-interest.tsx",
       "norm_label": "register-interest.tsx",
@@ -233671,7 +233791,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2631,
+      "community": 2633,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_walkthrough_test_tsx",
       "label": "walkthrough.test.tsx",
@@ -233680,7 +233800,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2632,
+      "community": 2634,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_walkthrough_tsx",
       "label": "walkthrough.tsx",
@@ -233689,7 +233809,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2633,
+      "community": 2635,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
       "label": "StoresSettingsAccordion.tsx",
@@ -233698,7 +233818,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2634,
+      "community": 2636,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stores_expensestore_test_ts",
       "label": "expenseStore.test.ts",
@@ -233707,7 +233827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2635,
+      "community": 2637,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -233716,7 +233836,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2636,
+      "community": 2638,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
       "label": "foundations-content.test.tsx",
@@ -233725,30 +233845,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2637,
+      "community": 2639,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
       "label": "Introduction.stories.tsx",
       "norm_label": "introduction.stories.tsx",
       "source_file": "packages/athena-webapp/src/stories/Guidance/Introduction.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2638,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
-      "label": "introduction-content.test.tsx",
-      "norm_label": "introduction-content.test.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2639,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
-      "label": "introduction-content.tsx",
-      "norm_label": "introduction-content.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.tsx",
       "source_location": "L1"
     },
     {
@@ -233844,6 +233946,24 @@
     {
       "community": 2640,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
+      "label": "introduction-content.test.tsx",
+      "norm_label": "introduction-content.test.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2641,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
+      "label": "introduction-content.tsx",
+      "norm_label": "introduction-content.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Guidance/introduction-content.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2642,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_adminshell_stories_tsx",
       "label": "AdminShell.stories.tsx",
       "norm_label": "adminshell.stories.tsx",
@@ -233851,7 +233971,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2641,
+      "community": 2643,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_view_stories_tsx",
       "label": "View.stories.tsx",
@@ -233860,7 +233980,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2642,
+      "community": 2644,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_test_tsx",
       "label": "admin-shell-patterns.test.tsx",
@@ -233869,7 +233989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2643,
+      "community": 2645,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_view_patterns_test_tsx",
       "label": "view-patterns.test.tsx",
@@ -233878,7 +233998,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2644,
+      "community": 2646,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_surfaces_stories_tsx",
       "label": "Surfaces.stories.tsx",
@@ -233887,7 +234007,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2645,
+      "community": 2647,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
       "label": "DashboardWorkspace.stories.tsx",
@@ -233896,7 +234016,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2646,
+      "community": 2648,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
       "label": "DataWorkspace.stories.tsx",
@@ -233905,30 +234025,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2647,
+      "community": 2649,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_settingsworkspace_stories_tsx",
       "label": "SettingsWorkspace.stories.tsx",
       "norm_label": "settingsworkspace.stories.tsx",
       "source_file": "packages/athena-webapp/src/stories/Templates/SettingsWorkspace.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2648,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_test_tsx",
-      "label": "reference-fixtures.test.tsx",
-      "norm_label": "reference-fixtures.test.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2649,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_operations_eodreviewfixtures_ts",
-      "label": "eodReviewFixtures.ts",
-      "norm_label": "eodreviewfixtures.ts",
-      "source_file": "packages/athena-webapp/src/stories/operations/eodReviewFixtures.ts",
       "source_location": "L1"
     },
     {
@@ -234024,6 +234126,24 @@
     {
       "community": 2650,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_test_tsx",
+      "label": "reference-fixtures.test.tsx",
+      "norm_label": "reference-fixtures.test.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/reference-fixtures.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2651,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_operations_eodreviewfixtures_ts",
+      "label": "eodReviewFixtures.ts",
+      "norm_label": "eodreviewfixtures.ts",
+      "source_file": "packages/athena-webapp/src/stories/operations/eodReviewFixtures.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2652,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_config_test_ts",
       "label": "storybook-config.test.ts",
       "norm_label": "storybook-config.test.ts",
@@ -234031,7 +234151,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2651,
+      "community": 2653,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_test_ts",
       "label": "storybook-theme-decorator.test.ts",
@@ -234040,7 +234160,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2652,
+      "community": 2654,
       "file_type": "code",
       "id": "packages_athena_webapp_src_test_setup_ts",
       "label": "setup.ts",
@@ -234049,7 +234169,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2653,
+      "community": 2655,
       "file_type": "code",
       "id": "packages_athena_webapp_src_vite_env_d_ts",
       "label": "vite-env.d.ts",
@@ -234058,7 +234178,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2654,
+      "community": 2656,
       "file_type": "code",
       "id": "packages_athena_webapp_src_viteconfig_test_ts",
       "label": "viteConfig.test.ts",
@@ -234067,7 +234187,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2655,
+      "community": 2657,
       "file_type": "code",
       "id": "packages_athena_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -234076,7 +234196,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2656,
+      "community": 2658,
       "file_type": "code",
       "id": "packages_athena_webapp_types_ts",
       "label": "types.ts",
@@ -234085,30 +234205,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2657,
+      "community": 2659,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
       "norm_label": "vitest.config.ts",
       "source_file": "packages/athena-webapp/vitest.config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2658,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_eslint_config_js",
-      "label": "eslint.config.js",
-      "norm_label": "eslint.config.js",
-      "source_file": "packages/storefront-webapp/eslint.config.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 2659,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_global_d_ts",
-      "label": "global.d.ts",
-      "norm_label": "global.d.ts",
-      "source_file": "packages/storefront-webapp/global.d.ts",
       "source_location": "L1"
     },
     {
@@ -234204,6 +234306,24 @@
     {
       "community": 2660,
       "file_type": "code",
+      "id": "packages_storefront_webapp_eslint_config_js",
+      "label": "eslint.config.js",
+      "norm_label": "eslint.config.js",
+      "source_file": "packages/storefront-webapp/eslint.config.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 2661,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_global_d_ts",
+      "label": "global.d.ts",
+      "norm_label": "global.d.ts",
+      "source_file": "packages/storefront-webapp/global.d.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2662,
+      "file_type": "code",
       "id": "packages_storefront_webapp_playwright_config_ts",
       "label": "playwright.config.ts",
       "norm_label": "playwright.config.ts",
@@ -234211,7 +234331,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2661,
+      "community": 2663,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_test_ts",
       "label": "analytics.test.ts",
@@ -234220,7 +234340,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2662,
+      "community": 2664,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_homepagesnapshot_test_ts",
       "label": "homepageSnapshot.test.ts",
@@ -234229,7 +234349,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2663,
+      "community": 2665,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_trackingevents_test_ts",
       "label": "trackingEvents.test.ts",
@@ -234238,7 +234358,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2664,
+      "community": 2666,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_types_ts",
       "label": "types.ts",
@@ -234247,7 +234367,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2665,
+      "community": 2667,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
       "label": "HeartIconFilled.tsx",
@@ -234256,7 +234376,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2666,
+      "community": 2668,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -234265,30 +234385,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2667,
+      "community": 2669,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
       "label": "HomePage.test.tsx",
       "norm_label": "homepage.test.tsx",
       "source_file": "packages/storefront-webapp/src/components/HomePage.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2668,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
-      "label": "ProductCard.test.tsx",
-      "norm_label": "productcard.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ProductCard.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2669,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_upsell_tsx",
-      "label": "Upsell.tsx",
-      "norm_label": "upsell.tsx",
-      "source_file": "packages/storefront-webapp/src/components/Upsell.tsx",
       "source_location": "L1"
     },
     {
@@ -234384,6 +234486,24 @@
     {
       "community": 2670,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
+      "label": "ProductCard.test.tsx",
+      "norm_label": "productcard.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ProductCard.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2671,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_upsell_tsx",
+      "label": "Upsell.tsx",
+      "norm_label": "upsell.tsx",
+      "source_file": "packages/storefront-webapp/src/components/Upsell.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2672,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_test_tsx",
       "label": "Checkout.test.tsx",
       "norm_label": "checkout.test.tsx",
@@ -234391,7 +234511,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2671,
+      "community": 2673,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
       "label": "Checkout.tsx",
@@ -234400,7 +234520,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2672,
+      "community": 2674,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
       "label": "CustomerInfoSection.tsx",
@@ -234409,7 +234529,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2673,
+      "community": 2675,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_schema_ts",
       "label": "schema.ts",
@@ -234418,7 +234538,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2674,
+      "community": 2676,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetailssection_tsx",
       "label": "DeliveryDetailsSection.tsx",
@@ -234427,7 +234547,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2675,
+      "community": 2677,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_test_ts",
       "label": "checkoutStorage.test.ts",
@@ -234436,7 +234556,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2676,
+      "community": 2678,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
       "label": "deliveryFees.test.ts",
@@ -234445,30 +234565,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2677,
+      "community": 2679,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
       "label": "deriveCheckoutState.test.ts",
       "norm_label": "derivecheckoutstate.test.ts",
       "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2678,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
-      "label": "billingDetailsSchema.ts",
-      "norm_label": "billingdetailsschema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/billingDetailsSchema.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2679,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
-      "label": "checkoutFormSchema.ts",
-      "norm_label": "checkoutformschema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutFormSchema.ts",
       "source_location": "L1"
     },
     {
@@ -234564,6 +234666,24 @@
     {
       "community": 2680,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
+      "label": "billingDetailsSchema.ts",
+      "norm_label": "billingdetailsschema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/billingDetailsSchema.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2681,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
+      "label": "checkoutFormSchema.ts",
+      "norm_label": "checkoutformschema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutFormSchema.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2682,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_customerdetailsschema_ts",
       "label": "customerDetailsSchema.ts",
       "norm_label": "customerdetailsschema.ts",
@@ -234571,7 +234691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2681,
+      "community": 2683,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
       "label": "deliveryDetailsSchema.ts",
@@ -234580,7 +234700,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2682,
+      "community": 2684,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
       "label": "webOrderSchema.ts",
@@ -234589,7 +234709,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2683,
+      "community": 2685,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_types_ts",
       "label": "types.ts",
@@ -234598,7 +234718,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2684,
+      "community": 2686,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_utils_test_ts",
       "label": "utils.test.ts",
@@ -234607,7 +234727,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2685,
+      "community": 2687,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilterbar_tsx",
       "label": "ProductFilterBar.tsx",
@@ -234616,7 +234736,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2686,
+      "community": 2688,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_test_tsx",
       "label": "BestSellersSection.test.tsx",
@@ -234625,30 +234745,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2687,
+      "community": 2689,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
       "label": "HomeHero.tsx",
       "norm_label": "homehero.tsx",
       "source_file": "packages/storefront-webapp/src/components/home/HomeHero.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2688,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
-      "label": "HomeHeroSection.tsx",
-      "norm_label": "homeherosection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/HomeHeroSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2689,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_homepagecontent_test_ts",
-      "label": "homePageContent.test.ts",
-      "norm_label": "homepagecontent.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/home/homePageContent.test.ts",
       "source_location": "L1"
     },
     {
@@ -234744,6 +234846,24 @@
     {
       "community": 2690,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
+      "label": "HomeHeroSection.tsx",
+      "norm_label": "homeherosection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/HomeHeroSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2691,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_homepagecontent_test_ts",
+      "label": "homePageContent.test.ts",
+      "norm_label": "homepagecontent.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/home/homePageContent.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2692,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilemenu_tsx",
       "label": "MobileMenu.tsx",
       "norm_label": "mobilemenu.tsx",
@@ -234751,7 +234871,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2691,
+      "community": 2693,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
       "label": "constants.ts",
@@ -234760,7 +234880,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2692,
+      "community": 2694,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
       "label": "navBarConstants.ts",
@@ -234769,7 +234889,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2693,
+      "community": 2695,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_about_tsx",
       "label": "About.tsx",
@@ -234778,7 +234898,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2694,
+      "community": 2696,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_aboutproduct_tsx",
       "label": "AboutProduct.tsx",
@@ -234787,7 +234907,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2695,
+      "community": 2697,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_test_tsx",
       "label": "ProductActions.test.tsx",
@@ -234796,7 +234916,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2696,
+      "community": 2698,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
       "label": "ProductInfo.tsx",
@@ -234805,30 +234925,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2697,
+      "community": 2699,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
       "label": "ProductReviews.tsx",
       "norm_label": "productreviews.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductReviews.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2698,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
-      "label": "ProductsNavigationBar.tsx",
-      "norm_label": "productsnavigationbar.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductsNavigationBar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2699,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
-      "label": "ErrorMessage.tsx",
-      "norm_label": "errormessage.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/ErrorMessage.tsx",
       "source_location": "L1"
     },
     {
@@ -234838,7 +234940,7 @@
       "label": "buildBlockers()",
       "norm_label": "buildblockers()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L844"
+      "source_location": "L903"
     },
     {
       "community": 27,
@@ -234847,7 +234949,7 @@
       "label": "buildCarryForwardItems()",
       "norm_label": "buildcarryforwarditems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L820"
+      "source_location": "L879"
     },
     {
       "community": 27,
@@ -234856,7 +234958,7 @@
       "label": "buildCashMetrics()",
       "norm_label": "buildcashmetrics()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1010"
+      "source_location": "L1069"
     },
     {
       "community": 27,
@@ -234865,7 +234967,7 @@
       "label": "buildDailyManagerReportPayload()",
       "norm_label": "builddailymanagerreportpayload()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L530"
+      "source_location": "L589"
     },
     {
       "community": 27,
@@ -234874,7 +234976,7 @@
       "label": "buildDailyTopMoversUrl()",
       "norm_label": "builddailytopmoversurl()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L515"
+      "source_location": "L574"
     },
     {
       "community": 27,
@@ -234883,7 +234985,7 @@
       "label": "buildOpenDailyManagerReportPayload()",
       "norm_label": "buildopendailymanagerreportpayload()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L607"
+      "source_location": "L666"
     },
     {
       "community": 27,
@@ -234892,7 +234994,7 @@
       "label": "buildPaymentTotals()",
       "norm_label": "buildpaymenttotals()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L888"
+      "source_location": "L947"
     },
     {
       "community": 27,
@@ -234901,7 +235003,7 @@
       "label": "buildPreparedBlockers()",
       "norm_label": "buildpreparedblockers()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L858"
+      "source_location": "L917"
     },
     {
       "community": 27,
@@ -234910,7 +235012,7 @@
       "label": "buildPreparedCarryForwardItems()",
       "norm_label": "buildpreparedcarryforwarditems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L833"
+      "source_location": "L892"
     },
     {
       "community": 27,
@@ -234919,7 +235021,7 @@
       "label": "buildPreparedDailyManagerReportPayload()",
       "norm_label": "buildprepareddailymanagerreportpayload()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L590"
+      "source_location": "L649"
     },
     {
       "community": 27,
@@ -234928,7 +235030,7 @@
       "label": "buildPreparedReviewItems()",
       "norm_label": "buildpreparedreviewitems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L809"
+      "source_location": "L868"
     },
     {
       "community": 27,
@@ -234937,7 +235039,7 @@
       "label": "buildRegisterCashPositionSummary()",
       "norm_label": "buildregistercashpositionsummary()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L646"
+      "source_location": "L705"
     },
     {
       "community": 27,
@@ -234946,7 +235048,7 @@
       "label": "buildReviewedItems()",
       "norm_label": "buildrevieweditems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L733"
+      "source_location": "L792"
     },
     {
       "community": 27,
@@ -234955,7 +235057,7 @@
       "label": "buildSummaryMetrics()",
       "norm_label": "buildsummarymetrics()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L928"
+      "source_location": "L987"
     },
     {
       "community": 27,
@@ -234964,7 +235066,7 @@
       "label": "buildTopItemsForDay()",
       "norm_label": "buildtopitemsforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L503"
+      "source_location": "L562"
     },
     {
       "community": 27,
@@ -234973,7 +235075,7 @@
       "label": "buildUnitsSoldSummary()",
       "norm_label": "buildunitssoldsummary()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L485"
+      "source_location": "L544"
     },
     {
       "community": 27,
@@ -234982,7 +235084,7 @@
       "label": "comparisonFromSummary()",
       "norm_label": "comparisonfromsummary()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1088"
+      "source_location": "L1147"
     },
     {
       "community": 27,
@@ -234991,7 +235093,7 @@
       "label": "countLabel()",
       "norm_label": "countlabel()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1124"
+      "source_location": "L1183"
     },
     {
       "community": 27,
@@ -235000,7 +235102,7 @@
       "label": "formatBlockerMessage()",
       "norm_label": "formatblockermessage()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L868"
+      "source_location": "L927"
     },
     {
       "community": 27,
@@ -235009,7 +235111,7 @@
       "label": "formatCompletedAt()",
       "norm_label": "formatcompletedat()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1168"
+      "source_location": "L1227"
     },
     {
       "community": 27,
@@ -235018,7 +235120,7 @@
       "label": "formatOperatingDate()",
       "norm_label": "formatoperatingdate()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1147"
+      "source_location": "L1206"
     },
     {
       "community": 27,
@@ -235027,7 +235129,7 @@
       "label": "formatPaymentMethod()",
       "norm_label": "formatpaymentmethod()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1134"
+      "source_location": "L1193"
     },
     {
       "community": 27,
@@ -235036,7 +235138,7 @@
       "label": "formatPriorDayComparison()",
       "norm_label": "formatpriordaycomparison()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1103"
+      "source_location": "L1162"
     },
     {
       "community": 27,
@@ -235045,7 +235147,7 @@
       "label": "formatUnitCount()",
       "norm_label": "formatunitcount()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1120"
+      "source_location": "L1179"
     },
     {
       "community": 27,
@@ -235054,7 +235156,7 @@
       "label": "isPaymentTotal()",
       "norm_label": "ispaymenttotal()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1055"
+      "source_location": "L1114"
     },
     {
       "community": 27,
@@ -235063,7 +235165,7 @@
       "label": "moneyFormatter()",
       "norm_label": "moneyformatter()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1068"
+      "source_location": "L1127"
     },
     {
       "community": 27,
@@ -235072,7 +235174,7 @@
       "label": "normalizeCurrency()",
       "norm_label": "normalizecurrency()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1128"
+      "source_location": "L1187"
     },
     {
       "community": 27,
@@ -235081,7 +235183,7 @@
       "label": "normalizePaymentMethod()",
       "norm_label": "normalizepaymentmethod()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1140"
+      "source_location": "L1199"
     },
     {
       "community": 27,
@@ -235090,7 +235192,7 @@
       "label": "numberFromSummary()",
       "norm_label": "numberfromsummary()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1074"
+      "source_location": "L1133"
     },
     {
       "community": 27,
@@ -235099,7 +235201,7 @@
       "label": "numberFromSummaryWithFallback()",
       "norm_label": "numberfromsummarywithfallback()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1079"
+      "source_location": "L1138"
     },
     {
       "community": 27,
@@ -235108,7 +235210,7 @@
       "label": "optionalMetadataLabel()",
       "norm_label": "optionalmetadatalabel()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L880"
+      "source_location": "L939"
     },
     {
       "community": 27,
@@ -235117,7 +235219,7 @@
       "label": "readUnitsSoldForDay()",
       "norm_label": "readunitssoldforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L467"
+      "source_location": "L526"
     },
     {
       "community": 27,
@@ -235126,7 +235228,7 @@
       "label": "resolveAppUrl()",
       "norm_label": "resolveappurl()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1176"
+      "source_location": "L1235"
     },
     {
       "community": 27,
@@ -235135,7 +235237,7 @@
       "label": "resolveStaffName()",
       "norm_label": "resolvestaffname()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L445"
+      "source_location": "L504"
     },
     {
       "community": 27,
@@ -235144,7 +235246,7 @@
       "label": "resolveStore()",
       "norm_label": "resolvestore()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L424"
+      "source_location": "L483"
     },
     {
       "community": 27,
@@ -235153,7 +235255,7 @@
       "label": "resolveStoreScheduleTimezoneForAt()",
       "norm_label": "resolvestorescheduletimezoneforat()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1160"
+      "source_location": "L1219"
     },
     {
       "community": 27,
@@ -235162,7 +235264,7 @@
       "label": "trimTrailingSlash()",
       "norm_label": "trimtrailingslash()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1189"
+      "source_location": "L1248"
     },
     {
       "community": 27,
@@ -235266,6 +235368,24 @@
     {
       "community": 2700,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
+      "label": "ProductsNavigationBar.tsx",
+      "norm_label": "productsnavigationbar.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductsNavigationBar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2701,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
+      "label": "ErrorMessage.tsx",
+      "norm_label": "errormessage.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/ErrorMessage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2702,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_existingreviewmessage_tsx",
       "label": "ExistingReviewMessage.tsx",
       "norm_label": "existingreviewmessage.tsx",
@@ -235273,7 +235393,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2701,
+      "community": 2703,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_test_tsx",
       "label": "OrderItem.test.tsx",
@@ -235282,7 +235402,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2702,
+      "community": 2704,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
       "label": "ReviewForm.tsx",
@@ -235291,7 +235411,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2703,
+      "community": 2705,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
       "label": "SuccessMessage.tsx",
@@ -235300,7 +235420,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2704,
+      "community": 2706,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_types_ts",
       "label": "types.ts",
@@ -235309,7 +235429,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2705,
+      "community": 2707,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
       "label": "SavedBag.tsx",
@@ -235318,7 +235438,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2706,
+      "community": 2708,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
       "label": "SavedIcon.tsx",
@@ -235327,30 +235447,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2707,
+      "community": 2709,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_carticon_tsx",
       "label": "CartIcon.tsx",
       "norm_label": "carticon.tsx",
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/CartIcon.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2708,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
-      "label": "ShoppingBag.test.tsx",
-      "norm_label": "shoppingbag.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2709,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
-      "label": "empty-state.tsx",
-      "norm_label": "empty-state.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/empty/empty-state.tsx",
       "source_location": "L1"
     },
     {
@@ -235446,6 +235548,24 @@
     {
       "community": 2710,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
+      "label": "ShoppingBag.test.tsx",
+      "norm_label": "shoppingbag.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2711,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
+      "label": "empty-state.tsx",
+      "norm_label": "empty-state.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/empty/empty-state.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2712,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_test_tsx",
       "label": "Maintenance.test.tsx",
       "norm_label": "maintenance.test.tsx",
@@ -235453,7 +235573,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2711,
+      "community": 2713,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_tsx",
       "label": "Maintenance.tsx",
@@ -235462,7 +235582,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2712,
+      "community": 2714,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
       "label": "AnimatedCard.tsx",
@@ -235471,7 +235591,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2713,
+      "community": 2715,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -235480,7 +235600,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2714,
+      "community": 2716,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
       "label": "alert.tsx",
@@ -235489,7 +235609,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2715,
+      "community": 2717,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
       "label": "breadcrumb.tsx",
@@ -235498,7 +235618,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2716,
+      "community": 2718,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -235507,30 +235627,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2717,
+      "community": 2719,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
       "norm_label": "card.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/card.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2718,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
-      "label": "checkbox.tsx",
-      "norm_label": "checkbox.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/checkbox.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2719,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_command_tsx",
-      "label": "command.tsx",
-      "norm_label": "command.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/command.tsx",
       "source_location": "L1"
     },
     {
@@ -235626,6 +235728,24 @@
     {
       "community": 2720,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
+      "label": "checkbox.tsx",
+      "norm_label": "checkbox.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/checkbox.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2721,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_command_tsx",
+      "label": "command.tsx",
+      "norm_label": "command.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/command.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2722,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
       "norm_label": "context-menu.tsx",
@@ -235633,7 +235753,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2721,
+      "community": 2723,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
@@ -235642,7 +235762,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2722,
+      "community": 2724,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
@@ -235651,7 +235771,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2723,
+      "community": 2725,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -235660,7 +235780,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2724,
+      "community": 2726,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -235669,7 +235789,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2725,
+      "community": 2727,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
       "label": "image-with-fallback.tsx",
@@ -235678,7 +235798,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2726,
+      "community": 2728,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -235687,30 +235807,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2727,
+      "community": 2729,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_with_end_button_tsx",
       "label": "input-with-end-button.tsx",
       "norm_label": "input-with-end-button.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/input-with-end-button.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2728,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_input_tsx",
-      "label": "input.tsx",
-      "norm_label": "input.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/input.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2729,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_label_tsx",
-      "label": "label.tsx",
-      "norm_label": "label.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/label.tsx",
       "source_location": "L1"
     },
     {
@@ -235806,6 +235908,24 @@
     {
       "community": 2730,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_input_tsx",
+      "label": "input.tsx",
+      "norm_label": "input.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/input.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2731,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_label_tsx",
+      "label": "label.tsx",
+      "norm_label": "label.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/label.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2732,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
       "label": "LeaveAReviewModalForm.tsx",
       "norm_label": "leaveareviewmodalform.tsx",
@@ -235813,7 +235933,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2731,
+      "community": 2733,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -235822,7 +235942,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2732,
+      "community": 2734,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_animations_welcomebackmodalanimations_ts",
       "label": "welcomeBackModalAnimations.ts",
@@ -235831,7 +235951,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2733,
+      "community": 2735,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_index_ts",
       "label": "index.ts",
@@ -235840,7 +235960,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2734,
+      "community": 2736,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_types_ts",
       "label": "types.ts",
@@ -235849,7 +235969,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2735,
+      "community": 2737,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_navigation_menu_tsx",
       "label": "navigation-menu.tsx",
@@ -235858,7 +235978,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2736,
+      "community": 2738,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -235867,30 +235987,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2737,
+      "community": 2739,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
       "norm_label": "radio-group.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/radio-group.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2738,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_scroll_area_tsx",
-      "label": "scroll-area.tsx",
-      "norm_label": "scroll-area.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/scroll-area.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2739,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_select_tsx",
-      "label": "select.tsx",
-      "norm_label": "select.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/select.tsx",
       "source_location": "L1"
     },
     {
@@ -235986,6 +236088,24 @@
     {
       "community": 2740,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_scroll_area_tsx",
+      "label": "scroll-area.tsx",
+      "norm_label": "scroll-area.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/scroll-area.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2741,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_select_tsx",
+      "label": "select.tsx",
+      "norm_label": "select.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/select.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2742,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
       "norm_label": "separator.tsx",
@@ -235993,7 +236113,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2741,
+      "community": 2743,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -236002,7 +236122,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2742,
+      "community": 2744,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -236011,7 +236131,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2743,
+      "community": 2745,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -236020,7 +236140,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2744,
+      "community": 2746,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -236029,7 +236149,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2745,
+      "community": 2747,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -236038,7 +236158,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2746,
+      "community": 2748,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -236047,30 +236167,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2747,
+      "community": 2749,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
       "norm_label": "tooltip.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/tooltip.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2748,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_config_ts",
-      "label": "config.ts",
-      "norm_label": "config.ts",
-      "source_file": "packages/storefront-webapp/src/config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2749,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_test_tsx",
-      "label": "StorefrontObservabilityProvider.test.tsx",
-      "norm_label": "storefrontobservabilityprovider.test.tsx",
-      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.test.tsx",
       "source_location": "L1"
     },
     {
@@ -236166,6 +236268,24 @@
     {
       "community": 2750,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_config_ts",
+      "label": "config.ts",
+      "norm_label": "config.ts",
+      "source_file": "packages/storefront-webapp/src/config.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2751,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_test_tsx",
+      "label": "StorefrontObservabilityProvider.test.tsx",
+      "norm_label": "storefrontobservabilityprovider.test.tsx",
+      "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2752,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
       "norm_label": "use-store-modal.tsx",
@@ -236173,7 +236293,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2751,
+      "community": 2753,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
@@ -236182,7 +236302,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2752,
+      "community": 2754,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usequeryenabled_test_ts",
       "label": "useQueryEnabled.test.ts",
@@ -236191,7 +236311,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2753,
+      "community": 2755,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
       "label": "useStorefrontObservability.ts",
@@ -236200,7 +236320,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2754,
+      "community": 2756,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -236209,7 +236329,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2755,
+      "community": 2757,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -236218,7 +236338,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2756,
+      "community": 2758,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_feeutils_test_ts",
       "label": "feeUtils.test.ts",
@@ -236227,30 +236347,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2757,
+      "community": 2759,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
       "norm_label": "ghana.ts",
       "source_file": "packages/storefront-webapp/src/lib/ghana.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2758,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_ghanaregions_ts",
-      "label": "ghanaRegions.ts",
-      "norm_label": "ghanaregions.ts",
-      "source_file": "packages/storefront-webapp/src/lib/ghanaRegions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2759,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
-      "label": "maintenanceUtils.test.ts",
-      "norm_label": "maintenanceutils.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.test.ts",
       "source_location": "L1"
     },
     {
@@ -236346,6 +236448,24 @@
     {
       "community": 2760,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_ghanaregions_ts",
+      "label": "ghanaRegions.ts",
+      "norm_label": "ghanaregions.ts",
+      "source_file": "packages/storefront-webapp/src/lib/ghanaRegions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2761,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
+      "label": "maintenanceUtils.test.ts",
+      "norm_label": "maintenanceutils.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2762,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
@@ -236353,7 +236473,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2761,
+      "community": 2763,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_productutils_test_ts",
       "label": "productUtils.test.ts",
@@ -236362,7 +236482,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2762,
+      "community": 2764,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_store_ts",
       "label": "store.ts",
@@ -236371,7 +236491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2763,
+      "community": 2765,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
       "label": "bag.ts",
@@ -236380,7 +236500,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2764,
+      "community": 2766,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
       "label": "bagItem.ts",
@@ -236389,7 +236509,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2765,
+      "community": 2767,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -236398,7 +236518,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2766,
+      "community": 2768,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_organization_ts",
       "label": "organization.ts",
@@ -236407,30 +236527,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2767,
+      "community": 2769,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
       "norm_label": "product.ts",
       "source_file": "packages/storefront-webapp/src/lib/schemas/product.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2768,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_store_ts",
-      "label": "store.ts",
-      "norm_label": "store.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/store.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2769,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_subcategory_ts",
-      "label": "subcategory.ts",
-      "norm_label": "subcategory.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/subcategory.ts",
       "source_location": "L1"
     },
     {
@@ -236526,6 +236628,24 @@
     {
       "community": 2770,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_store_ts",
+      "label": "store.ts",
+      "norm_label": "store.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/store.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2771,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_subcategory_ts",
+      "label": "subcategory.ts",
+      "norm_label": "subcategory.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/subcategory.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2772,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
       "norm_label": "user.ts",
@@ -236533,7 +236653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2771,
+      "community": 2773,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_states_ts",
       "label": "states.ts",
@@ -236542,7 +236662,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2772,
+      "community": 2774,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontcontextevents_test_ts",
       "label": "storefrontContextEvents.test.ts",
@@ -236551,7 +236671,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2773,
+      "community": 2775,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
       "label": "storefrontFailureObservability.test.ts",
@@ -236560,7 +236680,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2774,
+      "community": 2776,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
       "label": "storefrontJourneyEvents.test.ts",
@@ -236569,7 +236689,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2775,
+      "community": 2777,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -236578,7 +236698,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2776,
+      "community": 2778,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -236587,30 +236707,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2777,
+      "community": 2779,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_test_ts",
       "label": "-homePageLoader.test.ts",
       "norm_label": "-homepageloader.test.ts",
       "source_file": "packages/storefront-webapp/src/routes/-homePageLoader.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2778,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_root_tsx",
-      "label": "__root.tsx",
-      "norm_label": "__root.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/__root.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2779,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_orderitemid_review_tsx",
-      "label": "$orderItemId.review.tsx",
-      "norm_label": "$orderitemid.review.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/$orderItemId.review.tsx",
       "source_location": "L1"
     },
     {
@@ -236706,6 +236808,24 @@
     {
       "community": 2780,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_root_tsx",
+      "label": "__root.tsx",
+      "norm_label": "__root.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/__root.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2781,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_orderitemid_review_tsx",
+      "label": "$orderItemId.review.tsx",
+      "norm_label": "$orderitemid.review.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/$orderItemId.review.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2782,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
@@ -236713,7 +236833,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2781,
+      "community": 2783,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
       "label": "$subcategorySlug.tsx",
@@ -236722,7 +236842,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2782,
+      "community": 2784,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
       "label": "index.tsx",
@@ -236731,7 +236851,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2783,
+      "community": 2785,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
       "label": "rewards.index.tsx",
@@ -236740,7 +236860,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2784,
+      "community": 2786,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
       "label": "shop.saved.index.tsx",
@@ -236749,7 +236869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2785,
+      "community": 2787,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
       "label": "bag.index.tsx",
@@ -236758,7 +236878,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2786,
+      "community": 2788,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_complete_tsx",
       "label": "complete.tsx",
@@ -236767,30 +236887,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2787,
+      "community": 2789,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_incomplete_tsx",
       "label": "incomplete.tsx",
       "norm_label": "incomplete.tsx",
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/incomplete.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2788,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_checkout_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2789,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_checkout_pending_tsx",
-      "label": "pending.tsx",
-      "norm_label": "pending.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pending.tsx",
       "source_location": "L1"
     },
     {
@@ -236886,6 +236988,24 @@
     {
       "community": 2790,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_checkout_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2791,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_checkout_pending_tsx",
+      "label": "pending.tsx",
+      "norm_label": "pending.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pending.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2792,
+      "file_type": "code",
       "id": "packages_storefront_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
       "norm_label": "tailwind.config.js",
@@ -236893,7 +237013,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2791,
+      "community": 2793,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_storefront_boot_e2e_ts",
       "label": "storefront-boot.e2e.ts",
@@ -236902,7 +237022,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2792,
+      "community": 2794,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -236911,7 +237031,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2793,
+      "community": 2795,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
@@ -236920,7 +237040,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2794,
+      "community": 2796,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_index_js",
       "label": "index.js",
@@ -236929,7 +237049,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2795,
+      "community": 2797,
       "file_type": "code",
       "id": "scripts_check_register_session_authority_writers_test_ts",
       "label": "check-register-session-authority-writers.test.ts",
@@ -236938,7 +237058,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2796,
+      "community": 2798,
       "file_type": "code",
       "id": "scripts_delivery_documentation_check_test_ts",
       "label": "delivery-documentation-check.test.ts",
@@ -236947,30 +237067,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2797,
+      "community": 2799,
       "file_type": "code",
       "id": "scripts_harness_app_registry_test_ts",
       "label": "harness-app-registry.test.ts",
       "norm_label": "harness-app-registry.test.ts",
       "source_file": "scripts/harness-app-registry.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2798,
-      "file_type": "code",
-      "id": "scripts_harness_behavior_fixtures_athena_runtime_app_test_ts",
-      "label": "athena-runtime-app.test.ts",
-      "norm_label": "athena-runtime-app.test.ts",
-      "source_file": "scripts/harness-behavior-fixtures/athena-runtime-app.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2799,
-      "file_type": "code",
-      "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_test_ts",
-      "label": "storefront-runtime-api.test.ts",
-      "norm_label": "storefront-runtime-api.test.ts",
-      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.test.ts",
       "source_location": "L1"
     },
     {
@@ -237399,6 +237501,24 @@
     {
       "community": 2800,
       "file_type": "code",
+      "id": "scripts_harness_behavior_fixtures_athena_runtime_app_test_ts",
+      "label": "athena-runtime-app.test.ts",
+      "norm_label": "athena-runtime-app.test.ts",
+      "source_file": "scripts/harness-behavior-fixtures/athena-runtime-app.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2801,
+      "file_type": "code",
+      "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_test_ts",
+      "label": "storefront-runtime-api.test.ts",
+      "norm_label": "storefront-runtime-api.test.ts",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2802,
+      "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_test_ts",
       "label": "valkey-runtime-app.test.ts",
       "norm_label": "valkey-runtime-app.test.ts",
@@ -237406,7 +237526,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2801,
+      "community": 2803,
       "file_type": "code",
       "id": "scripts_harness_behavior_scenarios_test_ts",
       "label": "harness-behavior-scenarios.test.ts",
@@ -237415,7 +237535,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2802,
+      "community": 2804,
       "file_type": "code",
       "id": "scripts_harness_execution_context_test_ts",
       "label": "harness-execution-context.test.ts",
@@ -237424,7 +237544,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2803,
+      "community": 2805,
       "file_type": "code",
       "id": "scripts_harness_gate_registry_test_ts",
       "label": "harness-gate-registry.test.ts",
@@ -237433,7 +237553,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2804,
+      "community": 2806,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_test_ts",
       "label": "harness-repo-validation.test.ts",
@@ -237442,7 +237562,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2805,
+      "community": 2807,
       "file_type": "code",
       "id": "scripts_operational_work_repair_test_ts",
       "label": "operational-work-repair.test.ts",
@@ -237451,7 +237571,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2806,
+      "community": 2808,
       "file_type": "code",
       "id": "tools_screen_redact_extension_background_js",
       "label": "background.js",
@@ -237460,7 +237580,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2807,
+      "community": 2809,
       "file_type": "code",
       "id": "tools_screen_redact_extension_popup_js",
       "label": "popup.js",
@@ -242169,6 +242289,87 @@
     {
       "community": 318,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 318,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 318,
+      "file_type": "code",
+      "id": "productutils_getpreferredsku",
+      "label": "getPreferredSku()",
+      "norm_label": "getpreferredsku()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 318,
+      "file_type": "code",
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 318,
+      "file_type": "code",
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 318,
+      "file_type": "code",
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 318,
+      "file_type": "code",
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L82"
+    },
+    {
+      "community": 318,
+      "file_type": "code",
+      "id": "productutils_sortskusbyavailabilitythenlength",
+      "label": "sortSkusByAvailabilityThenLength()",
+      "norm_label": "sortskusbyavailabilitythenlength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 318,
+      "file_type": "code",
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
       "id": "applyremoteassistcontrolintent_applyacceptedcontrolresult",
       "label": "applyAcceptedControlResult()",
       "norm_label": "applyacceptedcontrolresult()",
@@ -242176,7 +242377,7 @@
       "source_location": "L84"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_applykeyevent",
       "label": "applyKeyEvent()",
@@ -242185,7 +242386,7 @@
       "source_location": "L155"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_applypointerevent",
       "label": "applyPointerEvent()",
@@ -242194,7 +242395,7 @@
       "source_location": "L116"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_applyremoteassistcontrolintent",
       "label": "applyRemoteAssistControlIntent()",
@@ -242203,7 +242404,7 @@
       "source_location": "L17"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_getrecentcontrolresult",
       "label": "getRecentControlResult()",
@@ -242212,7 +242413,7 @@
       "source_location": "L95"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_getremoteassistcontroltarget",
       "label": "getRemoteAssistControlTarget()",
@@ -242221,7 +242422,7 @@
       "source_location": "L145"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_prepareremoteassistcontrolintent",
       "label": "prepareRemoteAssistControlIntent()",
@@ -242230,7 +242431,7 @@
       "source_location": "L27"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_remembercontrolresult",
       "label": "rememberControlResult()",
@@ -242239,94 +242440,13 @@
       "source_location": "L101"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_remote_assist_runtime_applyremoteassistcontrolintent_ts",
       "label": "applyRemoteAssistControlIntent.ts",
       "norm_label": "applyremoteassistcontrolintent.ts",
       "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_offline_posofflinereadiness_ts",
-      "label": "posOfflineReadiness.ts",
-      "norm_label": "posofflinereadiness.ts",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "posofflinereadiness_buildposofflinereadinesssummary",
-      "label": "buildPosOfflineReadinessSummary()",
-      "norm_label": "buildposofflinereadinesssummary()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L152"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "posofflinereadiness_buildsignal",
-      "label": "buildSignal()",
-      "norm_label": "buildsignal()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L178"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "posofflinereadiness_formatage",
-      "label": "formatAge()",
-      "norm_label": "formatage()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L290"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsignaldescription",
-      "label": "getSignalDescription()",
-      "norm_label": "getsignaldescription()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L221"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsignalstatus",
-      "label": "getSignalStatus()",
-      "norm_label": "getsignalstatus()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L201"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsummarydescription",
-      "label": "getSummaryDescription()",
-      "norm_label": "getsummarydescription()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L262"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsummarytitle",
-      "label": "getSummaryTitle()",
-      "norm_label": "getsummarytitle()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L256"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "posofflinereadiness_isreadylike",
-      "label": "isReadyLike()",
-      "norm_label": "isreadylike()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L286"
     },
     {
       "community": 32,
@@ -242655,6 +242775,87 @@
     {
       "community": 320,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_offline_posofflinereadiness_ts",
+      "label": "posOfflineReadiness.ts",
+      "norm_label": "posofflinereadiness.ts",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "posofflinereadiness_buildposofflinereadinesssummary",
+      "label": "buildPosOfflineReadinessSummary()",
+      "norm_label": "buildposofflinereadinesssummary()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L152"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "posofflinereadiness_buildsignal",
+      "label": "buildSignal()",
+      "norm_label": "buildsignal()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L178"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "posofflinereadiness_formatage",
+      "label": "formatAge()",
+      "norm_label": "formatage()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L290"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsignaldescription",
+      "label": "getSignalDescription()",
+      "norm_label": "getsignaldescription()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L221"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsignalstatus",
+      "label": "getSignalStatus()",
+      "norm_label": "getsignalstatus()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L201"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsummarydescription",
+      "label": "getSummaryDescription()",
+      "norm_label": "getsummarydescription()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L262"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsummarytitle",
+      "label": "getSummaryTitle()",
+      "norm_label": "getsummarytitle()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L256"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "posofflinereadiness_isreadylike",
+      "label": "isReadyLike()",
+      "norm_label": "isreadylike()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L286"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
       "id": "foundations_content_colorrolecard",
       "label": "ColorRoleCard()",
       "norm_label": "colorrolecard()",
@@ -242662,7 +242863,7 @@
       "source_location": "L222"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "foundations_content_densitycard",
       "label": "DensityCard()",
@@ -242671,7 +242872,7 @@
       "source_location": "L283"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "foundations_content_detailviewrolecard",
       "label": "DetailViewRoleCard()",
@@ -242680,7 +242881,7 @@
       "source_location": "L363"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "foundations_content_hslvar",
       "label": "hslVar()",
@@ -242689,7 +242890,7 @@
       "source_location": "L214"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "foundations_content_motioncard",
       "label": "MotionCard()",
@@ -242698,7 +242899,7 @@
       "source_location": "L342"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "foundations_content_spacetokenrow",
       "label": "SpaceTokenRow()",
@@ -242707,7 +242908,7 @@
       "source_location": "L265"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "foundations_content_textvar",
       "label": "textVar()",
@@ -242716,7 +242917,7 @@
       "source_location": "L218"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "foundations_content_typespecimencard",
       "label": "TypeSpecimenCard()",
@@ -242725,7 +242926,7 @@
       "source_location": "L246"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_foundations_content_tsx",
       "label": "foundations-content.tsx",
@@ -242734,7 +242935,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -242743,7 +242944,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -242752,7 +242953,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "versionchecker_buildidfromscripts",
       "label": "buildIdFromScripts()",
@@ -242761,7 +242962,7 @@
       "source_location": "L192"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "versionchecker_createversionchecker",
       "label": "createVersionChecker()",
@@ -242770,7 +242971,7 @@
       "source_location": "L16"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "versionchecker_getinitialdeploybuildid",
       "label": "getInitialDeployBuildId()",
@@ -242779,7 +242980,7 @@
       "source_location": "L135"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "versionchecker_readdeploybuildid",
       "label": "readDeployBuildId()",
@@ -242788,7 +242989,7 @@
       "source_location": "L141"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "versionchecker_readdocumentscriptsources",
       "label": "readDocumentScriptSources()",
@@ -242797,7 +242998,7 @@
       "source_location": "L174"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "versionchecker_readentryhtmlscripts",
       "label": "readEntryHtmlScripts()",
@@ -242806,94 +243007,13 @@
       "source_location": "L151"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "versionchecker_readscriptsources",
       "label": "readScriptSources()",
       "norm_label": "readscriptsources()",
       "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
       "source_location": "L182"
-    },
-    {
-      "community": 322,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 322,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 322,
-      "file_type": "code",
-      "id": "productutils_getpreferredsku",
-      "label": "getPreferredSku()",
-      "norm_label": "getpreferredsku()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 322,
-      "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 322,
-      "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 322,
-      "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 322,
-      "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L82"
-    },
-    {
-      "community": 322,
-      "file_type": "code",
-      "id": "productutils_sortskusbyavailabilitythenlength",
-      "label": "sortSkusByAvailabilityThenLength()",
-      "norm_label": "sortskusbyavailabilitythenlength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 322,
-      "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L59"
     },
     {
       "community": 323,
@@ -260736,60 +260856,6 @@
     {
       "community": 505,
       "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L101"
-    },
-    {
-      "community": 505,
-      "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 505,
-      "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 505,
-      "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 505,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 505,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 506,
-      "file_type": "code",
       "id": "config_derivestorefrontfromadminhost",
       "label": "deriveStoreFrontFromAdminHost()",
       "norm_label": "derivestorefrontfromadminhost()",
@@ -260797,7 +260863,7 @@
       "source_location": "L29"
     },
     {
-      "community": 506,
+      "community": 505,
       "file_type": "code",
       "id": "config_getruntimeorigin",
       "label": "getRuntimeOrigin()",
@@ -260806,7 +260872,7 @@
       "source_location": "L12"
     },
     {
-      "community": 506,
+      "community": 505,
       "file_type": "code",
       "id": "config_islocalhost",
       "label": "isLocalHost()",
@@ -260815,7 +260881,7 @@
       "source_location": "L20"
     },
     {
-      "community": 506,
+      "community": 505,
       "file_type": "code",
       "id": "config_resolvestorefronturl",
       "label": "resolveStoreFrontUrl()",
@@ -260824,7 +260890,7 @@
       "source_location": "L51"
     },
     {
-      "community": 506,
+      "community": 505,
       "file_type": "code",
       "id": "config_trimtrailingslash",
       "label": "trimTrailingSlash()",
@@ -260833,7 +260899,7 @@
       "source_location": "L8"
     },
     {
-      "community": 506,
+      "community": 505,
       "file_type": "code",
       "id": "packages_athena_webapp_src_config_ts",
       "label": "config.ts",
@@ -260842,7 +260908,7 @@
       "source_location": "L1"
     },
     {
-      "community": 507,
+      "community": 506,
       "file_type": "code",
       "id": "managerelevationcontext_getstaffdisplayname",
       "label": "getStaffDisplayName()",
@@ -260851,7 +260917,7 @@
       "source_location": "L64"
     },
     {
-      "community": 507,
+      "community": 506,
       "file_type": "code",
       "id": "managerelevationcontext_managerelevationprovider",
       "label": "ManagerElevationProvider()",
@@ -260860,7 +260926,7 @@
       "source_location": "L87"
     },
     {
-      "community": 507,
+      "community": 506,
       "file_type": "code",
       "id": "managerelevationcontext_tostaffauthenticationresult",
       "label": "toStaffAuthenticationResult()",
@@ -260869,7 +260935,7 @@
       "source_location": "L74"
     },
     {
-      "community": 507,
+      "community": 506,
       "file_type": "code",
       "id": "managerelevationcontext_usemanagerelevation",
       "label": "useManagerElevation()",
@@ -260878,7 +260944,7 @@
       "source_location": "L242"
     },
     {
-      "community": 507,
+      "community": 506,
       "file_type": "code",
       "id": "managerelevationcontext_useoptionalmanagerelevation",
       "label": "useOptionalManagerElevation()",
@@ -260887,7 +260953,7 @@
       "source_location": "L251"
     },
     {
-      "community": 507,
+      "community": 506,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_managerelevationcontext_tsx",
       "label": "ManagerElevationContext.tsx",
@@ -260896,7 +260962,7 @@
       "source_location": "L1"
     },
     {
-      "community": 508,
+      "community": 507,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
       "label": "useExpenseSessions.ts",
@@ -260905,7 +260971,7 @@
       "source_location": "L1"
     },
     {
-      "community": 508,
+      "community": 507,
       "file_type": "code",
       "id": "useexpensesessions_useexpenseactivesession",
       "label": "useExpenseActiveSession()",
@@ -260914,7 +260980,7 @@
       "source_location": "L42"
     },
     {
-      "community": 508,
+      "community": 507,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesession",
       "label": "useExpenseSession()",
@@ -260923,7 +260989,7 @@
       "source_location": "L32"
     },
     {
-      "community": 508,
+      "community": 507,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessioncreate",
       "label": "useExpenseSessionCreate()",
@@ -260932,7 +260998,7 @@
       "source_location": "L62"
     },
     {
-      "community": 508,
+      "community": 507,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessionupdate",
       "label": "useExpenseSessionUpdate()",
@@ -260941,7 +261007,7 @@
       "source_location": "L101"
     },
     {
-      "community": 508,
+      "community": 507,
       "file_type": "code",
       "id": "useexpensesessions_useexpensestoresessions",
       "label": "useExpenseStoreSessions()",
@@ -260950,7 +261016,7 @@
       "source_location": "L10"
     },
     {
-      "community": 509,
+      "community": 508,
       "file_type": "code",
       "id": "capabilities_canaccesscashcontrolssurface",
       "label": "canAccessCashControlsSurface()",
@@ -260959,7 +261025,7 @@
       "source_location": "L54"
     },
     {
-      "community": 509,
+      "community": 508,
       "file_type": "code",
       "id": "capabilities_canaccessfulladminsurface",
       "label": "canAccessFullAdminSurface()",
@@ -260968,7 +261034,7 @@
       "source_location": "L41"
     },
     {
-      "community": 509,
+      "community": 508,
       "file_type": "code",
       "id": "capabilities_canaccessstoredaysurface",
       "label": "canAccessStoreDaySurface()",
@@ -260977,7 +261043,7 @@
       "source_location": "L47"
     },
     {
-      "community": 509,
+      "community": 508,
       "file_type": "code",
       "id": "capabilities_canviewfinancialdetails",
       "label": "canViewFinancialDetails()",
@@ -260986,7 +261052,7 @@
       "source_location": "L61"
     },
     {
-      "community": 509,
+      "community": 508,
       "file_type": "code",
       "id": "capabilities_getsurfaceaccess",
       "label": "getSurfaceAccess()",
@@ -260995,12 +261061,66 @@
       "source_location": "L68"
     },
     {
-      "community": 509,
+      "community": 508,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_access_capabilities_ts",
       "label": "capabilities.ts",
       "norm_label": "capabilities.ts",
       "source_file": "packages/athena-webapp/src/lib/access/capabilities.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 509,
+      "file_type": "code",
+      "id": "behaviorutils_calculateengagementmetrics",
+      "label": "calculateEngagementMetrics()",
+      "norm_label": "calculateengagementmetrics()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L173"
+    },
+    {
+      "community": 509,
+      "file_type": "code",
+      "id": "behaviorutils_calculateriskindicators",
+      "label": "calculateRiskIndicators()",
+      "norm_label": "calculateriskindicators()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 509,
+      "file_type": "code",
+      "id": "behaviorutils_getactivitypriority",
+      "label": "getActivityPriority()",
+      "norm_label": "getactivitypriority()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L251"
+    },
+    {
+      "community": 509,
+      "file_type": "code",
+      "id": "behaviorutils_getcustomerjourneystage",
+      "label": "getCustomerJourneyStage()",
+      "norm_label": "getcustomerjourneystage()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 509,
+      "file_type": "code",
+      "id": "behaviorutils_getjourneystageinfo",
+      "label": "getJourneyStageInfo()",
+      "norm_label": "getjourneystageinfo()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L277"
+    },
+    {
+      "community": 509,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
+      "label": "behaviorUtils.ts",
+      "norm_label": "behaviorutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L1"
     },
     {
@@ -261267,60 +261387,6 @@
     {
       "community": 510,
       "file_type": "code",
-      "id": "behaviorutils_calculateengagementmetrics",
-      "label": "calculateEngagementMetrics()",
-      "norm_label": "calculateengagementmetrics()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L173"
-    },
-    {
-      "community": 510,
-      "file_type": "code",
-      "id": "behaviorutils_calculateriskindicators",
-      "label": "calculateRiskIndicators()",
-      "norm_label": "calculateriskindicators()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 510,
-      "file_type": "code",
-      "id": "behaviorutils_getactivitypriority",
-      "label": "getActivityPriority()",
-      "norm_label": "getactivitypriority()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L251"
-    },
-    {
-      "community": 510,
-      "file_type": "code",
-      "id": "behaviorutils_getcustomerjourneystage",
-      "label": "getCustomerJourneyStage()",
-      "norm_label": "getcustomerjourneystage()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 510,
-      "file_type": "code",
-      "id": "behaviorutils_getjourneystageinfo",
-      "label": "getJourneyStageInfo()",
-      "norm_label": "getjourneystageinfo()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L277"
-    },
-    {
-      "community": 510,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
-      "label": "behaviorUtils.ts",
-      "norm_label": "behaviorutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 511,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
       "label": "results.ts",
       "norm_label": "results.ts",
@@ -261328,7 +261394,7 @@
       "source_location": "L1"
     },
     {
-      "community": 511,
+      "community": 510,
       "file_type": "code",
       "id": "results_isposusecasesuccess",
       "label": "isPosUseCaseSuccess()",
@@ -261337,7 +261403,7 @@
       "source_location": "L134"
     },
     {
-      "community": 511,
+      "community": 510,
       "file_type": "code",
       "id": "results_mapcommandoutcome",
       "label": "mapCommandOutcome()",
@@ -261346,7 +261412,7 @@
       "source_location": "L69"
     },
     {
-      "community": 511,
+      "community": 510,
       "file_type": "code",
       "id": "results_mapcommandresult",
       "label": "mapCommandResult()",
@@ -261355,7 +261421,7 @@
       "source_location": "L86"
     },
     {
-      "community": 511,
+      "community": 510,
       "file_type": "code",
       "id": "results_maplegacymutationresult",
       "label": "mapLegacyMutationResult()",
@@ -261364,7 +261430,7 @@
       "source_location": "L52"
     },
     {
-      "community": 511,
+      "community": 510,
       "file_type": "code",
       "id": "results_mapthrownerror",
       "label": "mapThrownError()",
@@ -261373,7 +261439,7 @@
       "source_location": "L103"
     },
     {
-      "community": 512,
+      "community": 511,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registerlifecycleauthoritycandidates_ts",
       "label": "registerLifecycleAuthorityCandidates.ts",
@@ -261382,7 +261448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 511,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_deriveregisterlifecycleauthoritycandidates",
       "label": "deriveRegisterLifecycleAuthorityCandidates()",
@@ -261391,7 +261457,7 @@
       "source_location": "L45"
     },
     {
-      "community": 512,
+      "community": 511,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_isboundedidentifier",
       "label": "isBoundedIdentifier()",
@@ -261400,7 +261466,7 @@
       "source_location": "L220"
     },
     {
-      "community": 512,
+      "community": 511,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_iseligibleregistermapping",
       "label": "isEligibleRegisterMapping()",
@@ -261409,7 +261475,7 @@
       "source_location": "L167"
     },
     {
-      "community": 512,
+      "community": 511,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_legacymappingmatchesactivesession",
       "label": "legacyMappingMatchesActiveSession()",
@@ -261418,7 +261484,7 @@
       "source_location": "L182"
     },
     {
-      "community": 512,
+      "community": 511,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_mappingcandidate",
       "label": "mappingCandidate()",
@@ -261427,7 +261493,7 @@
       "source_location": "L194"
     },
     {
-      "community": 513,
+      "community": 512,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_useposlocalsyncruntime_test_ts",
       "label": "usePosLocalSyncRuntime.test.ts",
@@ -261436,7 +261502,7 @@
       "source_location": "L1"
     },
     {
-      "community": 513,
+      "community": 512,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_buildlocalevent",
       "label": "buildLocalEvent()",
@@ -261445,7 +261511,7 @@
       "source_location": "L7449"
     },
     {
-      "community": 513,
+      "community": 512,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_buildrecoverycommand",
       "label": "buildRecoveryCommand()",
@@ -261454,7 +261520,7 @@
       "source_location": "L7472"
     },
     {
-      "community": 513,
+      "community": 512,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_buildrecoverycommandstore",
       "label": "buildRecoveryCommandStore()",
@@ -261463,7 +261529,7 @@
       "source_location": "L7491"
     },
     {
-      "community": 513,
+      "community": 512,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_deferred",
       "label": "deferred()",
@@ -261472,7 +261538,7 @@
       "source_location": "L108"
     },
     {
-      "community": 513,
+      "community": 512,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_storefactory",
       "label": "storeFactory()",
@@ -261481,7 +261547,7 @@
       "source_location": "L352"
     },
     {
-      "community": 514,
+      "community": 513,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
       "label": "selectors.ts",
@@ -261490,7 +261556,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 513,
       "file_type": "code",
       "id": "selectors_buildregisterheaderstate",
       "label": "buildRegisterHeaderState()",
@@ -261499,7 +261565,7 @@
       "source_location": "L28"
     },
     {
-      "community": 514,
+      "community": 513,
       "file_type": "code",
       "id": "selectors_buildregisterinfostate",
       "label": "buildRegisterInfoState()",
@@ -261508,7 +261574,7 @@
       "source_location": "L37"
     },
     {
-      "community": 514,
+      "community": 513,
       "file_type": "code",
       "id": "selectors_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -261517,7 +261583,7 @@
       "source_location": "L12"
     },
     {
-      "community": 514,
+      "community": 513,
       "file_type": "code",
       "id": "selectors_getregistercustomerinfo",
       "label": "getRegisterCustomerInfo()",
@@ -261526,7 +261592,7 @@
       "source_location": "L6"
     },
     {
-      "community": 514,
+      "community": 513,
       "file_type": "code",
       "id": "selectors_isregistersessionactive",
       "label": "isRegisterSessionActive()",
@@ -261535,7 +261601,7 @@
       "source_location": "L49"
     },
     {
-      "community": 515,
+      "community": 514,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
       "label": "toastService.ts",
@@ -261544,7 +261610,7 @@
       "source_location": "L1"
     },
     {
-      "community": 515,
+      "community": 514,
       "file_type": "code",
       "id": "toastservice_handleposoperation",
       "label": "handlePOSOperation()",
@@ -261553,7 +261619,7 @@
       "source_location": "L171"
     },
     {
-      "community": 515,
+      "community": 514,
       "file_type": "code",
       "id": "toastservice_showinventoryerror",
       "label": "showInventoryError()",
@@ -261562,7 +261628,7 @@
       "source_location": "L302"
     },
     {
-      "community": 515,
+      "community": 514,
       "file_type": "code",
       "id": "toastservice_shownoactivesessionerror",
       "label": "showNoActiveSessionError()",
@@ -261571,7 +261637,7 @@
       "source_location": "L319"
     },
     {
-      "community": 515,
+      "community": 514,
       "file_type": "code",
       "id": "toastservice_showsessionexpirederror",
       "label": "showSessionExpiredError()",
@@ -261580,7 +261646,7 @@
       "source_location": "L312"
     },
     {
-      "community": 515,
+      "community": 514,
       "file_type": "code",
       "id": "toastservice_showvalidationerror",
       "label": "showValidationError()",
@@ -261589,7 +261655,7 @@
       "source_location": "L293"
     },
     {
-      "community": 516,
+      "community": 515,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_sheetreturn_ts",
       "label": "sheetReturn.ts",
@@ -261598,7 +261664,7 @@
       "source_location": "L1"
     },
     {
-      "community": 516,
+      "community": 515,
       "file_type": "code",
       "id": "sheetreturn_decodesheetreturn",
       "label": "decodeSheetReturn()",
@@ -261607,7 +261673,7 @@
       "source_location": "L85"
     },
     {
-      "community": 516,
+      "community": 515,
       "file_type": "code",
       "id": "sheetreturn_encodefocuskey",
       "label": "encodeFocusKey()",
@@ -261616,7 +261682,7 @@
       "source_location": "L74"
     },
     {
-      "community": 516,
+      "community": 515,
       "file_type": "code",
       "id": "sheetreturn_encodesheetreturn",
       "label": "encodeSheetReturn()",
@@ -261625,7 +261691,7 @@
       "source_location": "L55"
     },
     {
-      "community": 516,
+      "community": 515,
       "file_type": "code",
       "id": "sheetreturn_sheetreturnfocusselector",
       "label": "sheetReturnFocusSelector()",
@@ -261634,7 +261700,7 @@
       "source_location": "L126"
     },
     {
-      "community": 516,
+      "community": 515,
       "file_type": "code",
       "id": "sheetreturn_sheetreturntargetprops",
       "label": "sheetReturnTargetProps()",
@@ -261643,7 +261709,7 @@
       "source_location": "L131"
     },
     {
-      "community": 517,
+      "community": 516,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_skusearch_productskusearchadapters_ts",
       "label": "productSkuSearchAdapters.ts",
@@ -261652,7 +261718,7 @@
       "source_location": "L1"
     },
     {
-      "community": 517,
+      "community": 516,
       "file_type": "code",
       "id": "productskusearchadapters_buildadminskusearchoption",
       "label": "buildAdminSkuSearchOption()",
@@ -261661,7 +261727,7 @@
       "source_location": "L80"
     },
     {
-      "community": 517,
+      "community": 516,
       "file_type": "code",
       "id": "productskusearchadapters_buildadminskusearchoptions",
       "label": "buildAdminSkuSearchOptions()",
@@ -261670,7 +261736,7 @@
       "source_location": "L132"
     },
     {
-      "community": 517,
+      "community": 516,
       "file_type": "code",
       "id": "productskusearchadapters_compactjoin",
       "label": "compactJoin()",
@@ -261679,7 +261745,7 @@
       "source_location": "L73"
     },
     {
-      "community": 517,
+      "community": 516,
       "file_type": "code",
       "id": "productskusearchadapters_groupadminskusearchoptionsbyproduct",
       "label": "groupAdminSkuSearchOptionsByProduct()",
@@ -261688,7 +261754,7 @@
       "source_location": "L138"
     },
     {
-      "community": 517,
+      "community": 516,
       "file_type": "code",
       "id": "productskusearchadapters_presentationtext",
       "label": "presentationText()",
@@ -261697,7 +261763,7 @@
       "source_location": "L66"
     },
     {
-      "community": 518,
+      "community": 517,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_stockops_skusearch_ts",
       "label": "skuSearch.ts",
@@ -261706,7 +261772,7 @@
       "source_location": "L1"
     },
     {
-      "community": 518,
+      "community": 517,
       "file_type": "code",
       "id": "skusearch_isbarcodeshapedsearchquery",
       "label": "isBarcodeShapedSearchQuery()",
@@ -261715,7 +261781,7 @@
       "source_location": "L49"
     },
     {
-      "community": 518,
+      "community": 517,
       "file_type": "code",
       "id": "skusearch_matchesskusearchterms",
       "label": "matchesSkuSearchTerms()",
@@ -261724,7 +261790,7 @@
       "source_location": "L11"
     },
     {
-      "community": 518,
+      "community": 517,
       "file_type": "code",
       "id": "skusearch_normalizeidentifier",
       "label": "normalizeIdentifier()",
@@ -261733,7 +261799,7 @@
       "source_location": "L53"
     },
     {
-      "community": 518,
+      "community": 517,
       "file_type": "code",
       "id": "skusearch_normalizeskusearchquery",
       "label": "normalizeSkuSearchQuery()",
@@ -261742,7 +261808,7 @@
       "source_location": "L7"
     },
     {
-      "community": 518,
+      "community": 517,
       "file_type": "code",
       "id": "skusearch_scoreskusearchterms",
       "label": "scoreSkuSearchTerms()",
@@ -261751,7 +261817,7 @@
       "source_location": "L18"
     },
     {
-      "community": 519,
+      "community": 518,
       "file_type": "code",
       "id": "packages_athena_webapp_src_offline_posappshellroutes_ts",
       "label": "posAppShellRoutes.ts",
@@ -261760,7 +261826,7 @@
       "source_location": "L1"
     },
     {
-      "community": 519,
+      "community": 518,
       "file_type": "code",
       "id": "posappshellroutes_isexcludedfromposappshellcache",
       "label": "isExcludedFromPosAppShellCache()",
@@ -261769,7 +261835,7 @@
       "source_location": "L53"
     },
     {
-      "community": 519,
+      "community": 518,
       "file_type": "code",
       "id": "posappshellroutes_isposappshellnavigationrequest",
       "label": "isPosAppShellNavigationRequest()",
@@ -261778,7 +261844,7 @@
       "source_location": "L71"
     },
     {
-      "community": 519,
+      "community": 518,
       "file_type": "code",
       "id": "posappshellroutes_isposappshellroutepath",
       "label": "isPosAppShellRoutePath()",
@@ -261787,7 +261853,7 @@
       "source_location": "L48"
     },
     {
-      "community": 519,
+      "community": 518,
       "file_type": "code",
       "id": "posappshellroutes_isposappshellstaticassetrequest",
       "label": "isPosAppShellStaticAssetRequest()",
@@ -261796,13 +261862,67 @@
       "source_location": "L88"
     },
     {
-      "community": 519,
+      "community": 518,
       "file_type": "code",
       "id": "posappshellroutes_readheader",
       "label": "readHeader()",
       "norm_label": "readheader()",
       "source_file": "packages/athena-webapp/src/offline/posAppShellRoutes.ts",
       "source_location": "L107"
+    },
+    {
+      "community": 519,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_offline_posappshellserviceworkerstaging_test_ts",
+      "label": "posAppShellServiceWorkerStaging.test.ts",
+      "norm_label": "posappshellserviceworkerstaging.test.ts",
+      "source_file": "packages/athena-webapp/src/offline/posAppShellServiceWorkerStaging.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 519,
+      "file_type": "code",
+      "id": "posappshellserviceworkerstaging_test_createserviceworkerfixture",
+      "label": "createServiceWorkerFixture()",
+      "norm_label": "createserviceworkerfixture()",
+      "source_file": "packages/athena-webapp/src/offline/posAppShellServiceWorkerStaging.test.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 519,
+      "file_type": "code",
+      "id": "posappshellserviceworkerstaging_test_memorycache",
+      "label": "MemoryCache",
+      "norm_label": "memorycache",
+      "source_file": "packages/athena-webapp/src/offline/posAppShellServiceWorkerStaging.test.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 519,
+      "file_type": "code",
+      "id": "posappshellserviceworkerstaging_test_memorycache_keys",
+      "label": ".keys()",
+      "norm_label": ".keys()",
+      "source_file": "packages/athena-webapp/src/offline/posAppShellServiceWorkerStaging.test.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 519,
+      "file_type": "code",
+      "id": "posappshellserviceworkerstaging_test_memorycache_match",
+      "label": ".match()",
+      "norm_label": ".match()",
+      "source_file": "packages/athena-webapp/src/offline/posAppShellServiceWorkerStaging.test.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 519,
+      "file_type": "code",
+      "id": "posappshellserviceworkerstaging_test_memorycache_put",
+      "label": ".put()",
+      "norm_label": ".put()",
+      "source_file": "packages/athena-webapp/src/offline/posAppShellServiceWorkerStaging.test.ts",
+      "source_location": "L22"
     },
     {
       "community": 52,
@@ -262068,60 +262188,6 @@
     {
       "community": 520,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_offline_posappshellserviceworkerstaging_test_ts",
-      "label": "posAppShellServiceWorkerStaging.test.ts",
-      "norm_label": "posappshellserviceworkerstaging.test.ts",
-      "source_file": "packages/athena-webapp/src/offline/posAppShellServiceWorkerStaging.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 520,
-      "file_type": "code",
-      "id": "posappshellserviceworkerstaging_test_createserviceworkerfixture",
-      "label": "createServiceWorkerFixture()",
-      "norm_label": "createserviceworkerfixture()",
-      "source_file": "packages/athena-webapp/src/offline/posAppShellServiceWorkerStaging.test.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 520,
-      "file_type": "code",
-      "id": "posappshellserviceworkerstaging_test_memorycache",
-      "label": "MemoryCache",
-      "norm_label": "memorycache",
-      "source_file": "packages/athena-webapp/src/offline/posAppShellServiceWorkerStaging.test.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 520,
-      "file_type": "code",
-      "id": "posappshellserviceworkerstaging_test_memorycache_keys",
-      "label": ".keys()",
-      "norm_label": ".keys()",
-      "source_file": "packages/athena-webapp/src/offline/posAppShellServiceWorkerStaging.test.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 520,
-      "file_type": "code",
-      "id": "posappshellserviceworkerstaging_test_memorycache_match",
-      "label": ".match()",
-      "norm_label": ".match()",
-      "source_file": "packages/athena-webapp/src/offline/posAppShellServiceWorkerStaging.test.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 520,
-      "file_type": "code",
-      "id": "posappshellserviceworkerstaging_test_memorycache_put",
-      "label": ".put()",
-      "norm_label": ".put()",
-      "source_file": "packages/athena-webapp/src/offline/posAppShellServiceWorkerStaging.test.ts",
-      "source_location": "L22"
-    },
-    {
-      "community": 521,
-      "file_type": "code",
       "id": "docs_shared_companionsection",
       "label": "CompanionSection()",
       "norm_label": "companionsection()",
@@ -262129,7 +262195,7 @@
       "source_location": "L81"
     },
     {
-      "community": 521,
+      "community": 520,
       "file_type": "code",
       "id": "docs_shared_formatcategorylabel",
       "label": "formatCategoryLabel()",
@@ -262138,7 +262204,7 @@
       "source_location": "L7"
     },
     {
-      "community": 521,
+      "community": 520,
       "file_type": "code",
       "id": "docs_shared_formatdocdate",
       "label": "formatDocDate()",
@@ -262147,7 +262213,7 @@
       "source_location": "L11"
     },
     {
-      "community": 521,
+      "community": 520,
       "file_type": "code",
       "id": "docs_shared_severityindicator",
       "label": "SeverityIndicator()",
@@ -262156,7 +262222,7 @@
       "source_location": "L32"
     },
     {
-      "community": 521,
+      "community": 520,
       "file_type": "code",
       "id": "docs_shared_solutiondoccard",
       "label": "SolutionDocCard()",
@@ -262165,7 +262231,7 @@
       "source_location": "L48"
     },
     {
-      "community": 521,
+      "community": 520,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_docs_shared_tsx",
       "label": "-docs-shared.tsx",
@@ -262174,7 +262240,7 @@
       "source_location": "L1"
     },
     {
-      "community": 522,
+      "community": 521,
       "file_type": "code",
       "id": "index_route_view_democtabutton",
       "label": "DemoCtaButton()",
@@ -262183,7 +262249,7 @@
       "source_location": "L192"
     },
     {
-      "community": 522,
+      "community": 521,
       "file_type": "code",
       "id": "index_route_view_herogrid",
       "label": "HeroGrid()",
@@ -262192,7 +262258,7 @@
       "source_location": "L178"
     },
     {
-      "community": 522,
+      "community": 521,
       "file_type": "code",
       "id": "index_route_view_rest",
       "label": "rest()",
@@ -262201,7 +262267,7 @@
       "source_location": "L246"
     },
     {
-      "community": 522,
+      "community": 521,
       "file_type": "code",
       "id": "index_route_view_useheroshotrevealref",
       "label": "useHeroShotRevealRef()",
@@ -262210,7 +262276,7 @@
       "source_location": "L54"
     },
     {
-      "community": 522,
+      "community": 521,
       "file_type": "code",
       "id": "index_route_view_useheroshottiltref",
       "label": "useHeroShotTiltRef()",
@@ -262219,7 +262285,7 @@
       "source_location": "L107"
     },
     {
-      "community": 522,
+      "community": 521,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_route_view_tsx",
       "label": "-index-route-view.tsx",
@@ -262228,7 +262294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 523,
+      "community": 522,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
       "label": "procurement.index.tsx",
@@ -262237,7 +262303,7 @@
       "source_location": "L1"
     },
     {
-      "community": 523,
+      "community": 522,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementmodesearch",
       "label": "getNextProcurementModeSearch()",
@@ -262246,7 +262312,7 @@
       "source_location": "L19"
     },
     {
-      "community": 523,
+      "community": 522,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementpagesearch",
       "label": "getNextProcurementPageSearch()",
@@ -262255,7 +262321,7 @@
       "source_location": "L37"
     },
     {
-      "community": 523,
+      "community": 522,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementquerysearch",
       "label": "getNextProcurementQuerySearch()",
@@ -262264,7 +262330,7 @@
       "source_location": "L47"
     },
     {
-      "community": 523,
+      "community": 522,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementselectedskusearch",
       "label": "getNextProcurementSelectedSkuSearch()",
@@ -262273,7 +262339,7 @@
       "source_location": "L62"
     },
     {
-      "community": 523,
+      "community": 522,
       "file_type": "code",
       "id": "procurement_index_procurementroute",
       "label": "ProcurementRoute()",
@@ -262282,7 +262348,7 @@
       "source_location": "L88"
     },
     {
-      "community": 524,
+      "community": 523,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_weekly_lifecycle_test_tsx",
       "label": "weekly.lifecycle.test.tsx",
@@ -262291,7 +262357,7 @@
       "source_location": "L1"
     },
     {
-      "community": 524,
+      "community": 523,
       "file_type": "code",
       "id": "weekly_lifecycle_test_installcompletedmovement",
       "label": "installCompletedMovement()",
@@ -262300,7 +262366,7 @@
       "source_location": "L283"
     },
     {
-      "community": 524,
+      "community": 523,
       "file_type": "code",
       "id": "weekly_lifecycle_test_isshareddemostandingread",
       "label": "isSharedDemoStandingRead()",
@@ -262309,7 +262375,7 @@
       "source_location": "L102"
     },
     {
-      "community": 524,
+      "community": 523,
       "file_type": "code",
       "id": "weekly_lifecycle_test_movementrow",
       "label": "movementRow()",
@@ -262318,7 +262384,7 @@
       "source_location": "L268"
     },
     {
-      "community": 524,
+      "community": 523,
       "file_type": "code",
       "id": "weekly_lifecycle_test_params",
       "label": "params()",
@@ -262327,7 +262393,7 @@
       "source_location": "L40"
     },
     {
-      "community": 524,
+      "community": 523,
       "file_type": "code",
       "id": "weekly_lifecycle_test_stubensuremutation",
       "label": "stubEnsureMutation()",
@@ -262336,7 +262402,7 @@
       "source_location": "L81"
     },
     {
-      "community": 525,
+      "community": 524,
       "file_type": "code",
       "id": "login_layout_completependingauthsync",
       "label": "completePendingAuthSync()",
@@ -262345,7 +262411,7 @@
       "source_location": "L145"
     },
     {
-      "community": 525,
+      "community": 524,
       "file_type": "code",
       "id": "login_layout_handlependingauthsync",
       "label": "handlePendingAuthSync()",
@@ -262354,7 +262420,7 @@
       "source_location": "L95"
     },
     {
-      "community": 525,
+      "community": 524,
       "file_type": "code",
       "id": "login_layout_navigationtargetforredirect",
       "label": "navigationTargetForRedirect()",
@@ -262363,7 +262429,7 @@
       "source_location": "L33"
     },
     {
-      "community": 525,
+      "community": 524,
       "file_type": "code",
       "id": "login_layout_sleep",
       "label": "sleep()",
@@ -262372,7 +262438,7 @@
       "source_location": "L29"
     },
     {
-      "community": 525,
+      "community": 524,
       "file_type": "code",
       "id": "login_layout_usedocumentscrolllock",
       "label": "useDocumentScrollLock()",
@@ -262381,7 +262447,7 @@
       "source_location": "L45"
     },
     {
-      "community": 525,
+      "community": 524,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_login_layout_tsx",
       "label": "-login-layout.tsx",
@@ -262390,7 +262456,7 @@
       "source_location": "L1"
     },
     {
-      "community": 526,
+      "community": 525,
       "file_type": "code",
       "id": "organizationsettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -262399,7 +262465,7 @@
       "source_location": "L155"
     },
     {
-      "community": 526,
+      "community": 525,
       "file_type": "code",
       "id": "organizationsettingsview_navigation",
       "label": "Navigation()",
@@ -262408,7 +262474,7 @@
       "source_location": "L197"
     },
     {
-      "community": 526,
+      "community": 525,
       "file_type": "code",
       "id": "organizationsettingsview_onsubmit",
       "label": "onSubmit()",
@@ -262417,7 +262483,7 @@
       "source_location": "L104"
     },
     {
-      "community": 526,
+      "community": 525,
       "file_type": "code",
       "id": "organizationsettingsview_organizationsettings",
       "label": "OrganizationSettings()",
@@ -262426,7 +262492,7 @@
       "source_location": "L25"
     },
     {
-      "community": 526,
+      "community": 525,
       "file_type": "code",
       "id": "organizationsettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -262435,7 +262501,7 @@
       "source_location": "L72"
     },
     {
-      "community": 526,
+      "community": 525,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
       "label": "OrganizationSettingsView.tsx",
@@ -262444,7 +262510,7 @@
       "source_location": "L1"
     },
     {
-      "community": 527,
+      "community": 526,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
       "label": "StoreSettingsView.tsx",
@@ -262453,7 +262519,7 @@
       "source_location": "L1"
     },
     {
-      "community": 527,
+      "community": 526,
       "file_type": "code",
       "id": "storesettingsview_handledeleteallproductsinstore",
       "label": "handleDeleteAllProductsInStore()",
@@ -262462,7 +262528,7 @@
       "source_location": "L231"
     },
     {
-      "community": 527,
+      "community": 526,
       "file_type": "code",
       "id": "storesettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -262471,7 +262537,7 @@
       "source_location": "L167"
     },
     {
-      "community": 527,
+      "community": 526,
       "file_type": "code",
       "id": "storesettingsview_onsubmit",
       "label": "onSubmit()",
@@ -262480,7 +262546,7 @@
       "source_location": "L116"
     },
     {
-      "community": 527,
+      "community": 526,
       "file_type": "code",
       "id": "storesettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -262489,7 +262555,7 @@
       "source_location": "L83"
     },
     {
-      "community": 527,
+      "community": 526,
       "file_type": "code",
       "id": "storesettingsview_storesettings",
       "label": "StoreSettings()",
@@ -262498,7 +262564,7 @@
       "source_location": "L29"
     },
     {
-      "community": 528,
+      "community": 527,
       "file_type": "code",
       "id": "devfixtureactivation_usedailyclosefixture",
       "label": "useDailyCloseFixture()",
@@ -262507,7 +262573,7 @@
       "source_location": "L102"
     },
     {
-      "community": 528,
+      "community": 527,
       "file_type": "code",
       "id": "devfixtureactivation_usedailyopeningfixture",
       "label": "useDailyOpeningFixture()",
@@ -262516,7 +262582,7 @@
       "source_location": "L96"
     },
     {
-      "community": 528,
+      "community": 527,
       "file_type": "code",
       "id": "devfixtureactivation_usedailyoperationsfixture",
       "label": "useDailyOperationsFixture()",
@@ -262525,7 +262591,7 @@
       "source_location": "L90"
     },
     {
-      "community": 528,
+      "community": 527,
       "file_type": "code",
       "id": "devfixtureactivation_useposhubfixture",
       "label": "usePosHubFixture()",
@@ -262534,7 +262600,7 @@
       "source_location": "L108"
     },
     {
-      "community": 528,
+      "community": 527,
       "file_type": "code",
       "id": "devfixtureactivation_useworkspacefixture",
       "label": "useWorkspaceFixture()",
@@ -262543,7 +262609,7 @@
       "source_location": "L46"
     },
     {
-      "community": 528,
+      "community": 527,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_operations_devfixtureactivation_ts",
       "label": "devFixtureActivation.ts",
@@ -262552,7 +262618,7 @@
       "source_location": "L1"
     },
     {
-      "community": 529,
+      "community": 528,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
       "label": "storybook-shell.tsx",
@@ -262561,7 +262627,7 @@
       "source_location": "L1"
     },
     {
-      "community": 529,
+      "community": 528,
       "file_type": "code",
       "id": "storybook_shell_storybookcallout",
       "label": "StorybookCallout()",
@@ -262570,7 +262636,7 @@
       "source_location": "L76"
     },
     {
-      "community": 529,
+      "community": 528,
       "file_type": "code",
       "id": "storybook_shell_storybooklist",
       "label": "StorybookList()",
@@ -262579,7 +262645,7 @@
       "source_location": "L55"
     },
     {
-      "community": 529,
+      "community": 528,
       "file_type": "code",
       "id": "storybook_shell_storybookpillrow",
       "label": "StorybookPillRow()",
@@ -262588,7 +262654,7 @@
       "source_location": "L88"
     },
     {
-      "community": 529,
+      "community": 528,
       "file_type": "code",
       "id": "storybook_shell_storybooksection",
       "label": "StorybookSection()",
@@ -262597,13 +262663,67 @@
       "source_location": "L34"
     },
     {
-      "community": 529,
+      "community": 528,
       "file_type": "code",
       "id": "storybook_shell_storybookshell",
       "label": "StorybookShell()",
       "norm_label": "storybookshell()",
       "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
       "source_location": "L13"
+    },
+    {
+      "community": 529,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_postransaction_ts",
+      "label": "posTransaction.ts",
+      "norm_label": "postransaction.ts",
+      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 529,
+      "file_type": "code",
+      "id": "postransaction_fetchpostransaction",
+      "label": "fetchPosTransaction()",
+      "norm_label": "fetchpostransaction()",
+      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
+      "source_location": "L69"
+    },
+    {
+      "community": 529,
+      "file_type": "code",
+      "id": "postransaction_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 529,
+      "file_type": "code",
+      "id": "postransaction_getpostransactionbyreceipttoken",
+      "label": "getPosTransactionByReceiptToken()",
+      "norm_label": "getpostransactionbyreceipttoken()",
+      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 529,
+      "file_type": "code",
+      "id": "postransaction_postransactionreceipterror",
+      "label": "PosTransactionReceiptError",
+      "norm_label": "postransactionreceipterror",
+      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 529,
+      "file_type": "code",
+      "id": "postransaction_postransactionreceipterror_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
+      "source_location": "L62"
     },
     {
       "community": 53,
@@ -262869,60 +262989,6 @@
     {
       "community": 530,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_postransaction_ts",
-      "label": "posTransaction.ts",
-      "norm_label": "postransaction.ts",
-      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 530,
-      "file_type": "code",
-      "id": "postransaction_fetchpostransaction",
-      "label": "fetchPosTransaction()",
-      "norm_label": "fetchpostransaction()",
-      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
-      "source_location": "L69"
-    },
-    {
-      "community": 530,
-      "file_type": "code",
-      "id": "postransaction_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 530,
-      "file_type": "code",
-      "id": "postransaction_getpostransactionbyreceipttoken",
-      "label": "getPosTransactionByReceiptToken()",
-      "norm_label": "getpostransactionbyreceipttoken()",
-      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 530,
-      "file_type": "code",
-      "id": "postransaction_postransactionreceipterror",
-      "label": "PosTransactionReceiptError",
-      "norm_label": "postransactionreceipterror",
-      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 530,
-      "file_type": "code",
-      "id": "postransaction_postransactionreceipterror_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 531,
-      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_promocodes_ts",
       "label": "promoCodes.ts",
       "norm_label": "promocodes.ts",
@@ -262930,7 +262996,7 @@
       "source_location": "L1"
     },
     {
-      "community": 531,
+      "community": 530,
       "file_type": "code",
       "id": "promocodes_getbaseurl",
       "label": "getBaseUrl()",
@@ -262939,7 +263005,7 @@
       "source_location": "L4"
     },
     {
-      "community": 531,
+      "community": 530,
       "file_type": "code",
       "id": "promocodes_getpromocodeitems",
       "label": "getPromoCodeItems()",
@@ -262948,7 +263014,7 @@
       "source_location": "L49"
     },
     {
-      "community": 531,
+      "community": 530,
       "file_type": "code",
       "id": "promocodes_getpromocodes",
       "label": "getPromoCodes()",
@@ -262957,7 +263023,7 @@
       "source_location": "L34"
     },
     {
-      "community": 531,
+      "community": 530,
       "file_type": "code",
       "id": "promocodes_getredeemedpromocodes",
       "label": "getRedeemedPromoCodes()",
@@ -262966,7 +263032,7 @@
       "source_location": "L74"
     },
     {
-      "community": 531,
+      "community": 530,
       "file_type": "code",
       "id": "promocodes_redeempromocode",
       "label": "redeemPromoCode()",
@@ -262975,7 +263041,7 @@
       "source_location": "L6"
     },
     {
-      "community": 532,
+      "community": 531,
       "file_type": "code",
       "id": "billingdetails_clearform",
       "label": "clearForm()",
@@ -262984,7 +263050,7 @@
       "source_location": "L173"
     },
     {
-      "community": 532,
+      "community": 531,
       "file_type": "code",
       "id": "billingdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -262993,7 +263059,7 @@
       "source_location": "L102"
     },
     {
-      "community": 532,
+      "community": 531,
       "file_type": "code",
       "id": "billingdetails_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -263002,7 +263068,7 @@
       "source_location": "L201"
     },
     {
-      "community": 532,
+      "community": 531,
       "file_type": "code",
       "id": "billingdetails_onsubmit",
       "label": "onSubmit()",
@@ -263011,7 +263077,7 @@
       "source_location": "L150"
     },
     {
-      "community": 532,
+      "community": 531,
       "file_type": "code",
       "id": "billingdetails_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -263020,7 +263086,7 @@
       "source_location": "L155"
     },
     {
-      "community": 532,
+      "community": 531,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
       "label": "BillingDetails.tsx",
@@ -263029,7 +263095,7 @@
       "source_location": "L1"
     },
     {
-      "community": 533,
+      "community": 532,
       "file_type": "code",
       "id": "homehero_test_attachmedia",
       "label": "attachMedia()",
@@ -263038,7 +263104,7 @@
       "source_location": "L22"
     },
     {
-      "community": 533,
+      "community": 532,
       "file_type": "code",
       "id": "homehero_test_destroy",
       "label": "destroy()",
@@ -263047,7 +263113,7 @@
       "source_location": "L24"
     },
     {
-      "community": 533,
+      "community": 532,
       "file_type": "code",
       "id": "homehero_test_issupported",
       "label": "isSupported()",
@@ -263056,7 +263122,7 @@
       "source_location": "L18"
     },
     {
-      "community": 533,
+      "community": 532,
       "file_type": "code",
       "id": "homehero_test_loadsource",
       "label": "loadSource()",
@@ -263065,7 +263131,7 @@
       "source_location": "L21"
     },
     {
-      "community": 533,
+      "community": 532,
       "file_type": "code",
       "id": "homehero_test_on",
       "label": "on()",
@@ -263074,7 +263140,7 @@
       "source_location": "L23"
     },
     {
-      "community": 533,
+      "community": 532,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homehero_test_tsx",
       "label": "HomeHero.test.tsx",
@@ -263083,7 +263149,7 @@
       "source_location": "L1"
     },
     {
-      "community": 534,
+      "community": 533,
       "file_type": "code",
       "id": "mobileproductactions_collapseonpageclick",
       "label": "collapseOnPageClick()",
@@ -263092,7 +263158,7 @@
       "source_location": "L76"
     },
     {
-      "community": 534,
+      "community": 533,
       "file_type": "code",
       "id": "mobileproductactions_handleconfirm",
       "label": "handleConfirm()",
@@ -263101,7 +263167,7 @@
       "source_location": "L120"
     },
     {
-      "community": 534,
+      "community": 533,
       "file_type": "code",
       "id": "mobileproductactions_handleprimaryaction",
       "label": "handlePrimaryAction()",
@@ -263110,7 +263176,7 @@
       "source_location": "L129"
     },
     {
-      "community": 534,
+      "community": 533,
       "file_type": "code",
       "id": "mobileproductactions_handlesecondaryaction",
       "label": "handleSecondaryAction()",
@@ -263119,7 +263185,7 @@
       "source_location": "L133"
     },
     {
-      "community": 534,
+      "community": 533,
       "file_type": "code",
       "id": "mobileproductactions_updateposition",
       "label": "updatePosition()",
@@ -263128,7 +263194,7 @@
       "source_location": "L44"
     },
     {
-      "community": 534,
+      "community": 533,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
       "label": "MobileProductActions.tsx",
@@ -263137,7 +263203,7 @@
       "source_location": "L1"
     },
     {
-      "community": 535,
+      "community": 534,
       "file_type": "code",
       "id": "checkoutexpired_checkoutexpired",
       "label": "CheckoutExpired()",
@@ -263146,7 +263212,7 @@
       "source_location": "L9"
     },
     {
-      "community": 535,
+      "community": 534,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessiongeneric",
       "label": "CheckoutSessionGeneric()",
@@ -263155,7 +263221,7 @@
       "source_location": "L73"
     },
     {
-      "community": 535,
+      "community": 534,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessionnotfound",
       "label": "CheckoutSessionNotFound()",
@@ -263164,7 +263230,7 @@
       "source_location": "L54"
     },
     {
-      "community": 535,
+      "community": 534,
       "file_type": "code",
       "id": "checkoutexpired_handlesendemail",
       "label": "handleSendEmail()",
@@ -263173,7 +263239,7 @@
       "source_location": "L98"
     },
     {
-      "community": 535,
+      "community": 534,
       "file_type": "code",
       "id": "checkoutexpired_nocheckoutsession",
       "label": "NoCheckoutSession()",
@@ -263182,12 +263248,66 @@
       "source_location": "L33"
     },
     {
-      "community": 535,
+      "community": 534,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
       "label": "CheckoutExpired.tsx",
       "norm_label": "checkoutexpired.tsx",
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 535,
+      "file_type": "code",
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L101"
+    },
+    {
+      "community": 535,
+      "file_type": "code",
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 535,
+      "file_type": "code",
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 535,
+      "file_type": "code",
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 535,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 535,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1"
     },
     {
@@ -265150,7 +265270,7 @@
       "label": "dedupeKey()",
       "norm_label": "dedupekey()",
       "source_file": "packages/athena-webapp/convex/notifications/registry.test.ts",
-      "source_location": "L558"
+      "source_location": "L609"
     },
     {
       "community": 561,
@@ -265159,7 +265279,7 @@
       "label": "keyFor()",
       "norm_label": "keyfor()",
       "source_file": "packages/athena-webapp/convex/notifications/registry.test.ts",
-      "source_location": "L733"
+      "source_location": "L794"
     },
     {
       "community": 561,
@@ -265366,7 +265486,7 @@
       "label": "completedOperatingDatesForStore()",
       "norm_label": "completedoperatingdatesforstore()",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L149"
+      "source_location": "L151"
     },
     {
       "community": 566,
@@ -265375,7 +265495,7 @@
       "label": "daysBetweenOperatingDates()",
       "norm_label": "daysbetweenoperatingdates()",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L354"
+      "source_location": "L369"
     },
     {
       "community": 566,
@@ -265384,7 +265504,7 @@
       "label": "listEnabledEodPolicies()",
       "norm_label": "listenabledeodpolicies()",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L135"
+      "source_location": "L137"
     },
     {
       "community": 566,
@@ -265393,7 +265513,7 @@
       "label": "selectOwedDailyCloseDates()",
       "norm_label": "selectoweddailyclosedates()",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L84"
+      "source_location": "L85"
     },
     {
       "community": 566,
@@ -273673,7 +273793,7 @@
       "label": "findNotificationKind()",
       "norm_label": "findnotificationkind()",
       "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
-      "source_location": "L358"
+      "source_location": "L395"
     },
     {
       "community": 681,
@@ -273682,7 +273802,7 @@
       "label": "getNotificationKind()",
       "norm_label": "getnotificationkind()",
       "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
-      "source_location": "L368"
+      "source_location": "L405"
     },
     {
       "community": 681,
@@ -273691,7 +273811,7 @@
       "label": "listNotificationKinds()",
       "norm_label": "listnotificationkinds()",
       "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
-      "source_location": "L376"
+      "source_location": "L413"
     },
     {
       "community": 682,

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -34259,7 +34259,7 @@
       "relation": "calls",
       "source": "oweddailyclosesweep_runoweddailyclosesweepwithctx",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L451",
+      "source_location": "L456",
       "target": "oweddailyclosesweep_daysbetweenoperatingdates",
       "weight": 1
     },
@@ -34271,7 +34271,7 @@
       "relation": "calls",
       "source": "oweddailyclosesweep_selectrotatingoweddailycloseattempt",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L401",
+      "source_location": "L404",
       "target": "oweddailyclosesweep_runoweddailyclosesweepwithctx",
       "weight": 1
     },
@@ -55499,7 +55499,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L485",
+      "source_location": "L499",
       "target": "oweddailyclosesweep_daysbetweenoperatingdates",
       "weight": 1
     },
@@ -55511,7 +55511,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L355",
+      "source_location": "L356",
       "target": "oweddailyclosesweep_runoweddailyclosesweepwithctx",
       "weight": 1
     },
@@ -244495,7 +244495,7 @@
       "label": "daysBetweenOperatingDates()",
       "norm_label": "daysbetweenoperatingdates()",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L485"
+      "source_location": "L499"
     },
     {
       "community": 335,
@@ -244504,7 +244504,7 @@
       "label": "runOwedDailyCloseSweepWithCtx()",
       "norm_label": "runoweddailyclosesweepwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L355"
+      "source_location": "L356"
     },
     {
       "community": 335,

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -9803,7 +9803,7 @@
       "relation": "calls",
       "source": "dailyclose_isinrange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1504",
+      "source_location": "L1501",
       "target": "dailyclose_approvalbelongstorange",
       "weight": 1
     },
@@ -9815,7 +9815,7 @@
       "relation": "calls",
       "source": "dailyclose_registersessionbelongstorange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1521",
+      "source_location": "L1518",
       "target": "dailyclose_approvalbelongstorange",
       "weight": 1
     },
@@ -9875,7 +9875,7 @@
       "relation": "calls",
       "source": "dailyclose_sourcecompletenessentry",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1843",
+      "source_location": "L1840",
       "target": "dailyclose_buildcompletedonlineordertotals",
       "weight": 1
     },
@@ -9887,7 +9887,7 @@
       "relation": "calls",
       "source": "dailyclose_getdailyclosefordate",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1177",
+      "source_location": "L1174",
       "target": "dailyclose_builddailycloselifecyclegatewithctx",
       "weight": 1
     },
@@ -9899,7 +9899,7 @@
       "relation": "calls",
       "source": "dailyclose_resolveoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1168",
+      "source_location": "L1165",
       "target": "dailyclose_builddailycloselifecyclegatewithctx",
       "weight": 1
     },
@@ -9911,7 +9911,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosereportsnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2266",
+      "source_location": "L2263",
       "target": "dailyclose_hasincompleteoperationalwork",
       "weight": 1
     },
@@ -9923,7 +9923,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosereportsnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2352",
+      "source_location": "L2349",
       "target": "dailyclose_snapshotrevieweditems",
       "weight": 1
     },
@@ -9935,7 +9935,7 @@
       "relation": "calls",
       "source": "dailyclose_uniquedailycloseitems",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2282",
+      "source_location": "L2279",
       "target": "dailyclose_builddailyclosereportsnapshot",
       "weight": 1
     },
@@ -9947,7 +9947,7 @@
       "relation": "calls",
       "source": "dailyclose_buildapprovalrequestsbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2909",
+      "source_location": "L2917",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -9959,7 +9959,7 @@
       "relation": "calls",
       "source": "dailyclose_buildcompletedonlineordertotals",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2843",
+      "source_location": "L2851",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -9971,7 +9971,7 @@
       "relation": "calls",
       "source": "dailyclose_buildexpensesessionsbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2964",
+      "source_location": "L2972",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -9983,7 +9983,7 @@
       "relation": "calls",
       "source": "dailyclose_buildexpensetransactionitemcountsbytransactionid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2856",
+      "source_location": "L2864",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -9995,7 +9995,7 @@
       "relation": "calls",
       "source": "dailyclose_buildreadiness",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3712",
+      "source_location": "L3720",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10007,7 +10007,7 @@
       "relation": "calls",
       "source": "dailyclose_buildregistersessionsbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2957",
+      "source_location": "L2965",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10019,7 +10019,7 @@
       "relation": "calls",
       "source": "dailyclose_buildstaffnamesbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2772",
+      "source_location": "L2780",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10031,7 +10031,7 @@
       "relation": "calls",
       "source": "dailyclose_buildterminallabelsbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2979",
+      "source_location": "L2987",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10043,7 +10043,7 @@
       "relation": "calls",
       "source": "dailyclose_buildtransactionitemcountsbytransactionid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2851",
+      "source_location": "L2859",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10055,7 +10055,7 @@
       "relation": "calls",
       "source": "dailyclose_cashdeltasbyregistersessionid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2954",
+      "source_location": "L2962",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10067,7 +10067,7 @@
       "relation": "calls",
       "source": "dailyclose_completesourcecompleteness",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2750",
+      "source_location": "L2758",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10079,7 +10079,7 @@
       "relation": "calls",
       "source": "dailyclose_emptysummary",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2744",
+      "source_location": "L2752",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10091,7 +10091,7 @@
       "relation": "calls",
       "source": "dailyclose_filterregistersessionsbelongingtorange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2897",
+      "source_location": "L2905",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10103,7 +10103,7 @@
       "relation": "calls",
       "source": "dailyclose_frozensyncedsaleinventoryreviewgroups",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3794",
+      "source_location": "L3802",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10115,7 +10115,7 @@
       "relation": "calls",
       "source": "dailyclose_getdailyclosecompletioneventstaffprofileid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2768",
+      "source_location": "L2776",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10127,7 +10127,7 @@
       "relation": "calls",
       "source": "dailyclose_getdailyclosefordate",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2763",
+      "source_location": "L2771",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10139,7 +10139,7 @@
       "relation": "calls",
       "source": "dailyclose_getpriorcompleteddailyclose",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2775",
+      "source_location": "L2783",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10151,7 +10151,7 @@
       "relation": "calls",
       "source": "dailyclose_getstore",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2700",
+      "source_location": "L2708",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10163,7 +10163,7 @@
       "relation": "calls",
       "source": "dailyclose_listactiveoversizedoperationalworkrepairs",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2818",
+      "source_location": "L2826",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10175,7 +10175,7 @@
       "relation": "calls",
       "source": "dailyclose_listcompletedonlineordersforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2824",
+      "source_location": "L2832",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10187,7 +10187,7 @@
       "relation": "calls",
       "source": "dailyclose_listdepositsforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2838",
+      "source_location": "L2846",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10199,7 +10199,7 @@
       "relation": "calls",
       "source": "dailyclose_listexpensesforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2837",
+      "source_location": "L2845",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10211,7 +10211,7 @@
       "relation": "calls",
       "source": "dailyclose_listopenoperationalworkitems",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2817",
+      "source_location": "L2825",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10223,7 +10223,7 @@
       "relation": "calls",
       "source": "dailyclose_listopenpossessions",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2816",
+      "source_location": "L2824",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10235,7 +10235,7 @@
       "relation": "calls",
       "source": "dailyclose_listpendingcloseoutapprovals",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2815",
+      "source_location": "L2823",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10247,7 +10247,7 @@
       "relation": "calls",
       "source": "dailyclose_listregistersessionsfordailyclose",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2810",
+      "source_location": "L2818",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10259,7 +10259,7 @@
       "relation": "calls",
       "source": "dailyclose_listtransactionsforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2819",
+      "source_location": "L2827",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10271,7 +10271,7 @@
       "relation": "calls",
       "source": "dailyclose_mayberedactdailyclosesnapshotforbroadview",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2786",
+      "source_location": "L2794",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10283,7 +10283,7 @@
       "relation": "calls",
       "source": "dailyclose_mergesourcecompleteness",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2881",
+      "source_location": "L2889",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10295,7 +10295,7 @@
       "relation": "calls",
       "source": "dailyclose_normalizecompleteddailyclosesnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2776",
+      "source_location": "L2784",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10307,7 +10307,7 @@
       "relation": "calls",
       "source": "dailyclose_normalizedailyclosesummary",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3783",
+      "source_location": "L3791",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10319,7 +10319,7 @@
       "relation": "calls",
       "source": "dailyclose_resolveoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2699",
+      "source_location": "L2707",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10331,7 +10331,7 @@
       "relation": "calls",
       "source": "dailyclose_sortdailycloseblockers",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3711",
+      "source_location": "L3719",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10343,7 +10343,7 @@
       "relation": "calls",
       "source": "dailyclose_uniquesourcesubjects",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3800",
+      "source_location": "L3808",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10355,7 +10355,7 @@
       "relation": "calls",
       "source": "dailyclose_buildexpensetransactionitemcountsbytransactionid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1962",
+      "source_location": "L1959",
       "target": "dailyclose_builddailycloseexpenseproductevidence",
       "weight": 1
     },
@@ -10367,7 +10367,7 @@
       "relation": "calls",
       "source": "dailyclose_stringfrommetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3905",
+      "source_location": "L3913",
       "target": "dailyclose_carryforwardbusinessdate",
       "weight": 1
     },
@@ -10379,7 +10379,7 @@
       "relation": "calls",
       "source": "dailyclose_carryforwardbusinessdate",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3937",
+      "source_location": "L3945",
       "target": "dailyclose_carryforwardmetadatamatches",
       "weight": 1
     },
@@ -10391,7 +10391,7 @@
       "relation": "calls",
       "source": "dailyclose_carryforwardsourceid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3938",
+      "source_location": "L3946",
       "target": "dailyclose_carryforwardmetadatamatches",
       "weight": 1
     },
@@ -10403,7 +10403,7 @@
       "relation": "calls",
       "source": "dailyclose_stringfrommetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3914",
+      "source_location": "L3922",
       "target": "dailyclose_carryforwardsourceid",
       "weight": 1
     },
@@ -10415,7 +10415,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosereportsnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4863",
+      "source_location": "L4888",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10427,7 +10427,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosesnapshotwithctx",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4674",
+      "source_location": "L4683",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10439,7 +10439,7 @@
       "relation": "calls",
       "source": "dailyclose_completionblockingincompletesources",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4741",
+      "source_location": "L4750",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10451,7 +10451,7 @@
       "relation": "calls",
       "source": "dailyclose_getnonactivedailyclosefordate",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4706",
+      "source_location": "L4715",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10463,7 +10463,7 @@
       "relation": "calls",
       "source": "dailyclose_getstore",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4649",
+      "source_location": "L4658",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10475,7 +10475,7 @@
       "relation": "calls",
       "source": "dailyclose_hasincompleteoperationalwork",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4795",
+      "source_location": "L4804",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10487,7 +10487,7 @@
       "relation": "calls",
       "source": "dailyclose_logicalcarryforwardselectioncount",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4814",
+      "source_location": "L4839",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10499,7 +10499,19 @@
       "relation": "calls",
       "source": "dailyclose_markotherdailyclosesnotcurrent",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4894",
+      "source_location": "L4919",
+      "target": "dailyclose_completedailycloseforautomationwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "dailyclose_completedailycloseforautomationwithctx",
+      "_tgt": "dailyclose_observedincompleteoperationalworkitemids",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailyclose_observedincompleteoperationalworkitemids",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L4807",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10511,7 +10523,7 @@
       "relation": "calls",
       "source": "dailyclose_patchdailyclosecarryforwardworkitemmetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4924",
+      "source_location": "L4949",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10523,7 +10535,7 @@
       "relation": "calls",
       "source": "dailyclose_recorddailyclosecompletedevent",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4930",
+      "source_location": "L4955",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10535,7 +10547,7 @@
       "relation": "calls",
       "source": "dailyclose_recorddailyclosecompletedreportfacts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4919",
+      "source_location": "L4944",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10547,7 +10559,7 @@
       "relation": "calls",
       "source": "dailyclose_resolveoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4665",
+      "source_location": "L4674",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10559,7 +10571,19 @@
       "relation": "calls",
       "source": "dailyclose_validateautomationcarryforwardworkitems",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4797",
+      "source_location": "L4822",
+      "target": "dailyclose_completedailycloseforautomationwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "dailyclose_completedailycloseforautomationwithctx",
+      "_tgt": "dailyclose_validatecarryforwardworkitemids",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailyclose_validatecarryforwardworkitemids",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L4805",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10571,7 +10595,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosereportsnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4534",
+      "source_location": "L4543",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10583,7 +10607,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosesnapshotwithctx",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4357",
+      "source_location": "L4365",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10595,7 +10619,7 @@
       "relation": "calls",
       "source": "dailyclose_completionblockingincompletesources",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4380",
+      "source_location": "L4388",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10607,7 +10631,7 @@
       "relation": "calls",
       "source": "dailyclose_createcarryforwardworkitems",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4454",
+      "source_location": "L4462",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10619,7 +10643,7 @@
       "relation": "calls",
       "source": "dailyclose_getstore",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4332",
+      "source_location": "L4340",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10631,7 +10655,7 @@
       "relation": "calls",
       "source": "dailyclose_hasincompleteoperationalwork",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4495",
+      "source_location": "L4504",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10643,7 +10667,7 @@
       "relation": "calls",
       "source": "dailyclose_logicalcarryforwardselectioncount",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4491",
+      "source_location": "L4500",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10655,7 +10679,19 @@
       "relation": "calls",
       "source": "dailyclose_markotherdailyclosesnotcurrent",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4567",
+      "source_location": "L4576",
+      "target": "dailyclose_completedailyclosewithctx",
+      "weight": 1
+    },
+    {
+      "_src": "dailyclose_completedailyclosewithctx",
+      "_tgt": "dailyclose_observedincompleteoperationalworkitemids",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailyclose_observedincompleteoperationalworkitemids",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L4488",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10667,7 +10703,7 @@
       "relation": "calls",
       "source": "dailyclose_patchdailyclosecarryforwardworkitemmetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4596",
+      "source_location": "L4605",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10679,7 +10715,7 @@
       "relation": "calls",
       "source": "dailyclose_recorddailyclosecompletedevent",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4602",
+      "source_location": "L4611",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10691,7 +10727,7 @@
       "relation": "calls",
       "source": "dailyclose_recorddailyclosecompletedreportfacts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4591",
+      "source_location": "L4600",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10703,7 +10739,7 @@
       "relation": "calls",
       "source": "dailyclose_resolveoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4348",
+      "source_location": "L4356",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10715,7 +10751,7 @@
       "relation": "calls",
       "source": "dailyclose_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4490",
+      "source_location": "L4499",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10727,7 +10763,7 @@
       "relation": "calls",
       "source": "dailyclose_uniqueoperationalworkitemids",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4400",
+      "source_location": "L4408",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10739,7 +10775,7 @@
       "relation": "calls",
       "source": "dailyclose_validatecarryforwardworkitemids",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4417",
+      "source_location": "L4425",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10751,7 +10787,7 @@
       "relation": "calls",
       "source": "dailyclose_validateselectedcarryforwardgroups",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4403",
+      "source_location": "L4411",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10763,7 +10799,7 @@
       "relation": "calls",
       "source": "dailyclose_incompletesourcecompletenessentries",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2404",
+      "source_location": "L2412",
       "target": "dailyclose_completionblockingincompletesources",
       "weight": 1
     },
@@ -10775,7 +10811,7 @@
       "relation": "calls",
       "source": "dailyclose_findcurrentcarryforwardworkitembysource",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4093",
+      "source_location": "L4101",
       "target": "dailyclose_createcarryforwardworkitems",
       "weight": 1
     },
@@ -10787,7 +10823,7 @@
       "relation": "calls",
       "source": "dailyclose_sourceidfromcarryforwardinput",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4090",
+      "source_location": "L4098",
       "target": "dailyclose_createcarryforwardworkitems",
       "weight": 1
     },
@@ -10799,7 +10835,7 @@
       "relation": "calls",
       "source": "dailyclose_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4081",
+      "source_location": "L4089",
       "target": "dailyclose_createcarryforwardworkitems",
       "weight": 1
     },
@@ -10823,7 +10859,7 @@
       "relation": "calls",
       "source": "dailyclose_buildstaffnamesbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5624",
+      "source_location": "L5643",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -10835,7 +10871,7 @@
       "relation": "calls",
       "source": "dailyclose_completionattributionfordailyclose",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5627",
+      "source_location": "L5646",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -10847,7 +10883,7 @@
       "relation": "calls",
       "source": "dailyclose_getdailyclosecompletioneventstaffprofileid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5620",
+      "source_location": "L5639",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -10859,7 +10895,7 @@
       "relation": "calls",
       "source": "dailyclose_redactdailyclosereportsnapshotforbroadview",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5650",
+      "source_location": "L5669",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -10871,7 +10907,7 @@
       "relation": "calls",
       "source": "dailyclose_getpriorcompleteddailyclose",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5492",
+      "source_location": "L5511",
       "target": "dailyclose_getdailycloseopeningcontextwithctx",
       "weight": 1
     },
@@ -10883,7 +10919,7 @@
       "relation": "calls",
       "source": "dailyclose_incompletesourcecompletenessentries",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2410",
+      "source_location": "L2418",
       "target": "dailyclose_hasincompleteoperationalwork",
       "weight": 1
     },
@@ -10895,7 +10931,7 @@
       "relation": "calls",
       "source": "dailyclose_sourcecompletenessentry",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1674",
+      "source_location": "L1671",
       "target": "dailyclose_listactiveoversizedoperationalworkrepairs",
       "weight": 1
     },
@@ -10907,7 +10943,7 @@
       "relation": "calls",
       "source": "dailyclose_buildstaffnamesbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5580",
+      "source_location": "L5599",
       "target": "dailyclose_listcompleteddailyclosehistorywithctx",
       "weight": 1
     },
@@ -10919,7 +10955,7 @@
       "relation": "calls",
       "source": "dailyclose_sourcecompletenessentry",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1775",
+      "source_location": "L1772",
       "target": "dailyclose_listcompletedonlineordersforday",
       "weight": 1
     },
@@ -10931,7 +10967,7 @@
       "relation": "calls",
       "source": "dailyclose_sourcecompletenessentry",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2108",
+      "source_location": "L2105",
       "target": "dailyclose_listdepositsforday",
       "weight": 1
     },
@@ -10943,7 +10979,7 @@
       "relation": "calls",
       "source": "dailyclose_sourcecompletenessentry",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1877",
+      "source_location": "L1874",
       "target": "dailyclose_listexpensesforday",
       "weight": 1
     },
@@ -10955,7 +10991,7 @@
       "relation": "calls",
       "source": "dailyclose_sourcecompletenessentry",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1637",
+      "source_location": "L1634",
       "target": "dailyclose_listopenoperationalworkitems",
       "weight": 1
     },
@@ -10967,7 +11003,7 @@
       "relation": "calls",
       "source": "dailyclose_sourcecompletenessentry",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1602",
+      "source_location": "L1599",
       "target": "dailyclose_listopenpossessions",
       "weight": 1
     },
@@ -10979,7 +11015,7 @@
       "relation": "calls",
       "source": "dailyclose_sourcecompletenessentry",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1562",
+      "source_location": "L1559",
       "target": "dailyclose_listpendingcloseoutapprovals",
       "weight": 1
     },
@@ -10991,7 +11027,7 @@
       "relation": "calls",
       "source": "dailyclose_completesourcecompleteness",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1369",
+      "source_location": "L1366",
       "target": "dailyclose_listregistersessionsfordailyclose",
       "weight": 1
     },
@@ -11003,7 +11039,7 @@
       "relation": "calls",
       "source": "dailyclose_sourcecompletenessentry",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1414",
+      "source_location": "L1411",
       "target": "dailyclose_listregistersessionsfordailyclose",
       "weight": 1
     },
@@ -11015,7 +11051,7 @@
       "relation": "calls",
       "source": "dailyclose_readcappedsource",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1726",
+      "source_location": "L1723",
       "target": "dailyclose_listtransactionsforday",
       "weight": 1
     },
@@ -11027,7 +11063,7 @@
       "relation": "calls",
       "source": "dailyclose_ascarryforwarditem",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1059",
+      "source_location": "L1060",
       "target": "dailyclose_logicalgroupascarryforwarditem",
       "weight": 1
     },
@@ -11039,7 +11075,7 @@
       "relation": "calls",
       "source": "dailyclose_mayberedactdailyclosesnapshotforbroadview",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2581",
+      "source_location": "L2589",
       "target": "dailyclose_emptysummary",
       "weight": 1
     },
@@ -11051,7 +11087,7 @@
       "relation": "calls",
       "source": "dailyclose_redactdailyclosesummaryforbroadview",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2582",
+      "source_location": "L2590",
       "target": "dailyclose_mayberedactdailyclosesnapshotforbroadview",
       "weight": 1
     },
@@ -11116,6 +11152,30 @@
       "weight": 1
     },
     {
+      "_src": "dailyclose_observedincompleteoperationalworkitemids",
+      "_tgt": "dailyclose_hasincompleteoperationalwork",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailyclose_observedincompleteoperationalworkitemids",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L2385",
+      "target": "dailyclose_hasincompleteoperationalwork",
+      "weight": 1
+    },
+    {
+      "_src": "dailyclose_observedincompleteoperationalworkitemids",
+      "_tgt": "dailyclose_uniqueoperationalworkitemids",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailyclose_observedincompleteoperationalworkitemids",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L2386",
+      "target": "dailyclose_uniqueoperationalworkitemids",
+      "weight": 1
+    },
+    {
       "_src": "dailyclose_patchdailyclosecarryforwardworkitemmetadata",
       "_tgt": "dailyclose_carryforwardbusinessdate",
       "confidence": "EXTRACTED",
@@ -11123,7 +11183,7 @@
       "relation": "calls",
       "source": "dailyclose_patchdailyclosecarryforwardworkitemmetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1104",
+      "source_location": "L1101",
       "target": "dailyclose_carryforwardbusinessdate",
       "weight": 1
     },
@@ -11135,7 +11195,7 @@
       "relation": "calls",
       "source": "dailyclose_patchdailyclosecarryforwardworkitemmetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1105",
+      "source_location": "L1102",
       "target": "dailyclose_carryforwardsourceid",
       "weight": 1
     },
@@ -11147,7 +11207,7 @@
       "relation": "calls",
       "source": "dailyclose_sourcecompletenessentry",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1703",
+      "source_location": "L1700",
       "target": "dailyclose_readcappedsource",
       "weight": 1
     },
@@ -11159,7 +11219,7 @@
       "relation": "calls",
       "source": "dailyclose_markreportdaydirty",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4320",
+      "source_location": "L4328",
       "target": "dailyclose_recorddailyclosecompletedreportfacts",
       "weight": 1
     },
@@ -11171,7 +11231,7 @@
       "relation": "calls",
       "source": "dailyclose_redactdailyclosesummaryforbroadview",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2541",
+      "source_location": "L2549",
       "target": "dailyclose_redactdailyclosereportsnapshotforbroadview",
       "weight": 1
     },
@@ -11183,7 +11243,7 @@
       "relation": "calls",
       "source": "dailyclose_normalizedailyclosesummary",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2504",
+      "source_location": "L2512",
       "target": "dailyclose_redactdailyclosesummaryforbroadview",
       "weight": 1
     },
@@ -11195,7 +11255,7 @@
       "relation": "calls",
       "source": "dailyclose_isinrange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1466",
+      "source_location": "L1463",
       "target": "dailyclose_registersessionbelongstorange",
       "weight": 1
     },
@@ -11207,7 +11267,7 @@
       "relation": "calls",
       "source": "dailyclose_registersessioncloseoutoperatingat",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1460",
+      "source_location": "L1457",
       "target": "dailyclose_registersessionbelongstorange",
       "weight": 1
     },
@@ -11219,7 +11279,7 @@
       "relation": "calls",
       "source": "dailyclose_registersessionintersectsrange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1469",
+      "source_location": "L1466",
       "target": "dailyclose_registersessionbelongstorange",
       "weight": 1
     },
@@ -11243,7 +11303,7 @@
       "relation": "calls",
       "source": "dailyclose_markotherdailyclosesnotcurrent",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5420",
+      "source_location": "L5439",
       "target": "dailyclose_reopendailyclosewithctx",
       "weight": 1
     },
@@ -11255,7 +11315,7 @@
       "relation": "calls",
       "source": "dailyclose_markreportdaydirty",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5471",
+      "source_location": "L5490",
       "target": "dailyclose_reopendailyclosewithctx",
       "weight": 1
     },
@@ -11267,7 +11327,7 @@
       "relation": "calls",
       "source": "dailyclose_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5257",
+      "source_location": "L5276",
       "target": "dailyclose_reopendailyclosewithctx",
       "weight": 1
     },
@@ -11279,7 +11339,7 @@
       "relation": "calls",
       "source": "dailyclose_carryforwardbusinessdate",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5075",
+      "source_location": "L5094",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -11291,7 +11351,7 @@
       "relation": "calls",
       "source": "dailyclose_carryforwardresolutionvalidationerror",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5026",
+      "source_location": "L5051",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -11303,7 +11363,7 @@
       "relation": "calls",
       "source": "dailyclose_carryforwardsourceid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5102",
+      "source_location": "L5121",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -11315,7 +11375,7 @@
       "relation": "calls",
       "source": "dailyclose_getstore",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5000",
+      "source_location": "L5025",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -11327,7 +11387,7 @@
       "relation": "calls",
       "source": "dailyclose_listdailyopeninghandoffsforcarryforward",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5147",
+      "source_location": "L5166",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -11339,7 +11399,7 @@
       "relation": "calls",
       "source": "dailyclose_stringfrommetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5084",
+      "source_location": "L5103",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -11351,7 +11411,7 @@
       "relation": "calls",
       "source": "dailyclose_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4991",
+      "source_location": "L5016",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -11387,7 +11447,7 @@
       "relation": "calls",
       "source": "dailyclose_stringfrommetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3926",
+      "source_location": "L3934",
       "target": "dailyclose_sourceidfromcarryforwardinput",
       "weight": 1
     },
@@ -11411,7 +11471,7 @@
       "relation": "calls",
       "source": "dailyclose_completionattributionfordailyclose",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2594",
+      "source_location": "L2602",
       "target": "dailyclose_todailyclosehistorylistitem",
       "weight": 1
     },
@@ -11423,7 +11483,7 @@
       "relation": "calls",
       "source": "dailyclose_redactdailyclosesummaryforbroadview",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2623",
+      "source_location": "L2631",
       "target": "dailyclose_todailyclosehistorylistitem",
       "weight": 1
     },
@@ -49439,7 +49499,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L6363",
+      "source_location": "L6423",
       "target": "dailyclose_test_createcommandargs",
       "weight": 1
     },
@@ -49559,7 +49619,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1488",
+      "source_location": "L1485",
       "target": "dailyclose_approvalbelongstorange",
       "weight": 1
     },
@@ -49607,7 +49667,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1788",
+      "source_location": "L1785",
       "target": "dailyclose_buildcompletedonlineordertotals",
       "weight": 1
     },
@@ -49619,7 +49679,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1972",
+      "source_location": "L1969",
       "target": "dailyclose_builddailycloseexpenseproductevidence",
       "weight": 1
     },
@@ -49631,7 +49691,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1159",
+      "source_location": "L1156",
       "target": "dailyclose_builddailycloselifecyclegatewithctx",
       "weight": 1
     },
@@ -49643,7 +49703,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2242",
+      "source_location": "L2239",
       "target": "dailyclose_builddailyclosereportsnapshot",
       "weight": 1
     },
@@ -49655,7 +49715,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2687",
+      "source_location": "L2695",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -49679,7 +49739,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1918",
+      "source_location": "L1915",
       "target": "dailyclose_buildexpensetransactionitemcountsbytransactionid",
       "weight": 1
     },
@@ -49691,7 +49751,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2139",
+      "source_location": "L2136",
       "target": "dailyclose_buildreadiness",
       "weight": 1
     },
@@ -49739,7 +49799,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1890",
+      "source_location": "L1887",
       "target": "dailyclose_buildtransactionitemcountsbytransactionid",
       "weight": 1
     },
@@ -49751,7 +49811,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3901",
+      "source_location": "L3909",
       "target": "dailyclose_carryforwardbusinessdate",
       "weight": 1
     },
@@ -49763,7 +49823,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3931",
+      "source_location": "L3939",
       "target": "dailyclose_carryforwardmetadatamatches",
       "weight": 1
     },
@@ -49775,7 +49835,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4980",
+      "source_location": "L5005",
       "target": "dailyclose_carryforwardresolutionvalidationerror",
       "weight": 1
     },
@@ -49787,7 +49847,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3910",
+      "source_location": "L3918",
       "target": "dailyclose_carryforwardsourceid",
       "weight": 1
     },
@@ -49799,7 +49859,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3975",
+      "source_location": "L3983",
       "target": "dailyclose_carryforwardworkitemidfromitem",
       "weight": 1
     },
@@ -49811,7 +49871,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2121",
+      "source_location": "L2118",
       "target": "dailyclose_cashdeltasbyregistersessionid",
       "weight": 1
     },
@@ -49835,7 +49895,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4643",
+      "source_location": "L4652",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -49847,7 +49907,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4328",
+      "source_location": "L4336",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -49871,7 +49931,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2415",
+      "source_location": "L2423",
       "target": "dailyclose_completionattributionfordailyclose",
       "weight": 1
     },
@@ -49883,7 +49943,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2403",
+      "source_location": "L2411",
       "target": "dailyclose_completionblockingincompletesources",
       "weight": 1
     },
@@ -49895,7 +49955,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4066",
+      "source_location": "L4074",
       "target": "dailyclose_createcarryforwardworkitems",
       "weight": 1
     },
@@ -49907,7 +49967,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2654",
+      "source_location": "L2662",
       "target": "dailyclose_emptysummary",
       "weight": 1
     },
@@ -49931,7 +49991,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3942",
+      "source_location": "L3950",
       "target": "dailyclose_findcurrentcarryforwardworkitembysource",
       "weight": 1
     },
@@ -49955,7 +50015,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2215",
+      "source_location": "L2212",
       "target": "dailyclose_frozensyncedsaleinventoryreviewgroups",
       "weight": 1
     },
@@ -49967,7 +50027,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5599",
+      "source_location": "L5618",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -49979,7 +50039,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2627",
+      "source_location": "L2635",
       "target": "dailyclose_getdailyclosecompletioneventstaffprofileid",
       "weight": 1
     },
@@ -49991,7 +50051,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1120",
+      "source_location": "L1117",
       "target": "dailyclose_getdailyclosefordate",
       "weight": 1
     },
@@ -50003,7 +50063,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5485",
+      "source_location": "L5504",
       "target": "dailyclose_getdailycloseopeningcontextwithctx",
       "weight": 1
     },
@@ -50015,7 +50075,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4165",
+      "source_location": "L4173",
       "target": "dailyclose_getnonactivedailyclosefordate",
       "weight": 1
     },
@@ -50027,7 +50087,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1195",
+      "source_location": "L1192",
       "target": "dailyclose_getpriorcompleteddailyclose",
       "weight": 1
     },
@@ -50039,7 +50099,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1113",
+      "source_location": "L1110",
       "target": "dailyclose_getstore",
       "weight": 1
     },
@@ -50051,7 +50111,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2409",
+      "source_location": "L2417",
       "target": "dailyclose_hasincompleteoperationalwork",
       "weight": 1
     },
@@ -50063,7 +50123,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2399",
+      "source_location": "L2407",
       "target": "dailyclose_incompletesourcecompletenessentries",
       "weight": 1
     },
@@ -50111,7 +50171,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1654",
+      "source_location": "L1651",
       "target": "dailyclose_listactiveoversizedoperationalworkrepairs",
       "weight": 1
     },
@@ -50123,7 +50183,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5546",
+      "source_location": "L5565",
       "target": "dailyclose_listcompleteddailyclosehistorywithctx",
       "weight": 1
     },
@@ -50135,7 +50195,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1745",
+      "source_location": "L1742",
       "target": "dailyclose_listcompletedonlineordersforday",
       "weight": 1
     },
@@ -50147,7 +50207,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4951",
+      "source_location": "L4976",
       "target": "dailyclose_listdailyopeninghandoffsforcarryforward",
       "weight": 1
     },
@@ -50159,7 +50219,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2083",
+      "source_location": "L2080",
       "target": "dailyclose_listdepositsforday",
       "weight": 1
     },
@@ -50171,7 +50231,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1854",
+      "source_location": "L1851",
       "target": "dailyclose_listexpensesforday",
       "weight": 1
     },
@@ -50183,7 +50243,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1617",
+      "source_location": "L1614",
       "target": "dailyclose_listopenoperationalworkitems",
       "weight": 1
     },
@@ -50195,7 +50255,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1574",
+      "source_location": "L1571",
       "target": "dailyclose_listopenpossessions",
       "weight": 1
     },
@@ -50207,7 +50267,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1528",
+      "source_location": "L1525",
       "target": "dailyclose_listpendingcloseoutapprovals",
       "weight": 1
     },
@@ -50219,7 +50279,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1228",
+      "source_location": "L1225",
       "target": "dailyclose_listregistersessionsfordailyclose",
       "weight": 1
     },
@@ -50231,7 +50291,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1715",
+      "source_location": "L1712",
       "target": "dailyclose_listtransactionsforday",
       "weight": 1
     },
@@ -50243,7 +50303,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3860",
+      "source_location": "L3868",
       "target": "dailyclose_logicalcarryforwardselectioncount",
       "weight": 1
     },
@@ -50267,7 +50327,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4142",
+      "source_location": "L4150",
       "target": "dailyclose_markotherdailyclosesnotcurrent",
       "weight": 1
     },
@@ -50279,7 +50339,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4249",
+      "source_location": "L4257",
       "target": "dailyclose_markreportdaydirty",
       "weight": 1
     },
@@ -50291,7 +50351,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2553",
+      "source_location": "L2561",
       "target": "dailyclose_mayberedactdailyclosesnapshotforbroadview",
       "weight": 1
     },
@@ -50327,7 +50387,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2464",
+      "source_location": "L2472",
       "target": "dailyclose_normalizebroadviewmetadatalabel",
       "weight": 1
     },
@@ -50357,13 +50417,25 @@
     },
     {
       "_src": "packages_athena_webapp_convex_operations_dailyclose_ts",
+      "_tgt": "dailyclose_observedincompleteoperationalworkitemids",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L2382",
+      "target": "dailyclose_observedincompleteoperationalworkitemids",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "_tgt": "dailyclose_patchdailyclosecarryforwardworkitemmetadata",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1088",
+      "source_location": "L1089",
       "target": "dailyclose_patchdailyclosecarryforwardworkitemmetadata",
       "weight": 1
     },
@@ -50375,7 +50447,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1472",
+      "source_location": "L1469",
       "target": "dailyclose_possessionintersectsrange",
       "weight": 1
     },
@@ -50387,7 +50459,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1691",
+      "source_location": "L1688",
       "target": "dailyclose_readcappedsource",
       "weight": 1
     },
@@ -50399,7 +50471,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4188",
+      "source_location": "L4196",
       "target": "dailyclose_recorddailyclosecompletedevent",
       "weight": 1
     },
@@ -50411,7 +50483,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4282",
+      "source_location": "L4290",
       "target": "dailyclose_recorddailyclosecompletedreportfacts",
       "weight": 1
     },
@@ -50423,7 +50495,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2468",
+      "source_location": "L2476",
       "target": "dailyclose_redactdailycloseitemforbroadview",
       "weight": 1
     },
@@ -50435,7 +50507,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5521",
+      "source_location": "L5540",
       "target": "dailyclose_redactdailycloseopeningcontextforbroadview",
       "weight": 1
     },
@@ -50447,7 +50519,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2521",
+      "source_location": "L2529",
       "target": "dailyclose_redactdailyclosereportsnapshotforbroadview",
       "weight": 1
     },
@@ -50459,7 +50531,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2501",
+      "source_location": "L2509",
       "target": "dailyclose_redactdailyclosesummaryforbroadview",
       "weight": 1
     },
@@ -50483,7 +50555,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1455",
+      "source_location": "L1452",
       "target": "dailyclose_registersessionbelongstorange",
       "weight": 1
     },
@@ -50507,7 +50579,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1445",
+      "source_location": "L1442",
       "target": "dailyclose_registersessionintersectsrange",
       "weight": 1
     },
@@ -50531,7 +50603,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5253",
+      "source_location": "L5272",
       "target": "dailyclose_reopendailyclosewithctx",
       "weight": 1
     },
@@ -50543,7 +50615,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4987",
+      "source_location": "L5012",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -50579,7 +50651,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2385",
+      "source_location": "L2393",
       "target": "dailyclose_snapshotrevieweditems",
       "weight": 1
     },
@@ -50615,7 +50687,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3920",
+      "source_location": "L3928",
       "target": "dailyclose_sourceidfromcarryforwardinput",
       "weight": 1
     },
@@ -50627,7 +50699,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3892",
+      "source_location": "L3900",
       "target": "dailyclose_stringfrommetadata",
       "weight": 1
     },
@@ -50639,7 +50711,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2588",
+      "source_location": "L2596",
       "target": "dailyclose_todailyclosehistorylistitem",
       "weight": 1
     },
@@ -50675,7 +50747,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2177",
+      "source_location": "L2174",
       "target": "dailyclose_trustedsyncedsaleinventoryreviewunits",
       "weight": 1
     },
@@ -50687,7 +50759,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2169",
+      "source_location": "L2166",
       "target": "dailyclose_uniquedailycloseitems",
       "weight": 1
     },
@@ -50699,7 +50771,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3886",
+      "source_location": "L3894",
       "target": "dailyclose_uniqueoperationalworkitemids",
       "weight": 1
     },
@@ -50711,7 +50783,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2159",
+      "source_location": "L2156",
       "target": "dailyclose_uniquesourcesubjects",
       "weight": 1
     },
@@ -50723,7 +50795,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3985",
+      "source_location": "L3993",
       "target": "dailyclose_validateautomationcarryforwardworkitems",
       "weight": 1
     },
@@ -50735,7 +50807,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3806",
+      "source_location": "L3814",
       "target": "dailyclose_validatecarryforwardworkitemids",
       "weight": 1
     },
@@ -50747,7 +50819,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3834",
+      "source_location": "L3842",
       "target": "dailyclose_validateselectedcarryforwardgroups",
       "weight": 1
     },
@@ -53207,7 +53279,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts",
-      "source_location": "L1432",
+      "source_location": "L1435",
       "target": "dailyoperationsautomation_test_insertlegacysentdelivery",
       "weight": 1
     },
@@ -53219,7 +53291,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts",
-      "source_location": "L1459",
+      "source_location": "L1462",
       "target": "dailyoperationsautomation_test_makeemitctx",
       "weight": 1
     },
@@ -53243,7 +53315,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts",
-      "source_location": "L1331",
+      "source_location": "L1334",
       "target": "dailyoperationsautomation_test_resultforrun",
       "weight": 1
     },
@@ -53255,7 +53327,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts",
-      "source_location": "L1383",
+      "source_location": "L1386",
       "target": "dailyoperationsautomation_test_seedcutoverfixture",
       "weight": 1
     },
@@ -181477,7 +181549,7 @@
       "label": "approvalBelongsToRange()",
       "norm_label": "approvalbelongstorange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1488"
+      "source_location": "L1485"
     },
     {
       "community": 0,
@@ -181513,7 +181585,7 @@
       "label": "buildCompletedOnlineOrderTotals()",
       "norm_label": "buildcompletedonlineordertotals()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1788"
+      "source_location": "L1785"
     },
     {
       "community": 0,
@@ -181522,7 +181594,7 @@
       "label": "buildDailyCloseExpenseProductEvidence()",
       "norm_label": "builddailycloseexpenseproductevidence()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1972"
+      "source_location": "L1969"
     },
     {
       "community": 0,
@@ -181531,7 +181603,7 @@
       "label": "buildDailyCloseLifecycleGateWithCtx()",
       "norm_label": "builddailycloselifecyclegatewithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1159"
+      "source_location": "L1156"
     },
     {
       "community": 0,
@@ -181540,7 +181612,7 @@
       "label": "buildDailyCloseReportSnapshot()",
       "norm_label": "builddailyclosereportsnapshot()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2242"
+      "source_location": "L2239"
     },
     {
       "community": 0,
@@ -181549,7 +181621,7 @@
       "label": "buildDailyCloseSnapshotWithCtx()",
       "norm_label": "builddailyclosesnapshotwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2687"
+      "source_location": "L2695"
     },
     {
       "community": 0,
@@ -181567,7 +181639,7 @@
       "label": "buildExpenseTransactionItemCountsByTransactionId()",
       "norm_label": "buildexpensetransactionitemcountsbytransactionid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1918"
+      "source_location": "L1915"
     },
     {
       "community": 0,
@@ -181576,7 +181648,7 @@
       "label": "buildReadiness()",
       "norm_label": "buildreadiness()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2139"
+      "source_location": "L2136"
     },
     {
       "community": 0,
@@ -181612,7 +181684,7 @@
       "label": "buildTransactionItemCountsByTransactionId()",
       "norm_label": "buildtransactionitemcountsbytransactionid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1890"
+      "source_location": "L1887"
     },
     {
       "community": 0,
@@ -181621,7 +181693,7 @@
       "label": "carryForwardBusinessDate()",
       "norm_label": "carryforwardbusinessdate()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3901"
+      "source_location": "L3909"
     },
     {
       "community": 0,
@@ -181630,7 +181702,7 @@
       "label": "carryForwardMetadataMatches()",
       "norm_label": "carryforwardmetadatamatches()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3931"
+      "source_location": "L3939"
     },
     {
       "community": 0,
@@ -181639,7 +181711,7 @@
       "label": "carryForwardResolutionValidationError()",
       "norm_label": "carryforwardresolutionvalidationerror()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4980"
+      "source_location": "L5005"
     },
     {
       "community": 0,
@@ -181648,7 +181720,7 @@
       "label": "carryForwardSourceId()",
       "norm_label": "carryforwardsourceid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3910"
+      "source_location": "L3918"
     },
     {
       "community": 0,
@@ -181657,7 +181729,7 @@
       "label": "carryForwardWorkItemIdFromItem()",
       "norm_label": "carryforwardworkitemidfromitem()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3975"
+      "source_location": "L3983"
     },
     {
       "community": 0,
@@ -181666,7 +181738,7 @@
       "label": "cashDeltasByRegisterSessionId()",
       "norm_label": "cashdeltasbyregistersessionid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2121"
+      "source_location": "L2118"
     },
     {
       "community": 0,
@@ -181684,7 +181756,7 @@
       "label": "completeDailyCloseForAutomationWithCtx()",
       "norm_label": "completedailycloseforautomationwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4643"
+      "source_location": "L4652"
     },
     {
       "community": 0,
@@ -181693,7 +181765,7 @@
       "label": "completeDailyCloseWithCtx()",
       "norm_label": "completedailyclosewithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4328"
+      "source_location": "L4336"
     },
     {
       "community": 0,
@@ -181711,7 +181783,7 @@
       "label": "completionAttributionForDailyClose()",
       "norm_label": "completionattributionfordailyclose()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2415"
+      "source_location": "L2423"
     },
     {
       "community": 0,
@@ -181720,7 +181792,7 @@
       "label": "completionBlockingIncompleteSources()",
       "norm_label": "completionblockingincompletesources()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2403"
+      "source_location": "L2411"
     },
     {
       "community": 0,
@@ -181729,7 +181801,7 @@
       "label": "createCarryForwardWorkItems()",
       "norm_label": "createcarryforwardworkitems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4066"
+      "source_location": "L4074"
     },
     {
       "community": 0,
@@ -181738,7 +181810,7 @@
       "label": "emptySummary()",
       "norm_label": "emptysummary()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2654"
+      "source_location": "L2662"
     },
     {
       "community": 0,
@@ -181756,7 +181828,7 @@
       "label": "findCurrentCarryForwardWorkItemBySource()",
       "norm_label": "findcurrentcarryforwardworkitembysource()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3942"
+      "source_location": "L3950"
     },
     {
       "community": 0,
@@ -181774,7 +181846,7 @@
       "label": "frozenSyncedSaleInventoryReviewGroups()",
       "norm_label": "frozensyncedsaleinventoryreviewgroups()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2215"
+      "source_location": "L2212"
     },
     {
       "community": 0,
@@ -181783,7 +181855,7 @@
       "label": "getCompletedDailyCloseHistoryDetailWithCtx()",
       "norm_label": "getcompleteddailyclosehistorydetailwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5599"
+      "source_location": "L5618"
     },
     {
       "community": 0,
@@ -181792,7 +181864,7 @@
       "label": "getDailyCloseCompletionEventStaffProfileId()",
       "norm_label": "getdailyclosecompletioneventstaffprofileid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2627"
+      "source_location": "L2635"
     },
     {
       "community": 0,
@@ -181801,7 +181873,7 @@
       "label": "getDailyCloseForDate()",
       "norm_label": "getdailyclosefordate()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1120"
+      "source_location": "L1117"
     },
     {
       "community": 0,
@@ -181810,7 +181882,7 @@
       "label": "getDailyCloseOpeningContextWithCtx()",
       "norm_label": "getdailycloseopeningcontextwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5485"
+      "source_location": "L5504"
     },
     {
       "community": 0,
@@ -181819,7 +181891,7 @@
       "label": "getNonActiveDailyCloseForDate()",
       "norm_label": "getnonactivedailyclosefordate()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4165"
+      "source_location": "L4173"
     },
     {
       "community": 0,
@@ -181828,7 +181900,7 @@
       "label": "getPriorCompletedDailyClose()",
       "norm_label": "getpriorcompleteddailyclose()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1195"
+      "source_location": "L1192"
     },
     {
       "community": 0,
@@ -181837,7 +181909,7 @@
       "label": "getStore()",
       "norm_label": "getstore()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1113"
+      "source_location": "L1110"
     },
     {
       "community": 0,
@@ -181846,7 +181918,7 @@
       "label": "hasIncompleteOperationalWork()",
       "norm_label": "hasincompleteoperationalwork()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2409"
+      "source_location": "L2417"
     },
     {
       "community": 0,
@@ -181855,7 +181927,7 @@
       "label": "incompleteSourceCompletenessEntries()",
       "norm_label": "incompletesourcecompletenessentries()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2399"
+      "source_location": "L2407"
     },
     {
       "community": 0,
@@ -181891,7 +181963,7 @@
       "label": "listActiveOversizedOperationalWorkRepairs()",
       "norm_label": "listactiveoversizedoperationalworkrepairs()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1654"
+      "source_location": "L1651"
     },
     {
       "community": 0,
@@ -181900,7 +181972,7 @@
       "label": "listCompletedDailyCloseHistoryWithCtx()",
       "norm_label": "listcompleteddailyclosehistorywithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5546"
+      "source_location": "L5565"
     },
     {
       "community": 0,
@@ -181909,7 +181981,7 @@
       "label": "listCompletedOnlineOrdersForDay()",
       "norm_label": "listcompletedonlineordersforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1745"
+      "source_location": "L1742"
     },
     {
       "community": 0,
@@ -181918,7 +181990,7 @@
       "label": "listDailyOpeningHandoffsForCarryForward()",
       "norm_label": "listdailyopeninghandoffsforcarryforward()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4951"
+      "source_location": "L4976"
     },
     {
       "community": 0,
@@ -181927,7 +181999,7 @@
       "label": "listDepositsForDay()",
       "norm_label": "listdepositsforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2083"
+      "source_location": "L2080"
     },
     {
       "community": 0,
@@ -181936,7 +182008,7 @@
       "label": "listExpensesForDay()",
       "norm_label": "listexpensesforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1854"
+      "source_location": "L1851"
     },
     {
       "community": 0,
@@ -181945,7 +182017,7 @@
       "label": "listOpenOperationalWorkItems()",
       "norm_label": "listopenoperationalworkitems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1617"
+      "source_location": "L1614"
     },
     {
       "community": 0,
@@ -181954,7 +182026,7 @@
       "label": "listOpenPosSessions()",
       "norm_label": "listopenpossessions()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1574"
+      "source_location": "L1571"
     },
     {
       "community": 0,
@@ -181963,7 +182035,7 @@
       "label": "listPendingCloseoutApprovals()",
       "norm_label": "listpendingcloseoutapprovals()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1528"
+      "source_location": "L1525"
     },
     {
       "community": 0,
@@ -181972,7 +182044,7 @@
       "label": "listRegisterSessionsForDailyClose()",
       "norm_label": "listregistersessionsfordailyclose()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1228"
+      "source_location": "L1225"
     },
     {
       "community": 0,
@@ -181981,7 +182053,7 @@
       "label": "listTransactionsForDay()",
       "norm_label": "listtransactionsforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1715"
+      "source_location": "L1712"
     },
     {
       "community": 0,
@@ -181990,7 +182062,7 @@
       "label": "logicalCarryForwardSelectionCount()",
       "norm_label": "logicalcarryforwardselectioncount()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3860"
+      "source_location": "L3868"
     },
     {
       "community": 0,
@@ -182008,7 +182080,7 @@
       "label": "markOtherDailyClosesNotCurrent()",
       "norm_label": "markotherdailyclosesnotcurrent()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4142"
+      "source_location": "L4150"
     },
     {
       "community": 0,
@@ -182017,7 +182089,7 @@
       "label": "markReportDayDirty()",
       "norm_label": "markreportdaydirty()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4249"
+      "source_location": "L4257"
     },
     {
       "community": 0,
@@ -182026,7 +182098,7 @@
       "label": "maybeRedactDailyCloseSnapshotForBroadView()",
       "norm_label": "mayberedactdailyclosesnapshotforbroadview()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2553"
+      "source_location": "L2561"
     },
     {
       "community": 0,
@@ -182053,7 +182125,7 @@
       "label": "normalizeBroadViewMetadataLabel()",
       "norm_label": "normalizebroadviewmetadatalabel()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2464"
+      "source_location": "L2472"
     },
     {
       "community": 0,
@@ -182076,11 +182148,20 @@
     {
       "community": 0,
       "file_type": "code",
+      "id": "dailyclose_observedincompleteoperationalworkitemids",
+      "label": "observedIncompleteOperationalWorkItemIds()",
+      "norm_label": "observedincompleteoperationalworkitemids()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L2382"
+    },
+    {
+      "community": 0,
+      "file_type": "code",
       "id": "dailyclose_patchdailyclosecarryforwardworkitemmetadata",
       "label": "patchDailyCloseCarryForwardWorkItemMetadata()",
       "norm_label": "patchdailyclosecarryforwardworkitemmetadata()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1088"
+      "source_location": "L1089"
     },
     {
       "community": 0,
@@ -182089,7 +182170,7 @@
       "label": "posSessionIntersectsRange()",
       "norm_label": "possessionintersectsrange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1472"
+      "source_location": "L1469"
     },
     {
       "community": 0,
@@ -182098,7 +182179,7 @@
       "label": "readCappedSource()",
       "norm_label": "readcappedsource()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1691"
+      "source_location": "L1688"
     },
     {
       "community": 0,
@@ -182107,7 +182188,7 @@
       "label": "recordDailyCloseCompletedEvent()",
       "norm_label": "recorddailyclosecompletedevent()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4188"
+      "source_location": "L4196"
     },
     {
       "community": 0,
@@ -182116,7 +182197,7 @@
       "label": "recordDailyCloseCompletedReportFacts()",
       "norm_label": "recorddailyclosecompletedreportfacts()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4282"
+      "source_location": "L4290"
     },
     {
       "community": 0,
@@ -182125,7 +182206,7 @@
       "label": "redactDailyCloseItemForBroadView()",
       "norm_label": "redactdailycloseitemforbroadview()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2468"
+      "source_location": "L2476"
     },
     {
       "community": 0,
@@ -182134,7 +182215,7 @@
       "label": "redactDailyCloseOpeningContextForBroadView()",
       "norm_label": "redactdailycloseopeningcontextforbroadview()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5521"
+      "source_location": "L5540"
     },
     {
       "community": 0,
@@ -182143,7 +182224,7 @@
       "label": "redactDailyCloseReportSnapshotForBroadView()",
       "norm_label": "redactdailyclosereportsnapshotforbroadview()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2521"
+      "source_location": "L2529"
     },
     {
       "community": 0,
@@ -182152,7 +182233,7 @@
       "label": "redactDailyCloseSummaryForBroadView()",
       "norm_label": "redactdailyclosesummaryforbroadview()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2501"
+      "source_location": "L2509"
     },
     {
       "community": 0,
@@ -182170,7 +182251,7 @@
       "label": "registerSessionBelongsToRange()",
       "norm_label": "registersessionbelongstorange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1455"
+      "source_location": "L1452"
     },
     {
       "community": 0,
@@ -182188,7 +182269,7 @@
       "label": "registerSessionIntersectsRange()",
       "norm_label": "registersessionintersectsrange()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1445"
+      "source_location": "L1442"
     },
     {
       "community": 0,
@@ -182206,7 +182287,7 @@
       "label": "reopenDailyCloseWithCtx()",
       "norm_label": "reopendailyclosewithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5253"
+      "source_location": "L5272"
     },
     {
       "community": 0,
@@ -182215,7 +182296,7 @@
       "label": "resolveDailyCloseCarryForwardWithCtx()",
       "norm_label": "resolvedailyclosecarryforwardwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4987"
+      "source_location": "L5012"
     },
     {
       "community": 0,
@@ -182242,7 +182323,7 @@
       "label": "snapshotReviewedItems()",
       "norm_label": "snapshotrevieweditems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2385"
+      "source_location": "L2393"
     },
     {
       "community": 0,
@@ -182269,7 +182350,7 @@
       "label": "sourceIdFromCarryForwardInput()",
       "norm_label": "sourceidfromcarryforwardinput()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3920"
+      "source_location": "L3928"
     },
     {
       "community": 0,
@@ -182278,7 +182359,7 @@
       "label": "stringFromMetadata()",
       "norm_label": "stringfrommetadata()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3892"
+      "source_location": "L3900"
     },
     {
       "community": 0,
@@ -182287,7 +182368,7 @@
       "label": "toDailyCloseHistoryListItem()",
       "norm_label": "todailyclosehistorylistitem()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2588"
+      "source_location": "L2596"
     },
     {
       "community": 0,
@@ -182314,7 +182395,7 @@
       "label": "trustedSyncedSaleInventoryReviewUnits()",
       "norm_label": "trustedsyncedsaleinventoryreviewunits()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2177"
+      "source_location": "L2174"
     },
     {
       "community": 0,
@@ -182323,7 +182404,7 @@
       "label": "uniqueDailyCloseItems()",
       "norm_label": "uniquedailycloseitems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2169"
+      "source_location": "L2166"
     },
     {
       "community": 0,
@@ -182332,7 +182413,7 @@
       "label": "uniqueOperationalWorkItemIds()",
       "norm_label": "uniqueoperationalworkitemids()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3886"
+      "source_location": "L3894"
     },
     {
       "community": 0,
@@ -182341,7 +182422,7 @@
       "label": "uniqueSourceSubjects()",
       "norm_label": "uniquesourcesubjects()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2159"
+      "source_location": "L2156"
     },
     {
       "community": 0,
@@ -182350,7 +182431,7 @@
       "label": "validateAutomationCarryForwardWorkItems()",
       "norm_label": "validateautomationcarryforwardworkitems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3985"
+      "source_location": "L3993"
     },
     {
       "community": 0,
@@ -182359,7 +182440,7 @@
       "label": "validateCarryForwardWorkItemIds()",
       "norm_label": "validatecarryforwardworkitemids()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3806"
+      "source_location": "L3814"
     },
     {
       "community": 0,
@@ -182368,7 +182449,7 @@
       "label": "validateSelectedCarryForwardGroups()",
       "norm_label": "validateselectedcarryforwardgroups()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3834"
+      "source_location": "L3842"
     },
     {
       "community": 0,
@@ -211213,7 +211294,7 @@
       "label": "createCommandArgs()",
       "norm_label": "createcommandargs()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L6363"
+      "source_location": "L6423"
     },
     {
       "community": 171,
@@ -217455,119 +217536,119 @@
     {
       "community": 195,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "id": "packages_athena_webapp_src_components_pos_sessions_possessionsview_tsx",
+      "label": "POSSessionsView.tsx",
+      "norm_label": "possessionsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
       "source_location": "L1"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
+      "id": "possessionsview_formatexpiry",
+      "label": "formatExpiry()",
+      "norm_label": "formatexpiry()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L190"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L1"
+      "id": "possessionsview_formatholddetails",
+      "label": "formatHoldDetails()",
+      "norm_label": "formatholddetails()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L216"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "utils_formatdeliveryaddress",
-      "label": "formatDeliveryAddress()",
-      "norm_label": "formatdeliveryaddress()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L74"
+      "id": "possessionsview_formatregisterlabel",
+      "label": "formatRegisterLabel()",
+      "norm_label": "formatregisterlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L147"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "utils_getamountpaidfororder",
-      "label": "getAmountPaidForOrder()",
-      "norm_label": "getamountpaidfororder()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L191"
+      "id": "possessionsview_formatstatuslabel",
+      "label": "formatStatusLabel()",
+      "norm_label": "formatstatuslabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L122"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "utils_getdiscountvalue",
-      "label": "getDiscountValue()",
-      "norm_label": "getdiscountvalue()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L17"
+      "id": "possessionsview_getcartcount",
+      "label": "getCartCount()",
+      "norm_label": "getcartcount()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L180"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "utils_getonlineorderplacedat",
-      "label": "getOnlineOrderPlacedAt()",
-      "norm_label": "getonlineorderplacedat()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
+      "id": "possessionsview_getcustomerlabel",
+      "label": "getCustomerLabel()",
+      "norm_label": "getcustomerlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L176"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "utils_getorderamount",
-      "label": "getOrderAmount()",
-      "norm_label": "getorderamount()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L51"
+      "id": "possessionsview_getoperatorlabel",
+      "label": "getOperatorLabel()",
+      "norm_label": "getoperatorlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L138"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "utils_getorderstate",
-      "label": "getOrderState()",
-      "norm_label": "getorderstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L40"
+      "id": "possessionsview_getregisterlabel",
+      "label": "getRegisterLabel()",
+      "norm_label": "getregisterlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L157"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "utils_getpickupactionstate",
-      "label": "getPickupActionState()",
-      "norm_label": "getpickupactionstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L102"
+      "id": "possessionsview_getsessioncode",
+      "label": "getSessionCode()",
+      "norm_label": "getsessioncode()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L131"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "utils_getpotentialpoints",
-      "label": "getPotentialPoints()",
-      "norm_label": "getpotentialpoints()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L107"
+      "id": "possessionsview_getsessions",
+      "label": "getSessions()",
+      "norm_label": "getsessions()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L114"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "utils_getproductdiscountvalue",
-      "label": "getProductDiscountValue()",
-      "norm_label": "getproductdiscountvalue()",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
-      "source_location": "L75"
+      "id": "possessionsview_getstatusbadgeclass",
+      "label": "getStatusBadgeClass()",
+      "norm_label": "getstatusbadgeclass()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L250"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "utils_shouldshowpickupexceptionaction",
-      "label": "shouldShowPickupExceptionAction()",
-      "norm_label": "shouldshowpickupexceptionaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L116"
+      "id": "possessionsview_possessionsheader",
+      "label": "POSSessionsHeader()",
+      "norm_label": "possessionsheader()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L261"
     },
     {
       "community": 1950,
@@ -217662,119 +217743,119 @@
     {
       "community": 196,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_sessions_possessionsview_tsx",
-      "label": "POSSessionsView.tsx",
-      "norm_label": "possessionsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "id": "localposreadiness_blocked",
+      "label": "blocked()",
+      "norm_label": "blocked()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L638"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "localposreadiness_evaluatelocalposreadiness",
+      "label": "evaluateLocalPosReadiness()",
+      "norm_label": "evaluatelocalposreadiness()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L124"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "localposreadiness_evaluatelocalposservicecatalogreadiness",
+      "label": "evaluateLocalPosServiceCatalogReadiness()",
+      "norm_label": "evaluatelocalposservicecatalogreadiness()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L258"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "localposreadiness_formatreadinessstatekey",
+      "label": "formatReadinessStateKey()",
+      "norm_label": "formatreadinessstatekey()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L591"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "localposreadiness_hassettledlocalcloseout",
+      "label": "hasSettledLocalCloseout()",
+      "norm_label": "hassettledlocalcloseout()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L248"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "localposreadiness_localreadinessmatchesinput",
+      "label": "localReadinessMatchesInput()",
+      "norm_label": "localreadinessmatchesinput()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L287"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "localposreadiness_localreadinessrecordfromsnapshots",
+      "label": "localReadinessRecordFromSnapshots()",
+      "norm_label": "localreadinessrecordfromsnapshots()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "localposreadiness_readinessstatekey",
+      "label": "readinessStateKey()",
+      "norm_label": "readinessstatekey()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L610"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "localposreadiness_readinessstatekeysequal",
+      "label": "readinessStateKeysEqual()",
+      "norm_label": "readinessstatekeysequal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L624"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "localposreadiness_readlocalposreadiness",
+      "label": "readLocalPosReadiness()",
+      "norm_label": "readlocalposreadiness()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L299"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "localposreadiness_refreshlocalposreadinessfromsnapshots",
+      "label": "refreshLocalPosReadinessFromSnapshots()",
+      "norm_label": "refreshlocalposreadinessfromsnapshots()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L343"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "localposreadiness_uselocalposreadiness",
+      "label": "useLocalPosReadiness()",
+      "norm_label": "uselocalposreadiness()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L391"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localposreadiness_ts",
+      "label": "localPosReadiness.ts",
+      "norm_label": "localposreadiness.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "possessionsview_formatexpiry",
-      "label": "formatExpiry()",
-      "norm_label": "formatexpiry()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L190"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "possessionsview_formatholddetails",
-      "label": "formatHoldDetails()",
-      "norm_label": "formatholddetails()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L216"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "possessionsview_formatregisterlabel",
-      "label": "formatRegisterLabel()",
-      "norm_label": "formatregisterlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L147"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "possessionsview_formatstatuslabel",
-      "label": "formatStatusLabel()",
-      "norm_label": "formatstatuslabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L122"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "possessionsview_getcartcount",
-      "label": "getCartCount()",
-      "norm_label": "getcartcount()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L180"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "possessionsview_getcustomerlabel",
-      "label": "getCustomerLabel()",
-      "norm_label": "getcustomerlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L176"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "possessionsview_getoperatorlabel",
-      "label": "getOperatorLabel()",
-      "norm_label": "getoperatorlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L138"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "possessionsview_getregisterlabel",
-      "label": "getRegisterLabel()",
-      "norm_label": "getregisterlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L157"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "possessionsview_getsessioncode",
-      "label": "getSessionCode()",
-      "norm_label": "getsessioncode()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L131"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "possessionsview_getsessions",
-      "label": "getSessions()",
-      "norm_label": "getsessions()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L114"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "possessionsview_getstatusbadgeclass",
-      "label": "getStatusBadgeClass()",
-      "norm_label": "getstatusbadgeclass()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L250"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "possessionsview_possessionsheader",
-      "label": "POSSessionsHeader()",
-      "norm_label": "possessionsheader()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L261"
     },
     {
       "community": 1960,
@@ -217869,119 +217950,119 @@
     {
       "community": 197,
       "file_type": "code",
-      "id": "localposreadiness_blocked",
-      "label": "blocked()",
-      "norm_label": "blocked()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L638"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "localposreadiness_evaluatelocalposreadiness",
-      "label": "evaluateLocalPosReadiness()",
-      "norm_label": "evaluatelocalposreadiness()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L124"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "localposreadiness_evaluatelocalposservicecatalogreadiness",
-      "label": "evaluateLocalPosServiceCatalogReadiness()",
-      "norm_label": "evaluatelocalposservicecatalogreadiness()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L258"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "localposreadiness_formatreadinessstatekey",
-      "label": "formatReadinessStateKey()",
-      "norm_label": "formatreadinessstatekey()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L591"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "localposreadiness_hassettledlocalcloseout",
-      "label": "hasSettledLocalCloseout()",
-      "norm_label": "hassettledlocalcloseout()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L248"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "localposreadiness_localreadinessmatchesinput",
-      "label": "localReadinessMatchesInput()",
-      "norm_label": "localreadinessmatchesinput()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L287"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "localposreadiness_localreadinessrecordfromsnapshots",
-      "label": "localReadinessRecordFromSnapshots()",
-      "norm_label": "localreadinessrecordfromsnapshots()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L83"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "localposreadiness_readinessstatekey",
-      "label": "readinessStateKey()",
-      "norm_label": "readinessstatekey()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L610"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "localposreadiness_readinessstatekeysequal",
-      "label": "readinessStateKeysEqual()",
-      "norm_label": "readinessstatekeysequal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L624"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "localposreadiness_readlocalposreadiness",
-      "label": "readLocalPosReadiness()",
-      "norm_label": "readlocalposreadiness()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L299"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "localposreadiness_refreshlocalposreadinessfromsnapshots",
-      "label": "refreshLocalPosReadinessFromSnapshots()",
-      "norm_label": "refreshlocalposreadinessfromsnapshots()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L343"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "localposreadiness_uselocalposreadiness",
-      "label": "useLocalPosReadiness()",
-      "norm_label": "uselocalposreadiness()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L391"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localposreadiness_ts",
-      "label": "localPosReadiness.ts",
-      "norm_label": "localposreadiness.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registercatalogpinruntime_ts",
+      "label": "registerCatalogPinRuntime.ts",
+      "norm_label": "registercatalogpinruntime.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_captureregistercatalogruntimepin",
+      "label": "captureRegisterCatalogRuntimePin()",
+      "norm_label": "captureregistercatalogruntimepin()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L138"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_chooseregistercatalogruntimeownerid",
+      "label": "chooseRegisterCatalogRuntimeOwnerId()",
+      "norm_label": "chooseregistercatalogruntimeownerid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_clearregistercatalogruntimeactionguard",
+      "label": "clearRegisterCatalogRuntimeActionGuard()",
+      "norm_label": "clearregistercatalogruntimeactionguard()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L171"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_clearregistercatalogruntimeselection",
+      "label": "clearRegisterCatalogRuntimeSelection()",
+      "norm_label": "clearregistercatalogruntimeselection()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L132"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_getregistercatalogruntimeownerid",
+      "label": "getRegisterCatalogRuntimeOwnerId()",
+      "norm_label": "getregistercatalogruntimeownerid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L177"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_hasregistercatalogruntimeactionguard",
+      "label": "hasRegisterCatalogRuntimeActionGuard()",
+      "norm_label": "hasregistercatalogruntimeactionguard()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L165"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_keyforscope",
+      "label": "keyForScope()",
+      "norm_label": "keyforscope()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L122"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_maintainownerclaim",
+      "label": "maintainOwnerClaim()",
+      "norm_label": "maintainownerclaim()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_ownerclaimkey",
+      "label": "ownerClaimKey()",
+      "norm_label": "ownerclaimkey()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L47"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_readownerclaim",
+      "label": "readOwnerClaim()",
+      "norm_label": "readownerclaim()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_setregistercatalogruntimeselection",
+      "label": "setRegisterCatalogRuntimeSelection()",
+      "norm_label": "setregistercatalogruntimeselection()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L126"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_writeownerclaim",
+      "label": "writeOwnerClaim()",
+      "norm_label": "writeownerclaim()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L71"
     },
     {
       "community": 1970,
@@ -218076,119 +218157,119 @@
     {
       "community": 198,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registercatalogpinruntime_ts",
-      "label": "registerCatalogPinRuntime.ts",
-      "norm_label": "registercatalogpinruntime.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_printattempttelemetry_ts",
+      "label": "printAttemptTelemetry.ts",
+      "norm_label": "printattempttelemetry.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
       "source_location": "L1"
     },
     {
       "community": 198,
       "file_type": "code",
-      "id": "registercatalogpinruntime_captureregistercatalogruntimepin",
-      "label": "captureRegisterCatalogRuntimePin()",
-      "norm_label": "captureregistercatalogruntimepin()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L138"
+      "id": "printattempttelemetry_appendevent",
+      "label": "appendEvent()",
+      "norm_label": "appendevent()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L81"
     },
     {
       "community": 198,
       "file_type": "code",
-      "id": "registercatalogpinruntime_chooseregistercatalogruntimeownerid",
-      "label": "chooseRegisterCatalogRuntimeOwnerId()",
-      "norm_label": "chooseregistercatalogruntimeownerid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L31"
+      "id": "printattempttelemetry_beginprintattempt",
+      "label": "beginPrintAttempt()",
+      "norm_label": "beginprintattempt()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L115"
     },
     {
       "community": 198,
       "file_type": "code",
-      "id": "registercatalogpinruntime_clearregistercatalogruntimeactionguard",
-      "label": "clearRegisterCatalogRuntimeActionGuard()",
-      "norm_label": "clearregistercatalogruntimeactionguard()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L171"
+      "id": "printattempttelemetry_buildmetadata",
+      "label": "buildMetadata()",
+      "norm_label": "buildmetadata()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L88"
     },
     {
       "community": 198,
       "file_type": "code",
-      "id": "registercatalogpinruntime_clearregistercatalogruntimeselection",
-      "label": "clearRegisterCatalogRuntimeSelection()",
-      "norm_label": "clearregistercatalogruntimeselection()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L132"
+      "id": "printattempttelemetry_finalizeprintattempt",
+      "label": "finalizePrintAttempt()",
+      "norm_label": "finalizeprintattempt()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L211"
     },
     {
       "community": 198,
       "file_type": "code",
-      "id": "registercatalogpinruntime_getregistercatalogruntimeownerid",
-      "label": "getRegisterCatalogRuntimeOwnerId()",
-      "norm_label": "getregistercatalogruntimeownerid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L177"
+      "id": "printattempttelemetry_getprintrejectionmetadata",
+      "label": "getPrintRejectionMetadata()",
+      "norm_label": "getprintrejectionmetadata()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L250"
     },
     {
       "community": 198,
       "file_type": "code",
-      "id": "registercatalogpinruntime_hasregistercatalogruntimeactionguard",
-      "label": "hasRegisterCatalogRuntimeActionGuard()",
-      "norm_label": "hasregistercatalogruntimeactionguard()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L165"
+      "id": "printattempttelemetry_getreasonmessage",
+      "label": "getReasonMessage()",
+      "norm_label": "getreasonmessage()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L108"
     },
     {
       "community": 198,
       "file_type": "code",
-      "id": "registercatalogpinruntime_keyforscope",
-      "label": "keyForScope()",
-      "norm_label": "keyforscope()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L122"
+      "id": "printattempttelemetry_istargetterminal",
+      "label": "isTargetTerminal()",
+      "norm_label": "istargetterminal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L62"
     },
     {
       "community": 198,
       "file_type": "code",
-      "id": "registercatalogpinruntime_maintainownerclaim",
-      "label": "maintainOwnerClaim()",
-      "norm_label": "maintainownerclaim()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L87"
+      "id": "printattempttelemetry_mintattemptid",
+      "label": "mintAttemptId()",
+      "norm_label": "mintattemptid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L70"
     },
     {
       "community": 198,
       "file_type": "code",
-      "id": "registercatalogpinruntime_ownerclaimkey",
-      "label": "ownerClaimKey()",
-      "norm_label": "ownerclaimkey()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L47"
+      "id": "printattempttelemetry_recordprintattemptevent",
+      "label": "recordPrintAttemptEvent()",
+      "norm_label": "recordprintattemptevent()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L195"
     },
     {
       "community": 198,
       "file_type": "code",
-      "id": "registercatalogpinruntime_readownerclaim",
-      "label": "readOwnerClaim()",
-      "norm_label": "readownerclaim()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L51"
+      "id": "printattempttelemetry_recordprintinvocation",
+      "label": "recordPrintInvocation()",
+      "norm_label": "recordprintinvocation()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L151"
     },
     {
       "community": 198,
       "file_type": "code",
-      "id": "registercatalogpinruntime_setregistercatalogruntimeselection",
-      "label": "setRegisterCatalogRuntimeSelection()",
-      "norm_label": "setregistercatalogruntimeselection()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L126"
+      "id": "printattempttelemetry_recordprintreturn",
+      "label": "recordPrintReturn()",
+      "norm_label": "recordprintreturn()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L174"
     },
     {
       "community": 198,
       "file_type": "code",
-      "id": "registercatalogpinruntime_writeownerclaim",
-      "label": "writeOwnerClaim()",
-      "norm_label": "writeownerclaim()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L71"
+      "id": "printattempttelemetry_resetprintattempttelemetryfortests",
+      "label": "resetPrintAttemptTelemetryForTests()",
+      "norm_label": "resetprintattempttelemetryfortests()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L294"
     },
     {
       "community": 1980,
@@ -218283,119 +218364,119 @@
     {
       "community": 199,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_printattempttelemetry_ts",
-      "label": "printAttemptTelemetry.ts",
-      "norm_label": "printattempttelemetry.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_telemetrybuffer_ts",
+      "label": "telemetryBuffer.ts",
+      "norm_label": "telemetrybuffer.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
       "source_location": "L1"
     },
     {
       "community": 199,
       "file_type": "code",
-      "id": "printattempttelemetry_appendevent",
-      "label": "appendEvent()",
-      "norm_label": "appendevent()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L81"
+      "id": "telemetrybuffer_clearposclienttelemetrybuffer",
+      "label": "clearPosClientTelemetryBuffer()",
+      "norm_label": "clearposclienttelemetrybuffer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L212"
     },
     {
       "community": 199,
       "file_type": "code",
-      "id": "printattempttelemetry_beginprintattempt",
-      "label": "beginPrintAttempt()",
-      "norm_label": "beginprintattempt()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L115"
+      "id": "telemetrybuffer_enqueueposclientevent",
+      "label": "enqueuePosClientEvent()",
+      "norm_label": "enqueueposclientevent()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L167"
     },
     {
       "community": 199,
       "file_type": "code",
-      "id": "printattempttelemetry_buildmetadata",
-      "label": "buildMetadata()",
-      "norm_label": "buildmetadata()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L88"
+      "id": "telemetrybuffer_isbufferedevent",
+      "label": "isBufferedEvent()",
+      "norm_label": "isbufferedevent()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L100"
     },
     {
       "community": 199,
       "file_type": "code",
-      "id": "printattempttelemetry_finalizeprintattempt",
-      "label": "finalizePrintAttempt()",
-      "norm_label": "finalizeprintattempt()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L211"
+      "id": "telemetrybuffer_mintclienteventid",
+      "label": "mintClientEventId()",
+      "norm_label": "mintclienteventid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L63"
     },
     {
       "community": 199,
       "file_type": "code",
-      "id": "printattempttelemetry_getprintrejectionmetadata",
-      "label": "getPrintRejectionMetadata()",
-      "norm_label": "getprintrejectionmetadata()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L250"
+      "id": "telemetrybuffer_normalizepostelemetryerror",
+      "label": "normalizePosTelemetryError()",
+      "norm_label": "normalizepostelemetryerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L116"
     },
     {
       "community": 199,
       "file_type": "code",
-      "id": "printattempttelemetry_getreasonmessage",
-      "label": "getReasonMessage()",
-      "norm_label": "getreasonmessage()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L108"
+      "id": "telemetrybuffer_peekposclienteventbatch",
+      "label": "peekPosClientEventBatch()",
+      "norm_label": "peekposclienteventbatch()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L194"
     },
     {
       "community": 199,
       "file_type": "code",
-      "id": "printattempttelemetry_istargetterminal",
-      "label": "isTargetTerminal()",
-      "norm_label": "istargetterminal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L62"
+      "id": "telemetrybuffer_posclienttelemetrybuffersize",
+      "label": "posClientTelemetryBufferSize()",
+      "norm_label": "posclienttelemetrybuffersize()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L208"
     },
     {
       "community": 199,
       "file_type": "code",
-      "id": "printattempttelemetry_mintattemptid",
-      "label": "mintAttemptId()",
-      "norm_label": "mintattemptid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L70"
+      "id": "telemetrybuffer_readbuffer",
+      "label": "readBuffer()",
+      "norm_label": "readbuffer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L74"
     },
     {
       "community": 199,
       "file_type": "code",
-      "id": "printattempttelemetry_recordprintattemptevent",
-      "label": "recordPrintAttemptEvent()",
-      "norm_label": "recordprintattemptevent()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L195"
+      "id": "telemetrybuffer_removeposclientevents",
+      "label": "removePosClientEvents()",
+      "norm_label": "removeposclientevents()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L200"
     },
     {
       "community": 199,
       "file_type": "code",
-      "id": "printattempttelemetry_recordprintinvocation",
-      "label": "recordPrintInvocation()",
-      "norm_label": "recordprintinvocation()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L151"
+      "id": "telemetrybuffer_sanitizemetadata",
+      "label": "sanitizeMetadata()",
+      "norm_label": "sanitizemetadata()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L145"
     },
     {
       "community": 199,
       "file_type": "code",
-      "id": "printattempttelemetry_recordprintreturn",
-      "label": "recordPrintReturn()",
-      "norm_label": "recordprintreturn()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L174"
+      "id": "telemetrybuffer_truncate",
+      "label": "truncate()",
+      "norm_label": "truncate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L59"
     },
     {
       "community": 199,
       "file_type": "code",
-      "id": "printattempttelemetry_resetprintattempttelemetryfortests",
-      "label": "resetPrintAttemptTelemetryForTests()",
-      "norm_label": "resetprintattempttelemetryfortests()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L294"
+      "id": "telemetrybuffer_writebuffer",
+      "label": "writeBuffer()",
+      "norm_label": "writebuffer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L90"
     },
     {
       "community": 1990,
@@ -219660,119 +219741,119 @@
     {
       "community": 200,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_telemetrybuffer_ts",
-      "label": "telemetryBuffer.ts",
-      "norm_label": "telemetrybuffer.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registercheckoutprojection_ts",
+      "label": "registerCheckoutProjection.ts",
+      "norm_label": "registercheckoutprojection.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
       "source_location": "L1"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "telemetrybuffer_clearposclienttelemetrybuffer",
-      "label": "clearPosClientTelemetryBuffer()",
-      "norm_label": "clearposclienttelemetrybuffer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L212"
+      "id": "registercheckoutprojection_buildcompletedsalepayload",
+      "label": "buildCompletedSalePayload()",
+      "norm_label": "buildcompletedsalepayload()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L121"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "telemetrybuffer_enqueueposclientevent",
-      "label": "enqueuePosClientEvent()",
-      "norm_label": "enqueueposclientevent()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L167"
+      "id": "registercheckoutprojection_buildservicecheckoutblockmessage",
+      "label": "buildServiceCheckoutBlockMessage()",
+      "norm_label": "buildservicecheckoutblockmessage()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L16"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "telemetrybuffer_isbufferedevent",
-      "label": "isBufferedEvent()",
-      "norm_label": "isbufferedevent()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L100"
+      "id": "registercheckoutprojection_combinepaymentsbymethod",
+      "label": "combinePaymentsByMethod()",
+      "norm_label": "combinepaymentsbymethod()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L78"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "telemetrybuffer_mintclienteventid",
-      "label": "mintClientEventId()",
-      "norm_label": "mintclienteventid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L63"
+      "id": "registercheckoutprojection_completedcustomerinfo",
+      "label": "completedCustomerInfo()",
+      "norm_label": "completedcustomerinfo()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L290"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "telemetrybuffer_normalizepostelemetryerror",
-      "label": "normalizePosTelemetryError()",
-      "norm_label": "normalizepostelemetryerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L116"
+      "id": "registercheckoutprojection_hascustomerdetails",
+      "label": "hasCustomerDetails()",
+      "norm_label": "hascustomerdetails()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L50"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "telemetrybuffer_peekposclienteventbatch",
-      "label": "peekPosClientEventBatch()",
-      "norm_label": "peekposclienteventbatch()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L194"
+      "id": "registercheckoutprojection_ispospaymentmethod",
+      "label": "isPosPaymentMethod()",
+      "norm_label": "ispospaymentmethod()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L98"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "telemetrybuffer_posclienttelemetrybuffersize",
-      "label": "posClientTelemetryBufferSize()",
-      "norm_label": "posclienttelemetrybuffersize()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L208"
+      "id": "registercheckoutprojection_maplocalpaymenttopayment",
+      "label": "mapLocalPaymentToPayment()",
+      "norm_label": "maplocalpaymenttopayment()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L102"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "telemetrybuffer_readbuffer",
-      "label": "readBuffer()",
-      "norm_label": "readbuffer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L74"
+      "id": "registercheckoutprojection_maplocalservicelinetostate",
+      "label": "mapLocalServiceLineToState()",
+      "norm_label": "maplocalservicelinetostate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L197"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "telemetrybuffer_removeposclientevents",
-      "label": "removePosClientEvents()",
-      "norm_label": "removeposclientevents()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L200"
+      "id": "registercheckoutprojection_mapsessioncustomer",
+      "label": "mapSessionCustomer()",
+      "norm_label": "mapsessioncustomer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L65"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "telemetrybuffer_sanitizemetadata",
-      "label": "sanitizeMetadata()",
-      "norm_label": "sanitizemetadata()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L145"
+      "id": "registercheckoutprojection_matchingservicelinedraft",
+      "label": "matchingServiceLineDraft()",
+      "norm_label": "matchingservicelinedraft()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L223"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "telemetrybuffer_truncate",
-      "label": "truncate()",
-      "norm_label": "truncate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L59"
+      "id": "registercheckoutprojection_servicelinestatetocartline",
+      "label": "serviceLineStateToCartLine()",
+      "norm_label": "servicelinestatetocartline()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L272"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "telemetrybuffer_writebuffer",
-      "label": "writeBuffer()",
-      "norm_label": "writebuffer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L90"
+      "id": "registercheckoutprojection_servicelinestatetolocalpayload",
+      "label": "serviceLineStateToLocalPayload()",
+      "norm_label": "servicelinestatetolocalpayload()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L254"
     },
     {
       "community": 2000,
@@ -219867,119 +219948,119 @@
     {
       "community": 201,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registercheckoutprojection_ts",
-      "label": "registerCheckoutProjection.ts",
-      "norm_label": "registercheckoutprojection.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registerdrawerpresentation_ts",
+      "label": "registerDrawerPresentation.ts",
+      "norm_label": "registerdrawerpresentation.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
       "source_location": "L1"
     },
     {
       "community": 201,
       "file_type": "code",
-      "id": "registercheckoutprojection_buildcompletedsalepayload",
-      "label": "buildCompletedSalePayload()",
-      "norm_label": "buildcompletedsalepayload()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L121"
+      "id": "registerdrawerpresentation_buildopendrawerfailuremessage",
+      "label": "buildOpenDrawerFailureMessage()",
+      "norm_label": "buildopendrawerfailuremessage()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L189"
     },
     {
       "community": 201,
       "file_type": "code",
-      "id": "registercheckoutprojection_buildservicecheckoutblockmessage",
-      "label": "buildServiceCheckoutBlockMessage()",
-      "norm_label": "buildservicecheckoutblockmessage()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L16"
+      "id": "registerdrawerpresentation_findregistercloseoutreviewitem",
+      "label": "findRegisterCloseoutReviewItem()",
+      "norm_label": "findregistercloseoutreviewitem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L171"
     },
     {
       "community": 201,
       "file_type": "code",
-      "id": "registercheckoutprojection_combinepaymentsbymethod",
-      "label": "combinePaymentsByMethod()",
-      "norm_label": "combinepaymentsbymethod()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 201,
-      "file_type": "code",
-      "id": "registercheckoutprojection_completedcustomerinfo",
-      "label": "completedCustomerInfo()",
-      "norm_label": "completedcustomerinfo()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L290"
-    },
-    {
-      "community": 201,
-      "file_type": "code",
-      "id": "registercheckoutprojection_hascustomerdetails",
-      "label": "hasCustomerDetails()",
-      "norm_label": "hascustomerdetails()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L50"
-    },
-    {
-      "community": 201,
-      "file_type": "code",
-      "id": "registercheckoutprojection_ispospaymentmethod",
-      "label": "isPosPaymentMethod()",
-      "norm_label": "ispospaymentmethod()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "id": "registerdrawerpresentation_formatcloseoutcloudregistersessioncode",
+      "label": "formatCloseoutCloudRegisterSessionCode()",
+      "norm_label": "formatcloseoutcloudregistersessioncode()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
       "source_location": "L98"
     },
     {
       "community": 201,
       "file_type": "code",
-      "id": "registercheckoutprojection_maplocalpaymenttopayment",
-      "label": "mapLocalPaymentToPayment()",
-      "norm_label": "maplocalpaymenttopayment()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L102"
+      "id": "registerdrawerpresentation_getcloseoutcloudregistersessioncode",
+      "label": "getCloseoutCloudRegisterSessionCode()",
+      "norm_label": "getcloseoutcloudregistersessioncode()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L68"
     },
     {
       "community": 201,
       "file_type": "code",
-      "id": "registercheckoutprojection_maplocalservicelinetostate",
-      "label": "mapLocalServiceLineToState()",
-      "norm_label": "maplocalservicelinetostate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L197"
+      "id": "registerdrawerpresentation_getcloseoutcloudregistersessionid",
+      "label": "getCloseoutCloudRegisterSessionId()",
+      "norm_label": "getcloseoutcloudregistersessionid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L50"
     },
     {
       "community": 201,
       "file_type": "code",
-      "id": "registercheckoutprojection_mapsessioncustomer",
-      "label": "mapSessionCustomer()",
-      "norm_label": "mapsessioncustomer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L65"
+      "id": "registerdrawerpresentation_getcloseoutlocalregistersessionid",
+      "label": "getCloseoutLocalRegisterSessionId()",
+      "norm_label": "getcloseoutlocalregistersessionid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L29"
     },
     {
       "community": 201,
       "file_type": "code",
-      "id": "registercheckoutprojection_matchingservicelinedraft",
-      "label": "matchingServiceLineDraft()",
-      "norm_label": "matchingservicelinedraft()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L223"
+      "id": "registerdrawerpresentation_getlatestlocalregisterlifecycleevent",
+      "label": "getLatestLocalRegisterLifecycleEvent()",
+      "norm_label": "getlatestlocalregisterlifecycleevent()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L207"
     },
     {
       "community": 201,
       "file_type": "code",
-      "id": "registercheckoutprojection_servicelinestatetocartline",
-      "label": "serviceLineStateToCartLine()",
-      "norm_label": "servicelinestatetocartline()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L272"
+      "id": "registerdrawerpresentation_getpendinglocalcashvoidapprovals",
+      "label": "getPendingLocalCashVoidApprovals()",
+      "norm_label": "getpendinglocalcashvoidapprovals()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L270"
     },
     {
       "community": 201,
       "file_type": "code",
-      "id": "registercheckoutprojection_servicelinestatetolocalpayload",
-      "label": "serviceLineStateToLocalPayload()",
-      "norm_label": "servicelinestatetolocalpayload()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L254"
+      "id": "registerdrawerpresentation_getpendinglocalcloseoutregistersession",
+      "label": "getPendingLocalCloseoutRegisterSession()",
+      "norm_label": "getpendinglocalcloseoutregistersession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L234"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "registerdrawerpresentation_isknowncloudregistersessionblockinglocalprojection",
+      "label": "isKnownCloudRegisterSessionBlockingLocalProjection()",
+      "norm_label": "isknowncloudregistersessionblockinglocalprojection()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L114"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "registerdrawerpresentation_readlocalsyncstatus",
+      "label": "readLocalSyncStatus()",
+      "norm_label": "readlocalsyncstatus()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L146"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "registerdrawerpresentation_stringfield",
+      "label": "stringField()",
+      "norm_label": "stringfield()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L334"
     },
     {
       "community": 2010,
@@ -220074,119 +220155,119 @@
     {
       "community": 202,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registerdrawerpresentation_ts",
-      "label": "registerDrawerPresentation.ts",
-      "norm_label": "registerdrawerpresentation.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 202,
-      "file_type": "code",
-      "id": "registerdrawerpresentation_buildopendrawerfailuremessage",
-      "label": "buildOpenDrawerFailureMessage()",
-      "norm_label": "buildopendrawerfailuremessage()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L189"
-    },
-    {
-      "community": 202,
-      "file_type": "code",
-      "id": "registerdrawerpresentation_findregistercloseoutreviewitem",
-      "label": "findRegisterCloseoutReviewItem()",
-      "norm_label": "findregistercloseoutreviewitem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L171"
-    },
-    {
-      "community": 202,
-      "file_type": "code",
-      "id": "registerdrawerpresentation_formatcloseoutcloudregistersessioncode",
-      "label": "formatCloseoutCloudRegisterSessionCode()",
-      "norm_label": "formatcloseoutcloudregistersessioncode()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L98"
-    },
-    {
-      "community": 202,
-      "file_type": "code",
-      "id": "registerdrawerpresentation_getcloseoutcloudregistersessioncode",
-      "label": "getCloseoutCloudRegisterSessionCode()",
-      "norm_label": "getcloseoutcloudregistersessioncode()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L68"
-    },
-    {
-      "community": 202,
-      "file_type": "code",
-      "id": "registerdrawerpresentation_getcloseoutcloudregistersessionid",
-      "label": "getCloseoutCloudRegisterSessionId()",
-      "norm_label": "getcloseoutcloudregistersessionid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "id": "localpinverifier_base64tobytes",
+      "label": "base64ToBytes()",
+      "norm_label": "base64tobytes()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
       "source_location": "L50"
     },
     {
       "community": 202,
       "file_type": "code",
-      "id": "registerdrawerpresentation_getcloseoutlocalregistersessionid",
-      "label": "getCloseoutLocalRegisterSessionId()",
-      "norm_label": "getcloseoutlocalregistersessionid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L29"
+      "id": "localpinverifier_bytestobase64",
+      "label": "bytesToBase64()",
+      "norm_label": "bytestobase64()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L38"
     },
     {
       "community": 202,
       "file_type": "code",
-      "id": "registerdrawerpresentation_getlatestlocalregisterlifecycleevent",
-      "label": "getLatestLocalRegisterLifecycleEvent()",
-      "norm_label": "getlatestlocalregisterlifecycleevent()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L207"
+      "id": "localpinverifier_createlocalpinverifier",
+      "label": "createLocalPinVerifier()",
+      "norm_label": "createlocalpinverifier()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L131"
     },
     {
       "community": 202,
       "file_type": "code",
-      "id": "registerdrawerpresentation_getpendinglocalcashvoidapprovals",
-      "label": "getPendingLocalCashVoidApprovals()",
-      "norm_label": "getpendinglocalcashvoidapprovals()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L270"
+      "id": "localpinverifier_cryptorefdecrypt",
+      "label": "cryptoRefDecrypt()",
+      "norm_label": "cryptorefdecrypt()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L268"
     },
     {
       "community": 202,
       "file_type": "code",
-      "id": "registerdrawerpresentation_getpendinglocalcloseoutregistersession",
-      "label": "getPendingLocalCloseoutRegisterSession()",
-      "norm_label": "getpendinglocalcloseoutregistersession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L234"
+      "id": "localpinverifier_derivepinhash",
+      "label": "derivePinHash()",
+      "norm_label": "derivepinhash()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L76"
     },
     {
       "community": 202,
       "file_type": "code",
-      "id": "registerdrawerpresentation_isknowncloudregistersessionblockinglocalprojection",
-      "label": "isKnownCloudRegisterSessionBlockingLocalProjection()",
-      "norm_label": "isknowncloudregistersessionblockinglocalprojection()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L114"
+      "id": "localpinverifier_derivewrappingkey",
+      "label": "deriveWrappingKey()",
+      "norm_label": "derivewrappingkey()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L103"
     },
     {
       "community": 202,
       "file_type": "code",
-      "id": "registerdrawerpresentation_readlocalsyncstatus",
-      "label": "readLocalSyncStatus()",
-      "norm_label": "readlocalsyncstatus()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L146"
+      "id": "localpinverifier_getcrypto",
+      "label": "getCrypto()",
+      "norm_label": "getcrypto()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L30"
     },
     {
       "community": 202,
       "file_type": "code",
-      "id": "registerdrawerpresentation_stringfield",
-      "label": "stringField()",
-      "norm_label": "stringfield()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L334"
+      "id": "localpinverifier_islocalpinverifiermetadata",
+      "label": "isLocalPinVerifierMetadata()",
+      "norm_label": "islocalpinverifiermetadata()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L281"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "localpinverifier_timingsafeequal",
+      "label": "timingSafeEqual()",
+      "norm_label": "timingsafeequal()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "localpinverifier_unwraplocalstaffprooftoken",
+      "label": "unwrapLocalStaffProofToken()",
+      "norm_label": "unwraplocalstaffprooftoken()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L221"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "localpinverifier_verifylocalpin",
+      "label": "verifyLocalPin()",
+      "norm_label": "verifylocalpin()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L152"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "localpinverifier_wraplocalstaffprooftoken",
+      "label": "wrapLocalStaffProofToken()",
+      "norm_label": "wraplocalstaffprooftoken()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L183"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_security_localpinverifier_ts",
+      "label": "localPinVerifier.ts",
+      "norm_label": "localpinverifier.ts",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L1"
     },
     {
       "community": 2020,
@@ -220281,119 +220362,119 @@
     {
       "community": 203,
       "file_type": "code",
-      "id": "localpinverifier_base64tobytes",
-      "label": "base64ToBytes()",
-      "norm_label": "base64tobytes()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L50"
+      "id": "packages_storefront_webapp_src_api_reviews_ts",
+      "label": "reviews.ts",
+      "norm_label": "reviews.ts",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L1"
     },
     {
       "community": 203,
       "file_type": "code",
-      "id": "localpinverifier_bytestobase64",
-      "label": "bytesToBase64()",
-      "norm_label": "bytestobase64()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L38"
+      "id": "reviews_createreview",
+      "label": "createReview()",
+      "norm_label": "createreview()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L13"
     },
     {
       "community": 203,
       "file_type": "code",
-      "id": "localpinverifier_createlocalpinverifier",
-      "label": "createLocalPinVerifier()",
-      "norm_label": "createlocalpinverifier()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L131"
+      "id": "reviews_deletereview",
+      "label": "deleteReview()",
+      "norm_label": "deletereview()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L69"
     },
     {
       "community": 203,
       "file_type": "code",
-      "id": "localpinverifier_cryptorefdecrypt",
-      "label": "cryptoRefDecrypt()",
-      "norm_label": "cryptorefdecrypt()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L268"
+      "id": "reviews_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L4"
     },
     {
       "community": 203,
       "file_type": "code",
-      "id": "localpinverifier_derivepinhash",
-      "label": "derivePinHash()",
-      "norm_label": "derivepinhash()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L76"
+      "id": "reviews_getreviewbyorderitem",
+      "label": "getReviewByOrderItem()",
+      "norm_label": "getreviewbyorderitem()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L32"
     },
     {
       "community": 203,
       "file_type": "code",
-      "id": "localpinverifier_derivewrappingkey",
-      "label": "deriveWrappingKey()",
-      "norm_label": "derivewrappingkey()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L103"
+      "id": "reviews_getreviewsbyproductid",
+      "label": "getReviewsByProductId()",
+      "norm_label": "getreviewsbyproductid()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L132"
     },
     {
       "community": 203,
       "file_type": "code",
-      "id": "localpinverifier_getcrypto",
-      "label": "getCrypto()",
-      "norm_label": "getcrypto()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L30"
+      "id": "reviews_getreviewsbyproductskuid",
+      "label": "getReviewsByProductSkuId()",
+      "norm_label": "getreviewsbyproductskuid()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L83"
     },
     {
       "community": 203,
       "file_type": "code",
-      "id": "localpinverifier_islocalpinverifiermetadata",
-      "label": "isLocalPinVerifierMetadata()",
-      "norm_label": "islocalpinverifiermetadata()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L281"
+      "id": "reviews_getuserreviews",
+      "label": "getUserReviews()",
+      "norm_label": "getuserreviews()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L99"
     },
     {
       "community": 203,
       "file_type": "code",
-      "id": "localpinverifier_timingsafeequal",
-      "label": "timingSafeEqual()",
-      "norm_label": "timingsafeequal()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L63"
+      "id": "reviews_getuserreviewsforproduct",
+      "label": "getUserReviewsForProduct()",
+      "norm_label": "getuserreviewsforproduct()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L113"
     },
     {
       "community": 203,
       "file_type": "code",
-      "id": "localpinverifier_unwraplocalstaffprooftoken",
-      "label": "unwrapLocalStaffProofToken()",
-      "norm_label": "unwraplocalstaffprooftoken()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L221"
+      "id": "reviews_hasreviewfororderitem",
+      "label": "hasReviewForOrderItem()",
+      "norm_label": "hasreviewfororderitem()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L164"
     },
     {
       "community": 203,
       "file_type": "code",
-      "id": "localpinverifier_verifylocalpin",
-      "label": "verifyLocalPin()",
-      "norm_label": "verifylocalpin()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L152"
-    },
-    {
-      "community": 203,
-      "file_type": "code",
-      "id": "localpinverifier_wraplocalstaffprooftoken",
-      "label": "wrapLocalStaffProofToken()",
-      "norm_label": "wraplocalstaffprooftoken()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "id": "reviews_hasuserreviewfororderitem",
+      "label": "hasUserReviewForOrderItem()",
+      "norm_label": "hasuserreviewfororderitem()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L183"
     },
     {
       "community": 203,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_security_localpinverifier_ts",
-      "label": "localPinVerifier.ts",
-      "norm_label": "localpinverifier.ts",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L1"
+      "id": "reviews_markreviewhelpful",
+      "label": "markReviewHelpful()",
+      "norm_label": "markreviewhelpful()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L148"
+    },
+    {
+      "community": 203,
+      "file_type": "code",
+      "id": "reviews_updatereview",
+      "label": "updateReview()",
+      "norm_label": "updatereview()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L48"
     },
     {
       "community": 2030,
@@ -220488,119 +220569,119 @@
     {
       "community": 204,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_reviews_ts",
-      "label": "reviews.ts",
-      "norm_label": "reviews.ts",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "id": "packages_athena_webapp_convex_inventory_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
       "source_location": "L1"
     },
     {
       "community": 204,
       "file_type": "code",
-      "id": "reviews_createreview",
-      "label": "createReview()",
-      "norm_label": "createreview()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L13"
+      "id": "packages_athena_webapp_src_components_orders_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 204,
       "file_type": "code",
-      "id": "reviews_deletereview",
-      "label": "deleteReview()",
-      "norm_label": "deletereview()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L69"
+      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 204,
       "file_type": "code",
-      "id": "reviews_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L4"
+      "id": "utils_formatdeliveryaddress",
+      "label": "formatDeliveryAddress()",
+      "norm_label": "formatdeliveryaddress()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L74"
     },
     {
       "community": 204,
       "file_type": "code",
-      "id": "reviews_getreviewbyorderitem",
-      "label": "getReviewByOrderItem()",
-      "norm_label": "getreviewbyorderitem()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L32"
+      "id": "utils_getamountpaidfororder",
+      "label": "getAmountPaidForOrder()",
+      "norm_label": "getamountpaidfororder()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L191"
     },
     {
       "community": 204,
       "file_type": "code",
-      "id": "reviews_getreviewsbyproductid",
-      "label": "getReviewsByProductId()",
-      "norm_label": "getreviewsbyproductid()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L132"
+      "id": "utils_getdiscountvalue",
+      "label": "getDiscountValue()",
+      "norm_label": "getdiscountvalue()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L17"
     },
     {
       "community": 204,
       "file_type": "code",
-      "id": "reviews_getreviewsbyproductskuid",
-      "label": "getReviewsByProductSkuId()",
-      "norm_label": "getreviewsbyproductskuid()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L83"
+      "id": "utils_getonlineorderplacedat",
+      "label": "getOnlineOrderPlacedAt()",
+      "norm_label": "getonlineorderplacedat()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 204,
       "file_type": "code",
-      "id": "reviews_getuserreviews",
-      "label": "getUserReviews()",
-      "norm_label": "getuserreviews()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L99"
+      "id": "utils_getorderamount",
+      "label": "getOrderAmount()",
+      "norm_label": "getorderamount()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L51"
     },
     {
       "community": 204,
       "file_type": "code",
-      "id": "reviews_getuserreviewsforproduct",
-      "label": "getUserReviewsForProduct()",
-      "norm_label": "getuserreviewsforproduct()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L113"
+      "id": "utils_getorderstate",
+      "label": "getOrderState()",
+      "norm_label": "getorderstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L40"
     },
     {
       "community": 204,
       "file_type": "code",
-      "id": "reviews_hasreviewfororderitem",
-      "label": "hasReviewForOrderItem()",
-      "norm_label": "hasreviewfororderitem()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L164"
+      "id": "utils_getpickupactionstate",
+      "label": "getPickupActionState()",
+      "norm_label": "getpickupactionstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L102"
     },
     {
       "community": 204,
       "file_type": "code",
-      "id": "reviews_hasuserreviewfororderitem",
-      "label": "hasUserReviewForOrderItem()",
-      "norm_label": "hasuserreviewfororderitem()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L183"
+      "id": "utils_getpotentialpoints",
+      "label": "getPotentialPoints()",
+      "norm_label": "getpotentialpoints()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L107"
     },
     {
       "community": 204,
       "file_type": "code",
-      "id": "reviews_markreviewhelpful",
-      "label": "markReviewHelpful()",
-      "norm_label": "markreviewhelpful()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L148"
+      "id": "utils_getproductdiscountvalue",
+      "label": "getProductDiscountValue()",
+      "norm_label": "getproductdiscountvalue()",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L75"
     },
     {
       "community": 204,
       "file_type": "code",
-      "id": "reviews_updatereview",
-      "label": "updateReview()",
-      "norm_label": "updatereview()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L48"
+      "id": "utils_shouldshowpickupexceptionaction",
+      "label": "shouldShowPickupExceptionAction()",
+      "norm_label": "shouldshowpickupexceptionaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L116"
     },
     {
       "community": 2040,
@@ -222130,7 +222211,7 @@
       "label": "insertLegacySentDelivery()",
       "norm_label": "insertlegacysentdelivery()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts",
-      "source_location": "L1432"
+      "source_location": "L1435"
     },
     {
       "community": 210,
@@ -222139,7 +222220,7 @@
       "label": "makeEmitCtx()",
       "norm_label": "makeemitctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts",
-      "source_location": "L1459"
+      "source_location": "L1462"
     },
     {
       "community": 210,
@@ -222157,7 +222238,7 @@
       "label": "resultForRun()",
       "norm_label": "resultforrun()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts",
-      "source_location": "L1331"
+      "source_location": "L1334"
     },
     {
       "community": 210,
@@ -222166,7 +222247,7 @@
       "label": "seedCutoverFixture()",
       "norm_label": "seedcutoverfixture()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts",
-      "source_location": "L1383"
+      "source_location": "L1386"
     },
     {
       "community": 210,
@@ -230244,92 +230325,92 @@
     {
       "community": 247,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_marketing_walkthroughconfig_ts",
-      "label": "walkthroughConfig.ts",
-      "norm_label": "walkthroughconfig.ts",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "id": "index_resolveverificationcoderecipient",
+      "label": "resolveVerificationCodeRecipient()",
+      "norm_label": "resolveverificationcoderecipient()",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "index_senddailymanagerreportemail",
+      "label": "sendDailyManagerReportEmail()",
+      "norm_label": "senddailymanagerreportemail()",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "source_location": "L373"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "index_senddiscountcodeemail",
+      "label": "sendDiscountCodeEmail()",
+      "norm_label": "senddiscountcodeemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L255"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "index_senddiscountreminderemail",
+      "label": "sendDiscountReminderEmail()",
+      "norm_label": "senddiscountreminderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L334"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "index_sendfeedbackrequestemail",
+      "label": "sendFeedbackRequestEmail()",
+      "norm_label": "sendfeedbackrequestemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "index_sendneworderemail",
+      "label": "sendNewOrderEmail()",
+      "norm_label": "sendneworderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L117"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "index_sendorderemail",
+      "label": "sendOrderEmail()",
+      "norm_label": "sendorderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "index_sendverificationcode",
+      "label": "sendVerificationCode()",
+      "norm_label": "sendverificationcode()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
       "source_location": "L1"
     },
     {
       "community": 247,
       "file_type": "code",
-      "id": "walkthroughconfig_landingfunnelhourlylimit",
-      "label": "landingFunnelHourlyLimit()",
-      "norm_label": "landingfunnelhourlylimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "walkthroughconfig_parseboundedpositiveinteger",
-      "label": "parseBoundedPositiveInteger()",
-      "norm_label": "parseboundedpositiveinteger()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "walkthroughconfig_resolvewalkthroughallowedorigins",
-      "label": "resolveWalkthroughAllowedOrigins()",
-      "norm_label": "resolvewalkthroughallowedorigins()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughallowedorigins",
-      "label": "walkthroughAllowedOrigins()",
-      "norm_label": "walkthroughallowedorigins()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughdailyperemaillimit",
-      "label": "walkthroughDailyPerEmailLimit()",
-      "norm_label": "walkthroughdailyperemaillimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L55"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughhourlygloballimit",
-      "label": "walkthroughHourlyGlobalLimit()",
-      "norm_label": "walkthroughhourlygloballimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughhourlynotificationlimit",
-      "label": "walkthroughHourlyNotificationLimit()",
-      "norm_label": "walkthroughhourlynotificationlimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughmaxbodybytes",
-      "label": "walkthroughMaxBodyBytes()",
-      "norm_label": "walkthroughmaxbodybytes()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughprivacycontact",
-      "label": "walkthroughPrivacyContact()",
-      "norm_label": "walkthroughprivacycontact()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L95"
+      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L1"
     },
     {
       "community": 2470,
@@ -230424,92 +230505,92 @@
     {
       "community": 248,
       "file_type": "code",
-      "id": "definitions_costoverlaystorewriteoperation",
-      "label": "costOverlayStoreWriteOperation()",
-      "norm_label": "costoverlaystorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L569"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "definitions_cyclecountdraftstorewriteoperation",
-      "label": "cycleCountDraftStoreWriteOperation()",
-      "norm_label": "cyclecountdraftstorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L383"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "definitions_defineoperation",
-      "label": "defineOperation()",
-      "norm_label": "defineoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "definitions_inventoryimportreviewpayloadwriteoperation",
-      "label": "inventoryImportReviewPayloadWriteOperation()",
-      "norm_label": "inventoryimportreviewpayloadwriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L544"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "definitions_notificationsubscriptionrowwriteoperation",
-      "label": "notificationSubscriptionRowWriteOperation()",
-      "norm_label": "notificationsubscriptionrowwriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L629"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "definitions_orderstorewriteoperation",
-      "label": "orderStoreWriteOperation()",
-      "norm_label": "orderstorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L155"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "definitions_storewriteoperation",
-      "label": "storeWriteOperation()",
-      "norm_label": "storewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L108"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "definitions_transactionstorewriteoperation",
-      "label": "transactionStoreWriteOperation()",
-      "norm_label": "transactionstorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "definitions_validateoperationdefinition",
-      "label": "validateOperationDefinition()",
-      "norm_label": "validateoperationdefinition()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L724"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operationadmission_definitions_ts",
-      "label": "definitions.ts",
-      "norm_label": "definitions.ts",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "id": "packages_athena_webapp_convex_marketing_walkthroughconfig_ts",
+      "label": "walkthroughConfig.ts",
+      "norm_label": "walkthroughconfig.ts",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "walkthroughconfig_landingfunnelhourlylimit",
+      "label": "landingFunnelHourlyLimit()",
+      "norm_label": "landingfunnelhourlylimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "walkthroughconfig_parseboundedpositiveinteger",
+      "label": "parseBoundedPositiveInteger()",
+      "norm_label": "parseboundedpositiveinteger()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "walkthroughconfig_resolvewalkthroughallowedorigins",
+      "label": "resolveWalkthroughAllowedOrigins()",
+      "norm_label": "resolvewalkthroughallowedorigins()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughallowedorigins",
+      "label": "walkthroughAllowedOrigins()",
+      "norm_label": "walkthroughallowedorigins()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughdailyperemaillimit",
+      "label": "walkthroughDailyPerEmailLimit()",
+      "norm_label": "walkthroughdailyperemaillimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughhourlygloballimit",
+      "label": "walkthroughHourlyGlobalLimit()",
+      "norm_label": "walkthroughhourlygloballimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughhourlynotificationlimit",
+      "label": "walkthroughHourlyNotificationLimit()",
+      "norm_label": "walkthroughhourlynotificationlimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughmaxbodybytes",
+      "label": "walkthroughMaxBodyBytes()",
+      "norm_label": "walkthroughmaxbodybytes()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughprivacycontact",
+      "label": "walkthroughPrivacyContact()",
+      "norm_label": "walkthroughprivacycontact()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L95"
     },
     {
       "community": 2480,
@@ -230604,91 +230685,91 @@
     {
       "community": 249,
       "file_type": "code",
-      "id": "adjustmentreports_adjustmentappliedat",
-      "label": "adjustmentAppliedAt()",
-      "norm_label": "adjustmentappliedat()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L101"
+      "id": "definitions_costoverlaystorewriteoperation",
+      "label": "costOverlayStoreWriteOperation()",
+      "norm_label": "costoverlaystorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L569"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "adjustmentreports_adjustmentsalesdelta",
-      "label": "adjustmentSalesDelta()",
-      "norm_label": "adjustmentsalesdelta()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L116"
+      "id": "definitions_cyclecountdraftstorewriteoperation",
+      "label": "cycleCountDraftStoreWriteOperation()",
+      "norm_label": "cyclecountdraftstorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L383"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "adjustmentreports_adjustmentsettlementamount",
-      "label": "adjustmentSettlementAmount()",
-      "norm_label": "adjustmentsettlementamount()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L143"
+      "id": "definitions_defineoperation",
+      "label": "defineOperation()",
+      "norm_label": "defineoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L11"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "adjustmentreports_adjustmenttransactionid",
-      "label": "adjustmentTransactionId()",
-      "norm_label": "adjustmenttransactionid()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L110"
+      "id": "definitions_inventoryimportreviewpayloadwriteoperation",
+      "label": "inventoryImportReviewPayloadWriteOperation()",
+      "norm_label": "inventoryimportreviewpayloadwriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L544"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "adjustmentreports_buildadjustmentpaymenttotals",
-      "label": "buildAdjustmentPaymentTotals()",
-      "norm_label": "buildadjustmentpaymenttotals()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L242"
+      "id": "definitions_notificationsubscriptionrowwriteoperation",
+      "label": "notificationSubscriptionRowWriteOperation()",
+      "norm_label": "notificationsubscriptionrowwriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L629"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "adjustmentreports_buildadjustmentreporttotals",
-      "label": "buildAdjustmentReportTotals()",
-      "norm_label": "buildadjustmentreporttotals()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L275"
+      "id": "definitions_orderstorewriteoperation",
+      "label": "orderStoreWriteOperation()",
+      "norm_label": "orderstorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L155"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "adjustmentreports_listappliedtransactionadjustmentsforday",
-      "label": "listAppliedTransactionAdjustmentsForDay()",
-      "norm_label": "listappliedtransactionadjustmentsforday()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L229"
+      "id": "definitions_storewriteoperation",
+      "label": "storeWriteOperation()",
+      "norm_label": "storewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L108"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "adjustmentreports_readappliedtransactionadjustmentsforday",
-      "label": "readAppliedTransactionAdjustmentsForDay()",
-      "norm_label": "readappliedtransactionadjustmentsforday()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L173"
+      "id": "definitions_transactionstorewriteoperation",
+      "label": "transactionStoreWriteOperation()",
+      "norm_label": "transactionstorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L128"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "adjustmentreports_sourcecompletenessentry",
-      "label": "sourceCompletenessEntry()",
-      "norm_label": "sourcecompletenessentry()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L76"
+      "id": "definitions_validateoperationdefinition",
+      "label": "validateOperationDefinition()",
+      "norm_label": "validateoperationdefinition()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L724"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_dailyclose_adjustmentreports_ts",
-      "label": "adjustmentReports.ts",
-      "norm_label": "adjustmentreports.ts",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "id": "packages_athena_webapp_convex_operationadmission_definitions_ts",
+      "label": "definitions.ts",
+      "norm_label": "definitions.ts",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
       "source_location": "L1"
     },
     {
@@ -231135,91 +231216,91 @@
     {
       "community": 250,
       "file_type": "code",
-      "id": "inventorymovements_assertnobusinesseventconflict",
-      "label": "assertNoBusinessEventConflict()",
-      "norm_label": "assertnobusinesseventconflict()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L178"
+      "id": "adjustmentreports_adjustmentappliedat",
+      "label": "adjustmentAppliedAt()",
+      "norm_label": "adjustmentappliedat()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L101"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "inventorymovements_buildinventorymovement",
-      "label": "buildInventoryMovement()",
-      "norm_label": "buildinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L124"
+      "id": "adjustmentreports_adjustmentsalesdelta",
+      "label": "adjustmentSalesDelta()",
+      "norm_label": "adjustmentsalesdelta()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L116"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "inventorymovements_buildskuactivityforinventorymovement",
-      "label": "buildSkuActivityForInventoryMovement()",
-      "norm_label": "buildskuactivityforinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L66"
+      "id": "adjustmentreports_adjustmentsettlementamount",
+      "label": "adjustmentSettlementAmount()",
+      "norm_label": "adjustmentsettlementamount()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L143"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "inventorymovements_getskuactivitytypeformovement",
-      "label": "getSkuActivityTypeForMovement()",
-      "norm_label": "getskuactivitytypeformovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L49"
+      "id": "adjustmentreports_adjustmenttransactionid",
+      "label": "adjustmentTransactionId()",
+      "norm_label": "adjustmenttransactionid()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L110"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "inventorymovements_matchesexistingmovement",
-      "label": "matchesExistingMovement()",
-      "norm_label": "matchesexistingmovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L150"
+      "id": "adjustmentreports_buildadjustmentpaymenttotals",
+      "label": "buildAdjustmentPaymentTotals()",
+      "norm_label": "buildadjustmentpaymenttotals()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L242"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "inventorymovements_recordinventorymovementwithctx",
-      "label": "recordInventoryMovementWithCtx()",
-      "norm_label": "recordinventorymovementwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L200"
+      "id": "adjustmentreports_buildadjustmentreporttotals",
+      "label": "buildAdjustmentReportTotals()",
+      "norm_label": "buildadjustmentreporttotals()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L275"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "inventorymovements_recordinventorymovementwithdispositionwithctx",
-      "label": "recordInventoryMovementWithDispositionWithCtx()",
-      "norm_label": "recordinventorymovementwithdispositionwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L245"
+      "id": "adjustmentreports_listappliedtransactionadjustmentsforday",
+      "label": "listAppliedTransactionAdjustmentsForDay()",
+      "norm_label": "listappliedtransactionadjustmentsforday()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L229"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "inventorymovements_recordskuactivityforinventorymovementwithctx",
-      "label": "recordSkuActivityForInventoryMovementWithCtx()",
-      "norm_label": "recordskuactivityforinventorymovementwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L111"
+      "id": "adjustmentreports_readappliedtransactionadjustmentsforday",
+      "label": "readAppliedTransactionAdjustmentsForDay()",
+      "norm_label": "readappliedtransactionadjustmentsforday()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L173"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "inventorymovements_summarizeinventorymovements",
-      "label": "summarizeInventoryMovements()",
-      "norm_label": "summarizeinventorymovements()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L135"
+      "id": "adjustmentreports_sourcecompletenessentry",
+      "label": "sourceCompletenessEntry()",
+      "norm_label": "sourcecompletenessentry()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L76"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
-      "label": "inventoryMovements.ts",
-      "norm_label": "inventorymovements.ts",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "id": "packages_athena_webapp_convex_operations_dailyclose_adjustmentreports_ts",
+      "label": "adjustmentReports.ts",
+      "norm_label": "adjustmentreports.ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
       "source_location": "L1"
     },
     {
@@ -231315,91 +231396,91 @@
     {
       "community": 251,
       "file_type": "code",
-      "id": "operationalevents_buildoperationalevent",
-      "label": "buildOperationalEvent()",
-      "norm_label": "buildoperationalevent()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L43"
+      "id": "inventorymovements_assertnobusinesseventconflict",
+      "label": "assertNoBusinessEventConflict()",
+      "norm_label": "assertnobusinesseventconflict()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L178"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "operationalevents_buildtracemetadata",
-      "label": "buildTraceMetadata()",
-      "norm_label": "buildtracemetadata()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L96"
+      "id": "inventorymovements_buildinventorymovement",
+      "label": "buildInventoryMovement()",
+      "norm_label": "buildinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L124"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "operationalevents_isrecord",
-      "label": "isRecord()",
-      "norm_label": "isrecord()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L145"
+      "id": "inventorymovements_buildskuactivityforinventorymovement",
+      "label": "buildSkuActivityForInventoryMovement()",
+      "norm_label": "buildskuactivityforinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L66"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "operationalevents_listproductoperationaltimelinewithctx",
-      "label": "listProductOperationalTimelineWithCtx()",
-      "norm_label": "listproductoperationaltimelinewithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L246"
+      "id": "inventorymovements_getskuactivitytypeformovement",
+      "label": "getSkuActivityTypeForMovement()",
+      "norm_label": "getskuactivitytypeformovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L49"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "operationalevents_matchesexistingevent",
-      "label": "matchesExistingEvent()",
-      "norm_label": "matchesexistingevent()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L149"
+      "id": "inventorymovements_matchesexistingmovement",
+      "label": "matchesExistingMovement()",
+      "norm_label": "matchesexistingmovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L150"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "operationalevents_metadatadedupekeysmatch",
-      "label": "metadataDedupeKeysMatch()",
-      "norm_label": "metadatadedupekeysmatch()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L205"
+      "id": "inventorymovements_recordinventorymovementwithctx",
+      "label": "recordInventoryMovementWithCtx()",
+      "norm_label": "recordinventorymovementwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L200"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "operationalevents_normalizeoperationaleventtracefields",
-      "label": "normalizeOperationalEventTraceFields()",
-      "norm_label": "normalizeoperationaleventtracefields()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L60"
+      "id": "inventorymovements_recordinventorymovementwithdispositionwithctx",
+      "label": "recordInventoryMovementWithDispositionWithCtx()",
+      "norm_label": "recordinventorymovementwithdispositionwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L245"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "operationalevents_recordoperationaleventwithctx",
-      "label": "recordOperationalEventWithCtx()",
-      "norm_label": "recordoperationaleventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L215"
+      "id": "inventorymovements_recordskuactivityforinventorymovementwithctx",
+      "label": "recordSkuActivityForInventoryMovementWithCtx()",
+      "norm_label": "recordskuactivityforinventorymovementwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L111"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "operationalevents_shouldnormalizepostrace",
-      "label": "shouldNormalizePosTrace()",
-      "norm_label": "shouldnormalizepostrace()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L118"
+      "id": "inventorymovements_summarizeinventorymovements",
+      "label": "summarizeInventoryMovements()",
+      "norm_label": "summarizeinventorymovements()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L135"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
-      "label": "operationalEvents.ts",
-      "norm_label": "operationalevents.ts",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
+      "label": "inventoryMovements.ts",
+      "norm_label": "inventorymovements.ts",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
       "source_location": "L1"
     },
     {
@@ -231495,91 +231576,91 @@
     {
       "community": 252,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_amendrepairwithctx",
-      "label": "amendRepairWithCtx()",
-      "norm_label": "amendrepairwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L430"
+      "id": "operationalevents_buildoperationalevent",
+      "label": "buildOperationalEvent()",
+      "norm_label": "buildoperationalevent()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L43"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_createrepairwithctx",
-      "label": "createRepairWithCtx()",
-      "norm_label": "createrepairwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L160"
+      "id": "operationalevents_buildtracemetadata",
+      "label": "buildTraceMetadata()",
+      "norm_label": "buildtracemetadata()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L96"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_pauserepair",
-      "label": "pauseRepair()",
-      "norm_label": "pauserepair()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L231"
+      "id": "operationalevents_isrecord",
+      "label": "isRecord()",
+      "norm_label": "isrecord()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L145"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_processrepairbatchwithctx",
-      "label": "processRepairBatchWithCtx()",
-      "norm_label": "processrepairbatchwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L249"
+      "id": "operationalevents_listproductoperationaltimelinewithctx",
+      "label": "listProductOperationalTimelineWithCtx()",
+      "norm_label": "listproductoperationaltimelinewithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L246"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_readcurrentgroup",
-      "label": "readCurrentGroup()",
-      "norm_label": "readcurrentgroup()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L49"
+      "id": "operationalevents_matchesexistingevent",
+      "label": "matchesExistingEvent()",
+      "norm_label": "matchesexistingevent()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L149"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_recordrepairauditevent",
-      "label": "recordRepairAuditEvent()",
-      "norm_label": "recordrepairauditevent()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L85"
+      "id": "operationalevents_metadatadedupekeysmatch",
+      "label": "metadataDedupeKeysMatch()",
+      "norm_label": "metadatadedupekeysmatch()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L205"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_requireevidence",
-      "label": "requireEvidence()",
-      "norm_label": "requireevidence()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L37"
+      "id": "operationalevents_normalizeoperationaleventtracefields",
+      "label": "normalizeOperationalEventTraceFields()",
+      "norm_label": "normalizeoperationaleventtracefields()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L60"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_resumerepairwithctx",
-      "label": "resumeRepairWithCtx()",
-      "norm_label": "resumerepairwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L472"
+      "id": "operationalevents_recordoperationaleventwithctx",
+      "label": "recordOperationalEventWithCtx()",
+      "norm_label": "recordoperationaleventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L215"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_schedulenextbatch",
-      "label": "scheduleNextBatch()",
-      "norm_label": "schedulenextbatch()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L153"
+      "id": "operationalevents_shouldnormalizepostrace",
+      "label": "shouldNormalizePosTrace()",
+      "norm_label": "shouldnormalizepostrace()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L118"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_oversizedoperationalworkrepair_ts",
-      "label": "oversizedOperationalWorkRepair.ts",
-      "norm_label": "oversizedoperationalworkrepair.ts",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
+      "label": "operationalEvents.ts",
+      "norm_label": "operationalevents.ts",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
       "source_location": "L1"
     },
     {
@@ -231675,92 +231756,92 @@
     {
       "community": 253,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
-      "label": "registerSessionTracing.ts",
-      "norm_label": "registersessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "id": "oversizedoperationalworkrepair_amendrepairwithctx",
+      "label": "amendRepairWithCtx()",
+      "norm_label": "amendrepairwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L430"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_createrepairwithctx",
+      "label": "createRepairWithCtx()",
+      "norm_label": "createrepairwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L160"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_pauserepair",
+      "label": "pauseRepair()",
+      "norm_label": "pauserepair()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L231"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_processrepairbatchwithctx",
+      "label": "processRepairBatchWithCtx()",
+      "norm_label": "processrepairbatchwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L249"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_readcurrentgroup",
+      "label": "readCurrentGroup()",
+      "norm_label": "readcurrentgroup()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_recordrepairauditevent",
+      "label": "recordRepairAuditEvent()",
+      "norm_label": "recordrepairauditevent()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_requireevidence",
+      "label": "requireEvidence()",
+      "norm_label": "requireevidence()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_resumerepairwithctx",
+      "label": "resumeRepairWithCtx()",
+      "norm_label": "resumerepairwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L472"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_schedulenextbatch",
+      "label": "scheduleNextBatch()",
+      "norm_label": "schedulenextbatch()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L153"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_oversizedoperationalworkrepair_ts",
+      "label": "oversizedOperationalWorkRepair.ts",
+      "norm_label": "oversizedoperationalworkrepair.ts",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "registersessiontracing_buildactorrefs",
-      "label": "buildActorRefs()",
-      "norm_label": "buildactorrefs()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "registersessiontracing_buildtraceevent",
-      "label": "buildTraceEvent()",
-      "norm_label": "buildtraceevent()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L196"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "registersessiontracing_buildtracerecord",
-      "label": "buildTraceRecord()",
-      "norm_label": "buildtracerecord()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L161"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "registersessiontracing_displaytraceamount",
-      "label": "displayTraceAmount()",
-      "norm_label": "displaytraceamount()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L114"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "registersessiontracing_formattransactionlabel",
-      "label": "formatTransactionLabel()",
-      "norm_label": "formattransactionlabel()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L132"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "registersessiontracing_recordregistersessiontracebesteffort",
-      "label": "recordRegisterSessionTraceBestEffort()",
-      "norm_label": "recordregistersessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L407"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "registersessiontracing_resolveoccurredat",
-      "label": "resolveOccurredAt()",
-      "norm_label": "resolveoccurredat()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L76"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "registersessiontracing_resolvestorecurrency",
-      "label": "resolveStoreCurrency()",
-      "norm_label": "resolvestorecurrency()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L146"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "registersessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L92"
     },
     {
       "community": 2530,
@@ -231855,92 +231936,92 @@
     {
       "community": 254,
       "file_type": "code",
-      "id": "finalizedlineageremediation_classifyfinalizedlineagerepairconflicts",
-      "label": "classifyFinalizedLineageRepairConflicts()",
-      "norm_label": "classifyfinalizedlineagerepairconflicts()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L222"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_classifyrepaircandidate",
-      "label": "classifyRepairCandidate()",
-      "norm_label": "classifyrepaircandidate()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L164"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_countrepairablefinalizedlineagelines",
-      "label": "countRepairableFinalizedLineageLines()",
-      "norm_label": "countrepairablefinalizedlineagelines()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L284"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_getprovisionalimportsku",
-      "label": "getProvisionalImportSku()",
-      "norm_label": "getprovisionalimportsku()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L318"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_isclosedregisterrepairreplayconflict",
-      "label": "isClosedRegisterRepairReplayConflict()",
-      "norm_label": "isclosedregisterrepairreplayconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L273"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_isfinalizedlineagerepairconflict",
-      "label": "isFinalizedLineageRepairConflict()",
-      "norm_label": "isfinalizedlineagerepairconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L258"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_isprovisionalrowchangedconflict",
-      "label": "isProvisionalRowChangedConflict()",
-      "norm_label": "isprovisionalrowchangedconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L265"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_recordfinalizedlineagerepairevent",
-      "label": "recordFinalizedLineageRepairEvent()",
-      "norm_label": "recordfinalizedlineagerepairevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L358"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_skipped",
-      "label": "skipped()",
-      "norm_label": "skipped()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L346"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sync_finalizedlineageremediation_ts",
-      "label": "finalizedLineageRemediation.ts",
-      "norm_label": "finalizedlineageremediation.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "id": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
+      "label": "registerSessionTracing.ts",
+      "norm_label": "registersessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "registersessiontracing_buildactorrefs",
+      "label": "buildActorRefs()",
+      "norm_label": "buildactorrefs()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "registersessiontracing_buildtraceevent",
+      "label": "buildTraceEvent()",
+      "norm_label": "buildtraceevent()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L196"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "registersessiontracing_buildtracerecord",
+      "label": "buildTraceRecord()",
+      "norm_label": "buildtracerecord()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L161"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "registersessiontracing_displaytraceamount",
+      "label": "displayTraceAmount()",
+      "norm_label": "displaytraceamount()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L114"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "registersessiontracing_formattransactionlabel",
+      "label": "formatTransactionLabel()",
+      "norm_label": "formattransactionlabel()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L132"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "registersessiontracing_recordregistersessiontracebesteffort",
+      "label": "recordRegisterSessionTraceBestEffort()",
+      "norm_label": "recordregistersessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L407"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "registersessiontracing_resolveoccurredat",
+      "label": "resolveOccurredAt()",
+      "norm_label": "resolveoccurredat()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "registersessiontracing_resolvestorecurrency",
+      "label": "resolveStoreCurrency()",
+      "norm_label": "resolvestorecurrency()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L146"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "registersessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L92"
     },
     {
       "community": 2540,
@@ -232035,92 +232116,92 @@
     {
       "community": 255,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_terminalrecoveryrepository_ts",
-      "label": "terminalRecoveryRepository.ts",
-      "norm_label": "terminalrecoveryrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_createterminalrecoverycommandreadrepository",
-      "label": "createTerminalRecoveryCommandReadRepository()",
-      "norm_label": "createterminalrecoverycommandreadrepository()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_createterminalrecoverycommandrepository",
-      "label": "createTerminalRecoveryCommandRepository()",
-      "norm_label": "createterminalrecoverycommandrepository()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L127"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_deduperecoverycommandsbyid",
-      "label": "dedupeRecoveryCommandsById()",
-      "norm_label": "deduperecoverycommandsbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_deduperecoveryconflictsbyid",
-      "label": "dedupeRecoveryConflictsById()",
-      "norm_label": "deduperecoveryconflictsbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L193"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_getterminalrecoverysourceevent",
-      "label": "getTerminalRecoverySourceEvent()",
-      "norm_label": "getterminalrecoverysourceevent()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "id": "finalizedlineageremediation_classifyfinalizedlineagerepairconflicts",
+      "label": "classifyFinalizedLineageRepairConflicts()",
+      "norm_label": "classifyfinalizedlineagerepairconflicts()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
       "source_location": "L222"
     },
     {
       "community": 255,
       "file_type": "code",
-      "id": "terminalrecoveryrepository_iscurrentterminalrecoveryconflict",
-      "label": "isCurrentTerminalRecoveryConflict()",
-      "norm_label": "iscurrentterminalrecoveryconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L206"
+      "id": "finalizedlineageremediation_classifyrepaircandidate",
+      "label": "classifyRepairCandidate()",
+      "norm_label": "classifyrepaircandidate()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L164"
     },
     {
       "community": 255,
       "file_type": "code",
-      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsforrepair",
-      "label": "listTerminalRecoveryConflictsForRepair()",
-      "norm_label": "listterminalrecoveryconflictsforrepair()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L141"
+      "id": "finalizedlineageremediation_countrepairablefinalizedlineagelines",
+      "label": "countRepairableFinalizedLineageLines()",
+      "norm_label": "countrepairablefinalizedlineagelines()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L284"
     },
     {
       "community": 255,
       "file_type": "code",
-      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsources",
-      "label": "listTerminalRecoveryConflictSources()",
-      "norm_label": "listterminalrecoveryconflictsources()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L162"
+      "id": "finalizedlineageremediation_getprovisionalimportsku",
+      "label": "getProvisionalImportSku()",
+      "norm_label": "getprovisionalimportsku()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L318"
     },
     {
       "community": 255,
       "file_type": "code",
-      "id": "terminalrecoveryrepository_patchterminalrecoveryconflict",
-      "label": "patchTerminalRecoveryConflict()",
-      "norm_label": "patchterminalrecoveryconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L241"
+      "id": "finalizedlineageremediation_isclosedregisterrepairreplayconflict",
+      "label": "isClosedRegisterRepairReplayConflict()",
+      "norm_label": "isclosedregisterrepairreplayconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L273"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_isfinalizedlineagerepairconflict",
+      "label": "isFinalizedLineageRepairConflict()",
+      "norm_label": "isfinalizedlineagerepairconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L258"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_isprovisionalrowchangedconflict",
+      "label": "isProvisionalRowChangedConflict()",
+      "norm_label": "isprovisionalrowchangedconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L265"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_recordfinalizedlineagerepairevent",
+      "label": "recordFinalizedLineageRepairEvent()",
+      "norm_label": "recordfinalizedlineagerepairevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L358"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_skipped",
+      "label": "skipped()",
+      "norm_label": "skipped()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L346"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_sync_finalizedlineageremediation_ts",
+      "label": "finalizedLineageRemediation.ts",
+      "norm_label": "finalizedlineageremediation.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L1"
     },
     {
       "community": 2550,
@@ -232215,92 +232296,92 @@
     {
       "community": 256,
       "file_type": "code",
-      "id": "contract_test_day",
-      "label": "day()",
-      "norm_label": "day()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L1308"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "contract_test_fieldsof",
-      "label": "fieldsOf()",
-      "norm_label": "fieldsof()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L86"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "contract_test_headerfor",
-      "label": "headerFor()",
-      "norm_label": "headerfor()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L972"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "contract_test_inclusivedays",
-      "label": "inclusiveDays()",
-      "norm_label": "inclusivedays()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L1216"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "contract_test_movementidentityargs",
-      "label": "movementIdentityArgs()",
-      "norm_label": "movementidentityargs()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L602"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "contract_test_probe",
-      "label": "probe()",
-      "norm_label": "probe()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L1312"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "contract_test_seedproductsku",
-      "label": "seedProductSku()",
-      "norm_label": "seedproductsku()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L561"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "contract_test_seedstore",
-      "label": "seedStore()",
-      "norm_label": "seedstore()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L542"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "contract_test_unionliterals",
-      "label": "unionLiterals()",
-      "norm_label": "unionliterals()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L92"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_contract_test_ts",
-      "label": "contract.test.ts",
-      "norm_label": "contract.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_terminalrecoveryrepository_ts",
+      "label": "terminalRecoveryRepository.ts",
+      "norm_label": "terminalrecoveryrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_createterminalrecoverycommandreadrepository",
+      "label": "createTerminalRecoveryCommandReadRepository()",
+      "norm_label": "createterminalrecoverycommandreadrepository()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_createterminalrecoverycommandrepository",
+      "label": "createTerminalRecoveryCommandRepository()",
+      "norm_label": "createterminalrecoverycommandrepository()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L127"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_deduperecoverycommandsbyid",
+      "label": "dedupeRecoveryCommandsById()",
+      "norm_label": "deduperecoverycommandsbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L116"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_deduperecoveryconflictsbyid",
+      "label": "dedupeRecoveryConflictsById()",
+      "norm_label": "deduperecoveryconflictsbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L193"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_getterminalrecoverysourceevent",
+      "label": "getTerminalRecoverySourceEvent()",
+      "norm_label": "getterminalrecoverysourceevent()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L222"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_iscurrentterminalrecoveryconflict",
+      "label": "isCurrentTerminalRecoveryConflict()",
+      "norm_label": "iscurrentterminalrecoveryconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L206"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsforrepair",
+      "label": "listTerminalRecoveryConflictsForRepair()",
+      "norm_label": "listterminalrecoveryconflictsforrepair()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L141"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsources",
+      "label": "listTerminalRecoveryConflictSources()",
+      "norm_label": "listterminalrecoveryconflictsources()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L162"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_patchterminalrecoveryconflict",
+      "label": "patchTerminalRecoveryConflict()",
+      "norm_label": "patchterminalrecoveryconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L241"
     },
     {
       "community": 2560,
@@ -232395,91 +232476,91 @@
     {
       "community": 257,
       "file_type": "code",
-      "id": "customrange_aggregateskudays",
-      "label": "aggregateSkuDays()",
-      "norm_label": "aggregateskudays()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L217"
+      "id": "contract_test_day",
+      "label": "day()",
+      "norm_label": "day()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L1308"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "customrange_computerange",
-      "label": "computeRange()",
-      "norm_label": "computerange()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L253"
+      "id": "contract_test_fieldsof",
+      "label": "fieldsOf()",
+      "norm_label": "fieldsof()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L86"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "customrange_computerequestkey",
-      "label": "computeRequestKey()",
-      "norm_label": "computerequestkey()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L84"
+      "id": "contract_test_headerfor",
+      "label": "headerFor()",
+      "norm_label": "headerfor()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L972"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "customrange_inclusivedayspan",
-      "label": "inclusiveDaySpan()",
-      "norm_label": "inclusivedayspan()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L52"
+      "id": "contract_test_inclusivedays",
+      "label": "inclusiveDays()",
+      "norm_label": "inclusivedays()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L1216"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "customrange_isvalidoperatingdate",
-      "label": "isValidOperatingDate()",
-      "norm_label": "isvalidoperatingdate()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L35"
+      "id": "contract_test_movementidentityargs",
+      "label": "movementIdentityArgs()",
+      "norm_label": "movementidentityargs()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L602"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "customrange_requestrangecore",
-      "label": "requestRangeCore()",
-      "norm_label": "requestrangecore()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L112"
+      "id": "contract_test_probe",
+      "label": "probe()",
+      "norm_label": "probe()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L1312"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "customrange_sumdays",
-      "label": "sumDays()",
-      "norm_label": "sumdays()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L189"
+      "id": "contract_test_seedproductsku",
+      "label": "seedProductSku()",
+      "norm_label": "seedproductsku()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L561"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "customrange_utcmillisforlabel",
-      "label": "utcMillisForLabel()",
-      "norm_label": "utcmillisforlabel()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L46"
+      "id": "contract_test_seedstore",
+      "label": "seedStore()",
+      "norm_label": "seedstore()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L542"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "customrange_validaterangeargs",
-      "label": "validateRangeArgs()",
-      "norm_label": "validaterangeargs()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L58"
+      "id": "contract_test_unionliterals",
+      "label": "unionLiterals()",
+      "norm_label": "unionliterals()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L92"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_customrange_ts",
-      "label": "customRange.ts",
-      "norm_label": "customrange.ts",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "id": "packages_athena_webapp_convex_reports_contract_test_ts",
+      "label": "contract.test.ts",
+      "norm_label": "contract.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
       "source_location": "L1"
     },
     {
@@ -232575,92 +232656,92 @@
     {
       "community": 258,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_rangesnapshotlifecycle_test_ts",
-      "label": "rangeSnapshotLifecycle.test.ts",
-      "norm_label": "rangesnapshotlifecycle.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "id": "customrange_aggregateskudays",
+      "label": "aggregateSkuDays()",
+      "norm_label": "aggregateskudays()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L217"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "customrange_computerange",
+      "label": "computeRange()",
+      "norm_label": "computerange()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L253"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "customrange_computerequestkey",
+      "label": "computeRequestKey()",
+      "norm_label": "computerequestkey()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "customrange_inclusivedayspan",
+      "label": "inclusiveDaySpan()",
+      "norm_label": "inclusivedayspan()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "customrange_isvalidoperatingdate",
+      "label": "isValidOperatingDate()",
+      "norm_label": "isvalidoperatingdate()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "customrange_requestrangecore",
+      "label": "requestRangeCore()",
+      "norm_label": "requestrangecore()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L112"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "customrange_sumdays",
+      "label": "sumDays()",
+      "norm_label": "sumdays()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L189"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "customrange_utcmillisforlabel",
+      "label": "utcMillisForLabel()",
+      "norm_label": "utcmillisforlabel()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "customrange_validaterangeargs",
+      "label": "validateRangeArgs()",
+      "norm_label": "validaterangeargs()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_reports_customrange_ts",
+      "label": "customRange.ts",
+      "norm_label": "customrange.ts",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_allow",
-      "label": "allow()",
-      "norm_label": "allow()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L53"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_certifyday",
-      "label": "certifyDay()",
-      "norm_label": "certifyday()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L109"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_consume",
-      "label": "consume()",
-      "norm_label": "consume()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L296"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_drive",
-      "label": "drive()",
-      "norm_label": "drive()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L247"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_ensuresynthetic",
-      "label": "ensureSynthetic()",
-      "norm_label": "ensuresynthetic()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L208"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_headerbykey",
-      "label": "headerByKey()",
-      "norm_label": "headerbykey()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L230"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_insertkindedheader",
-      "label": "insertKindedHeader()",
-      "norm_label": "insertkindedheader()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L612"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_seedstore",
-      "label": "seedStore()",
-      "norm_label": "seedstore()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_synthetickind",
-      "label": "syntheticKind()",
-      "norm_label": "synthetickind()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L150"
     },
     {
       "community": 2580,
@@ -232755,92 +232836,92 @@
     {
       "community": 259,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_verificationclassify_ts",
-      "label": "verificationClassify.ts",
-      "norm_label": "verificationclassify.ts",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "id": "packages_athena_webapp_convex_reports_rangesnapshotlifecycle_test_ts",
+      "label": "rangeSnapshotLifecycle.test.ts",
+      "norm_label": "rangesnapshotlifecycle.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
       "source_location": "L1"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "verificationclassify_buildclassification",
-      "label": "buildClassification()",
-      "norm_label": "buildclassification()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L448"
+      "id": "rangesnapshotlifecycle_test_allow",
+      "label": "allow()",
+      "norm_label": "allow()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L53"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "verificationclassify_classifydayresult",
-      "label": "classifyDayResult()",
-      "norm_label": "classifydayresult()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L481"
+      "id": "rangesnapshotlifecycle_test_certifyday",
+      "label": "certifyDay()",
+      "norm_label": "certifyday()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L109"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "verificationclassify_classifyweekresult",
-      "label": "classifyWeekResult()",
-      "norm_label": "classifyweekresult()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L562"
+      "id": "rangesnapshotlifecycle_test_consume",
+      "label": "consume()",
+      "norm_label": "consume()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L296"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "verificationclassify_confirmsclean",
-      "label": "confirmsClean()",
-      "norm_label": "confirmsclean()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L681"
+      "id": "rangesnapshotlifecycle_test_drive",
+      "label": "drive()",
+      "norm_label": "drive()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L247"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "verificationclassify_explainmetricdifference",
-      "label": "explainMetricDifference()",
-      "norm_label": "explainmetricdifference()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L378"
+      "id": "rangesnapshotlifecycle_test_ensuresynthetic",
+      "label": "ensureSynthetic()",
+      "norm_label": "ensuresynthetic()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L208"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "verificationclassify_fingerprintdifferences",
-      "label": "fingerprintDifferences()",
-      "norm_label": "fingerprintdifferences()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L354"
+      "id": "rangesnapshotlifecycle_test_headerbykey",
+      "label": "headerByKey()",
+      "norm_label": "headerbykey()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L230"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "verificationclassify_initialstreakstate",
-      "label": "initialStreakState()",
-      "norm_label": "initialstreakstate()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L658"
+      "id": "rangesnapshotlifecycle_test_insertkindedheader",
+      "label": "insertKindedHeader()",
+      "norm_label": "insertkindedheader()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L612"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "verificationclassify_nextstreakstate",
-      "label": "nextStreakState()",
-      "norm_label": "nextstreakstate()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L707"
+      "id": "rangesnapshotlifecycle_test_seedstore",
+      "label": "seedStore()",
+      "norm_label": "seedstore()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L73"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "verificationclassify_partitiondifferences",
-      "label": "partitionDifferences()",
-      "norm_label": "partitiondifferences()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L434"
+      "id": "rangesnapshotlifecycle_test_synthetickind",
+      "label": "syntheticKind()",
+      "norm_label": "synthetickind()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L150"
     },
     {
       "community": 2590,
@@ -233277,92 +233358,92 @@
     {
       "community": 260,
       "file_type": "code",
-      "id": "index_resolveverificationcoderecipient",
-      "label": "resolveVerificationCodeRecipient()",
-      "norm_label": "resolveverificationcoderecipient()",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "index_senddailymanagerreportemail",
-      "label": "sendDailyManagerReportEmail()",
-      "norm_label": "senddailymanagerreportemail()",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
-      "source_location": "L373"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "index_senddiscountcodeemail",
-      "label": "sendDiscountCodeEmail()",
-      "norm_label": "senddiscountcodeemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L255"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "index_senddiscountreminderemail",
-      "label": "sendDiscountReminderEmail()",
-      "norm_label": "senddiscountreminderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L334"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "index_sendfeedbackrequestemail",
-      "label": "sendFeedbackRequestEmail()",
-      "norm_label": "sendfeedbackrequestemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L167"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "index_sendneworderemail",
-      "label": "sendNewOrderEmail()",
-      "norm_label": "sendneworderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L117"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "index_sendorderemail",
-      "label": "sendOrderEmail()",
-      "norm_label": "sendorderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "index_sendverificationcode",
-      "label": "sendVerificationCode()",
-      "norm_label": "sendverificationcode()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "id": "packages_athena_webapp_convex_reports_verificationclassify_ts",
+      "label": "verificationClassify.ts",
+      "norm_label": "verificationclassify.ts",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
       "source_location": "L1"
     },
     {
       "community": 260,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L1"
+      "id": "verificationclassify_buildclassification",
+      "label": "buildClassification()",
+      "norm_label": "buildclassification()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L448"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "verificationclassify_classifydayresult",
+      "label": "classifyDayResult()",
+      "norm_label": "classifydayresult()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L481"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "verificationclassify_classifyweekresult",
+      "label": "classifyWeekResult()",
+      "norm_label": "classifyweekresult()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L562"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "verificationclassify_confirmsclean",
+      "label": "confirmsClean()",
+      "norm_label": "confirmsclean()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L681"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "verificationclassify_explainmetricdifference",
+      "label": "explainMetricDifference()",
+      "norm_label": "explainmetricdifference()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L378"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "verificationclassify_fingerprintdifferences",
+      "label": "fingerprintDifferences()",
+      "norm_label": "fingerprintdifferences()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L354"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "verificationclassify_initialstreakstate",
+      "label": "initialStreakState()",
+      "norm_label": "initialstreakstate()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L658"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "verificationclassify_nextstreakstate",
+      "label": "nextStreakState()",
+      "norm_label": "nextstreakstate()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L707"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "verificationclassify_partitiondifferences",
+      "label": "partitionDifferences()",
+      "norm_label": "partitiondifferences()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L434"
     },
     {
       "community": 2600,
@@ -242430,6 +242511,87 @@
     {
       "community": 318,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 318,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 318,
+      "file_type": "code",
+      "id": "productutils_getpreferredsku",
+      "label": "getPreferredSku()",
+      "norm_label": "getpreferredsku()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 318,
+      "file_type": "code",
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 318,
+      "file_type": "code",
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 318,
+      "file_type": "code",
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 318,
+      "file_type": "code",
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L82"
+    },
+    {
+      "community": 318,
+      "file_type": "code",
+      "id": "productutils_sortskusbyavailabilitythenlength",
+      "label": "sortSkusByAvailabilityThenLength()",
+      "norm_label": "sortskusbyavailabilitythenlength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 318,
+      "file_type": "code",
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
       "id": "applyremoteassistcontrolintent_applyacceptedcontrolresult",
       "label": "applyAcceptedControlResult()",
       "norm_label": "applyacceptedcontrolresult()",
@@ -242437,7 +242599,7 @@
       "source_location": "L84"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_applykeyevent",
       "label": "applyKeyEvent()",
@@ -242446,7 +242608,7 @@
       "source_location": "L155"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_applypointerevent",
       "label": "applyPointerEvent()",
@@ -242455,7 +242617,7 @@
       "source_location": "L116"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_applyremoteassistcontrolintent",
       "label": "applyRemoteAssistControlIntent()",
@@ -242464,7 +242626,7 @@
       "source_location": "L17"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_getrecentcontrolresult",
       "label": "getRecentControlResult()",
@@ -242473,7 +242635,7 @@
       "source_location": "L95"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_getremoteassistcontroltarget",
       "label": "getRemoteAssistControlTarget()",
@@ -242482,7 +242644,7 @@
       "source_location": "L145"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_prepareremoteassistcontrolintent",
       "label": "prepareRemoteAssistControlIntent()",
@@ -242491,7 +242653,7 @@
       "source_location": "L27"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_remembercontrolresult",
       "label": "rememberControlResult()",
@@ -242500,94 +242662,13 @@
       "source_location": "L101"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_remote_assist_runtime_applyremoteassistcontrolintent_ts",
       "label": "applyRemoteAssistControlIntent.ts",
       "norm_label": "applyremoteassistcontrolintent.ts",
       "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_offline_posofflinereadiness_ts",
-      "label": "posOfflineReadiness.ts",
-      "norm_label": "posofflinereadiness.ts",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "posofflinereadiness_buildposofflinereadinesssummary",
-      "label": "buildPosOfflineReadinessSummary()",
-      "norm_label": "buildposofflinereadinesssummary()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L152"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "posofflinereadiness_buildsignal",
-      "label": "buildSignal()",
-      "norm_label": "buildsignal()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L178"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "posofflinereadiness_formatage",
-      "label": "formatAge()",
-      "norm_label": "formatage()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L290"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsignaldescription",
-      "label": "getSignalDescription()",
-      "norm_label": "getsignaldescription()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L221"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsignalstatus",
-      "label": "getSignalStatus()",
-      "norm_label": "getsignalstatus()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L201"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsummarydescription",
-      "label": "getSummaryDescription()",
-      "norm_label": "getsummarydescription()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L262"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsummarytitle",
-      "label": "getSummaryTitle()",
-      "norm_label": "getsummarytitle()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L256"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "posofflinereadiness_isreadylike",
-      "label": "isReadyLike()",
-      "norm_label": "isreadylike()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L286"
     },
     {
       "community": 32,
@@ -242916,6 +242997,87 @@
     {
       "community": 320,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_offline_posofflinereadiness_ts",
+      "label": "posOfflineReadiness.ts",
+      "norm_label": "posofflinereadiness.ts",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "posofflinereadiness_buildposofflinereadinesssummary",
+      "label": "buildPosOfflineReadinessSummary()",
+      "norm_label": "buildposofflinereadinesssummary()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L152"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "posofflinereadiness_buildsignal",
+      "label": "buildSignal()",
+      "norm_label": "buildsignal()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L178"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "posofflinereadiness_formatage",
+      "label": "formatAge()",
+      "norm_label": "formatage()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L290"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsignaldescription",
+      "label": "getSignalDescription()",
+      "norm_label": "getsignaldescription()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L221"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsignalstatus",
+      "label": "getSignalStatus()",
+      "norm_label": "getsignalstatus()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L201"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsummarydescription",
+      "label": "getSummaryDescription()",
+      "norm_label": "getsummarydescription()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L262"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsummarytitle",
+      "label": "getSummaryTitle()",
+      "norm_label": "getsummarytitle()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L256"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "posofflinereadiness_isreadylike",
+      "label": "isReadyLike()",
+      "norm_label": "isreadylike()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L286"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
       "id": "foundations_content_colorrolecard",
       "label": "ColorRoleCard()",
       "norm_label": "colorrolecard()",
@@ -242923,7 +243085,7 @@
       "source_location": "L222"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "foundations_content_densitycard",
       "label": "DensityCard()",
@@ -242932,7 +243094,7 @@
       "source_location": "L283"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "foundations_content_detailviewrolecard",
       "label": "DetailViewRoleCard()",
@@ -242941,7 +243103,7 @@
       "source_location": "L363"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "foundations_content_hslvar",
       "label": "hslVar()",
@@ -242950,7 +243112,7 @@
       "source_location": "L214"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "foundations_content_motioncard",
       "label": "MotionCard()",
@@ -242959,7 +243121,7 @@
       "source_location": "L342"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "foundations_content_spacetokenrow",
       "label": "SpaceTokenRow()",
@@ -242968,7 +243130,7 @@
       "source_location": "L265"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "foundations_content_textvar",
       "label": "textVar()",
@@ -242977,7 +243139,7 @@
       "source_location": "L218"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "foundations_content_typespecimencard",
       "label": "TypeSpecimenCard()",
@@ -242986,94 +243148,13 @@
       "source_location": "L246"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_foundations_content_tsx",
       "label": "foundations-content.tsx",
       "norm_label": "foundations-content.tsx",
       "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 321,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 321,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 321,
-      "file_type": "code",
-      "id": "productutils_getpreferredsku",
-      "label": "getPreferredSku()",
-      "norm_label": "getpreferredsku()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 321,
-      "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 321,
-      "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 321,
-      "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 321,
-      "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L82"
-    },
-    {
-      "community": 321,
-      "file_type": "code",
-      "id": "productutils_sortskusbyavailabilitythenlength",
-      "label": "sortSkusByAvailabilityThenLength()",
-      "norm_label": "sortskusbyavailabilitythenlength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 321,
-      "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L59"
     },
     {
       "community": 322,
@@ -261123,60 +261204,6 @@
     {
       "community": 507,
       "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L101"
-    },
-    {
-      "community": 507,
-      "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 507,
-      "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 507,
-      "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 507,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 507,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 508,
-      "file_type": "code",
       "id": "config_derivestorefrontfromadminhost",
       "label": "deriveStoreFrontFromAdminHost()",
       "norm_label": "derivestorefrontfromadminhost()",
@@ -261184,7 +261211,7 @@
       "source_location": "L29"
     },
     {
-      "community": 508,
+      "community": 507,
       "file_type": "code",
       "id": "config_getruntimeorigin",
       "label": "getRuntimeOrigin()",
@@ -261193,7 +261220,7 @@
       "source_location": "L12"
     },
     {
-      "community": 508,
+      "community": 507,
       "file_type": "code",
       "id": "config_islocalhost",
       "label": "isLocalHost()",
@@ -261202,7 +261229,7 @@
       "source_location": "L20"
     },
     {
-      "community": 508,
+      "community": 507,
       "file_type": "code",
       "id": "config_resolvestorefronturl",
       "label": "resolveStoreFrontUrl()",
@@ -261211,7 +261238,7 @@
       "source_location": "L51"
     },
     {
-      "community": 508,
+      "community": 507,
       "file_type": "code",
       "id": "config_trimtrailingslash",
       "label": "trimTrailingSlash()",
@@ -261220,7 +261247,7 @@
       "source_location": "L8"
     },
     {
-      "community": 508,
+      "community": 507,
       "file_type": "code",
       "id": "packages_athena_webapp_src_config_ts",
       "label": "config.ts",
@@ -261229,7 +261256,7 @@
       "source_location": "L1"
     },
     {
-      "community": 509,
+      "community": 508,
       "file_type": "code",
       "id": "managerelevationcontext_getstaffdisplayname",
       "label": "getStaffDisplayName()",
@@ -261238,7 +261265,7 @@
       "source_location": "L64"
     },
     {
-      "community": 509,
+      "community": 508,
       "file_type": "code",
       "id": "managerelevationcontext_managerelevationprovider",
       "label": "ManagerElevationProvider()",
@@ -261247,7 +261274,7 @@
       "source_location": "L87"
     },
     {
-      "community": 509,
+      "community": 508,
       "file_type": "code",
       "id": "managerelevationcontext_tostaffauthenticationresult",
       "label": "toStaffAuthenticationResult()",
@@ -261256,7 +261283,7 @@
       "source_location": "L74"
     },
     {
-      "community": 509,
+      "community": 508,
       "file_type": "code",
       "id": "managerelevationcontext_usemanagerelevation",
       "label": "useManagerElevation()",
@@ -261265,7 +261292,7 @@
       "source_location": "L242"
     },
     {
-      "community": 509,
+      "community": 508,
       "file_type": "code",
       "id": "managerelevationcontext_useoptionalmanagerelevation",
       "label": "useOptionalManagerElevation()",
@@ -261274,13 +261301,67 @@
       "source_location": "L251"
     },
     {
-      "community": 509,
+      "community": 508,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_managerelevationcontext_tsx",
       "label": "ManagerElevationContext.tsx",
       "norm_label": "managerelevationcontext.tsx",
       "source_file": "packages/athena-webapp/src/contexts/ManagerElevationContext.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 509,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
+      "label": "useExpenseSessions.ts",
+      "norm_label": "useexpensesessions.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 509,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpenseactivesession",
+      "label": "useExpenseActiveSession()",
+      "norm_label": "useexpenseactivesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 509,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesession",
+      "label": "useExpenseSession()",
+      "norm_label": "useexpensesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 509,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesessioncreate",
+      "label": "useExpenseSessionCreate()",
+      "norm_label": "useexpensesessioncreate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 509,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesessionupdate",
+      "label": "useExpenseSessionUpdate()",
+      "norm_label": "useexpensesessionupdate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 509,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensestoresessions",
+      "label": "useExpenseStoreSessions()",
+      "norm_label": "useexpensestoresessions()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L10"
     },
     {
       "community": 51,
@@ -261546,60 +261627,6 @@
     {
       "community": 510,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
-      "label": "useExpenseSessions.ts",
-      "norm_label": "useexpensesessions.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 510,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpenseactivesession",
-      "label": "useExpenseActiveSession()",
-      "norm_label": "useexpenseactivesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 510,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesession",
-      "label": "useExpenseSession()",
-      "norm_label": "useexpensesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 510,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesessioncreate",
-      "label": "useExpenseSessionCreate()",
-      "norm_label": "useexpensesessioncreate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 510,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesessionupdate",
-      "label": "useExpenseSessionUpdate()",
-      "norm_label": "useexpensesessionupdate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 510,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensestoresessions",
-      "label": "useExpenseStoreSessions()",
-      "norm_label": "useexpensestoresessions()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 511,
-      "file_type": "code",
       "id": "capabilities_canaccesscashcontrolssurface",
       "label": "canAccessCashControlsSurface()",
       "norm_label": "canaccesscashcontrolssurface()",
@@ -261607,7 +261634,7 @@
       "source_location": "L54"
     },
     {
-      "community": 511,
+      "community": 510,
       "file_type": "code",
       "id": "capabilities_canaccessfulladminsurface",
       "label": "canAccessFullAdminSurface()",
@@ -261616,7 +261643,7 @@
       "source_location": "L41"
     },
     {
-      "community": 511,
+      "community": 510,
       "file_type": "code",
       "id": "capabilities_canaccessstoredaysurface",
       "label": "canAccessStoreDaySurface()",
@@ -261625,7 +261652,7 @@
       "source_location": "L47"
     },
     {
-      "community": 511,
+      "community": 510,
       "file_type": "code",
       "id": "capabilities_canviewfinancialdetails",
       "label": "canViewFinancialDetails()",
@@ -261634,7 +261661,7 @@
       "source_location": "L61"
     },
     {
-      "community": 511,
+      "community": 510,
       "file_type": "code",
       "id": "capabilities_getsurfaceaccess",
       "label": "getSurfaceAccess()",
@@ -261643,7 +261670,7 @@
       "source_location": "L68"
     },
     {
-      "community": 511,
+      "community": 510,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_access_capabilities_ts",
       "label": "capabilities.ts",
@@ -261652,7 +261679,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 511,
       "file_type": "code",
       "id": "behaviorutils_calculateengagementmetrics",
       "label": "calculateEngagementMetrics()",
@@ -261661,7 +261688,7 @@
       "source_location": "L173"
     },
     {
-      "community": 512,
+      "community": 511,
       "file_type": "code",
       "id": "behaviorutils_calculateriskindicators",
       "label": "calculateRiskIndicators()",
@@ -261670,7 +261697,7 @@
       "source_location": "L71"
     },
     {
-      "community": 512,
+      "community": 511,
       "file_type": "code",
       "id": "behaviorutils_getactivitypriority",
       "label": "getActivityPriority()",
@@ -261679,7 +261706,7 @@
       "source_location": "L251"
     },
     {
-      "community": 512,
+      "community": 511,
       "file_type": "code",
       "id": "behaviorutils_getcustomerjourneystage",
       "label": "getCustomerJourneyStage()",
@@ -261688,7 +261715,7 @@
       "source_location": "L36"
     },
     {
-      "community": 512,
+      "community": 511,
       "file_type": "code",
       "id": "behaviorutils_getjourneystageinfo",
       "label": "getJourneyStageInfo()",
@@ -261697,7 +261724,7 @@
       "source_location": "L277"
     },
     {
-      "community": 512,
+      "community": 511,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
       "label": "behaviorUtils.ts",
@@ -261706,7 +261733,7 @@
       "source_location": "L1"
     },
     {
-      "community": 513,
+      "community": 512,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
       "label": "results.ts",
@@ -261715,7 +261742,7 @@
       "source_location": "L1"
     },
     {
-      "community": 513,
+      "community": 512,
       "file_type": "code",
       "id": "results_isposusecasesuccess",
       "label": "isPosUseCaseSuccess()",
@@ -261724,7 +261751,7 @@
       "source_location": "L134"
     },
     {
-      "community": 513,
+      "community": 512,
       "file_type": "code",
       "id": "results_mapcommandoutcome",
       "label": "mapCommandOutcome()",
@@ -261733,7 +261760,7 @@
       "source_location": "L69"
     },
     {
-      "community": 513,
+      "community": 512,
       "file_type": "code",
       "id": "results_mapcommandresult",
       "label": "mapCommandResult()",
@@ -261742,7 +261769,7 @@
       "source_location": "L86"
     },
     {
-      "community": 513,
+      "community": 512,
       "file_type": "code",
       "id": "results_maplegacymutationresult",
       "label": "mapLegacyMutationResult()",
@@ -261751,7 +261778,7 @@
       "source_location": "L52"
     },
     {
-      "community": 513,
+      "community": 512,
       "file_type": "code",
       "id": "results_mapthrownerror",
       "label": "mapThrownError()",
@@ -261760,7 +261787,7 @@
       "source_location": "L103"
     },
     {
-      "community": 514,
+      "community": 513,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registerlifecycleauthoritycandidates_ts",
       "label": "registerLifecycleAuthorityCandidates.ts",
@@ -261769,7 +261796,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 513,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_deriveregisterlifecycleauthoritycandidates",
       "label": "deriveRegisterLifecycleAuthorityCandidates()",
@@ -261778,7 +261805,7 @@
       "source_location": "L45"
     },
     {
-      "community": 514,
+      "community": 513,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_isboundedidentifier",
       "label": "isBoundedIdentifier()",
@@ -261787,7 +261814,7 @@
       "source_location": "L220"
     },
     {
-      "community": 514,
+      "community": 513,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_iseligibleregistermapping",
       "label": "isEligibleRegisterMapping()",
@@ -261796,7 +261823,7 @@
       "source_location": "L167"
     },
     {
-      "community": 514,
+      "community": 513,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_legacymappingmatchesactivesession",
       "label": "legacyMappingMatchesActiveSession()",
@@ -261805,7 +261832,7 @@
       "source_location": "L182"
     },
     {
-      "community": 514,
+      "community": 513,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_mappingcandidate",
       "label": "mappingCandidate()",
@@ -261814,7 +261841,7 @@
       "source_location": "L194"
     },
     {
-      "community": 515,
+      "community": 514,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_useposlocalsyncruntime_test_ts",
       "label": "usePosLocalSyncRuntime.test.ts",
@@ -261823,7 +261850,7 @@
       "source_location": "L1"
     },
     {
-      "community": 515,
+      "community": 514,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_buildlocalevent",
       "label": "buildLocalEvent()",
@@ -261832,7 +261859,7 @@
       "source_location": "L7449"
     },
     {
-      "community": 515,
+      "community": 514,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_buildrecoverycommand",
       "label": "buildRecoveryCommand()",
@@ -261841,7 +261868,7 @@
       "source_location": "L7472"
     },
     {
-      "community": 515,
+      "community": 514,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_buildrecoverycommandstore",
       "label": "buildRecoveryCommandStore()",
@@ -261850,7 +261877,7 @@
       "source_location": "L7491"
     },
     {
-      "community": 515,
+      "community": 514,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_deferred",
       "label": "deferred()",
@@ -261859,7 +261886,7 @@
       "source_location": "L108"
     },
     {
-      "community": 515,
+      "community": 514,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_storefactory",
       "label": "storeFactory()",
@@ -261868,7 +261895,7 @@
       "source_location": "L352"
     },
     {
-      "community": 516,
+      "community": 515,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
       "label": "selectors.ts",
@@ -261877,7 +261904,7 @@
       "source_location": "L1"
     },
     {
-      "community": 516,
+      "community": 515,
       "file_type": "code",
       "id": "selectors_buildregisterheaderstate",
       "label": "buildRegisterHeaderState()",
@@ -261886,7 +261913,7 @@
       "source_location": "L28"
     },
     {
-      "community": 516,
+      "community": 515,
       "file_type": "code",
       "id": "selectors_buildregisterinfostate",
       "label": "buildRegisterInfoState()",
@@ -261895,7 +261922,7 @@
       "source_location": "L37"
     },
     {
-      "community": 516,
+      "community": 515,
       "file_type": "code",
       "id": "selectors_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -261904,7 +261931,7 @@
       "source_location": "L12"
     },
     {
-      "community": 516,
+      "community": 515,
       "file_type": "code",
       "id": "selectors_getregistercustomerinfo",
       "label": "getRegisterCustomerInfo()",
@@ -261913,7 +261940,7 @@
       "source_location": "L6"
     },
     {
-      "community": 516,
+      "community": 515,
       "file_type": "code",
       "id": "selectors_isregistersessionactive",
       "label": "isRegisterSessionActive()",
@@ -261922,7 +261949,7 @@
       "source_location": "L49"
     },
     {
-      "community": 517,
+      "community": 516,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
       "label": "toastService.ts",
@@ -261931,7 +261958,7 @@
       "source_location": "L1"
     },
     {
-      "community": 517,
+      "community": 516,
       "file_type": "code",
       "id": "toastservice_handleposoperation",
       "label": "handlePOSOperation()",
@@ -261940,7 +261967,7 @@
       "source_location": "L171"
     },
     {
-      "community": 517,
+      "community": 516,
       "file_type": "code",
       "id": "toastservice_showinventoryerror",
       "label": "showInventoryError()",
@@ -261949,7 +261976,7 @@
       "source_location": "L302"
     },
     {
-      "community": 517,
+      "community": 516,
       "file_type": "code",
       "id": "toastservice_shownoactivesessionerror",
       "label": "showNoActiveSessionError()",
@@ -261958,7 +261985,7 @@
       "source_location": "L319"
     },
     {
-      "community": 517,
+      "community": 516,
       "file_type": "code",
       "id": "toastservice_showsessionexpirederror",
       "label": "showSessionExpiredError()",
@@ -261967,7 +261994,7 @@
       "source_location": "L312"
     },
     {
-      "community": 517,
+      "community": 516,
       "file_type": "code",
       "id": "toastservice_showvalidationerror",
       "label": "showValidationError()",
@@ -261976,7 +262003,7 @@
       "source_location": "L293"
     },
     {
-      "community": 518,
+      "community": 517,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_sheetreturn_ts",
       "label": "sheetReturn.ts",
@@ -261985,7 +262012,7 @@
       "source_location": "L1"
     },
     {
-      "community": 518,
+      "community": 517,
       "file_type": "code",
       "id": "sheetreturn_decodesheetreturn",
       "label": "decodeSheetReturn()",
@@ -261994,7 +262021,7 @@
       "source_location": "L85"
     },
     {
-      "community": 518,
+      "community": 517,
       "file_type": "code",
       "id": "sheetreturn_encodefocuskey",
       "label": "encodeFocusKey()",
@@ -262003,7 +262030,7 @@
       "source_location": "L74"
     },
     {
-      "community": 518,
+      "community": 517,
       "file_type": "code",
       "id": "sheetreturn_encodesheetreturn",
       "label": "encodeSheetReturn()",
@@ -262012,7 +262039,7 @@
       "source_location": "L55"
     },
     {
-      "community": 518,
+      "community": 517,
       "file_type": "code",
       "id": "sheetreturn_sheetreturnfocusselector",
       "label": "sheetReturnFocusSelector()",
@@ -262021,7 +262048,7 @@
       "source_location": "L126"
     },
     {
-      "community": 518,
+      "community": 517,
       "file_type": "code",
       "id": "sheetreturn_sheetreturntargetprops",
       "label": "sheetReturnTargetProps()",
@@ -262030,7 +262057,7 @@
       "source_location": "L131"
     },
     {
-      "community": 519,
+      "community": 518,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_skusearch_productskusearchadapters_ts",
       "label": "productSkuSearchAdapters.ts",
@@ -262039,7 +262066,7 @@
       "source_location": "L1"
     },
     {
-      "community": 519,
+      "community": 518,
       "file_type": "code",
       "id": "productskusearchadapters_buildadminskusearchoption",
       "label": "buildAdminSkuSearchOption()",
@@ -262048,7 +262075,7 @@
       "source_location": "L80"
     },
     {
-      "community": 519,
+      "community": 518,
       "file_type": "code",
       "id": "productskusearchadapters_buildadminskusearchoptions",
       "label": "buildAdminSkuSearchOptions()",
@@ -262057,7 +262084,7 @@
       "source_location": "L132"
     },
     {
-      "community": 519,
+      "community": 518,
       "file_type": "code",
       "id": "productskusearchadapters_compactjoin",
       "label": "compactJoin()",
@@ -262066,7 +262093,7 @@
       "source_location": "L73"
     },
     {
-      "community": 519,
+      "community": 518,
       "file_type": "code",
       "id": "productskusearchadapters_groupadminskusearchoptionsbyproduct",
       "label": "groupAdminSkuSearchOptionsByProduct()",
@@ -262075,13 +262102,67 @@
       "source_location": "L138"
     },
     {
-      "community": 519,
+      "community": 518,
       "file_type": "code",
       "id": "productskusearchadapters_presentationtext",
       "label": "presentationText()",
       "norm_label": "presentationtext()",
       "source_file": "packages/athena-webapp/src/lib/skuSearch/productSkuSearchAdapters.ts",
       "source_location": "L66"
+    },
+    {
+      "community": 519,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_stockops_skusearch_ts",
+      "label": "skuSearch.ts",
+      "norm_label": "skusearch.ts",
+      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 519,
+      "file_type": "code",
+      "id": "skusearch_isbarcodeshapedsearchquery",
+      "label": "isBarcodeShapedSearchQuery()",
+      "norm_label": "isbarcodeshapedsearchquery()",
+      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 519,
+      "file_type": "code",
+      "id": "skusearch_matchesskusearchterms",
+      "label": "matchesSkuSearchTerms()",
+      "norm_label": "matchesskusearchterms()",
+      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 519,
+      "file_type": "code",
+      "id": "skusearch_normalizeidentifier",
+      "label": "normalizeIdentifier()",
+      "norm_label": "normalizeidentifier()",
+      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 519,
+      "file_type": "code",
+      "id": "skusearch_normalizeskusearchquery",
+      "label": "normalizeSkuSearchQuery()",
+      "norm_label": "normalizeskusearchquery()",
+      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 519,
+      "file_type": "code",
+      "id": "skusearch_scoreskusearchterms",
+      "label": "scoreSkuSearchTerms()",
+      "norm_label": "scoreskusearchterms()",
+      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
+      "source_location": "L18"
     },
     {
       "community": 52,
@@ -262347,60 +262428,6 @@
     {
       "community": 520,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_stockops_skusearch_ts",
-      "label": "skuSearch.ts",
-      "norm_label": "skusearch.ts",
-      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 520,
-      "file_type": "code",
-      "id": "skusearch_isbarcodeshapedsearchquery",
-      "label": "isBarcodeShapedSearchQuery()",
-      "norm_label": "isbarcodeshapedsearchquery()",
-      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 520,
-      "file_type": "code",
-      "id": "skusearch_matchesskusearchterms",
-      "label": "matchesSkuSearchTerms()",
-      "norm_label": "matchesskusearchterms()",
-      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 520,
-      "file_type": "code",
-      "id": "skusearch_normalizeidentifier",
-      "label": "normalizeIdentifier()",
-      "norm_label": "normalizeidentifier()",
-      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
-      "source_location": "L53"
-    },
-    {
-      "community": 520,
-      "file_type": "code",
-      "id": "skusearch_normalizeskusearchquery",
-      "label": "normalizeSkuSearchQuery()",
-      "norm_label": "normalizeskusearchquery()",
-      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 520,
-      "file_type": "code",
-      "id": "skusearch_scoreskusearchterms",
-      "label": "scoreSkuSearchTerms()",
-      "norm_label": "scoreskusearchterms()",
-      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 521,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_offline_posappshellroutes_ts",
       "label": "posAppShellRoutes.ts",
       "norm_label": "posappshellroutes.ts",
@@ -262408,7 +262435,7 @@
       "source_location": "L1"
     },
     {
-      "community": 521,
+      "community": 520,
       "file_type": "code",
       "id": "posappshellroutes_isexcludedfromposappshellcache",
       "label": "isExcludedFromPosAppShellCache()",
@@ -262417,7 +262444,7 @@
       "source_location": "L53"
     },
     {
-      "community": 521,
+      "community": 520,
       "file_type": "code",
       "id": "posappshellroutes_isposappshellnavigationrequest",
       "label": "isPosAppShellNavigationRequest()",
@@ -262426,7 +262453,7 @@
       "source_location": "L71"
     },
     {
-      "community": 521,
+      "community": 520,
       "file_type": "code",
       "id": "posappshellroutes_isposappshellroutepath",
       "label": "isPosAppShellRoutePath()",
@@ -262435,7 +262462,7 @@
       "source_location": "L48"
     },
     {
-      "community": 521,
+      "community": 520,
       "file_type": "code",
       "id": "posappshellroutes_isposappshellstaticassetrequest",
       "label": "isPosAppShellStaticAssetRequest()",
@@ -262444,7 +262471,7 @@
       "source_location": "L88"
     },
     {
-      "community": 521,
+      "community": 520,
       "file_type": "code",
       "id": "posappshellroutes_readheader",
       "label": "readHeader()",
@@ -262453,7 +262480,7 @@
       "source_location": "L107"
     },
     {
-      "community": 522,
+      "community": 521,
       "file_type": "code",
       "id": "packages_athena_webapp_src_offline_posappshellserviceworkerstaging_test_ts",
       "label": "posAppShellServiceWorkerStaging.test.ts",
@@ -262462,7 +262489,7 @@
       "source_location": "L1"
     },
     {
-      "community": 522,
+      "community": 521,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_createserviceworkerfixture",
       "label": "createServiceWorkerFixture()",
@@ -262471,7 +262498,7 @@
       "source_location": "L32"
     },
     {
-      "community": 522,
+      "community": 521,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_memorycache",
       "label": "MemoryCache",
@@ -262480,7 +262507,7 @@
       "source_location": "L14"
     },
     {
-      "community": 522,
+      "community": 521,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_memorycache_keys",
       "label": ".keys()",
@@ -262489,7 +262516,7 @@
       "source_location": "L27"
     },
     {
-      "community": 522,
+      "community": 521,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_memorycache_match",
       "label": ".match()",
@@ -262498,7 +262525,7 @@
       "source_location": "L17"
     },
     {
-      "community": 522,
+      "community": 521,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_memorycache_put",
       "label": ".put()",
@@ -262507,7 +262534,7 @@
       "source_location": "L22"
     },
     {
-      "community": 523,
+      "community": 522,
       "file_type": "code",
       "id": "docs_shared_companionsection",
       "label": "CompanionSection()",
@@ -262516,7 +262543,7 @@
       "source_location": "L81"
     },
     {
-      "community": 523,
+      "community": 522,
       "file_type": "code",
       "id": "docs_shared_formatcategorylabel",
       "label": "formatCategoryLabel()",
@@ -262525,7 +262552,7 @@
       "source_location": "L7"
     },
     {
-      "community": 523,
+      "community": 522,
       "file_type": "code",
       "id": "docs_shared_formatdocdate",
       "label": "formatDocDate()",
@@ -262534,7 +262561,7 @@
       "source_location": "L11"
     },
     {
-      "community": 523,
+      "community": 522,
       "file_type": "code",
       "id": "docs_shared_severityindicator",
       "label": "SeverityIndicator()",
@@ -262543,7 +262570,7 @@
       "source_location": "L32"
     },
     {
-      "community": 523,
+      "community": 522,
       "file_type": "code",
       "id": "docs_shared_solutiondoccard",
       "label": "SolutionDocCard()",
@@ -262552,7 +262579,7 @@
       "source_location": "L48"
     },
     {
-      "community": 523,
+      "community": 522,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_docs_shared_tsx",
       "label": "-docs-shared.tsx",
@@ -262561,7 +262588,7 @@
       "source_location": "L1"
     },
     {
-      "community": 524,
+      "community": 523,
       "file_type": "code",
       "id": "index_route_view_democtabutton",
       "label": "DemoCtaButton()",
@@ -262570,7 +262597,7 @@
       "source_location": "L192"
     },
     {
-      "community": 524,
+      "community": 523,
       "file_type": "code",
       "id": "index_route_view_herogrid",
       "label": "HeroGrid()",
@@ -262579,7 +262606,7 @@
       "source_location": "L178"
     },
     {
-      "community": 524,
+      "community": 523,
       "file_type": "code",
       "id": "index_route_view_rest",
       "label": "rest()",
@@ -262588,7 +262615,7 @@
       "source_location": "L246"
     },
     {
-      "community": 524,
+      "community": 523,
       "file_type": "code",
       "id": "index_route_view_useheroshotrevealref",
       "label": "useHeroShotRevealRef()",
@@ -262597,7 +262624,7 @@
       "source_location": "L54"
     },
     {
-      "community": 524,
+      "community": 523,
       "file_type": "code",
       "id": "index_route_view_useheroshottiltref",
       "label": "useHeroShotTiltRef()",
@@ -262606,7 +262633,7 @@
       "source_location": "L107"
     },
     {
-      "community": 524,
+      "community": 523,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_route_view_tsx",
       "label": "-index-route-view.tsx",
@@ -262615,7 +262642,7 @@
       "source_location": "L1"
     },
     {
-      "community": 525,
+      "community": 524,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
       "label": "procurement.index.tsx",
@@ -262624,7 +262651,7 @@
       "source_location": "L1"
     },
     {
-      "community": 525,
+      "community": 524,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementmodesearch",
       "label": "getNextProcurementModeSearch()",
@@ -262633,7 +262660,7 @@
       "source_location": "L19"
     },
     {
-      "community": 525,
+      "community": 524,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementpagesearch",
       "label": "getNextProcurementPageSearch()",
@@ -262642,7 +262669,7 @@
       "source_location": "L37"
     },
     {
-      "community": 525,
+      "community": 524,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementquerysearch",
       "label": "getNextProcurementQuerySearch()",
@@ -262651,7 +262678,7 @@
       "source_location": "L47"
     },
     {
-      "community": 525,
+      "community": 524,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementselectedskusearch",
       "label": "getNextProcurementSelectedSkuSearch()",
@@ -262660,7 +262687,7 @@
       "source_location": "L62"
     },
     {
-      "community": 525,
+      "community": 524,
       "file_type": "code",
       "id": "procurement_index_procurementroute",
       "label": "ProcurementRoute()",
@@ -262669,7 +262696,7 @@
       "source_location": "L88"
     },
     {
-      "community": 526,
+      "community": 525,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_weekly_lifecycle_test_tsx",
       "label": "weekly.lifecycle.test.tsx",
@@ -262678,7 +262705,7 @@
       "source_location": "L1"
     },
     {
-      "community": 526,
+      "community": 525,
       "file_type": "code",
       "id": "weekly_lifecycle_test_installcompletedmovement",
       "label": "installCompletedMovement()",
@@ -262687,7 +262714,7 @@
       "source_location": "L283"
     },
     {
-      "community": 526,
+      "community": 525,
       "file_type": "code",
       "id": "weekly_lifecycle_test_isshareddemostandingread",
       "label": "isSharedDemoStandingRead()",
@@ -262696,7 +262723,7 @@
       "source_location": "L102"
     },
     {
-      "community": 526,
+      "community": 525,
       "file_type": "code",
       "id": "weekly_lifecycle_test_movementrow",
       "label": "movementRow()",
@@ -262705,7 +262732,7 @@
       "source_location": "L268"
     },
     {
-      "community": 526,
+      "community": 525,
       "file_type": "code",
       "id": "weekly_lifecycle_test_params",
       "label": "params()",
@@ -262714,7 +262741,7 @@
       "source_location": "L40"
     },
     {
-      "community": 526,
+      "community": 525,
       "file_type": "code",
       "id": "weekly_lifecycle_test_stubensuremutation",
       "label": "stubEnsureMutation()",
@@ -262723,7 +262750,7 @@
       "source_location": "L81"
     },
     {
-      "community": 527,
+      "community": 526,
       "file_type": "code",
       "id": "login_layout_completependingauthsync",
       "label": "completePendingAuthSync()",
@@ -262732,7 +262759,7 @@
       "source_location": "L145"
     },
     {
-      "community": 527,
+      "community": 526,
       "file_type": "code",
       "id": "login_layout_handlependingauthsync",
       "label": "handlePendingAuthSync()",
@@ -262741,7 +262768,7 @@
       "source_location": "L95"
     },
     {
-      "community": 527,
+      "community": 526,
       "file_type": "code",
       "id": "login_layout_navigationtargetforredirect",
       "label": "navigationTargetForRedirect()",
@@ -262750,7 +262777,7 @@
       "source_location": "L33"
     },
     {
-      "community": 527,
+      "community": 526,
       "file_type": "code",
       "id": "login_layout_sleep",
       "label": "sleep()",
@@ -262759,7 +262786,7 @@
       "source_location": "L29"
     },
     {
-      "community": 527,
+      "community": 526,
       "file_type": "code",
       "id": "login_layout_usedocumentscrolllock",
       "label": "useDocumentScrollLock()",
@@ -262768,7 +262795,7 @@
       "source_location": "L45"
     },
     {
-      "community": 527,
+      "community": 526,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_login_layout_tsx",
       "label": "-login-layout.tsx",
@@ -262777,7 +262804,7 @@
       "source_location": "L1"
     },
     {
-      "community": 528,
+      "community": 527,
       "file_type": "code",
       "id": "organizationsettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -262786,7 +262813,7 @@
       "source_location": "L155"
     },
     {
-      "community": 528,
+      "community": 527,
       "file_type": "code",
       "id": "organizationsettingsview_navigation",
       "label": "Navigation()",
@@ -262795,7 +262822,7 @@
       "source_location": "L197"
     },
     {
-      "community": 528,
+      "community": 527,
       "file_type": "code",
       "id": "organizationsettingsview_onsubmit",
       "label": "onSubmit()",
@@ -262804,7 +262831,7 @@
       "source_location": "L104"
     },
     {
-      "community": 528,
+      "community": 527,
       "file_type": "code",
       "id": "organizationsettingsview_organizationsettings",
       "label": "OrganizationSettings()",
@@ -262813,7 +262840,7 @@
       "source_location": "L25"
     },
     {
-      "community": 528,
+      "community": 527,
       "file_type": "code",
       "id": "organizationsettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -262822,7 +262849,7 @@
       "source_location": "L72"
     },
     {
-      "community": 528,
+      "community": 527,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
       "label": "OrganizationSettingsView.tsx",
@@ -262831,7 +262858,7 @@
       "source_location": "L1"
     },
     {
-      "community": 529,
+      "community": 528,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
       "label": "StoreSettingsView.tsx",
@@ -262840,7 +262867,7 @@
       "source_location": "L1"
     },
     {
-      "community": 529,
+      "community": 528,
       "file_type": "code",
       "id": "storesettingsview_handledeleteallproductsinstore",
       "label": "handleDeleteAllProductsInStore()",
@@ -262849,7 +262876,7 @@
       "source_location": "L231"
     },
     {
-      "community": 529,
+      "community": 528,
       "file_type": "code",
       "id": "storesettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -262858,7 +262885,7 @@
       "source_location": "L167"
     },
     {
-      "community": 529,
+      "community": 528,
       "file_type": "code",
       "id": "storesettingsview_onsubmit",
       "label": "onSubmit()",
@@ -262867,7 +262894,7 @@
       "source_location": "L116"
     },
     {
-      "community": 529,
+      "community": 528,
       "file_type": "code",
       "id": "storesettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -262876,13 +262903,67 @@
       "source_location": "L83"
     },
     {
-      "community": 529,
+      "community": 528,
       "file_type": "code",
       "id": "storesettingsview_storesettings",
       "label": "StoreSettings()",
       "norm_label": "storesettings()",
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L29"
+    },
+    {
+      "community": 529,
+      "file_type": "code",
+      "id": "devfixtureactivation_usedailyclosefixture",
+      "label": "useDailyCloseFixture()",
+      "norm_label": "usedailyclosefixture()",
+      "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
+      "source_location": "L102"
+    },
+    {
+      "community": 529,
+      "file_type": "code",
+      "id": "devfixtureactivation_usedailyopeningfixture",
+      "label": "useDailyOpeningFixture()",
+      "norm_label": "usedailyopeningfixture()",
+      "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 529,
+      "file_type": "code",
+      "id": "devfixtureactivation_usedailyoperationsfixture",
+      "label": "useDailyOperationsFixture()",
+      "norm_label": "usedailyoperationsfixture()",
+      "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 529,
+      "file_type": "code",
+      "id": "devfixtureactivation_useposhubfixture",
+      "label": "usePosHubFixture()",
+      "norm_label": "useposhubfixture()",
+      "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
+      "source_location": "L108"
+    },
+    {
+      "community": 529,
+      "file_type": "code",
+      "id": "devfixtureactivation_useworkspacefixture",
+      "label": "useWorkspaceFixture()",
+      "norm_label": "useworkspacefixture()",
+      "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 529,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_operations_devfixtureactivation_ts",
+      "label": "devFixtureActivation.ts",
+      "norm_label": "devfixtureactivation.ts",
+      "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
+      "source_location": "L1"
     },
     {
       "community": 53,
@@ -263148,60 +263229,6 @@
     {
       "community": 530,
       "file_type": "code",
-      "id": "devfixtureactivation_usedailyclosefixture",
-      "label": "useDailyCloseFixture()",
-      "norm_label": "usedailyclosefixture()",
-      "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 530,
-      "file_type": "code",
-      "id": "devfixtureactivation_usedailyopeningfixture",
-      "label": "useDailyOpeningFixture()",
-      "norm_label": "usedailyopeningfixture()",
-      "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 530,
-      "file_type": "code",
-      "id": "devfixtureactivation_usedailyoperationsfixture",
-      "label": "useDailyOperationsFixture()",
-      "norm_label": "usedailyoperationsfixture()",
-      "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 530,
-      "file_type": "code",
-      "id": "devfixtureactivation_useposhubfixture",
-      "label": "usePosHubFixture()",
-      "norm_label": "useposhubfixture()",
-      "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
-      "source_location": "L108"
-    },
-    {
-      "community": 530,
-      "file_type": "code",
-      "id": "devfixtureactivation_useworkspacefixture",
-      "label": "useWorkspaceFixture()",
-      "norm_label": "useworkspacefixture()",
-      "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 530,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_operations_devfixtureactivation_ts",
-      "label": "devFixtureActivation.ts",
-      "norm_label": "devfixtureactivation.ts",
-      "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 531,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
       "label": "storybook-shell.tsx",
       "norm_label": "storybook-shell.tsx",
@@ -263209,7 +263236,7 @@
       "source_location": "L1"
     },
     {
-      "community": 531,
+      "community": 530,
       "file_type": "code",
       "id": "storybook_shell_storybookcallout",
       "label": "StorybookCallout()",
@@ -263218,7 +263245,7 @@
       "source_location": "L76"
     },
     {
-      "community": 531,
+      "community": 530,
       "file_type": "code",
       "id": "storybook_shell_storybooklist",
       "label": "StorybookList()",
@@ -263227,7 +263254,7 @@
       "source_location": "L55"
     },
     {
-      "community": 531,
+      "community": 530,
       "file_type": "code",
       "id": "storybook_shell_storybookpillrow",
       "label": "StorybookPillRow()",
@@ -263236,7 +263263,7 @@
       "source_location": "L88"
     },
     {
-      "community": 531,
+      "community": 530,
       "file_type": "code",
       "id": "storybook_shell_storybooksection",
       "label": "StorybookSection()",
@@ -263245,7 +263272,7 @@
       "source_location": "L34"
     },
     {
-      "community": 531,
+      "community": 530,
       "file_type": "code",
       "id": "storybook_shell_storybookshell",
       "label": "StorybookShell()",
@@ -263254,7 +263281,7 @@
       "source_location": "L13"
     },
     {
-      "community": 532,
+      "community": 531,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_postransaction_ts",
       "label": "posTransaction.ts",
@@ -263263,7 +263290,7 @@
       "source_location": "L1"
     },
     {
-      "community": 532,
+      "community": 531,
       "file_type": "code",
       "id": "postransaction_fetchpostransaction",
       "label": "fetchPosTransaction()",
@@ -263272,7 +263299,7 @@
       "source_location": "L69"
     },
     {
-      "community": 532,
+      "community": 531,
       "file_type": "code",
       "id": "postransaction_getbaseurl",
       "label": "getBaseUrl()",
@@ -263281,7 +263308,7 @@
       "source_location": "L57"
     },
     {
-      "community": 532,
+      "community": 531,
       "file_type": "code",
       "id": "postransaction_getpostransactionbyreceipttoken",
       "label": "getPosTransactionByReceiptToken()",
@@ -263290,7 +263317,7 @@
       "source_location": "L90"
     },
     {
-      "community": 532,
+      "community": 531,
       "file_type": "code",
       "id": "postransaction_postransactionreceipterror",
       "label": "PosTransactionReceiptError",
@@ -263299,7 +263326,7 @@
       "source_location": "L59"
     },
     {
-      "community": 532,
+      "community": 531,
       "file_type": "code",
       "id": "postransaction_postransactionreceipterror_constructor",
       "label": ".constructor()",
@@ -263308,7 +263335,7 @@
       "source_location": "L62"
     },
     {
-      "community": 533,
+      "community": 532,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_promocodes_ts",
       "label": "promoCodes.ts",
@@ -263317,7 +263344,7 @@
       "source_location": "L1"
     },
     {
-      "community": 533,
+      "community": 532,
       "file_type": "code",
       "id": "promocodes_getbaseurl",
       "label": "getBaseUrl()",
@@ -263326,7 +263353,7 @@
       "source_location": "L4"
     },
     {
-      "community": 533,
+      "community": 532,
       "file_type": "code",
       "id": "promocodes_getpromocodeitems",
       "label": "getPromoCodeItems()",
@@ -263335,7 +263362,7 @@
       "source_location": "L49"
     },
     {
-      "community": 533,
+      "community": 532,
       "file_type": "code",
       "id": "promocodes_getpromocodes",
       "label": "getPromoCodes()",
@@ -263344,7 +263371,7 @@
       "source_location": "L34"
     },
     {
-      "community": 533,
+      "community": 532,
       "file_type": "code",
       "id": "promocodes_getredeemedpromocodes",
       "label": "getRedeemedPromoCodes()",
@@ -263353,7 +263380,7 @@
       "source_location": "L74"
     },
     {
-      "community": 533,
+      "community": 532,
       "file_type": "code",
       "id": "promocodes_redeempromocode",
       "label": "redeemPromoCode()",
@@ -263362,7 +263389,7 @@
       "source_location": "L6"
     },
     {
-      "community": 534,
+      "community": 533,
       "file_type": "code",
       "id": "billingdetails_clearform",
       "label": "clearForm()",
@@ -263371,7 +263398,7 @@
       "source_location": "L173"
     },
     {
-      "community": 534,
+      "community": 533,
       "file_type": "code",
       "id": "billingdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -263380,7 +263407,7 @@
       "source_location": "L102"
     },
     {
-      "community": 534,
+      "community": 533,
       "file_type": "code",
       "id": "billingdetails_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -263389,7 +263416,7 @@
       "source_location": "L201"
     },
     {
-      "community": 534,
+      "community": 533,
       "file_type": "code",
       "id": "billingdetails_onsubmit",
       "label": "onSubmit()",
@@ -263398,7 +263425,7 @@
       "source_location": "L150"
     },
     {
-      "community": 534,
+      "community": 533,
       "file_type": "code",
       "id": "billingdetails_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -263407,7 +263434,7 @@
       "source_location": "L155"
     },
     {
-      "community": 534,
+      "community": 533,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
       "label": "BillingDetails.tsx",
@@ -263416,7 +263443,7 @@
       "source_location": "L1"
     },
     {
-      "community": 535,
+      "community": 534,
       "file_type": "code",
       "id": "homehero_test_attachmedia",
       "label": "attachMedia()",
@@ -263425,7 +263452,7 @@
       "source_location": "L22"
     },
     {
-      "community": 535,
+      "community": 534,
       "file_type": "code",
       "id": "homehero_test_destroy",
       "label": "destroy()",
@@ -263434,7 +263461,7 @@
       "source_location": "L24"
     },
     {
-      "community": 535,
+      "community": 534,
       "file_type": "code",
       "id": "homehero_test_issupported",
       "label": "isSupported()",
@@ -263443,7 +263470,7 @@
       "source_location": "L18"
     },
     {
-      "community": 535,
+      "community": 534,
       "file_type": "code",
       "id": "homehero_test_loadsource",
       "label": "loadSource()",
@@ -263452,7 +263479,7 @@
       "source_location": "L21"
     },
     {
-      "community": 535,
+      "community": 534,
       "file_type": "code",
       "id": "homehero_test_on",
       "label": "on()",
@@ -263461,7 +263488,7 @@
       "source_location": "L23"
     },
     {
-      "community": 535,
+      "community": 534,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homehero_test_tsx",
       "label": "HomeHero.test.tsx",
@@ -263470,7 +263497,7 @@
       "source_location": "L1"
     },
     {
-      "community": 536,
+      "community": 535,
       "file_type": "code",
       "id": "mobileproductactions_collapseonpageclick",
       "label": "collapseOnPageClick()",
@@ -263479,7 +263506,7 @@
       "source_location": "L76"
     },
     {
-      "community": 536,
+      "community": 535,
       "file_type": "code",
       "id": "mobileproductactions_handleconfirm",
       "label": "handleConfirm()",
@@ -263488,7 +263515,7 @@
       "source_location": "L120"
     },
     {
-      "community": 536,
+      "community": 535,
       "file_type": "code",
       "id": "mobileproductactions_handleprimaryaction",
       "label": "handlePrimaryAction()",
@@ -263497,7 +263524,7 @@
       "source_location": "L129"
     },
     {
-      "community": 536,
+      "community": 535,
       "file_type": "code",
       "id": "mobileproductactions_handlesecondaryaction",
       "label": "handleSecondaryAction()",
@@ -263506,7 +263533,7 @@
       "source_location": "L133"
     },
     {
-      "community": 536,
+      "community": 535,
       "file_type": "code",
       "id": "mobileproductactions_updateposition",
       "label": "updatePosition()",
@@ -263515,7 +263542,7 @@
       "source_location": "L44"
     },
     {
-      "community": 536,
+      "community": 535,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
       "label": "MobileProductActions.tsx",
@@ -263524,7 +263551,7 @@
       "source_location": "L1"
     },
     {
-      "community": 537,
+      "community": 536,
       "file_type": "code",
       "id": "checkoutexpired_checkoutexpired",
       "label": "CheckoutExpired()",
@@ -263533,7 +263560,7 @@
       "source_location": "L9"
     },
     {
-      "community": 537,
+      "community": 536,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessiongeneric",
       "label": "CheckoutSessionGeneric()",
@@ -263542,7 +263569,7 @@
       "source_location": "L73"
     },
     {
-      "community": 537,
+      "community": 536,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessionnotfound",
       "label": "CheckoutSessionNotFound()",
@@ -263551,7 +263578,7 @@
       "source_location": "L54"
     },
     {
-      "community": 537,
+      "community": 536,
       "file_type": "code",
       "id": "checkoutexpired_handlesendemail",
       "label": "handleSendEmail()",
@@ -263560,7 +263587,7 @@
       "source_location": "L98"
     },
     {
-      "community": 537,
+      "community": 536,
       "file_type": "code",
       "id": "checkoutexpired_nocheckoutsession",
       "label": "NoCheckoutSession()",
@@ -263569,12 +263596,66 @@
       "source_location": "L33"
     },
     {
-      "community": 537,
+      "community": 536,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
       "label": "CheckoutExpired.tsx",
       "norm_label": "checkoutexpired.tsx",
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 537,
+      "file_type": "code",
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L101"
+    },
+    {
+      "community": 537,
+      "file_type": "code",
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 537,
+      "file_type": "code",
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 537,
+      "file_type": "code",
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 537,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 537,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1"
     },
     {

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -9947,7 +9947,7 @@
       "relation": "calls",
       "source": "dailyclose_buildapprovalrequestsbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2917",
+      "source_location": "L2924",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -9959,7 +9959,7 @@
       "relation": "calls",
       "source": "dailyclose_buildcompletedonlineordertotals",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2851",
+      "source_location": "L2858",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -9971,7 +9971,7 @@
       "relation": "calls",
       "source": "dailyclose_buildexpensesessionsbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2972",
+      "source_location": "L2979",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -9983,7 +9983,7 @@
       "relation": "calls",
       "source": "dailyclose_buildexpensetransactionitemcountsbytransactionid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2864",
+      "source_location": "L2871",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -9995,7 +9995,7 @@
       "relation": "calls",
       "source": "dailyclose_buildreadiness",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3720",
+      "source_location": "L3727",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10007,7 +10007,7 @@
       "relation": "calls",
       "source": "dailyclose_buildregistersessionsbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2965",
+      "source_location": "L2972",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10019,7 +10019,7 @@
       "relation": "calls",
       "source": "dailyclose_buildstaffnamesbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2780",
+      "source_location": "L2787",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10031,7 +10031,7 @@
       "relation": "calls",
       "source": "dailyclose_buildterminallabelsbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2987",
+      "source_location": "L2994",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10043,7 +10043,7 @@
       "relation": "calls",
       "source": "dailyclose_buildtransactionitemcountsbytransactionid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2859",
+      "source_location": "L2866",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10055,7 +10055,7 @@
       "relation": "calls",
       "source": "dailyclose_cashdeltasbyregistersessionid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2962",
+      "source_location": "L2969",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10067,7 +10067,7 @@
       "relation": "calls",
       "source": "dailyclose_completesourcecompleteness",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2758",
+      "source_location": "L2765",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10079,7 +10079,7 @@
       "relation": "calls",
       "source": "dailyclose_emptysummary",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2752",
+      "source_location": "L2759",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10091,7 +10091,7 @@
       "relation": "calls",
       "source": "dailyclose_filterregistersessionsbelongingtorange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2905",
+      "source_location": "L2912",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10103,7 +10103,7 @@
       "relation": "calls",
       "source": "dailyclose_frozensyncedsaleinventoryreviewgroups",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3802",
+      "source_location": "L3809",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10115,7 +10115,7 @@
       "relation": "calls",
       "source": "dailyclose_getdailyclosecompletioneventstaffprofileid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2776",
+      "source_location": "L2783",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10127,7 +10127,7 @@
       "relation": "calls",
       "source": "dailyclose_getdailyclosefordate",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2771",
+      "source_location": "L2778",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10139,7 +10139,7 @@
       "relation": "calls",
       "source": "dailyclose_getpriorcompleteddailyclose",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2783",
+      "source_location": "L2790",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10151,7 +10151,7 @@
       "relation": "calls",
       "source": "dailyclose_getstore",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2708",
+      "source_location": "L2715",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10163,7 +10163,7 @@
       "relation": "calls",
       "source": "dailyclose_listactiveoversizedoperationalworkrepairs",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2826",
+      "source_location": "L2833",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10175,7 +10175,7 @@
       "relation": "calls",
       "source": "dailyclose_listcompletedonlineordersforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2832",
+      "source_location": "L2839",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10187,7 +10187,7 @@
       "relation": "calls",
       "source": "dailyclose_listdepositsforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2846",
+      "source_location": "L2853",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10199,7 +10199,7 @@
       "relation": "calls",
       "source": "dailyclose_listexpensesforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2845",
+      "source_location": "L2852",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10211,7 +10211,7 @@
       "relation": "calls",
       "source": "dailyclose_listopenoperationalworkitems",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2825",
+      "source_location": "L2832",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10223,7 +10223,7 @@
       "relation": "calls",
       "source": "dailyclose_listopenpossessions",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2824",
+      "source_location": "L2831",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10235,7 +10235,7 @@
       "relation": "calls",
       "source": "dailyclose_listpendingcloseoutapprovals",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2823",
+      "source_location": "L2830",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10247,7 +10247,7 @@
       "relation": "calls",
       "source": "dailyclose_listregistersessionsfordailyclose",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2818",
+      "source_location": "L2825",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10259,7 +10259,7 @@
       "relation": "calls",
       "source": "dailyclose_listtransactionsforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2827",
+      "source_location": "L2834",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10271,7 +10271,7 @@
       "relation": "calls",
       "source": "dailyclose_mayberedactdailyclosesnapshotforbroadview",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2794",
+      "source_location": "L2801",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10283,7 +10283,7 @@
       "relation": "calls",
       "source": "dailyclose_mergesourcecompleteness",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2889",
+      "source_location": "L2896",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10295,7 +10295,7 @@
       "relation": "calls",
       "source": "dailyclose_normalizecompleteddailyclosesnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2784",
+      "source_location": "L2791",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10307,7 +10307,7 @@
       "relation": "calls",
       "source": "dailyclose_normalizedailyclosesummary",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3791",
+      "source_location": "L3798",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10319,7 +10319,7 @@
       "relation": "calls",
       "source": "dailyclose_resolveoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2707",
+      "source_location": "L2714",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10331,7 +10331,7 @@
       "relation": "calls",
       "source": "dailyclose_sortdailycloseblockers",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3719",
+      "source_location": "L3726",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10343,7 +10343,7 @@
       "relation": "calls",
       "source": "dailyclose_uniquesourcesubjects",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3808",
+      "source_location": "L3815",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -10367,7 +10367,7 @@
       "relation": "calls",
       "source": "dailyclose_stringfrommetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3913",
+      "source_location": "L3920",
       "target": "dailyclose_carryforwardbusinessdate",
       "weight": 1
     },
@@ -10379,7 +10379,7 @@
       "relation": "calls",
       "source": "dailyclose_carryforwardbusinessdate",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3945",
+      "source_location": "L3952",
       "target": "dailyclose_carryforwardmetadatamatches",
       "weight": 1
     },
@@ -10391,7 +10391,7 @@
       "relation": "calls",
       "source": "dailyclose_carryforwardsourceid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3946",
+      "source_location": "L3953",
       "target": "dailyclose_carryforwardmetadatamatches",
       "weight": 1
     },
@@ -10403,7 +10403,7 @@
       "relation": "calls",
       "source": "dailyclose_stringfrommetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3922",
+      "source_location": "L3929",
       "target": "dailyclose_carryforwardsourceid",
       "weight": 1
     },
@@ -10415,7 +10415,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosereportsnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4888",
+      "source_location": "L4895",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10427,7 +10427,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosesnapshotwithctx",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4683",
+      "source_location": "L4690",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10439,7 +10439,7 @@
       "relation": "calls",
       "source": "dailyclose_completionblockingincompletesources",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4750",
+      "source_location": "L4757",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10451,7 +10451,7 @@
       "relation": "calls",
       "source": "dailyclose_getnonactivedailyclosefordate",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4715",
+      "source_location": "L4722",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10463,7 +10463,7 @@
       "relation": "calls",
       "source": "dailyclose_getstore",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4658",
+      "source_location": "L4665",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10475,7 +10475,7 @@
       "relation": "calls",
       "source": "dailyclose_hasincompleteoperationalwork",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4804",
+      "source_location": "L4811",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10487,7 +10487,7 @@
       "relation": "calls",
       "source": "dailyclose_logicalcarryforwardselectioncount",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4839",
+      "source_location": "L4846",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10499,7 +10499,7 @@
       "relation": "calls",
       "source": "dailyclose_markotherdailyclosesnotcurrent",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4919",
+      "source_location": "L4926",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10511,7 +10511,7 @@
       "relation": "calls",
       "source": "dailyclose_observedincompleteoperationalworkitemids",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4807",
+      "source_location": "L4814",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10523,7 +10523,7 @@
       "relation": "calls",
       "source": "dailyclose_patchdailyclosecarryforwardworkitemmetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4949",
+      "source_location": "L4956",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10535,7 +10535,7 @@
       "relation": "calls",
       "source": "dailyclose_recorddailyclosecompletedevent",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4955",
+      "source_location": "L4962",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10547,7 +10547,7 @@
       "relation": "calls",
       "source": "dailyclose_recorddailyclosecompletedreportfacts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4944",
+      "source_location": "L4951",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10559,7 +10559,7 @@
       "relation": "calls",
       "source": "dailyclose_resolveoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4674",
+      "source_location": "L4681",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10571,7 +10571,7 @@
       "relation": "calls",
       "source": "dailyclose_validateautomationcarryforwardworkitems",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4822",
+      "source_location": "L4829",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10583,7 +10583,7 @@
       "relation": "calls",
       "source": "dailyclose_validatecarryforwardworkitemids",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4805",
+      "source_location": "L4812",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -10595,7 +10595,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosereportsnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4543",
+      "source_location": "L4550",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10607,7 +10607,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosesnapshotwithctx",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4365",
+      "source_location": "L4372",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10619,7 +10619,7 @@
       "relation": "calls",
       "source": "dailyclose_completionblockingincompletesources",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4388",
+      "source_location": "L4395",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10631,7 +10631,7 @@
       "relation": "calls",
       "source": "dailyclose_createcarryforwardworkitems",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4462",
+      "source_location": "L4469",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10643,7 +10643,7 @@
       "relation": "calls",
       "source": "dailyclose_getstore",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4340",
+      "source_location": "L4347",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10655,7 +10655,7 @@
       "relation": "calls",
       "source": "dailyclose_hasincompleteoperationalwork",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4504",
+      "source_location": "L4511",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10667,7 +10667,7 @@
       "relation": "calls",
       "source": "dailyclose_logicalcarryforwardselectioncount",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4500",
+      "source_location": "L4507",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10679,7 +10679,7 @@
       "relation": "calls",
       "source": "dailyclose_markotherdailyclosesnotcurrent",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4576",
+      "source_location": "L4583",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10691,7 +10691,7 @@
       "relation": "calls",
       "source": "dailyclose_observedincompleteoperationalworkitemids",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4488",
+      "source_location": "L4495",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10703,7 +10703,7 @@
       "relation": "calls",
       "source": "dailyclose_patchdailyclosecarryforwardworkitemmetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4605",
+      "source_location": "L4612",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10715,7 +10715,7 @@
       "relation": "calls",
       "source": "dailyclose_recorddailyclosecompletedevent",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4611",
+      "source_location": "L4618",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10727,7 +10727,7 @@
       "relation": "calls",
       "source": "dailyclose_recorddailyclosecompletedreportfacts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4600",
+      "source_location": "L4607",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10739,7 +10739,7 @@
       "relation": "calls",
       "source": "dailyclose_resolveoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4356",
+      "source_location": "L4363",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10751,7 +10751,7 @@
       "relation": "calls",
       "source": "dailyclose_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4499",
+      "source_location": "L4506",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10763,7 +10763,7 @@
       "relation": "calls",
       "source": "dailyclose_uniqueoperationalworkitemids",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4408",
+      "source_location": "L4415",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10775,7 +10775,7 @@
       "relation": "calls",
       "source": "dailyclose_validatecarryforwardworkitemids",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4425",
+      "source_location": "L4432",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10787,7 +10787,7 @@
       "relation": "calls",
       "source": "dailyclose_validateselectedcarryforwardgroups",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4411",
+      "source_location": "L4418",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -10799,7 +10799,7 @@
       "relation": "calls",
       "source": "dailyclose_incompletesourcecompletenessentries",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2412",
+      "source_location": "L2419",
       "target": "dailyclose_completionblockingincompletesources",
       "weight": 1
     },
@@ -10811,7 +10811,7 @@
       "relation": "calls",
       "source": "dailyclose_findcurrentcarryforwardworkitembysource",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4101",
+      "source_location": "L4108",
       "target": "dailyclose_createcarryforwardworkitems",
       "weight": 1
     },
@@ -10823,7 +10823,7 @@
       "relation": "calls",
       "source": "dailyclose_sourceidfromcarryforwardinput",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4098",
+      "source_location": "L4105",
       "target": "dailyclose_createcarryforwardworkitems",
       "weight": 1
     },
@@ -10835,7 +10835,7 @@
       "relation": "calls",
       "source": "dailyclose_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4089",
+      "source_location": "L4096",
       "target": "dailyclose_createcarryforwardworkitems",
       "weight": 1
     },
@@ -10859,7 +10859,7 @@
       "relation": "calls",
       "source": "dailyclose_buildstaffnamesbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5643",
+      "source_location": "L5650",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -10871,7 +10871,7 @@
       "relation": "calls",
       "source": "dailyclose_completionattributionfordailyclose",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5646",
+      "source_location": "L5653",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -10883,7 +10883,7 @@
       "relation": "calls",
       "source": "dailyclose_getdailyclosecompletioneventstaffprofileid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5639",
+      "source_location": "L5646",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -10895,7 +10895,7 @@
       "relation": "calls",
       "source": "dailyclose_redactdailyclosereportsnapshotforbroadview",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5669",
+      "source_location": "L5676",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -10907,20 +10907,8 @@
       "relation": "calls",
       "source": "dailyclose_getpriorcompleteddailyclose",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5511",
+      "source_location": "L5518",
       "target": "dailyclose_getdailycloseopeningcontextwithctx",
-      "weight": 1
-    },
-    {
-      "_src": "dailyclose_hasincompleteoperationalwork",
-      "_tgt": "dailyclose_incompletesourcecompletenessentries",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "calls",
-      "source": "dailyclose_incompletesourcecompletenessentries",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2418",
-      "target": "dailyclose_hasincompleteoperationalwork",
       "weight": 1
     },
     {
@@ -10943,7 +10931,7 @@
       "relation": "calls",
       "source": "dailyclose_buildstaffnamesbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5599",
+      "source_location": "L5606",
       "target": "dailyclose_listcompleteddailyclosehistorywithctx",
       "weight": 1
     },
@@ -11075,7 +11063,7 @@
       "relation": "calls",
       "source": "dailyclose_mayberedactdailyclosesnapshotforbroadview",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2589",
+      "source_location": "L2596",
       "target": "dailyclose_emptysummary",
       "weight": 1
     },
@@ -11087,7 +11075,7 @@
       "relation": "calls",
       "source": "dailyclose_redactdailyclosesummaryforbroadview",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2590",
+      "source_location": "L2597",
       "target": "dailyclose_mayberedactdailyclosesnapshotforbroadview",
       "weight": 1
     },
@@ -11219,7 +11207,7 @@
       "relation": "calls",
       "source": "dailyclose_markreportdaydirty",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4328",
+      "source_location": "L4335",
       "target": "dailyclose_recorddailyclosecompletedreportfacts",
       "weight": 1
     },
@@ -11231,7 +11219,7 @@
       "relation": "calls",
       "source": "dailyclose_redactdailyclosesummaryforbroadview",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2549",
+      "source_location": "L2556",
       "target": "dailyclose_redactdailyclosereportsnapshotforbroadview",
       "weight": 1
     },
@@ -11243,7 +11231,7 @@
       "relation": "calls",
       "source": "dailyclose_normalizedailyclosesummary",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2512",
+      "source_location": "L2519",
       "target": "dailyclose_redactdailyclosesummaryforbroadview",
       "weight": 1
     },
@@ -11303,7 +11291,7 @@
       "relation": "calls",
       "source": "dailyclose_markotherdailyclosesnotcurrent",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5439",
+      "source_location": "L5446",
       "target": "dailyclose_reopendailyclosewithctx",
       "weight": 1
     },
@@ -11315,7 +11303,7 @@
       "relation": "calls",
       "source": "dailyclose_markreportdaydirty",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5490",
+      "source_location": "L5497",
       "target": "dailyclose_reopendailyclosewithctx",
       "weight": 1
     },
@@ -11327,7 +11315,7 @@
       "relation": "calls",
       "source": "dailyclose_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5276",
+      "source_location": "L5283",
       "target": "dailyclose_reopendailyclosewithctx",
       "weight": 1
     },
@@ -11339,7 +11327,7 @@
       "relation": "calls",
       "source": "dailyclose_carryforwardbusinessdate",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5094",
+      "source_location": "L5101",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -11351,7 +11339,7 @@
       "relation": "calls",
       "source": "dailyclose_carryforwardresolutionvalidationerror",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5051",
+      "source_location": "L5058",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -11363,7 +11351,7 @@
       "relation": "calls",
       "source": "dailyclose_carryforwardsourceid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5121",
+      "source_location": "L5128",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -11375,7 +11363,7 @@
       "relation": "calls",
       "source": "dailyclose_getstore",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5025",
+      "source_location": "L5032",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -11387,7 +11375,7 @@
       "relation": "calls",
       "source": "dailyclose_listdailyopeninghandoffsforcarryforward",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5166",
+      "source_location": "L5173",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -11399,7 +11387,7 @@
       "relation": "calls",
       "source": "dailyclose_stringfrommetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5103",
+      "source_location": "L5110",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -11411,7 +11399,7 @@
       "relation": "calls",
       "source": "dailyclose_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5016",
+      "source_location": "L5023",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -11447,7 +11435,7 @@
       "relation": "calls",
       "source": "dailyclose_stringfrommetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3934",
+      "source_location": "L3941",
       "target": "dailyclose_sourceidfromcarryforwardinput",
       "weight": 1
     },
@@ -11471,7 +11459,7 @@
       "relation": "calls",
       "source": "dailyclose_completionattributionfordailyclose",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2602",
+      "source_location": "L2609",
       "target": "dailyclose_todailyclosehistorylistitem",
       "weight": 1
     },
@@ -11483,7 +11471,7 @@
       "relation": "calls",
       "source": "dailyclose_redactdailyclosesummaryforbroadview",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2631",
+      "source_location": "L2638",
       "target": "dailyclose_todailyclosehistorylistitem",
       "weight": 1
     },
@@ -14087,7 +14075,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_eodpolicycompletionatforstoreday",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1646",
+      "source_location": "L1649",
       "target": "dailyoperationsautomation_configuredeodautocompletestoredaycontext",
       "weight": 1
     },
@@ -14099,7 +14087,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_openingpolicystartatforstoreday",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1601",
+      "source_location": "L1604",
       "target": "dailyoperationsautomation_configuredopeningoperatingdate",
       "weight": 1
     },
@@ -14111,7 +14099,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_sourcesubjectsorstoreday",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L455",
+      "source_location": "L456",
       "target": "dailyoperationsautomation_eodautocompletedecision",
       "weight": 1
     },
@@ -14123,7 +14111,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_localdateforpolicy",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1773",
+      "source_location": "L1776",
       "target": "dailyoperationsautomation_eodautocompletepolicycronwindow",
       "weight": 1
     },
@@ -14135,7 +14123,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_localdateforpolicy",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1702",
+      "source_location": "L1705",
       "target": "dailyoperationsautomation_eodautocompletetiming",
       "weight": 1
     },
@@ -14147,7 +14135,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_scheduleevidenceforstoredaycontext",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1695",
+      "source_location": "L1698",
       "target": "dailyoperationsautomation_eodautocompletetiming",
       "weight": 1
     },
@@ -14159,7 +14147,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_sourcesubjectsorstoreday",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L400",
+      "source_location": "L401",
       "target": "dailyoperationsautomation_eoddecision",
       "weight": 1
     },
@@ -14171,7 +14159,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_eodlocalcompletionwindowminutesforpolicy",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1573",
+      "source_location": "L1576",
       "target": "dailyoperationsautomation_eodpolicycompletionatforstoreday",
       "weight": 1
     },
@@ -14183,7 +14171,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_normalizedpolicyoffsetfromschedulestart",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1572",
+      "source_location": "L1575",
       "target": "dailyoperationsautomation_eodpolicycompletionatforstoreday",
       "weight": 1
     },
@@ -14195,7 +14183,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_requireautomationpolicyreadaccess",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L249",
+      "source_location": "L250",
       "target": "dailyoperationsautomation_geteodautocompletepolicyforapi",
       "weight": 1
     },
@@ -14207,7 +14195,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_summarizeautomationrun",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L304",
+      "source_location": "L305",
       "target": "dailyoperationsautomation_getlatestdailyoperationsautomationstatuswithctx",
       "weight": 1
     },
@@ -14219,7 +14207,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_requireautomationpolicyreadaccess",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L227",
+      "source_location": "L228",
       "target": "dailyoperationsautomation_getopeningautostartpolicyforapi",
       "weight": 1
     },
@@ -14231,7 +14219,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_toapiopeningblockerhandling",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L234",
+      "source_location": "L235",
       "target": "dailyoperationsautomation_getopeningautostartpolicyforapi",
       "weight": 1
     },
@@ -14243,7 +14231,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_policyevidenceforhistoricrun",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L930",
+      "source_location": "L931",
       "target": "dailyoperationsautomation_historicquarantineevidence",
       "weight": 1
     },
@@ -14255,7 +14243,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_sourcesubjectsorstoreday",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L344",
+      "source_location": "L345",
       "target": "dailyoperationsautomation_openingdecision",
       "weight": 1
     },
@@ -14267,7 +14255,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_localdateforpolicy",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1465",
+      "source_location": "L1468",
       "target": "dailyoperationsautomation_openingpolicycronwindow",
       "weight": 1
     },
@@ -14279,7 +14267,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_normalizedpolicyoffsetfromschedulestart",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1553",
+      "source_location": "L1556",
       "target": "dailyoperationsautomation_openingpolicystartatforstoreday",
       "weight": 1
     },
@@ -14291,7 +14279,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_openinglocalstartminutesforpolicy",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1554",
+      "source_location": "L1557",
       "target": "dailyoperationsautomation_openingpolicystartatforstoreday",
       "weight": 1
     },
@@ -14303,7 +14291,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_operatingdateforpolicy",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1436",
+      "source_location": "L1439",
       "target": "dailyoperationsautomation_localdateforpolicy",
       "weight": 1
     },
@@ -14315,7 +14303,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_automationidempotencykey",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L732",
+      "source_location": "L733",
       "target": "dailyoperationsautomation_preparedailycloseautomationwithctx",
       "weight": 1
     },
@@ -14327,7 +14315,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_eoddecision",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L731",
+      "source_location": "L732",
       "target": "dailyoperationsautomation_preparedailycloseautomationwithctx",
       "weight": 1
     },
@@ -14339,7 +14327,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_automationerrormessage",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1828",
+      "source_location": "L1831",
       "target": "dailyoperationsautomation_recordconfiguredautomationfailurewithctx",
       "weight": 1
     },
@@ -14351,7 +14339,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_historiceodautocloseidempotencykey",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L958",
+      "source_location": "L959",
       "target": "dailyoperationsautomation_recordhistoriceodquarantinewithctx",
       "weight": 1
     },
@@ -14363,7 +14351,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_historicquarantineevidence",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L948",
+      "source_location": "L949",
       "target": "dailyoperationsautomation_recordhistoriceodquarantinewithctx",
       "weight": 1
     },
@@ -14375,7 +14363,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_listconfiguredautomationpolicies",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1990",
+      "source_location": "L1993",
       "target": "dailyoperationsautomation_runconfigureddailyoperationsautomationwithctx",
       "weight": 1
     },
@@ -14387,7 +14375,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_recordconfiguredautomationfailurewithctx",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1867",
+      "source_location": "L1870",
       "target": "dailyoperationsautomation_runconfiguredpolicysafely",
       "weight": 1
     },
@@ -14399,7 +14387,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_automationidempotencykey",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L844",
+      "source_location": "L845",
       "target": "dailyoperationsautomation_rundailycloseautocompleteeligibilitywithctx",
       "weight": 1
     },
@@ -14411,7 +14399,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_eodautocompletedecision",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L760",
+      "source_location": "L761",
       "target": "dailyoperationsautomation_rundailycloseautocompleteeligibilitywithctx",
       "weight": 1
     },
@@ -14423,7 +14411,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_rundailycloseautocompleteeligibilitywithctx",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L775",
+      "source_location": "L776",
       "target": "dailyoperationsautomation_eodautocompletetiming",
       "weight": 1
     },
@@ -14435,7 +14423,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_rundailycloseautocompleteeligibilitywithctx",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L769",
+      "source_location": "L770",
       "target": "dailyoperationsautomation_scheduleevidenceforstoredaycontext",
       "weight": 1
     },
@@ -14447,7 +14435,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_automationidempotencykey",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L706",
+      "source_location": "L707",
       "target": "dailyoperationsautomation_rundailyopeningautomationwithctx",
       "weight": 1
     },
@@ -14459,7 +14447,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_openingdecision",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L658",
+      "source_location": "L659",
       "target": "dailyoperationsautomation_rundailyopeningautomationwithctx",
       "weight": 1
     },
@@ -14471,7 +14459,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_adddaystooperatingdate",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L2289",
+      "source_location": "L2292",
       "target": "dailyoperationsautomation_runhistoriceodautoclosebatchactionwithctx",
       "weight": 1
     },
@@ -14483,7 +14471,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_isvalidoperatingdate",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L2248",
+      "source_location": "L2251",
       "target": "dailyoperationsautomation_runhistoriceodautoclosebatchactionwithctx",
       "weight": 1
     },
@@ -14495,7 +14483,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_summarizehistoriceodautoclosebatch",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L2292",
+      "source_location": "L2295",
       "target": "dailyoperationsautomation_runhistoriceodautoclosebatchactionwithctx",
       "weight": 1
     },
@@ -14507,7 +14495,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_adddaystooperatingdate",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1396",
+      "source_location": "L1399",
       "target": "dailyoperationsautomation_runhistoriceodautoclosebatchwithctx",
       "weight": 1
     },
@@ -14519,7 +14507,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_isvalidoperatingdate",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1359",
+      "source_location": "L1362",
       "target": "dailyoperationsautomation_runhistoriceodautoclosebatchwithctx",
       "weight": 1
     },
@@ -14531,7 +14519,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_runhistoriceodautoclosefordatewithctx",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1388",
+      "source_location": "L1391",
       "target": "dailyoperationsautomation_runhistoriceodautoclosebatchwithctx",
       "weight": 1
     },
@@ -14543,7 +14531,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_runhistoriceodautoclosebatchwithctx",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1399",
+      "source_location": "L1402",
       "target": "dailyoperationsautomation_summarizehistoriceodautoclosebatch",
       "weight": 1
     },
@@ -14555,7 +14543,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_eodautocompletedecision",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1208",
+      "source_location": "L1211",
       "target": "dailyoperationsautomation_runhistoriceodautoclosefordatewithctx",
       "weight": 1
     },
@@ -14567,7 +14555,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_historiceodautocloseidempotencykey",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1079",
+      "source_location": "L1080",
       "target": "dailyoperationsautomation_runhistoriceodautoclosefordatewithctx",
       "weight": 1
     },
@@ -14579,7 +14567,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_isvalidoperatingdate",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1112",
+      "source_location": "L1113",
       "target": "dailyoperationsautomation_runhistoriceodautoclosefordatewithctx",
       "weight": 1
     },
@@ -14591,7 +14579,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_recordhistoriceodquarantinewithctx",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1113",
+      "source_location": "L1114",
       "target": "dailyoperationsautomation_runhistoriceodautoclosefordatewithctx",
       "weight": 1
     },
@@ -14603,7 +14591,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_resolvehistoriceodstorerangefordatewithctx",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1136",
+      "source_location": "L1137",
       "target": "dailyoperationsautomation_runhistoriceodautoclosefordatewithctx",
       "weight": 1
     },
@@ -14615,7 +14603,7 @@
       "relation": "calls",
       "source": "dailyoperationsautomation_listconfiguredautomationpolicies",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1922",
+      "source_location": "L1925",
       "target": "dailyoperationsautomation_runscheduleddailyoperationsautomationwithctx",
       "weight": 1
     },
@@ -34247,7 +34235,7 @@
       "relation": "calls",
       "source": "oweddailyclosesweep_completedoperatingdatesforstore",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L210",
+      "source_location": "L205",
       "target": "oweddailyclosesweep_candidatesforpolicies",
       "weight": 1
     },
@@ -34259,7 +34247,7 @@
       "relation": "calls",
       "source": "oweddailyclosesweep_selectoweddailyclosedates",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L222",
+      "source_location": "L217",
       "target": "oweddailyclosesweep_candidatesforpolicies",
       "weight": 1
     },
@@ -34271,7 +34259,7 @@
       "relation": "calls",
       "source": "oweddailyclosesweep_runoweddailyclosesweepwithctx",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L456",
+      "source_location": "L451",
       "target": "oweddailyclosesweep_daysbetweenoperatingdates",
       "weight": 1
     },
@@ -34283,7 +34271,7 @@
       "relation": "calls",
       "source": "oweddailyclosesweep_selectrotatingoweddailycloseattempt",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L406",
+      "source_location": "L401",
       "target": "oweddailyclosesweep_runoweddailyclosesweepwithctx",
       "weight": 1
     },
@@ -49715,7 +49703,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2695",
+      "source_location": "L2702",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -49811,7 +49799,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3909",
+      "source_location": "L3916",
       "target": "dailyclose_carryforwardbusinessdate",
       "weight": 1
     },
@@ -49823,7 +49811,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3939",
+      "source_location": "L3946",
       "target": "dailyclose_carryforwardmetadatamatches",
       "weight": 1
     },
@@ -49835,7 +49823,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5005",
+      "source_location": "L5012",
       "target": "dailyclose_carryforwardresolutionvalidationerror",
       "weight": 1
     },
@@ -49847,7 +49835,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3918",
+      "source_location": "L3925",
       "target": "dailyclose_carryforwardsourceid",
       "weight": 1
     },
@@ -49859,7 +49847,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3983",
+      "source_location": "L3990",
       "target": "dailyclose_carryforwardworkitemidfromitem",
       "weight": 1
     },
@@ -49895,7 +49883,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4652",
+      "source_location": "L4659",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -49907,7 +49895,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4336",
+      "source_location": "L4343",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -49931,7 +49919,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2423",
+      "source_location": "L2430",
       "target": "dailyclose_completionattributionfordailyclose",
       "weight": 1
     },
@@ -49943,7 +49931,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2411",
+      "source_location": "L2418",
       "target": "dailyclose_completionblockingincompletesources",
       "weight": 1
     },
@@ -49955,7 +49943,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4074",
+      "source_location": "L4081",
       "target": "dailyclose_createcarryforwardworkitems",
       "weight": 1
     },
@@ -49967,7 +49955,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2662",
+      "source_location": "L2669",
       "target": "dailyclose_emptysummary",
       "weight": 1
     },
@@ -49991,7 +49979,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3950",
+      "source_location": "L3957",
       "target": "dailyclose_findcurrentcarryforwardworkitembysource",
       "weight": 1
     },
@@ -50027,7 +50015,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5618",
+      "source_location": "L5625",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -50039,7 +50027,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2635",
+      "source_location": "L2642",
       "target": "dailyclose_getdailyclosecompletioneventstaffprofileid",
       "weight": 1
     },
@@ -50063,7 +50051,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5504",
+      "source_location": "L5511",
       "target": "dailyclose_getdailycloseopeningcontextwithctx",
       "weight": 1
     },
@@ -50075,7 +50063,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4173",
+      "source_location": "L4180",
       "target": "dailyclose_getnonactivedailyclosefordate",
       "weight": 1
     },
@@ -50111,7 +50099,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2417",
+      "source_location": "L2424",
       "target": "dailyclose_hasincompleteoperationalwork",
       "weight": 1
     },
@@ -50153,6 +50141,18 @@
     },
     {
       "_src": "packages_athena_webapp_convex_operations_dailyclose_ts",
+      "_tgt": "dailyclose_istoleratedincompletedailyclosecompletionsource",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L2411",
+      "target": "dailyclose_istoleratedincompletedailyclosecompletionsource",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "_tgt": "dailyclose_isvalidoperatingdaterange",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
@@ -50183,7 +50183,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5565",
+      "source_location": "L5572",
       "target": "dailyclose_listcompleteddailyclosehistorywithctx",
       "weight": 1
     },
@@ -50207,7 +50207,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4976",
+      "source_location": "L4983",
       "target": "dailyclose_listdailyopeninghandoffsforcarryforward",
       "weight": 1
     },
@@ -50303,7 +50303,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3868",
+      "source_location": "L3875",
       "target": "dailyclose_logicalcarryforwardselectioncount",
       "weight": 1
     },
@@ -50327,7 +50327,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4150",
+      "source_location": "L4157",
       "target": "dailyclose_markotherdailyclosesnotcurrent",
       "weight": 1
     },
@@ -50339,7 +50339,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4257",
+      "source_location": "L4264",
       "target": "dailyclose_markreportdaydirty",
       "weight": 1
     },
@@ -50351,7 +50351,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2561",
+      "source_location": "L2568",
       "target": "dailyclose_mayberedactdailyclosesnapshotforbroadview",
       "weight": 1
     },
@@ -50387,7 +50387,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2472",
+      "source_location": "L2479",
       "target": "dailyclose_normalizebroadviewmetadatalabel",
       "weight": 1
     },
@@ -50471,7 +50471,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4196",
+      "source_location": "L4203",
       "target": "dailyclose_recorddailyclosecompletedevent",
       "weight": 1
     },
@@ -50483,7 +50483,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4290",
+      "source_location": "L4297",
       "target": "dailyclose_recorddailyclosecompletedreportfacts",
       "weight": 1
     },
@@ -50495,7 +50495,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2476",
+      "source_location": "L2483",
       "target": "dailyclose_redactdailycloseitemforbroadview",
       "weight": 1
     },
@@ -50507,7 +50507,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5540",
+      "source_location": "L5547",
       "target": "dailyclose_redactdailycloseopeningcontextforbroadview",
       "weight": 1
     },
@@ -50519,7 +50519,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2529",
+      "source_location": "L2536",
       "target": "dailyclose_redactdailyclosereportsnapshotforbroadview",
       "weight": 1
     },
@@ -50531,7 +50531,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2509",
+      "source_location": "L2516",
       "target": "dailyclose_redactdailyclosesummaryforbroadview",
       "weight": 1
     },
@@ -50603,7 +50603,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5272",
+      "source_location": "L5279",
       "target": "dailyclose_reopendailyclosewithctx",
       "weight": 1
     },
@@ -50615,7 +50615,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5012",
+      "source_location": "L5019",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -50687,7 +50687,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3928",
+      "source_location": "L3935",
       "target": "dailyclose_sourceidfromcarryforwardinput",
       "weight": 1
     },
@@ -50699,7 +50699,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3900",
+      "source_location": "L3907",
       "target": "dailyclose_stringfrommetadata",
       "weight": 1
     },
@@ -50711,7 +50711,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2596",
+      "source_location": "L2603",
       "target": "dailyclose_todailyclosehistorylistitem",
       "weight": 1
     },
@@ -50771,7 +50771,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3894",
+      "source_location": "L3901",
       "target": "dailyclose_uniqueoperationalworkitemids",
       "weight": 1
     },
@@ -50795,7 +50795,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3993",
+      "source_location": "L4000",
       "target": "dailyclose_validateautomationcarryforwardworkitems",
       "weight": 1
     },
@@ -50807,7 +50807,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3814",
+      "source_location": "L3821",
       "target": "dailyclose_validatecarryforwardworkitemids",
       "weight": 1
     },
@@ -50819,7 +50819,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3842",
+      "source_location": "L3849",
       "target": "dailyclose_validateselectedcarryforwardgroups",
       "weight": 1
     },
@@ -53351,7 +53351,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L867",
+      "source_location": "L868",
       "target": "dailyoperationsautomation_adddaystooperatingdate",
       "weight": 1
     },
@@ -53363,7 +53363,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L2437",
+      "source_location": "L2440",
       "target": "dailyoperationsautomation_asrecord",
       "weight": 1
     },
@@ -53375,7 +53375,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1809",
+      "source_location": "L1812",
       "target": "dailyoperationsautomation_automationerrormessage",
       "weight": 1
     },
@@ -53387,7 +53387,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L307",
+      "source_location": "L308",
       "target": "dailyoperationsautomation_automationidempotencykey",
       "weight": 1
     },
@@ -53399,7 +53399,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1622",
+      "source_location": "L1625",
       "target": "dailyoperationsautomation_configuredeodautocompletestoredaycontext",
       "weight": 1
     },
@@ -53411,7 +53411,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1582",
+      "source_location": "L1585",
       "target": "dailyoperationsautomation_configuredopeningoperatingdate",
       "weight": 1
     },
@@ -53423,7 +53423,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L2111",
+      "source_location": "L2114",
       "target": "dailyoperationsautomation_dailymanagerreportstatusforeodautocompleteresult",
       "weight": 1
     },
@@ -53435,7 +53435,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L2132",
+      "source_location": "L2135",
       "target": "dailyoperationsautomation_emitdailymanagerreportnotificationsforeodautomationwithctx",
       "weight": 1
     },
@@ -53447,7 +53447,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L439",
+      "source_location": "L440",
       "target": "dailyoperationsautomation_eodautocompletedecision",
       "weight": 1
     },
@@ -53459,7 +53459,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1769",
+      "source_location": "L1772",
       "target": "dailyoperationsautomation_eodautocompletepolicycronwindow",
       "weight": 1
     },
@@ -53471,7 +53471,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1680",
+      "source_location": "L1683",
       "target": "dailyoperationsautomation_eodautocompletetiming",
       "weight": 1
     },
@@ -53483,7 +53483,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L391",
+      "source_location": "L392",
       "target": "dailyoperationsautomation_eoddecision",
       "weight": 1
     },
@@ -53495,7 +53495,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1533",
+      "source_location": "L1536",
       "target": "dailyoperationsautomation_eodlocalcompletionwindowminutesforpolicy",
       "weight": 1
     },
@@ -53507,7 +53507,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1561",
+      "source_location": "L1564",
       "target": "dailyoperationsautomation_eodpolicycompletionatforstoreday",
       "weight": 1
     },
@@ -53519,7 +53519,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L217",
+      "source_location": "L218",
       "target": "dailyoperationsautomation_fromapiopeningblockerhandling",
       "weight": 1
     },
@@ -53531,7 +53531,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L245",
+      "source_location": "L246",
       "target": "dailyoperationsautomation_geteodautocompletepolicyforapi",
       "weight": 1
     },
@@ -53543,7 +53543,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L282",
+      "source_location": "L283",
       "target": "dailyoperationsautomation_getlatestdailyoperationsautomationstatuswithctx",
       "weight": 1
     },
@@ -53555,7 +53555,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L223",
+      "source_location": "L224",
       "target": "dailyoperationsautomation_getopeningautostartpolicyforapi",
       "weight": 1
     },
@@ -53567,7 +53567,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L875",
+      "source_location": "L876",
       "target": "dailyoperationsautomation_historiceodautocloseidempotencykey",
       "weight": 1
     },
@@ -53579,7 +53579,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L895",
+      "source_location": "L896",
       "target": "dailyoperationsautomation_historicquarantineevidence",
       "weight": 1
     },
@@ -53591,7 +53591,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L856",
+      "source_location": "L857",
       "target": "dailyoperationsautomation_isvalidoperatingdate",
       "weight": 1
     },
@@ -53603,7 +53603,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1876",
+      "source_location": "L1879",
       "target": "dailyoperationsautomation_listconfiguredautomationpolicies",
       "weight": 1
     },
@@ -53615,7 +53615,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1441",
+      "source_location": "L1444",
       "target": "dailyoperationsautomation_localdateforpolicy",
       "weight": 1
     },
@@ -53627,7 +53627,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1520",
+      "source_location": "L1523",
       "target": "dailyoperationsautomation_normalizedpolicyoffsetfromschedulestart",
       "weight": 1
     },
@@ -53639,7 +53639,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L430",
+      "source_location": "L431",
       "target": "dailyoperationsautomation_numberfromrecord",
       "weight": 1
     },
@@ -53651,7 +53651,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L332",
+      "source_location": "L333",
       "target": "dailyoperationsautomation_openingdecision",
       "weight": 1
     },
@@ -53663,7 +53663,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1513",
+      "source_location": "L1516",
       "target": "dailyoperationsautomation_openinglocalstartminutesforpolicy",
       "weight": 1
     },
@@ -53675,7 +53675,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1461",
+      "source_location": "L1464",
       "target": "dailyoperationsautomation_openingpolicycronwindow",
       "weight": 1
     },
@@ -53687,7 +53687,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1542",
+      "source_location": "L1545",
       "target": "dailyoperationsautomation_openingpolicystartatforstoreday",
       "weight": 1
     },
@@ -53699,7 +53699,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1432",
+      "source_location": "L1435",
       "target": "dailyoperationsautomation_operatingdateforpolicy",
       "weight": 1
     },
@@ -53711,7 +53711,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L882",
+      "source_location": "L883",
       "target": "dailyoperationsautomation_policyevidenceforhistoricrun",
       "weight": 1
     },
@@ -53723,7 +53723,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L718",
+      "source_location": "L719",
       "target": "dailyoperationsautomation_preparedailycloseautomationwithctx",
       "weight": 1
     },
@@ -53735,7 +53735,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1813",
+      "source_location": "L1816",
       "target": "dailyoperationsautomation_recordconfiguredautomationfailurewithctx",
       "weight": 1
     },
@@ -53747,7 +53747,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L934",
+      "source_location": "L935",
       "target": "dailyoperationsautomation_recordhistoriceodquarantinewithctx",
       "weight": 1
     },
@@ -53759,7 +53759,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L69",
+      "source_location": "L70",
       "target": "dailyoperationsautomation_requireautomationpolicyreadaccess",
       "weight": 1
     },
@@ -53771,7 +53771,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1725",
+      "source_location": "L1728",
       "target": "dailyoperationsautomation_resolveconfiguredstoreschedulecontext",
       "weight": 1
     },
@@ -53783,7 +53783,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L987",
+      "source_location": "L988",
       "target": "dailyoperationsautomation_resolvehistoriceodstorerangefordatewithctx",
       "weight": 1
     },
@@ -53795,7 +53795,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1981",
+      "source_location": "L1984",
       "target": "dailyoperationsautomation_runconfigureddailyoperationsautomationwithctx",
       "weight": 1
     },
@@ -53807,7 +53807,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1853",
+      "source_location": "L1856",
       "target": "dailyoperationsautomation_runconfiguredpolicysafely",
       "weight": 1
     },
@@ -53819,7 +53819,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L744",
+      "source_location": "L745",
       "target": "dailyoperationsautomation_rundailycloseautocompleteeligibilitywithctx",
       "weight": 1
     },
@@ -53831,7 +53831,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L643",
+      "source_location": "L644",
       "target": "dailyoperationsautomation_rundailyopeningautomationwithctx",
       "weight": 1
     },
@@ -53843,7 +53843,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L2236",
+      "source_location": "L2239",
       "target": "dailyoperationsautomation_runhistoriceodautoclosebatchactionwithctx",
       "weight": 1
     },
@@ -53855,7 +53855,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1347",
+      "source_location": "L1350",
       "target": "dailyoperationsautomation_runhistoriceodautoclosebatchwithctx",
       "weight": 1
     },
@@ -53867,7 +53867,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1067",
+      "source_location": "L1068",
       "target": "dailyoperationsautomation_runhistoriceodautoclosefordatewithctx",
       "weight": 1
     },
@@ -53879,7 +53879,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1912",
+      "source_location": "L1915",
       "target": "dailyoperationsautomation_runscheduleddailyoperationsautomationwithctx",
       "weight": 1
     },
@@ -53891,7 +53891,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1661",
+      "source_location": "L1664",
       "target": "dailyoperationsautomation_scheduleevidenceforstoredaycontext",
       "weight": 1
     },
@@ -53903,7 +53903,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L316",
+      "source_location": "L317",
       "target": "dailyoperationsautomation_sourcesubjectsorstoreday",
       "weight": 1
     },
@@ -53915,7 +53915,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L268",
+      "source_location": "L269",
       "target": "dailyoperationsautomation_summarizeautomationrun",
       "weight": 1
     },
@@ -53927,7 +53927,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1405",
+      "source_location": "L1408",
       "target": "dailyoperationsautomation_summarizehistoriceodautoclosebatch",
       "weight": 1
     },
@@ -53939,7 +53939,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyoperationsautomation_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L209",
+      "source_location": "L210",
       "target": "dailyoperationsautomation_toapiopeningblockerhandling",
       "weight": 1
     },
@@ -55451,7 +55451,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.test.ts",
-      "source_location": "L15",
+      "source_location": "L14",
       "target": "oweddailyclosesweep_test_fullwindow",
       "weight": 1
     },
@@ -55463,7 +55463,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L196",
+      "source_location": "L191",
       "target": "oweddailyclosesweep_candidatesforpolicies",
       "weight": 1
     },
@@ -55475,7 +55475,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L171",
+      "source_location": "L166",
       "target": "oweddailyclosesweep_completedoperatingdatesforstore",
       "weight": 1
     },
@@ -55487,7 +55487,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L79",
+      "source_location": "L77",
       "target": "oweddailyclosesweep_dailyclosesweepresultsettled",
       "weight": 1
     },
@@ -55499,7 +55499,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L490",
+      "source_location": "L485",
       "target": "oweddailyclosesweep_daysbetweenoperatingdates",
       "weight": 1
     },
@@ -55511,7 +55511,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L360",
+      "source_location": "L355",
       "target": "oweddailyclosesweep_runoweddailyclosesweepwithctx",
       "weight": 1
     },
@@ -55523,7 +55523,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L117",
+      "source_location": "L115",
       "target": "oweddailyclosesweep_selectoweddailyclosedates",
       "weight": 1
     },
@@ -55535,7 +55535,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L90",
+      "source_location": "L88",
       "target": "oweddailyclosesweep_selectrotatingoweddailycloseattempt",
       "weight": 1
     },
@@ -181621,7 +181621,7 @@
       "label": "buildDailyCloseSnapshotWithCtx()",
       "norm_label": "builddailyclosesnapshotwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2695"
+      "source_location": "L2702"
     },
     {
       "community": 0,
@@ -181693,7 +181693,7 @@
       "label": "carryForwardBusinessDate()",
       "norm_label": "carryforwardbusinessdate()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3909"
+      "source_location": "L3916"
     },
     {
       "community": 0,
@@ -181702,7 +181702,7 @@
       "label": "carryForwardMetadataMatches()",
       "norm_label": "carryforwardmetadatamatches()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3939"
+      "source_location": "L3946"
     },
     {
       "community": 0,
@@ -181711,7 +181711,7 @@
       "label": "carryForwardResolutionValidationError()",
       "norm_label": "carryforwardresolutionvalidationerror()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5005"
+      "source_location": "L5012"
     },
     {
       "community": 0,
@@ -181720,7 +181720,7 @@
       "label": "carryForwardSourceId()",
       "norm_label": "carryforwardsourceid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3918"
+      "source_location": "L3925"
     },
     {
       "community": 0,
@@ -181729,7 +181729,7 @@
       "label": "carryForwardWorkItemIdFromItem()",
       "norm_label": "carryforwardworkitemidfromitem()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3983"
+      "source_location": "L3990"
     },
     {
       "community": 0,
@@ -181756,7 +181756,7 @@
       "label": "completeDailyCloseForAutomationWithCtx()",
       "norm_label": "completedailycloseforautomationwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4652"
+      "source_location": "L4659"
     },
     {
       "community": 0,
@@ -181765,7 +181765,7 @@
       "label": "completeDailyCloseWithCtx()",
       "norm_label": "completedailyclosewithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4336"
+      "source_location": "L4343"
     },
     {
       "community": 0,
@@ -181783,7 +181783,7 @@
       "label": "completionAttributionForDailyClose()",
       "norm_label": "completionattributionfordailyclose()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2423"
+      "source_location": "L2430"
     },
     {
       "community": 0,
@@ -181792,7 +181792,7 @@
       "label": "completionBlockingIncompleteSources()",
       "norm_label": "completionblockingincompletesources()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2411"
+      "source_location": "L2418"
     },
     {
       "community": 0,
@@ -181801,7 +181801,7 @@
       "label": "createCarryForwardWorkItems()",
       "norm_label": "createcarryforwardworkitems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4074"
+      "source_location": "L4081"
     },
     {
       "community": 0,
@@ -181810,7 +181810,7 @@
       "label": "emptySummary()",
       "norm_label": "emptysummary()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2662"
+      "source_location": "L2669"
     },
     {
       "community": 0,
@@ -181828,7 +181828,7 @@
       "label": "findCurrentCarryForwardWorkItemBySource()",
       "norm_label": "findcurrentcarryforwardworkitembysource()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3950"
+      "source_location": "L3957"
     },
     {
       "community": 0,
@@ -181855,7 +181855,7 @@
       "label": "getCompletedDailyCloseHistoryDetailWithCtx()",
       "norm_label": "getcompleteddailyclosehistorydetailwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5618"
+      "source_location": "L5625"
     },
     {
       "community": 0,
@@ -181864,7 +181864,7 @@
       "label": "getDailyCloseCompletionEventStaffProfileId()",
       "norm_label": "getdailyclosecompletioneventstaffprofileid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2635"
+      "source_location": "L2642"
     },
     {
       "community": 0,
@@ -181882,7 +181882,7 @@
       "label": "getDailyCloseOpeningContextWithCtx()",
       "norm_label": "getdailycloseopeningcontextwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5504"
+      "source_location": "L5511"
     },
     {
       "community": 0,
@@ -181891,7 +181891,7 @@
       "label": "getNonActiveDailyCloseForDate()",
       "norm_label": "getnonactivedailyclosefordate()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4173"
+      "source_location": "L4180"
     },
     {
       "community": 0,
@@ -181918,7 +181918,7 @@
       "label": "hasIncompleteOperationalWork()",
       "norm_label": "hasincompleteoperationalwork()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2417"
+      "source_location": "L2424"
     },
     {
       "community": 0,
@@ -181950,6 +181950,15 @@
     {
       "community": 0,
       "file_type": "code",
+      "id": "dailyclose_istoleratedincompletedailyclosecompletionsource",
+      "label": "isToleratedIncompleteDailyCloseCompletionSource()",
+      "norm_label": "istoleratedincompletedailyclosecompletionsource()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L2411"
+    },
+    {
+      "community": 0,
+      "file_type": "code",
       "id": "dailyclose_isvalidoperatingdaterange",
       "label": "isValidOperatingDateRange()",
       "norm_label": "isvalidoperatingdaterange()",
@@ -181972,7 +181981,7 @@
       "label": "listCompletedDailyCloseHistoryWithCtx()",
       "norm_label": "listcompleteddailyclosehistorywithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5565"
+      "source_location": "L5572"
     },
     {
       "community": 0,
@@ -181990,7 +181999,7 @@
       "label": "listDailyOpeningHandoffsForCarryForward()",
       "norm_label": "listdailyopeninghandoffsforcarryforward()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4976"
+      "source_location": "L4983"
     },
     {
       "community": 0,
@@ -182062,7 +182071,7 @@
       "label": "logicalCarryForwardSelectionCount()",
       "norm_label": "logicalcarryforwardselectioncount()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3868"
+      "source_location": "L3875"
     },
     {
       "community": 0,
@@ -182080,7 +182089,7 @@
       "label": "markOtherDailyClosesNotCurrent()",
       "norm_label": "markotherdailyclosesnotcurrent()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4150"
+      "source_location": "L4157"
     },
     {
       "community": 0,
@@ -182089,7 +182098,7 @@
       "label": "markReportDayDirty()",
       "norm_label": "markreportdaydirty()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4257"
+      "source_location": "L4264"
     },
     {
       "community": 0,
@@ -182098,7 +182107,7 @@
       "label": "maybeRedactDailyCloseSnapshotForBroadView()",
       "norm_label": "mayberedactdailyclosesnapshotforbroadview()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2561"
+      "source_location": "L2568"
     },
     {
       "community": 0,
@@ -182125,7 +182134,7 @@
       "label": "normalizeBroadViewMetadataLabel()",
       "norm_label": "normalizebroadviewmetadatalabel()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2472"
+      "source_location": "L2479"
     },
     {
       "community": 0,
@@ -182188,7 +182197,7 @@
       "label": "recordDailyCloseCompletedEvent()",
       "norm_label": "recorddailyclosecompletedevent()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4196"
+      "source_location": "L4203"
     },
     {
       "community": 0,
@@ -182197,7 +182206,7 @@
       "label": "recordDailyCloseCompletedReportFacts()",
       "norm_label": "recorddailyclosecompletedreportfacts()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4290"
+      "source_location": "L4297"
     },
     {
       "community": 0,
@@ -182206,7 +182215,7 @@
       "label": "redactDailyCloseItemForBroadView()",
       "norm_label": "redactdailycloseitemforbroadview()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2476"
+      "source_location": "L2483"
     },
     {
       "community": 0,
@@ -182215,7 +182224,7 @@
       "label": "redactDailyCloseOpeningContextForBroadView()",
       "norm_label": "redactdailycloseopeningcontextforbroadview()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5540"
+      "source_location": "L5547"
     },
     {
       "community": 0,
@@ -182224,7 +182233,7 @@
       "label": "redactDailyCloseReportSnapshotForBroadView()",
       "norm_label": "redactdailyclosereportsnapshotforbroadview()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2529"
+      "source_location": "L2536"
     },
     {
       "community": 0,
@@ -182233,7 +182242,7 @@
       "label": "redactDailyCloseSummaryForBroadView()",
       "norm_label": "redactdailyclosesummaryforbroadview()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2509"
+      "source_location": "L2516"
     },
     {
       "community": 0,
@@ -182287,7 +182296,7 @@
       "label": "reopenDailyCloseWithCtx()",
       "norm_label": "reopendailyclosewithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5272"
+      "source_location": "L5279"
     },
     {
       "community": 0,
@@ -182296,7 +182305,7 @@
       "label": "resolveDailyCloseCarryForwardWithCtx()",
       "norm_label": "resolvedailyclosecarryforwardwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5012"
+      "source_location": "L5019"
     },
     {
       "community": 0,
@@ -182350,7 +182359,7 @@
       "label": "sourceIdFromCarryForwardInput()",
       "norm_label": "sourceidfromcarryforwardinput()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3928"
+      "source_location": "L3935"
     },
     {
       "community": 0,
@@ -182359,7 +182368,7 @@
       "label": "stringFromMetadata()",
       "norm_label": "stringfrommetadata()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3900"
+      "source_location": "L3907"
     },
     {
       "community": 0,
@@ -182368,7 +182377,7 @@
       "label": "toDailyCloseHistoryListItem()",
       "norm_label": "todailyclosehistorylistitem()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2596"
+      "source_location": "L2603"
     },
     {
       "community": 0,
@@ -182413,7 +182422,7 @@
       "label": "uniqueOperationalWorkItemIds()",
       "norm_label": "uniqueoperationalworkitemids()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3894"
+      "source_location": "L3901"
     },
     {
       "community": 0,
@@ -182431,7 +182440,7 @@
       "label": "validateAutomationCarryForwardWorkItems()",
       "norm_label": "validateautomationcarryforwardworkitems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3993"
+      "source_location": "L4000"
     },
     {
       "community": 0,
@@ -182440,7 +182449,7 @@
       "label": "validateCarryForwardWorkItemIds()",
       "norm_label": "validatecarryforwardworkitemids()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3814"
+      "source_location": "L3821"
     },
     {
       "community": 0,
@@ -182449,7 +182458,7 @@
       "label": "validateSelectedCarryForwardGroups()",
       "norm_label": "validateselectedcarryforwardgroups()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3842"
+      "source_location": "L3849"
     },
     {
       "community": 0,
@@ -183295,7 +183304,7 @@
       "label": "addDaysToOperatingDate()",
       "norm_label": "adddaystooperatingdate()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L867"
+      "source_location": "L868"
     },
     {
       "community": 10,
@@ -183304,7 +183313,7 @@
       "label": "asRecord()",
       "norm_label": "asrecord()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L2437"
+      "source_location": "L2440"
     },
     {
       "community": 10,
@@ -183313,7 +183322,7 @@
       "label": "automationErrorMessage()",
       "norm_label": "automationerrormessage()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1809"
+      "source_location": "L1812"
     },
     {
       "community": 10,
@@ -183322,7 +183331,7 @@
       "label": "automationIdempotencyKey()",
       "norm_label": "automationidempotencykey()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L307"
+      "source_location": "L308"
     },
     {
       "community": 10,
@@ -183331,7 +183340,7 @@
       "label": "configuredEodAutoCompleteStoreDayContext()",
       "norm_label": "configuredeodautocompletestoredaycontext()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1622"
+      "source_location": "L1625"
     },
     {
       "community": 10,
@@ -183340,7 +183349,7 @@
       "label": "configuredOpeningOperatingDate()",
       "norm_label": "configuredopeningoperatingdate()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1582"
+      "source_location": "L1585"
     },
     {
       "community": 10,
@@ -183349,7 +183358,7 @@
       "label": "dailyManagerReportStatusForEodAutoCompleteResult()",
       "norm_label": "dailymanagerreportstatusforeodautocompleteresult()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L2111"
+      "source_location": "L2114"
     },
     {
       "community": 10,
@@ -183358,7 +183367,7 @@
       "label": "emitDailyManagerReportNotificationsForEodAutomationWithCtx()",
       "norm_label": "emitdailymanagerreportnotificationsforeodautomationwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L2132"
+      "source_location": "L2135"
     },
     {
       "community": 10,
@@ -183367,7 +183376,7 @@
       "label": "eodAutoCompleteDecision()",
       "norm_label": "eodautocompletedecision()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L439"
+      "source_location": "L440"
     },
     {
       "community": 10,
@@ -183376,7 +183385,7 @@
       "label": "eodAutoCompletePolicyCronWindow()",
       "norm_label": "eodautocompletepolicycronwindow()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1769"
+      "source_location": "L1772"
     },
     {
       "community": 10,
@@ -183385,7 +183394,7 @@
       "label": "eodAutoCompleteTiming()",
       "norm_label": "eodautocompletetiming()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1680"
+      "source_location": "L1683"
     },
     {
       "community": 10,
@@ -183394,7 +183403,7 @@
       "label": "eodDecision()",
       "norm_label": "eoddecision()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L391"
+      "source_location": "L392"
     },
     {
       "community": 10,
@@ -183403,7 +183412,7 @@
       "label": "eodLocalCompletionWindowMinutesForPolicy()",
       "norm_label": "eodlocalcompletionwindowminutesforpolicy()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1533"
+      "source_location": "L1536"
     },
     {
       "community": 10,
@@ -183412,7 +183421,7 @@
       "label": "eodPolicyCompletionAtForStoreDay()",
       "norm_label": "eodpolicycompletionatforstoreday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1561"
+      "source_location": "L1564"
     },
     {
       "community": 10,
@@ -183421,7 +183430,7 @@
       "label": "fromApiOpeningBlockerHandling()",
       "norm_label": "fromapiopeningblockerhandling()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L217"
+      "source_location": "L218"
     },
     {
       "community": 10,
@@ -183430,7 +183439,7 @@
       "label": "getEodAutoCompletePolicyForApi()",
       "norm_label": "geteodautocompletepolicyforapi()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L245"
+      "source_location": "L246"
     },
     {
       "community": 10,
@@ -183439,7 +183448,7 @@
       "label": "getLatestDailyOperationsAutomationStatusWithCtx()",
       "norm_label": "getlatestdailyoperationsautomationstatuswithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L282"
+      "source_location": "L283"
     },
     {
       "community": 10,
@@ -183448,7 +183457,7 @@
       "label": "getOpeningAutoStartPolicyForApi()",
       "norm_label": "getopeningautostartpolicyforapi()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L223"
+      "source_location": "L224"
     },
     {
       "community": 10,
@@ -183457,7 +183466,7 @@
       "label": "historicEodAutoCloseIdempotencyKey()",
       "norm_label": "historiceodautocloseidempotencykey()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L875"
+      "source_location": "L876"
     },
     {
       "community": 10,
@@ -183466,7 +183475,7 @@
       "label": "historicQuarantineEvidence()",
       "norm_label": "historicquarantineevidence()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L895"
+      "source_location": "L896"
     },
     {
       "community": 10,
@@ -183475,7 +183484,7 @@
       "label": "isValidOperatingDate()",
       "norm_label": "isvalidoperatingdate()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L856"
+      "source_location": "L857"
     },
     {
       "community": 10,
@@ -183484,7 +183493,7 @@
       "label": "listConfiguredAutomationPolicies()",
       "norm_label": "listconfiguredautomationpolicies()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1876"
+      "source_location": "L1879"
     },
     {
       "community": 10,
@@ -183493,7 +183502,7 @@
       "label": "localDateForPolicy()",
       "norm_label": "localdateforpolicy()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1441"
+      "source_location": "L1444"
     },
     {
       "community": 10,
@@ -183502,7 +183511,7 @@
       "label": "normalizedPolicyOffsetFromScheduleStart()",
       "norm_label": "normalizedpolicyoffsetfromschedulestart()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1520"
+      "source_location": "L1523"
     },
     {
       "community": 10,
@@ -183511,7 +183520,7 @@
       "label": "numberFromRecord()",
       "norm_label": "numberfromrecord()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L430"
+      "source_location": "L431"
     },
     {
       "community": 10,
@@ -183520,7 +183529,7 @@
       "label": "openingDecision()",
       "norm_label": "openingdecision()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L332"
+      "source_location": "L333"
     },
     {
       "community": 10,
@@ -183529,7 +183538,7 @@
       "label": "openingLocalStartMinutesForPolicy()",
       "norm_label": "openinglocalstartminutesforpolicy()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1513"
+      "source_location": "L1516"
     },
     {
       "community": 10,
@@ -183538,7 +183547,7 @@
       "label": "openingPolicyCronWindow()",
       "norm_label": "openingpolicycronwindow()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1461"
+      "source_location": "L1464"
     },
     {
       "community": 10,
@@ -183547,7 +183556,7 @@
       "label": "openingPolicyStartAtForStoreDay()",
       "norm_label": "openingpolicystartatforstoreday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1542"
+      "source_location": "L1545"
     },
     {
       "community": 10,
@@ -183556,7 +183565,7 @@
       "label": "operatingDateForPolicy()",
       "norm_label": "operatingdateforpolicy()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1432"
+      "source_location": "L1435"
     },
     {
       "community": 10,
@@ -183565,7 +183574,7 @@
       "label": "policyEvidenceForHistoricRun()",
       "norm_label": "policyevidenceforhistoricrun()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L882"
+      "source_location": "L883"
     },
     {
       "community": 10,
@@ -183574,7 +183583,7 @@
       "label": "prepareDailyCloseAutomationWithCtx()",
       "norm_label": "preparedailycloseautomationwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L718"
+      "source_location": "L719"
     },
     {
       "community": 10,
@@ -183583,7 +183592,7 @@
       "label": "recordConfiguredAutomationFailureWithCtx()",
       "norm_label": "recordconfiguredautomationfailurewithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1813"
+      "source_location": "L1816"
     },
     {
       "community": 10,
@@ -183592,7 +183601,7 @@
       "label": "recordHistoricEodQuarantineWithCtx()",
       "norm_label": "recordhistoriceodquarantinewithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L934"
+      "source_location": "L935"
     },
     {
       "community": 10,
@@ -183601,7 +183610,7 @@
       "label": "requireAutomationPolicyReadAccess()",
       "norm_label": "requireautomationpolicyreadaccess()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L69"
+      "source_location": "L70"
     },
     {
       "community": 10,
@@ -183610,7 +183619,7 @@
       "label": "resolveConfiguredStoreScheduleContext()",
       "norm_label": "resolveconfiguredstoreschedulecontext()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1725"
+      "source_location": "L1728"
     },
     {
       "community": 10,
@@ -183619,7 +183628,7 @@
       "label": "resolveHistoricEodStoreRangeForDateWithCtx()",
       "norm_label": "resolvehistoriceodstorerangefordatewithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L987"
+      "source_location": "L988"
     },
     {
       "community": 10,
@@ -183628,7 +183637,7 @@
       "label": "runConfiguredDailyOperationsAutomationWithCtx()",
       "norm_label": "runconfigureddailyoperationsautomationwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1981"
+      "source_location": "L1984"
     },
     {
       "community": 10,
@@ -183637,7 +183646,7 @@
       "label": "runConfiguredPolicySafely()",
       "norm_label": "runconfiguredpolicysafely()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1853"
+      "source_location": "L1856"
     },
     {
       "community": 10,
@@ -183646,7 +183655,7 @@
       "label": "runDailyCloseAutoCompleteEligibilityWithCtx()",
       "norm_label": "rundailycloseautocompleteeligibilitywithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L744"
+      "source_location": "L745"
     },
     {
       "community": 10,
@@ -183655,7 +183664,7 @@
       "label": "runDailyOpeningAutomationWithCtx()",
       "norm_label": "rundailyopeningautomationwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L643"
+      "source_location": "L644"
     },
     {
       "community": 10,
@@ -183664,7 +183673,7 @@
       "label": "runHistoricEodAutoCloseBatchActionWithCtx()",
       "norm_label": "runhistoriceodautoclosebatchactionwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L2236"
+      "source_location": "L2239"
     },
     {
       "community": 10,
@@ -183673,7 +183682,7 @@
       "label": "runHistoricEodAutoCloseBatchWithCtx()",
       "norm_label": "runhistoriceodautoclosebatchwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1347"
+      "source_location": "L1350"
     },
     {
       "community": 10,
@@ -183682,7 +183691,7 @@
       "label": "runHistoricEodAutoCloseForDateWithCtx()",
       "norm_label": "runhistoriceodautoclosefordatewithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1067"
+      "source_location": "L1068"
     },
     {
       "community": 10,
@@ -183691,7 +183700,7 @@
       "label": "runScheduledDailyOperationsAutomationWithCtx()",
       "norm_label": "runscheduleddailyoperationsautomationwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1912"
+      "source_location": "L1915"
     },
     {
       "community": 10,
@@ -183700,7 +183709,7 @@
       "label": "scheduleEvidenceForStoreDayContext()",
       "norm_label": "scheduleevidenceforstoredaycontext()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1661"
+      "source_location": "L1664"
     },
     {
       "community": 10,
@@ -183709,7 +183718,7 @@
       "label": "sourceSubjectsOrStoreDay()",
       "norm_label": "sourcesubjectsorstoreday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L316"
+      "source_location": "L317"
     },
     {
       "community": 10,
@@ -183718,7 +183727,7 @@
       "label": "summarizeAutomationRun()",
       "norm_label": "summarizeautomationrun()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L268"
+      "source_location": "L269"
     },
     {
       "community": 10,
@@ -183727,7 +183736,7 @@
       "label": "summarizeHistoricEodAutoCloseBatch()",
       "norm_label": "summarizehistoriceodautoclosebatch()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L1405"
+      "source_location": "L1408"
     },
     {
       "community": 10,
@@ -183736,7 +183745,7 @@
       "label": "toApiOpeningBlockerHandling()",
       "norm_label": "toapiopeningblockerhandling()",
       "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts",
-      "source_location": "L209"
+      "source_location": "L210"
     },
     {
       "community": 10,
@@ -192241,7 +192250,7 @@
       "label": "fullWindow()",
       "norm_label": "fullwindow()",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.test.ts",
-      "source_location": "L15"
+      "source_location": "L14"
     },
     {
       "community": 1196,
@@ -215511,119 +215520,119 @@
     {
       "community": 187,
       "file_type": "code",
-      "id": "backfillstoreschedules_backfillstoreschedulesfromlegacypolicywithctx",
-      "label": "backfillStoreSchedulesFromLegacyPolicyWithCtx()",
-      "norm_label": "backfillstoreschedulesfromlegacypolicywithctx()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L324"
+      "id": "packages_athena_webapp_convex_inventory_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 187,
       "file_type": "code",
-      "id": "backfillstoreschedules_buildbackfillrow",
-      "label": "buildBackfillRow()",
-      "norm_label": "buildbackfillrow()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L187"
+      "id": "packages_athena_webapp_src_components_orders_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 187,
       "file_type": "code",
-      "id": "backfillstoreschedules_buildcandidateweeklywindows",
-      "label": "buildCandidateWeeklyWindows()",
-      "norm_label": "buildcandidateweeklywindows()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L163"
+      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 187,
       "file_type": "code",
-      "id": "backfillstoreschedules_compatibilitymetadata",
-      "label": "compatibilityMetadata()",
-      "norm_label": "compatibilitymetadata()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L133"
+      "id": "utils_formatdeliveryaddress",
+      "label": "formatDeliveryAddress()",
+      "norm_label": "formatdeliveryaddress()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L74"
     },
     {
       "community": 187,
       "file_type": "code",
-      "id": "backfillstoreschedules_compatibilityonlyrow",
-      "label": "compatibilityOnlyRow()",
-      "norm_label": "compatibilityonlyrow()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L174"
+      "id": "utils_getamountpaidfororder",
+      "label": "getAmountPaidForOrder()",
+      "norm_label": "getamountpaidfororder()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L191"
     },
     {
       "community": 187,
       "file_type": "code",
-      "id": "backfillstoreschedules_findexistingscheduletoskip",
-      "label": "findExistingScheduleToSkip()",
-      "norm_label": "findexistingscheduletoskip()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L114"
+      "id": "utils_getdiscountvalue",
+      "label": "getDiscountValue()",
+      "norm_label": "getdiscountvalue()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L17"
     },
     {
       "community": 187,
       "file_type": "code",
-      "id": "backfillstoreschedules_firstpolicy",
-      "label": "firstPolicy()",
-      "norm_label": "firstpolicy()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "id": "utils_getonlineorderplacedat",
+      "label": "getOnlineOrderPlacedAt()",
+      "norm_label": "getonlineorderplacedat()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 187,
+      "file_type": "code",
+      "id": "utils_getorderamount",
+      "label": "getOrderAmount()",
+      "norm_label": "getorderamount()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 187,
+      "file_type": "code",
+      "id": "utils_getorderstate",
+      "label": "getOrderState()",
+      "norm_label": "getorderstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 187,
+      "file_type": "code",
+      "id": "utils_getpickupactionstate",
+      "label": "getPickupActionState()",
+      "norm_label": "getpickupactionstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L102"
+    },
+    {
+      "community": 187,
+      "file_type": "code",
+      "id": "utils_getpotentialpoints",
+      "label": "getPotentialPoints()",
+      "norm_label": "getpotentialpoints()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 187,
+      "file_type": "code",
+      "id": "utils_getproductdiscountvalue",
+      "label": "getProductDiscountValue()",
+      "norm_label": "getproductdiscountvalue()",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
       "source_location": "L75"
     },
     {
       "community": 187,
       "file_type": "code",
-      "id": "backfillstoreschedules_isvalidminute",
-      "label": "isValidMinute()",
-      "norm_label": "isvalidminute()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "backfillstoreschedules_listpoliciesforstoreaction",
-      "label": "listPoliciesForStoreAction()",
-      "norm_label": "listpoliciesforstoreaction()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L81"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "backfillstoreschedules_listschedulesforstorebystatus",
-      "label": "listSchedulesForStoreByStatus()",
-      "norm_label": "listschedulesforstorebystatus()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L99"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "backfillstoreschedules_normalizelimit",
-      "label": "normalizeLimit()",
-      "norm_label": "normalizelimit()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "backfillstoreschedules_trustedtimezoneforstore",
-      "label": "trustedTimezoneForStore()",
-      "norm_label": "trustedtimezoneforstore()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L126"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_migrations_backfillstoreschedules_ts",
-      "label": "backfillStoreSchedules.ts",
-      "norm_label": "backfillstoreschedules.ts",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L1"
+      "id": "utils_shouldshowpickupexceptionaction",
+      "label": "shouldShowPickupExceptionAction()",
+      "norm_label": "shouldshowpickupexceptionaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L116"
     },
     {
       "community": 1870,
@@ -215718,119 +215727,119 @@
     {
       "community": 188,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operationadmission_readdefinitions_ts",
-      "label": "readDefinitions.ts",
-      "norm_label": "readdefinitions.ts",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "id": "backfillstoreschedules_backfillstoreschedulesfromlegacypolicywithctx",
+      "label": "backfillStoreSchedulesFromLegacyPolicyWithCtx()",
+      "norm_label": "backfillstoreschedulesfromlegacypolicywithctx()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L324"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "backfillstoreschedules_buildbackfillrow",
+      "label": "buildBackfillRow()",
+      "norm_label": "buildbackfillrow()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L187"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "backfillstoreschedules_buildcandidateweeklywindows",
+      "label": "buildCandidateWeeklyWindows()",
+      "norm_label": "buildcandidateweeklywindows()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L163"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "backfillstoreschedules_compatibilitymetadata",
+      "label": "compatibilityMetadata()",
+      "norm_label": "compatibilitymetadata()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L133"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "backfillstoreschedules_compatibilityonlyrow",
+      "label": "compatibilityOnlyRow()",
+      "norm_label": "compatibilityonlyrow()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L174"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "backfillstoreschedules_findexistingscheduletoskip",
+      "label": "findExistingScheduleToSkip()",
+      "norm_label": "findexistingscheduletoskip()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L114"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "backfillstoreschedules_firstpolicy",
+      "label": "firstPolicy()",
+      "norm_label": "firstpolicy()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "backfillstoreschedules_isvalidminute",
+      "label": "isValidMinute()",
+      "norm_label": "isvalidminute()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "backfillstoreschedules_listpoliciesforstoreaction",
+      "label": "listPoliciesForStoreAction()",
+      "norm_label": "listpoliciesforstoreaction()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L81"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "backfillstoreschedules_listschedulesforstorebystatus",
+      "label": "listSchedulesForStoreByStatus()",
+      "norm_label": "listschedulesforstorebystatus()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L99"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "backfillstoreschedules_normalizelimit",
+      "label": "normalizeLimit()",
+      "norm_label": "normalizelimit()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "backfillstoreschedules_trustedtimezoneforstore",
+      "label": "trustedTimezoneForStore()",
+      "norm_label": "trustedtimezoneforstore()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L126"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_migrations_backfillstoreschedules_ts",
+      "label": "backfillStoreSchedules.ts",
+      "norm_label": "backfillstoreschedules.ts",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "readdefinitions_definecashcontrolsread",
-      "label": "defineCashControlsRead()",
-      "norm_label": "definecashcontrolsread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L50"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "readdefinitions_definedailycloseread",
-      "label": "defineDailyCloseRead()",
-      "norm_label": "definedailycloseread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "readdefinitions_definedailyoperationsread",
-      "label": "defineDailyOperationsRead()",
-      "norm_label": "definedailyoperationsread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "readdefinitions_defineinventorycatalogread",
-      "label": "defineInventoryCatalogRead()",
-      "norm_label": "defineinventorycatalogread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "readdefinitions_defineinventorycostoverlayread",
-      "label": "defineInventoryCostOverlayRead()",
-      "norm_label": "defineinventorycostoverlayread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L639"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "readdefinitions_defineonlineordersread",
-      "label": "defineOnlineOrdersRead()",
-      "norm_label": "defineonlineordersread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L84"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "readdefinitions_defineoperationalworkread",
-      "label": "defineOperationalWorkRead()",
-      "norm_label": "defineoperationalworkread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "readdefinitions_defineorganizationread",
-      "label": "defineOrganizationRead()",
-      "norm_label": "defineorganizationread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L94"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "readdefinitions_defineposread",
-      "label": "definePosRead()",
-      "norm_label": "defineposread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "readdefinitions_definereadoperation",
-      "label": "defineReadOperation()",
-      "norm_label": "definereadoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "readdefinitions_definestockadjustmentsread",
-      "label": "defineStockAdjustmentsRead()",
-      "norm_label": "definestockadjustmentsread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L60"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "readdefinitions_validatereadoperationdefinition",
-      "label": "validateReadOperationDefinition()",
-      "norm_label": "validatereadoperationdefinition()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L781"
     },
     {
       "community": 1880,
@@ -215925,119 +215934,119 @@
     {
       "community": 189,
       "file_type": "code",
-      "id": "frozenmetricauthority_closecandidateoperatingrange",
-      "label": "closeCandidateOperatingRange()",
-      "norm_label": "closecandidateoperatingrange()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L199"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "frozenmetricauthority_emptyclosesummary",
-      "label": "emptyCloseSummary()",
-      "norm_label": "emptyclosesummary()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "frozenmetricauthority_exactstatuses",
-      "label": "exactStatuses()",
-      "norm_label": "exactstatuses()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "frozenmetricauthority_finitenumber",
-      "label": "finiteNumber()",
-      "norm_label": "finitenumber()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L91"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "frozenmetricauthority_frozenfinancialsourcecounts",
-      "label": "frozenFinancialSourceCounts()",
-      "norm_label": "frozenfinancialsourcecounts()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L133"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "frozenmetricauthority_frozenweekmetricfordate",
-      "label": "frozenWeekMetricForDate()",
-      "norm_label": "frozenweekmetricfordate()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L481"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "frozenmetricauthority_matchesrequestedoperatingrange",
-      "label": "matchesRequestedOperatingRange()",
-      "norm_label": "matchesrequestedoperatingrange()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "frozenmetricauthority_normalizefrozenpaymenttotals",
-      "label": "normalizeFrozenPaymentTotals()",
-      "norm_label": "normalizefrozenpaymenttotals()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L241"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "frozenmetricauthority_recordvalue",
-      "label": "recordValue()",
-      "norm_label": "recordvalue()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "frozenmetricauthority_resolvefrozendailycloseauthority",
-      "label": "resolveFrozenDailyCloseAuthority()",
-      "norm_label": "resolvefrozendailycloseauthority()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L393"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "frozenmetricauthority_samedailycloseid",
-      "label": "sameDailyCloseId()",
-      "norm_label": "samedailycloseid()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L386"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "frozenmetricauthority_usablefrozenweeksummary",
-      "label": "usableFrozenWeekSummary()",
-      "norm_label": "usablefrozenweeksummary()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L273"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_dailyoperations_frozenmetricauthority_ts",
-      "label": "frozenMetricAuthority.ts",
-      "norm_label": "frozenmetricauthority.ts",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "id": "packages_athena_webapp_convex_operationadmission_readdefinitions_ts",
+      "label": "readDefinitions.ts",
+      "norm_label": "readdefinitions.ts",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "readdefinitions_definecashcontrolsread",
+      "label": "defineCashControlsRead()",
+      "norm_label": "definecashcontrolsread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "readdefinitions_definedailycloseread",
+      "label": "defineDailyCloseRead()",
+      "norm_label": "definedailycloseread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "readdefinitions_definedailyoperationsread",
+      "label": "defineDailyOperationsRead()",
+      "norm_label": "definedailyoperationsread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "readdefinitions_defineinventorycatalogread",
+      "label": "defineInventoryCatalogRead()",
+      "norm_label": "defineinventorycatalogread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "readdefinitions_defineinventorycostoverlayread",
+      "label": "defineInventoryCostOverlayRead()",
+      "norm_label": "defineinventorycostoverlayread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L639"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "readdefinitions_defineonlineordersread",
+      "label": "defineOnlineOrdersRead()",
+      "norm_label": "defineonlineordersread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "readdefinitions_defineoperationalworkread",
+      "label": "defineOperationalWorkRead()",
+      "norm_label": "defineoperationalworkread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "readdefinitions_defineorganizationread",
+      "label": "defineOrganizationRead()",
+      "norm_label": "defineorganizationread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L94"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "readdefinitions_defineposread",
+      "label": "definePosRead()",
+      "norm_label": "defineposread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "readdefinitions_definereadoperation",
+      "label": "defineReadOperation()",
+      "norm_label": "definereadoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "readdefinitions_definestockadjustmentsread",
+      "label": "defineStockAdjustmentsRead()",
+      "norm_label": "definestockadjustmentsread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L60"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "readdefinitions_validatereadoperationdefinition",
+      "label": "validateReadOperationDefinition()",
+      "norm_label": "validatereadoperationdefinition()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L781"
     },
     {
       "community": 1890,
@@ -216501,118 +216510,118 @@
     {
       "community": 190,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildctx",
-      "label": "buildCtx()",
-      "norm_label": "buildctx()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L956"
+      "id": "frozenmetricauthority_closecandidateoperatingrange",
+      "label": "closeCandidateOperatingRange()",
+      "norm_label": "closecandidateoperatingrange()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L199"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildinventorymovement",
-      "label": "buildInventoryMovement()",
-      "norm_label": "buildinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1109"
+      "id": "frozenmetricauthority_emptyclosesummary",
+      "label": "emptyCloseSummary()",
+      "norm_label": "emptyclosesummary()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L62"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildmapping",
-      "label": "buildMapping()",
-      "norm_label": "buildmapping()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1213"
+      "id": "frozenmetricauthority_exactstatuses",
+      "label": "exactStatuses()",
+      "norm_label": "exactstatuses()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L96"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildproductsku",
-      "label": "buildProductSku()",
-      "norm_label": "buildproductsku()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1130"
+      "id": "frozenmetricauthority_finitenumber",
+      "label": "finiteNumber()",
+      "norm_label": "finitenumber()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L91"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1169"
+      "id": "frozenmetricauthority_frozenfinancialsourcecounts",
+      "label": "frozenFinancialSourceCounts()",
+      "norm_label": "frozenfinancialsourcecounts()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L133"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildstaffprofile",
-      "label": "buildStaffProfile()",
-      "norm_label": "buildstaffprofile()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1065"
+      "id": "frozenmetricauthority_frozenweekmetricfordate",
+      "label": "frozenWeekMetricForDate()",
+      "norm_label": "frozenweekmetricfordate()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L481"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildstore",
-      "label": "buildStore()",
-      "norm_label": "buildstore()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1052"
+      "id": "frozenmetricauthority_matchesrequestedoperatingrange",
+      "label": "matchesRequestedOperatingRange()",
+      "norm_label": "matchesrequestedoperatingrange()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L102"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildterminal",
-      "label": "buildTerminal()",
-      "norm_label": "buildterminal()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1149"
+      "id": "frozenmetricauthority_normalizefrozenpaymenttotals",
+      "label": "normalizeFrozenPaymentTotals()",
+      "norm_label": "normalizefrozenpaymenttotals()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L241"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildtransaction",
-      "label": "buildTransaction()",
-      "norm_label": "buildtransaction()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1189"
+      "id": "frozenmetricauthority_recordvalue",
+      "label": "recordValue()",
+      "norm_label": "recordvalue()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L85"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildworkitem",
-      "label": "buildWorkItem()",
-      "norm_label": "buildworkitem()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1079"
+      "id": "frozenmetricauthority_resolvefrozendailycloseauthority",
+      "label": "resolveFrozenDailyCloseAuthority()",
+      "norm_label": "resolvefrozendailycloseauthority()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L393"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_defaultargs",
-      "label": "defaultArgs()",
-      "norm_label": "defaultargs()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L909"
+      "id": "frozenmetricauthority_samedailycloseid",
+      "label": "sameDailyCloseId()",
+      "norm_label": "samedailycloseid()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L386"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_expectrejectedcontext",
-      "label": "expectRejectedContext()",
-      "norm_label": "expectrejectedcontext()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L891"
+      "id": "frozenmetricauthority_usablefrozenweeksummary",
+      "label": "usableFrozenWeekSummary()",
+      "norm_label": "usablefrozenweeksummary()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L273"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_openworkinventoryreviews_test_ts",
-      "label": "openWorkInventoryReviews.test.ts",
-      "norm_label": "openworkinventoryreviews.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "id": "packages_athena_webapp_convex_operations_dailyoperations_frozenmetricauthority_ts",
+      "label": "frozenMetricAuthority.ts",
+      "norm_label": "frozenmetricauthority.ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
       "source_location": "L1"
     },
     {
@@ -216708,118 +216717,118 @@
     {
       "community": 191,
       "file_type": "code",
-      "id": "assigncustomer_createcustomer",
-      "label": "createCustomer()",
-      "norm_label": "createcustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L132"
+      "id": "openworkinventoryreviews_test_buildctx",
+      "label": "buildCtx()",
+      "norm_label": "buildctx()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L956"
     },
     {
       "community": 191,
       "file_type": "code",
-      "id": "assigncustomer_fullnamefromparts",
-      "label": "fullNameFromParts()",
-      "norm_label": "fullnamefromparts()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L58"
+      "id": "openworkinventoryreviews_test_buildinventorymovement",
+      "label": "buildInventoryMovement()",
+      "norm_label": "buildinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1109"
     },
     {
       "community": 191,
       "file_type": "code",
-      "id": "assigncustomer_guestresult",
-      "label": "guestResult()",
-      "norm_label": "guestresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L111"
+      "id": "openworkinventoryreviews_test_buildmapping",
+      "label": "buildMapping()",
+      "norm_label": "buildmapping()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1213"
     },
     {
       "community": 191,
       "file_type": "code",
-      "id": "assigncustomer_linktoguest",
-      "label": "linkToGuest()",
-      "norm_label": "linktoguest()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L348"
+      "id": "openworkinventoryreviews_test_buildproductsku",
+      "label": "buildProductSku()",
+      "norm_label": "buildproductsku()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1130"
     },
     {
       "community": 191,
       "file_type": "code",
-      "id": "assigncustomer_linktostorefrontuser",
-      "label": "linkToStoreFrontUser()",
-      "norm_label": "linktostorefrontuser()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L290"
+      "id": "openworkinventoryreviews_test_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1169"
     },
     {
       "community": 191,
       "file_type": "code",
-      "id": "assigncustomer_poscustomerresult",
-      "label": "posCustomerResult()",
-      "norm_label": "poscustomerresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L71"
+      "id": "openworkinventoryreviews_test_buildstaffprofile",
+      "label": "buildStaffProfile()",
+      "norm_label": "buildstaffprofile()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1065"
     },
     {
       "community": 191,
       "file_type": "code",
-      "id": "assigncustomer_resolveguestmatch",
-      "label": "resolveGuestMatch()",
-      "norm_label": "resolveguestmatch()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L478"
+      "id": "openworkinventoryreviews_test_buildstore",
+      "label": "buildStore()",
+      "norm_label": "buildstore()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1052"
     },
     {
       "community": 191,
       "file_type": "code",
-      "id": "assigncustomer_resolveposcustomerselection",
-      "label": "resolvePosCustomerSelection()",
-      "norm_label": "resolveposcustomerselection()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L267"
+      "id": "openworkinventoryreviews_test_buildterminal",
+      "label": "buildTerminal()",
+      "norm_label": "buildterminal()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1149"
     },
     {
       "community": 191,
       "file_type": "code",
-      "id": "assigncustomer_resolvestorefrontusermatch",
-      "label": "resolveStoreFrontUserMatch()",
-      "norm_label": "resolvestorefrontusermatch()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L384"
+      "id": "openworkinventoryreviews_test_buildtransaction",
+      "label": "buildTransaction()",
+      "norm_label": "buildtransaction()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1189"
     },
     {
       "community": 191,
       "file_type": "code",
-      "id": "assigncustomer_storefrontresult",
-      "label": "storefrontResult()",
-      "norm_label": "storefrontresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L90"
+      "id": "openworkinventoryreviews_test_buildworkitem",
+      "label": "buildWorkItem()",
+      "norm_label": "buildworkitem()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1079"
     },
     {
       "community": 191,
       "file_type": "code",
-      "id": "assigncustomer_updatecustomer",
-      "label": "updateCustomer()",
-      "norm_label": "updatecustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L220"
+      "id": "openworkinventoryreviews_test_defaultargs",
+      "label": "defaultArgs()",
+      "norm_label": "defaultargs()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L909"
     },
     {
       "community": 191,
       "file_type": "code",
-      "id": "assigncustomer_updatecustomerstats",
-      "label": "updateCustomerStats()",
-      "norm_label": "updatecustomerstats()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L251"
+      "id": "openworkinventoryreviews_test_expectrejectedcontext",
+      "label": "expectRejectedContext()",
+      "norm_label": "expectrejectedcontext()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L891"
     },
     {
       "community": 191,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_ts",
-      "label": "assignCustomer.ts",
-      "norm_label": "assigncustomer.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "id": "packages_athena_webapp_convex_operations_openworkinventoryreviews_test_ts",
+      "label": "openWorkInventoryReviews.test.ts",
+      "norm_label": "openworkinventoryreviews.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
       "source_location": "L1"
     },
     {
@@ -216915,118 +216924,118 @@
     {
       "community": 192,
       "file_type": "code",
-      "id": "catalogrepository_findactivependingcheckoutlookupaliasbycode",
-      "label": "findActivePendingCheckoutLookupAliasByCode()",
-      "norm_label": "findactivependingcheckoutlookupaliasbycode()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L97"
+      "id": "assigncustomer_createcustomer",
+      "label": "createCustomer()",
+      "norm_label": "createcustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L132"
     },
     {
       "community": 192,
       "file_type": "code",
-      "id": "catalogrepository_findactiveprovisionalimportskuforstoresku",
-      "label": "findActiveProvisionalImportSkuForStoreSku()",
-      "norm_label": "findactiveprovisionalimportskuforstoresku()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L120"
+      "id": "assigncustomer_fullnamefromparts",
+      "label": "fullNameFromParts()",
+      "norm_label": "fullnamefromparts()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L58"
     },
     {
       "community": 192,
       "file_type": "code",
-      "id": "catalogrepository_findstoreskubybarcode",
-      "label": "findStoreSkuByBarcode()",
-      "norm_label": "findstoreskubybarcode()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L62"
+      "id": "assigncustomer_guestresult",
+      "label": "guestResult()",
+      "norm_label": "guestresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L111"
     },
     {
       "community": 192,
       "file_type": "code",
-      "id": "catalogrepository_findstoreskubysku",
-      "label": "findStoreSkuBySku()",
-      "norm_label": "findstoreskubysku()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L77"
+      "id": "assigncustomer_linktoguest",
+      "label": "linkToGuest()",
+      "norm_label": "linktoguest()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L348"
     },
     {
       "community": 192,
       "file_type": "code",
-      "id": "catalogrepository_getcategorybyid",
-      "label": "getCategoryById()",
-      "norm_label": "getcategorybyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L29"
+      "id": "assigncustomer_linktostorefrontuser",
+      "label": "linkToStoreFrontUser()",
+      "norm_label": "linktostorefrontuser()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L290"
     },
     {
       "community": 192,
       "file_type": "code",
-      "id": "catalogrepository_getcolorbyid",
-      "label": "getColorById()",
-      "norm_label": "getcolorbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L40"
+      "id": "assigncustomer_poscustomerresult",
+      "label": "posCustomerResult()",
+      "norm_label": "poscustomerresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L71"
     },
     {
       "community": 192,
       "file_type": "code",
-      "id": "catalogrepository_getproductbyid",
-      "label": "getProductById()",
-      "norm_label": "getproductbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L25"
+      "id": "assigncustomer_resolveguestmatch",
+      "label": "resolveGuestMatch()",
+      "norm_label": "resolveguestmatch()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L478"
     },
     {
       "community": 192,
       "file_type": "code",
-      "id": "catalogrepository_isconvexproductid",
-      "label": "isConvexProductId()",
-      "norm_label": "isconvexproductid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L11"
+      "id": "assigncustomer_resolveposcustomerselection",
+      "label": "resolvePosCustomerSelection()",
+      "norm_label": "resolveposcustomerselection()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L267"
     },
     {
       "community": 192,
       "file_type": "code",
-      "id": "catalogrepository_listmatchingstoreskus",
-      "label": "listMatchingStoreSkus()",
-      "norm_label": "listmatchingstoreskus()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L140"
+      "id": "assigncustomer_resolvestorefrontusermatch",
+      "label": "resolveStoreFrontUserMatch()",
+      "norm_label": "resolvestorefrontusermatch()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L384"
     },
     {
       "community": 192,
       "file_type": "code",
-      "id": "catalogrepository_listproductskusbyproductid",
-      "label": "listProductSkusByProductId()",
-      "norm_label": "listproductskusbyproductid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L51"
+      "id": "assigncustomer_storefrontresult",
+      "label": "storefrontResult()",
+      "norm_label": "storefrontresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L90"
     },
     {
       "community": 192,
       "file_type": "code",
-      "id": "catalogrepository_normalizelookupcode",
-      "label": "normalizeLookupCode()",
-      "norm_label": "normalizelookupcode()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L92"
+      "id": "assigncustomer_updatecustomer",
+      "label": "updateCustomer()",
+      "norm_label": "updatecustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L220"
     },
     {
       "community": 192,
       "file_type": "code",
-      "id": "catalogrepository_readallqueryresults",
-      "label": "readAllQueryResults()",
-      "norm_label": "readallqueryresults()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L15"
+      "id": "assigncustomer_updatecustomerstats",
+      "label": "updateCustomerStats()",
+      "norm_label": "updatecustomerstats()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L251"
     },
     {
       "community": 192,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_catalogrepository_ts",
-      "label": "catalogRepository.ts",
-      "norm_label": "catalogrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_ts",
+      "label": "assignCustomer.ts",
+      "norm_label": "assigncustomer.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
       "source_location": "L1"
     },
     {
@@ -217122,119 +217131,119 @@
     {
       "community": 193,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_skumovementrange_test_ts",
-      "label": "skuMovementRange.test.ts",
-      "norm_label": "skumovementrange.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L1"
+      "id": "catalogrepository_findactivependingcheckoutlookupaliasbycode",
+      "label": "findActivePendingCheckoutLookupAliasByCode()",
+      "norm_label": "findactivependingcheckoutlookupaliasbycode()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L97"
     },
     {
       "community": 193,
       "file_type": "code",
-      "id": "skumovementrange_test_admitone",
-      "label": "admitOne()",
-      "norm_label": "admitone()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L352"
+      "id": "catalogrepository_findactiveprovisionalimportskuforstoresku",
+      "label": "findActiveProvisionalImportSkuForStoreSku()",
+      "norm_label": "findactiveprovisionalimportskuforstoresku()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L120"
     },
     {
       "community": 193,
       "file_type": "code",
-      "id": "skumovementrange_test_allow",
-      "label": "allow()",
-      "norm_label": "allow()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L113"
+      "id": "catalogrepository_findstoreskubybarcode",
+      "label": "findStoreSkuByBarcode()",
+      "norm_label": "findstoreskubybarcode()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L62"
     },
     {
       "community": 193,
       "file_type": "code",
-      "id": "skumovementrange_test_certifyday",
-      "label": "certifyDay()",
-      "norm_label": "certifyday()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L238"
+      "id": "catalogrepository_findstoreskubysku",
+      "label": "findStoreSkuBySku()",
+      "norm_label": "findstoreskubysku()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L77"
     },
     {
       "community": 193,
       "file_type": "code",
-      "id": "skumovementrange_test_dailyfor",
-      "label": "dailyFor()",
-      "norm_label": "dailyfor()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L656"
+      "id": "catalogrepository_getcategorybyid",
+      "label": "getCategoryById()",
+      "norm_label": "getcategorybyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L29"
     },
     {
       "community": 193,
       "file_type": "code",
-      "id": "skumovementrange_test_drive",
-      "label": "drive()",
-      "norm_label": "drive()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L322"
+      "id": "catalogrepository_getcolorbyid",
+      "label": "getColorById()",
+      "norm_label": "getcolorbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L40"
     },
     {
       "community": 193,
       "file_type": "code",
-      "id": "skumovementrange_test_ensure",
-      "label": "ensure()",
-      "norm_label": "ensure()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L283"
+      "id": "catalogrepository_getproductbyid",
+      "label": "getProductById()",
+      "norm_label": "getproductbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L25"
     },
     {
       "community": 193,
       "file_type": "code",
-      "id": "skumovementrange_test_handlerof",
-      "label": "handlerOf()",
-      "norm_label": "handlerof()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L108"
+      "id": "catalogrepository_isconvexproductid",
+      "label": "isConvexProductId()",
+      "norm_label": "isconvexproductid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L11"
     },
     {
       "community": 193,
       "file_type": "code",
-      "id": "skumovementrange_test_headerbykey",
-      "label": "headerByKey()",
-      "norm_label": "headerbykey()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L304"
-    },
-    {
-      "community": 193,
-      "file_type": "code",
-      "id": "skumovementrange_test_seedskus",
-      "label": "seedSkus()",
-      "norm_label": "seedskus()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L162"
-    },
-    {
-      "community": 193,
-      "file_type": "code",
-      "id": "skumovementrange_test_seedstore",
-      "label": "seedStore()",
-      "norm_label": "seedstore()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "id": "catalogrepository_listmatchingstoreskus",
+      "label": "listMatchingStoreSkus()",
+      "norm_label": "listmatchingstoreskus()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
       "source_location": "L140"
     },
     {
       "community": 193,
       "file_type": "code",
-      "id": "skumovementrange_test_step",
-      "label": "step()",
-      "norm_label": "step()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L955"
+      "id": "catalogrepository_listproductskusbyproductid",
+      "label": "listProductSkusByProductId()",
+      "norm_label": "listproductskusbyproductid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L51"
     },
     {
       "community": 193,
       "file_type": "code",
-      "id": "skumovementrange_test_twodayfixture",
-      "label": "twoDayFixture()",
-      "norm_label": "twodayfixture()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L939"
+      "id": "catalogrepository_normalizelookupcode",
+      "label": "normalizeLookupCode()",
+      "norm_label": "normalizelookupcode()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 193,
+      "file_type": "code",
+      "id": "catalogrepository_readallqueryresults",
+      "label": "readAllQueryResults()",
+      "norm_label": "readallqueryresults()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 193,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_catalogrepository_ts",
+      "label": "catalogRepository.ts",
+      "norm_label": "catalogrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L1"
     },
     {
       "community": 1930,
@@ -217329,119 +217338,119 @@
     {
       "community": 194,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productview_tsx",
-      "label": "ProductView.tsx",
-      "norm_label": "productview.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "id": "packages_athena_webapp_convex_reports_skumovementrange_test_ts",
+      "label": "skuMovementRange.test.ts",
+      "norm_label": "skumovementrange.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
       "source_location": "L1"
     },
     {
       "community": 194,
       "file_type": "code",
-      "id": "productview_archivedproductnestedorigin",
-      "label": "archivedProductNestedOrigin()",
-      "norm_label": "archivedproductnestedorigin()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L107"
+      "id": "skumovementrange_test_admitone",
+      "label": "admitOne()",
+      "norm_label": "admitone()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L352"
     },
     {
       "community": 194,
       "file_type": "code",
-      "id": "productview_buildvariantskumoneypayload",
-      "label": "buildVariantSkuMoneyPayload()",
-      "norm_label": "buildvariantskumoneypayload()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L67"
+      "id": "skumovementrange_test_allow",
+      "label": "allow()",
+      "norm_label": "allow()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L113"
     },
     {
       "community": 194,
       "file_type": "code",
-      "id": "productview_createvariantsku",
-      "label": "createVariantSku()",
-      "norm_label": "createvariantsku()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L346"
+      "id": "skumovementrange_test_certifyday",
+      "label": "certifyDay()",
+      "norm_label": "certifyday()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L238"
     },
     {
       "community": 194,
       "file_type": "code",
-      "id": "productview_decodeoriginvalue",
-      "label": "decodeOriginValue()",
-      "norm_label": "decodeoriginvalue()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L93"
+      "id": "skumovementrange_test_dailyfor",
+      "label": "dailyFor()",
+      "norm_label": "dailyfor()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L656"
     },
     {
       "community": 194,
       "file_type": "code",
-      "id": "productview_deleteactiveproduct",
-      "label": "deleteActiveProduct()",
-      "norm_label": "deleteactiveproduct()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L177"
+      "id": "skumovementrange_test_drive",
+      "label": "drive()",
+      "norm_label": "drive()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L322"
     },
     {
       "community": 194,
       "file_type": "code",
-      "id": "productview_getarchivedproductredirect",
-      "label": "getArchivedProductRedirect()",
-      "norm_label": "getarchivedproductredirect()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L74"
+      "id": "skumovementrange_test_ensure",
+      "label": "ensure()",
+      "norm_label": "ensure()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L283"
     },
     {
       "community": 194,
       "file_type": "code",
-      "id": "productview_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L506"
+      "id": "skumovementrange_test_handlerof",
+      "label": "handlerOf()",
+      "norm_label": "handlerof()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L108"
     },
     {
       "community": 194,
       "file_type": "code",
-      "id": "productview_modifyproduct",
-      "label": "modifyProduct()",
-      "norm_label": "modifyproduct()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L271"
+      "id": "skumovementrange_test_headerbykey",
+      "label": "headerByKey()",
+      "norm_label": "headerbykey()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L304"
     },
     {
       "community": 194,
       "file_type": "code",
-      "id": "productview_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L490"
+      "id": "skumovementrange_test_seedskus",
+      "label": "seedSkus()",
+      "norm_label": "seedskus()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L162"
     },
     {
       "community": 194,
       "file_type": "code",
-      "id": "productview_resolvelegacytaxonomysavegate",
-      "label": "resolveLegacyTaxonomySaveGate()",
-      "norm_label": "resolvelegacytaxonomysavegate()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L40"
+      "id": "skumovementrange_test_seedstore",
+      "label": "seedStore()",
+      "norm_label": "seedstore()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L140"
     },
     {
       "community": 194,
       "file_type": "code",
-      "id": "productview_saveproduct",
-      "label": "saveProduct()",
-      "norm_label": "saveproduct()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L217"
+      "id": "skumovementrange_test_step",
+      "label": "step()",
+      "norm_label": "step()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L955"
     },
     {
       "community": 194,
       "file_type": "code",
-      "id": "productview_updatevariantsku",
-      "label": "updateVariantSku()",
-      "norm_label": "updatevariantsku()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L404"
+      "id": "skumovementrange_test_twodayfixture",
+      "label": "twoDayFixture()",
+      "norm_label": "twodayfixture()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L939"
     },
     {
       "community": 1940,
@@ -217536,119 +217545,119 @@
     {
       "community": 195,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_sessions_possessionsview_tsx",
-      "label": "POSSessionsView.tsx",
-      "norm_label": "possessionsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "id": "packages_athena_webapp_src_components_add_product_productview_tsx",
+      "label": "ProductView.tsx",
+      "norm_label": "productview.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L1"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "possessionsview_formatexpiry",
-      "label": "formatExpiry()",
-      "norm_label": "formatexpiry()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L190"
+      "id": "productview_archivedproductnestedorigin",
+      "label": "archivedProductNestedOrigin()",
+      "norm_label": "archivedproductnestedorigin()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L107"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "possessionsview_formatholddetails",
-      "label": "formatHoldDetails()",
-      "norm_label": "formatholddetails()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L216"
+      "id": "productview_buildvariantskumoneypayload",
+      "label": "buildVariantSkuMoneyPayload()",
+      "norm_label": "buildvariantskumoneypayload()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L67"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "possessionsview_formatregisterlabel",
-      "label": "formatRegisterLabel()",
-      "norm_label": "formatregisterlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L147"
+      "id": "productview_createvariantsku",
+      "label": "createVariantSku()",
+      "norm_label": "createvariantsku()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L346"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "possessionsview_formatstatuslabel",
-      "label": "formatStatusLabel()",
-      "norm_label": "formatstatuslabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L122"
+      "id": "productview_decodeoriginvalue",
+      "label": "decodeOriginValue()",
+      "norm_label": "decodeoriginvalue()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L93"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "possessionsview_getcartcount",
-      "label": "getCartCount()",
-      "norm_label": "getcartcount()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L180"
+      "id": "productview_deleteactiveproduct",
+      "label": "deleteActiveProduct()",
+      "norm_label": "deleteactiveproduct()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L177"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "possessionsview_getcustomerlabel",
-      "label": "getCustomerLabel()",
-      "norm_label": "getcustomerlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L176"
+      "id": "productview_getarchivedproductredirect",
+      "label": "getArchivedProductRedirect()",
+      "norm_label": "getarchivedproductredirect()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L74"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "possessionsview_getoperatorlabel",
-      "label": "getOperatorLabel()",
-      "norm_label": "getoperatorlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L138"
+      "id": "productview_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L506"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "possessionsview_getregisterlabel",
-      "label": "getRegisterLabel()",
-      "norm_label": "getregisterlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L157"
+      "id": "productview_modifyproduct",
+      "label": "modifyProduct()",
+      "norm_label": "modifyproduct()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L271"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "possessionsview_getsessioncode",
-      "label": "getSessionCode()",
-      "norm_label": "getsessioncode()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L131"
+      "id": "productview_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L490"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "possessionsview_getsessions",
-      "label": "getSessions()",
-      "norm_label": "getsessions()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L114"
+      "id": "productview_resolvelegacytaxonomysavegate",
+      "label": "resolveLegacyTaxonomySaveGate()",
+      "norm_label": "resolvelegacytaxonomysavegate()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L40"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "possessionsview_getstatusbadgeclass",
-      "label": "getStatusBadgeClass()",
-      "norm_label": "getstatusbadgeclass()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L250"
+      "id": "productview_saveproduct",
+      "label": "saveProduct()",
+      "norm_label": "saveproduct()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L217"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "possessionsview_possessionsheader",
-      "label": "POSSessionsHeader()",
-      "norm_label": "possessionsheader()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L261"
+      "id": "productview_updatevariantsku",
+      "label": "updateVariantSku()",
+      "norm_label": "updatevariantsku()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L404"
     },
     {
       "community": 1950,
@@ -217743,119 +217752,119 @@
     {
       "community": 196,
       "file_type": "code",
-      "id": "localposreadiness_blocked",
-      "label": "blocked()",
-      "norm_label": "blocked()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L638"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "localposreadiness_evaluatelocalposreadiness",
-      "label": "evaluateLocalPosReadiness()",
-      "norm_label": "evaluatelocalposreadiness()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L124"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "localposreadiness_evaluatelocalposservicecatalogreadiness",
-      "label": "evaluateLocalPosServiceCatalogReadiness()",
-      "norm_label": "evaluatelocalposservicecatalogreadiness()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L258"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "localposreadiness_formatreadinessstatekey",
-      "label": "formatReadinessStateKey()",
-      "norm_label": "formatreadinessstatekey()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L591"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "localposreadiness_hassettledlocalcloseout",
-      "label": "hasSettledLocalCloseout()",
-      "norm_label": "hassettledlocalcloseout()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L248"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "localposreadiness_localreadinessmatchesinput",
-      "label": "localReadinessMatchesInput()",
-      "norm_label": "localreadinessmatchesinput()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L287"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "localposreadiness_localreadinessrecordfromsnapshots",
-      "label": "localReadinessRecordFromSnapshots()",
-      "norm_label": "localreadinessrecordfromsnapshots()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L83"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "localposreadiness_readinessstatekey",
-      "label": "readinessStateKey()",
-      "norm_label": "readinessstatekey()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L610"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "localposreadiness_readinessstatekeysequal",
-      "label": "readinessStateKeysEqual()",
-      "norm_label": "readinessstatekeysequal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L624"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "localposreadiness_readlocalposreadiness",
-      "label": "readLocalPosReadiness()",
-      "norm_label": "readlocalposreadiness()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L299"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "localposreadiness_refreshlocalposreadinessfromsnapshots",
-      "label": "refreshLocalPosReadinessFromSnapshots()",
-      "norm_label": "refreshlocalposreadinessfromsnapshots()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L343"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "localposreadiness_uselocalposreadiness",
-      "label": "useLocalPosReadiness()",
-      "norm_label": "uselocalposreadiness()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L391"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localposreadiness_ts",
-      "label": "localPosReadiness.ts",
-      "norm_label": "localposreadiness.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "id": "packages_athena_webapp_src_components_pos_sessions_possessionsview_tsx",
+      "label": "POSSessionsView.tsx",
+      "norm_label": "possessionsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "possessionsview_formatexpiry",
+      "label": "formatExpiry()",
+      "norm_label": "formatexpiry()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L190"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "possessionsview_formatholddetails",
+      "label": "formatHoldDetails()",
+      "norm_label": "formatholddetails()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L216"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "possessionsview_formatregisterlabel",
+      "label": "formatRegisterLabel()",
+      "norm_label": "formatregisterlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L147"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "possessionsview_formatstatuslabel",
+      "label": "formatStatusLabel()",
+      "norm_label": "formatstatuslabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L122"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "possessionsview_getcartcount",
+      "label": "getCartCount()",
+      "norm_label": "getcartcount()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L180"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "possessionsview_getcustomerlabel",
+      "label": "getCustomerLabel()",
+      "norm_label": "getcustomerlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L176"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "possessionsview_getoperatorlabel",
+      "label": "getOperatorLabel()",
+      "norm_label": "getoperatorlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L138"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "possessionsview_getregisterlabel",
+      "label": "getRegisterLabel()",
+      "norm_label": "getregisterlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L157"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "possessionsview_getsessioncode",
+      "label": "getSessionCode()",
+      "norm_label": "getsessioncode()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L131"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "possessionsview_getsessions",
+      "label": "getSessions()",
+      "norm_label": "getsessions()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L114"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "possessionsview_getstatusbadgeclass",
+      "label": "getStatusBadgeClass()",
+      "norm_label": "getstatusbadgeclass()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L250"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "possessionsview_possessionsheader",
+      "label": "POSSessionsHeader()",
+      "norm_label": "possessionsheader()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L261"
     },
     {
       "community": 1960,
@@ -217950,119 +217959,119 @@
     {
       "community": 197,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registercatalogpinruntime_ts",
-      "label": "registerCatalogPinRuntime.ts",
-      "norm_label": "registercatalogpinruntime.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "id": "localposreadiness_blocked",
+      "label": "blocked()",
+      "norm_label": "blocked()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L638"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "localposreadiness_evaluatelocalposreadiness",
+      "label": "evaluateLocalPosReadiness()",
+      "norm_label": "evaluatelocalposreadiness()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L124"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "localposreadiness_evaluatelocalposservicecatalogreadiness",
+      "label": "evaluateLocalPosServiceCatalogReadiness()",
+      "norm_label": "evaluatelocalposservicecatalogreadiness()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L258"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "localposreadiness_formatreadinessstatekey",
+      "label": "formatReadinessStateKey()",
+      "norm_label": "formatreadinessstatekey()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L591"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "localposreadiness_hassettledlocalcloseout",
+      "label": "hasSettledLocalCloseout()",
+      "norm_label": "hassettledlocalcloseout()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L248"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "localposreadiness_localreadinessmatchesinput",
+      "label": "localReadinessMatchesInput()",
+      "norm_label": "localreadinessmatchesinput()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L287"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "localposreadiness_localreadinessrecordfromsnapshots",
+      "label": "localReadinessRecordFromSnapshots()",
+      "norm_label": "localreadinessrecordfromsnapshots()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "localposreadiness_readinessstatekey",
+      "label": "readinessStateKey()",
+      "norm_label": "readinessstatekey()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L610"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "localposreadiness_readinessstatekeysequal",
+      "label": "readinessStateKeysEqual()",
+      "norm_label": "readinessstatekeysequal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L624"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "localposreadiness_readlocalposreadiness",
+      "label": "readLocalPosReadiness()",
+      "norm_label": "readlocalposreadiness()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L299"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "localposreadiness_refreshlocalposreadinessfromsnapshots",
+      "label": "refreshLocalPosReadinessFromSnapshots()",
+      "norm_label": "refreshlocalposreadinessfromsnapshots()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L343"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "localposreadiness_uselocalposreadiness",
+      "label": "useLocalPosReadiness()",
+      "norm_label": "uselocalposreadiness()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L391"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localposreadiness_ts",
+      "label": "localPosReadiness.ts",
+      "norm_label": "localposreadiness.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "registercatalogpinruntime_captureregistercatalogruntimepin",
-      "label": "captureRegisterCatalogRuntimePin()",
-      "norm_label": "captureregistercatalogruntimepin()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L138"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "registercatalogpinruntime_chooseregistercatalogruntimeownerid",
-      "label": "chooseRegisterCatalogRuntimeOwnerId()",
-      "norm_label": "chooseregistercatalogruntimeownerid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "registercatalogpinruntime_clearregistercatalogruntimeactionguard",
-      "label": "clearRegisterCatalogRuntimeActionGuard()",
-      "norm_label": "clearregistercatalogruntimeactionguard()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L171"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "registercatalogpinruntime_clearregistercatalogruntimeselection",
-      "label": "clearRegisterCatalogRuntimeSelection()",
-      "norm_label": "clearregistercatalogruntimeselection()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L132"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "registercatalogpinruntime_getregistercatalogruntimeownerid",
-      "label": "getRegisterCatalogRuntimeOwnerId()",
-      "norm_label": "getregistercatalogruntimeownerid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L177"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "registercatalogpinruntime_hasregistercatalogruntimeactionguard",
-      "label": "hasRegisterCatalogRuntimeActionGuard()",
-      "norm_label": "hasregistercatalogruntimeactionguard()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L165"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "registercatalogpinruntime_keyforscope",
-      "label": "keyForScope()",
-      "norm_label": "keyforscope()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L122"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "registercatalogpinruntime_maintainownerclaim",
-      "label": "maintainOwnerClaim()",
-      "norm_label": "maintainownerclaim()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L87"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "registercatalogpinruntime_ownerclaimkey",
-      "label": "ownerClaimKey()",
-      "norm_label": "ownerclaimkey()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L47"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "registercatalogpinruntime_readownerclaim",
-      "label": "readOwnerClaim()",
-      "norm_label": "readownerclaim()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "registercatalogpinruntime_setregistercatalogruntimeselection",
-      "label": "setRegisterCatalogRuntimeSelection()",
-      "norm_label": "setregistercatalogruntimeselection()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L126"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "registercatalogpinruntime_writeownerclaim",
-      "label": "writeOwnerClaim()",
-      "norm_label": "writeownerclaim()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L71"
     },
     {
       "community": 1970,
@@ -218157,119 +218166,119 @@
     {
       "community": 198,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_printattempttelemetry_ts",
-      "label": "printAttemptTelemetry.ts",
-      "norm_label": "printattempttelemetry.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registercatalogpinruntime_ts",
+      "label": "registerCatalogPinRuntime.ts",
+      "norm_label": "registercatalogpinruntime.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
       "source_location": "L1"
     },
     {
       "community": 198,
       "file_type": "code",
-      "id": "printattempttelemetry_appendevent",
-      "label": "appendEvent()",
-      "norm_label": "appendevent()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L81"
+      "id": "registercatalogpinruntime_captureregistercatalogruntimepin",
+      "label": "captureRegisterCatalogRuntimePin()",
+      "norm_label": "captureregistercatalogruntimepin()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L138"
     },
     {
       "community": 198,
       "file_type": "code",
-      "id": "printattempttelemetry_beginprintattempt",
-      "label": "beginPrintAttempt()",
-      "norm_label": "beginprintattempt()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L115"
+      "id": "registercatalogpinruntime_chooseregistercatalogruntimeownerid",
+      "label": "chooseRegisterCatalogRuntimeOwnerId()",
+      "norm_label": "chooseregistercatalogruntimeownerid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L31"
     },
     {
       "community": 198,
       "file_type": "code",
-      "id": "printattempttelemetry_buildmetadata",
-      "label": "buildMetadata()",
-      "norm_label": "buildmetadata()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L88"
+      "id": "registercatalogpinruntime_clearregistercatalogruntimeactionguard",
+      "label": "clearRegisterCatalogRuntimeActionGuard()",
+      "norm_label": "clearregistercatalogruntimeactionguard()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L171"
     },
     {
       "community": 198,
       "file_type": "code",
-      "id": "printattempttelemetry_finalizeprintattempt",
-      "label": "finalizePrintAttempt()",
-      "norm_label": "finalizeprintattempt()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L211"
+      "id": "registercatalogpinruntime_clearregistercatalogruntimeselection",
+      "label": "clearRegisterCatalogRuntimeSelection()",
+      "norm_label": "clearregistercatalogruntimeselection()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L132"
     },
     {
       "community": 198,
       "file_type": "code",
-      "id": "printattempttelemetry_getprintrejectionmetadata",
-      "label": "getPrintRejectionMetadata()",
-      "norm_label": "getprintrejectionmetadata()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L250"
+      "id": "registercatalogpinruntime_getregistercatalogruntimeownerid",
+      "label": "getRegisterCatalogRuntimeOwnerId()",
+      "norm_label": "getregistercatalogruntimeownerid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L177"
     },
     {
       "community": 198,
       "file_type": "code",
-      "id": "printattempttelemetry_getreasonmessage",
-      "label": "getReasonMessage()",
-      "norm_label": "getreasonmessage()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L108"
+      "id": "registercatalogpinruntime_hasregistercatalogruntimeactionguard",
+      "label": "hasRegisterCatalogRuntimeActionGuard()",
+      "norm_label": "hasregistercatalogruntimeactionguard()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L165"
     },
     {
       "community": 198,
       "file_type": "code",
-      "id": "printattempttelemetry_istargetterminal",
-      "label": "isTargetTerminal()",
-      "norm_label": "istargetterminal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L62"
+      "id": "registercatalogpinruntime_keyforscope",
+      "label": "keyForScope()",
+      "norm_label": "keyforscope()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L122"
     },
     {
       "community": 198,
       "file_type": "code",
-      "id": "printattempttelemetry_mintattemptid",
-      "label": "mintAttemptId()",
-      "norm_label": "mintattemptid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L70"
+      "id": "registercatalogpinruntime_maintainownerclaim",
+      "label": "maintainOwnerClaim()",
+      "norm_label": "maintainownerclaim()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L87"
     },
     {
       "community": 198,
       "file_type": "code",
-      "id": "printattempttelemetry_recordprintattemptevent",
-      "label": "recordPrintAttemptEvent()",
-      "norm_label": "recordprintattemptevent()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L195"
+      "id": "registercatalogpinruntime_ownerclaimkey",
+      "label": "ownerClaimKey()",
+      "norm_label": "ownerclaimkey()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L47"
     },
     {
       "community": 198,
       "file_type": "code",
-      "id": "printattempttelemetry_recordprintinvocation",
-      "label": "recordPrintInvocation()",
-      "norm_label": "recordprintinvocation()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L151"
+      "id": "registercatalogpinruntime_readownerclaim",
+      "label": "readOwnerClaim()",
+      "norm_label": "readownerclaim()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L51"
     },
     {
       "community": 198,
       "file_type": "code",
-      "id": "printattempttelemetry_recordprintreturn",
-      "label": "recordPrintReturn()",
-      "norm_label": "recordprintreturn()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L174"
+      "id": "registercatalogpinruntime_setregistercatalogruntimeselection",
+      "label": "setRegisterCatalogRuntimeSelection()",
+      "norm_label": "setregistercatalogruntimeselection()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L126"
     },
     {
       "community": 198,
       "file_type": "code",
-      "id": "printattempttelemetry_resetprintattempttelemetryfortests",
-      "label": "resetPrintAttemptTelemetryForTests()",
-      "norm_label": "resetprintattempttelemetryfortests()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L294"
+      "id": "registercatalogpinruntime_writeownerclaim",
+      "label": "writeOwnerClaim()",
+      "norm_label": "writeownerclaim()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L71"
     },
     {
       "community": 1980,
@@ -218364,119 +218373,119 @@
     {
       "community": 199,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_telemetrybuffer_ts",
-      "label": "telemetryBuffer.ts",
-      "norm_label": "telemetrybuffer.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_printattempttelemetry_ts",
+      "label": "printAttemptTelemetry.ts",
+      "norm_label": "printattempttelemetry.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
       "source_location": "L1"
     },
     {
       "community": 199,
       "file_type": "code",
-      "id": "telemetrybuffer_clearposclienttelemetrybuffer",
-      "label": "clearPosClientTelemetryBuffer()",
-      "norm_label": "clearposclienttelemetrybuffer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L212"
+      "id": "printattempttelemetry_appendevent",
+      "label": "appendEvent()",
+      "norm_label": "appendevent()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L81"
     },
     {
       "community": 199,
       "file_type": "code",
-      "id": "telemetrybuffer_enqueueposclientevent",
-      "label": "enqueuePosClientEvent()",
-      "norm_label": "enqueueposclientevent()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L167"
+      "id": "printattempttelemetry_beginprintattempt",
+      "label": "beginPrintAttempt()",
+      "norm_label": "beginprintattempt()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L115"
     },
     {
       "community": 199,
       "file_type": "code",
-      "id": "telemetrybuffer_isbufferedevent",
-      "label": "isBufferedEvent()",
-      "norm_label": "isbufferedevent()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L100"
+      "id": "printattempttelemetry_buildmetadata",
+      "label": "buildMetadata()",
+      "norm_label": "buildmetadata()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L88"
     },
     {
       "community": 199,
       "file_type": "code",
-      "id": "telemetrybuffer_mintclienteventid",
-      "label": "mintClientEventId()",
-      "norm_label": "mintclienteventid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L63"
+      "id": "printattempttelemetry_finalizeprintattempt",
+      "label": "finalizePrintAttempt()",
+      "norm_label": "finalizeprintattempt()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L211"
     },
     {
       "community": 199,
       "file_type": "code",
-      "id": "telemetrybuffer_normalizepostelemetryerror",
-      "label": "normalizePosTelemetryError()",
-      "norm_label": "normalizepostelemetryerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L116"
+      "id": "printattempttelemetry_getprintrejectionmetadata",
+      "label": "getPrintRejectionMetadata()",
+      "norm_label": "getprintrejectionmetadata()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L250"
     },
     {
       "community": 199,
       "file_type": "code",
-      "id": "telemetrybuffer_peekposclienteventbatch",
-      "label": "peekPosClientEventBatch()",
-      "norm_label": "peekposclienteventbatch()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L194"
+      "id": "printattempttelemetry_getreasonmessage",
+      "label": "getReasonMessage()",
+      "norm_label": "getreasonmessage()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L108"
     },
     {
       "community": 199,
       "file_type": "code",
-      "id": "telemetrybuffer_posclienttelemetrybuffersize",
-      "label": "posClientTelemetryBufferSize()",
-      "norm_label": "posclienttelemetrybuffersize()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L208"
+      "id": "printattempttelemetry_istargetterminal",
+      "label": "isTargetTerminal()",
+      "norm_label": "istargetterminal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L62"
     },
     {
       "community": 199,
       "file_type": "code",
-      "id": "telemetrybuffer_readbuffer",
-      "label": "readBuffer()",
-      "norm_label": "readbuffer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L74"
+      "id": "printattempttelemetry_mintattemptid",
+      "label": "mintAttemptId()",
+      "norm_label": "mintattemptid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L70"
     },
     {
       "community": 199,
       "file_type": "code",
-      "id": "telemetrybuffer_removeposclientevents",
-      "label": "removePosClientEvents()",
-      "norm_label": "removeposclientevents()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L200"
+      "id": "printattempttelemetry_recordprintattemptevent",
+      "label": "recordPrintAttemptEvent()",
+      "norm_label": "recordprintattemptevent()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L195"
     },
     {
       "community": 199,
       "file_type": "code",
-      "id": "telemetrybuffer_sanitizemetadata",
-      "label": "sanitizeMetadata()",
-      "norm_label": "sanitizemetadata()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L145"
+      "id": "printattempttelemetry_recordprintinvocation",
+      "label": "recordPrintInvocation()",
+      "norm_label": "recordprintinvocation()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L151"
     },
     {
       "community": 199,
       "file_type": "code",
-      "id": "telemetrybuffer_truncate",
-      "label": "truncate()",
-      "norm_label": "truncate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L59"
+      "id": "printattempttelemetry_recordprintreturn",
+      "label": "recordPrintReturn()",
+      "norm_label": "recordprintreturn()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L174"
     },
     {
       "community": 199,
       "file_type": "code",
-      "id": "telemetrybuffer_writebuffer",
-      "label": "writeBuffer()",
-      "norm_label": "writebuffer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L90"
+      "id": "printattempttelemetry_resetprintattempttelemetryfortests",
+      "label": "resetPrintAttemptTelemetryForTests()",
+      "norm_label": "resetprintattempttelemetryfortests()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L294"
     },
     {
       "community": 1990,
@@ -219741,119 +219750,119 @@
     {
       "community": 200,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registercheckoutprojection_ts",
-      "label": "registerCheckoutProjection.ts",
-      "norm_label": "registercheckoutprojection.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_telemetrybuffer_ts",
+      "label": "telemetryBuffer.ts",
+      "norm_label": "telemetrybuffer.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
       "source_location": "L1"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "registercheckoutprojection_buildcompletedsalepayload",
-      "label": "buildCompletedSalePayload()",
-      "norm_label": "buildcompletedsalepayload()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L121"
+      "id": "telemetrybuffer_clearposclienttelemetrybuffer",
+      "label": "clearPosClientTelemetryBuffer()",
+      "norm_label": "clearposclienttelemetrybuffer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L212"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "registercheckoutprojection_buildservicecheckoutblockmessage",
-      "label": "buildServiceCheckoutBlockMessage()",
-      "norm_label": "buildservicecheckoutblockmessage()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L16"
+      "id": "telemetrybuffer_enqueueposclientevent",
+      "label": "enqueuePosClientEvent()",
+      "norm_label": "enqueueposclientevent()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L167"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "registercheckoutprojection_combinepaymentsbymethod",
-      "label": "combinePaymentsByMethod()",
-      "norm_label": "combinepaymentsbymethod()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L78"
+      "id": "telemetrybuffer_isbufferedevent",
+      "label": "isBufferedEvent()",
+      "norm_label": "isbufferedevent()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L100"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "registercheckoutprojection_completedcustomerinfo",
-      "label": "completedCustomerInfo()",
-      "norm_label": "completedcustomerinfo()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L290"
+      "id": "telemetrybuffer_mintclienteventid",
+      "label": "mintClientEventId()",
+      "norm_label": "mintclienteventid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L63"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "registercheckoutprojection_hascustomerdetails",
-      "label": "hasCustomerDetails()",
-      "norm_label": "hascustomerdetails()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L50"
+      "id": "telemetrybuffer_normalizepostelemetryerror",
+      "label": "normalizePosTelemetryError()",
+      "norm_label": "normalizepostelemetryerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L116"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "registercheckoutprojection_ispospaymentmethod",
-      "label": "isPosPaymentMethod()",
-      "norm_label": "ispospaymentmethod()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L98"
+      "id": "telemetrybuffer_peekposclienteventbatch",
+      "label": "peekPosClientEventBatch()",
+      "norm_label": "peekposclienteventbatch()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L194"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "registercheckoutprojection_maplocalpaymenttopayment",
-      "label": "mapLocalPaymentToPayment()",
-      "norm_label": "maplocalpaymenttopayment()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L102"
+      "id": "telemetrybuffer_posclienttelemetrybuffersize",
+      "label": "posClientTelemetryBufferSize()",
+      "norm_label": "posclienttelemetrybuffersize()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L208"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "registercheckoutprojection_maplocalservicelinetostate",
-      "label": "mapLocalServiceLineToState()",
-      "norm_label": "maplocalservicelinetostate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L197"
+      "id": "telemetrybuffer_readbuffer",
+      "label": "readBuffer()",
+      "norm_label": "readbuffer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L74"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "registercheckoutprojection_mapsessioncustomer",
-      "label": "mapSessionCustomer()",
-      "norm_label": "mapsessioncustomer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L65"
+      "id": "telemetrybuffer_removeposclientevents",
+      "label": "removePosClientEvents()",
+      "norm_label": "removeposclientevents()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L200"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "registercheckoutprojection_matchingservicelinedraft",
-      "label": "matchingServiceLineDraft()",
-      "norm_label": "matchingservicelinedraft()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L223"
+      "id": "telemetrybuffer_sanitizemetadata",
+      "label": "sanitizeMetadata()",
+      "norm_label": "sanitizemetadata()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L145"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "registercheckoutprojection_servicelinestatetocartline",
-      "label": "serviceLineStateToCartLine()",
-      "norm_label": "servicelinestatetocartline()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L272"
+      "id": "telemetrybuffer_truncate",
+      "label": "truncate()",
+      "norm_label": "truncate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L59"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "registercheckoutprojection_servicelinestatetolocalpayload",
-      "label": "serviceLineStateToLocalPayload()",
-      "norm_label": "servicelinestatetolocalpayload()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L254"
+      "id": "telemetrybuffer_writebuffer",
+      "label": "writeBuffer()",
+      "norm_label": "writebuffer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L90"
     },
     {
       "community": 2000,
@@ -219948,119 +219957,119 @@
     {
       "community": 201,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registerdrawerpresentation_ts",
-      "label": "registerDrawerPresentation.ts",
-      "norm_label": "registerdrawerpresentation.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registercheckoutprojection_ts",
+      "label": "registerCheckoutProjection.ts",
+      "norm_label": "registercheckoutprojection.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
       "source_location": "L1"
     },
     {
       "community": 201,
       "file_type": "code",
-      "id": "registerdrawerpresentation_buildopendrawerfailuremessage",
-      "label": "buildOpenDrawerFailureMessage()",
-      "norm_label": "buildopendrawerfailuremessage()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L189"
+      "id": "registercheckoutprojection_buildcompletedsalepayload",
+      "label": "buildCompletedSalePayload()",
+      "norm_label": "buildcompletedsalepayload()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L121"
     },
     {
       "community": 201,
       "file_type": "code",
-      "id": "registerdrawerpresentation_findregistercloseoutreviewitem",
-      "label": "findRegisterCloseoutReviewItem()",
-      "norm_label": "findregistercloseoutreviewitem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L171"
+      "id": "registercheckoutprojection_buildservicecheckoutblockmessage",
+      "label": "buildServiceCheckoutBlockMessage()",
+      "norm_label": "buildservicecheckoutblockmessage()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L16"
     },
     {
       "community": 201,
       "file_type": "code",
-      "id": "registerdrawerpresentation_formatcloseoutcloudregistersessioncode",
-      "label": "formatCloseoutCloudRegisterSessionCode()",
-      "norm_label": "formatcloseoutcloudregistersessioncode()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L98"
+      "id": "registercheckoutprojection_combinepaymentsbymethod",
+      "label": "combinePaymentsByMethod()",
+      "norm_label": "combinepaymentsbymethod()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L78"
     },
     {
       "community": 201,
       "file_type": "code",
-      "id": "registerdrawerpresentation_getcloseoutcloudregistersessioncode",
-      "label": "getCloseoutCloudRegisterSessionCode()",
-      "norm_label": "getcloseoutcloudregistersessioncode()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L68"
+      "id": "registercheckoutprojection_completedcustomerinfo",
+      "label": "completedCustomerInfo()",
+      "norm_label": "completedcustomerinfo()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L290"
     },
     {
       "community": 201,
       "file_type": "code",
-      "id": "registerdrawerpresentation_getcloseoutcloudregistersessionid",
-      "label": "getCloseoutCloudRegisterSessionId()",
-      "norm_label": "getcloseoutcloudregistersessionid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "id": "registercheckoutprojection_hascustomerdetails",
+      "label": "hasCustomerDetails()",
+      "norm_label": "hascustomerdetails()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
       "source_location": "L50"
     },
     {
       "community": 201,
       "file_type": "code",
-      "id": "registerdrawerpresentation_getcloseoutlocalregistersessionid",
-      "label": "getCloseoutLocalRegisterSessionId()",
-      "norm_label": "getcloseoutlocalregistersessionid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L29"
+      "id": "registercheckoutprojection_ispospaymentmethod",
+      "label": "isPosPaymentMethod()",
+      "norm_label": "ispospaymentmethod()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L98"
     },
     {
       "community": 201,
       "file_type": "code",
-      "id": "registerdrawerpresentation_getlatestlocalregisterlifecycleevent",
-      "label": "getLatestLocalRegisterLifecycleEvent()",
-      "norm_label": "getlatestlocalregisterlifecycleevent()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L207"
+      "id": "registercheckoutprojection_maplocalpaymenttopayment",
+      "label": "mapLocalPaymentToPayment()",
+      "norm_label": "maplocalpaymenttopayment()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L102"
     },
     {
       "community": 201,
       "file_type": "code",
-      "id": "registerdrawerpresentation_getpendinglocalcashvoidapprovals",
-      "label": "getPendingLocalCashVoidApprovals()",
-      "norm_label": "getpendinglocalcashvoidapprovals()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L270"
+      "id": "registercheckoutprojection_maplocalservicelinetostate",
+      "label": "mapLocalServiceLineToState()",
+      "norm_label": "maplocalservicelinetostate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L197"
     },
     {
       "community": 201,
       "file_type": "code",
-      "id": "registerdrawerpresentation_getpendinglocalcloseoutregistersession",
-      "label": "getPendingLocalCloseoutRegisterSession()",
-      "norm_label": "getpendinglocalcloseoutregistersession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L234"
+      "id": "registercheckoutprojection_mapsessioncustomer",
+      "label": "mapSessionCustomer()",
+      "norm_label": "mapsessioncustomer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L65"
     },
     {
       "community": 201,
       "file_type": "code",
-      "id": "registerdrawerpresentation_isknowncloudregistersessionblockinglocalprojection",
-      "label": "isKnownCloudRegisterSessionBlockingLocalProjection()",
-      "norm_label": "isknowncloudregistersessionblockinglocalprojection()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L114"
+      "id": "registercheckoutprojection_matchingservicelinedraft",
+      "label": "matchingServiceLineDraft()",
+      "norm_label": "matchingservicelinedraft()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L223"
     },
     {
       "community": 201,
       "file_type": "code",
-      "id": "registerdrawerpresentation_readlocalsyncstatus",
-      "label": "readLocalSyncStatus()",
-      "norm_label": "readlocalsyncstatus()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L146"
+      "id": "registercheckoutprojection_servicelinestatetocartline",
+      "label": "serviceLineStateToCartLine()",
+      "norm_label": "servicelinestatetocartline()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L272"
     },
     {
       "community": 201,
       "file_type": "code",
-      "id": "registerdrawerpresentation_stringfield",
-      "label": "stringField()",
-      "norm_label": "stringfield()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L334"
+      "id": "registercheckoutprojection_servicelinestatetolocalpayload",
+      "label": "serviceLineStateToLocalPayload()",
+      "norm_label": "servicelinestatetolocalpayload()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L254"
     },
     {
       "community": 2010,
@@ -220155,119 +220164,119 @@
     {
       "community": 202,
       "file_type": "code",
-      "id": "localpinverifier_base64tobytes",
-      "label": "base64ToBytes()",
-      "norm_label": "base64tobytes()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registerdrawerpresentation_ts",
+      "label": "registerDrawerPresentation.ts",
+      "norm_label": "registerdrawerpresentation.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "registerdrawerpresentation_buildopendrawerfailuremessage",
+      "label": "buildOpenDrawerFailureMessage()",
+      "norm_label": "buildopendrawerfailuremessage()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L189"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "registerdrawerpresentation_findregistercloseoutreviewitem",
+      "label": "findRegisterCloseoutReviewItem()",
+      "norm_label": "findregistercloseoutreviewitem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L171"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "registerdrawerpresentation_formatcloseoutcloudregistersessioncode",
+      "label": "formatCloseoutCloudRegisterSessionCode()",
+      "norm_label": "formatcloseoutcloudregistersessioncode()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L98"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "registerdrawerpresentation_getcloseoutcloudregistersessioncode",
+      "label": "getCloseoutCloudRegisterSessionCode()",
+      "norm_label": "getcloseoutcloudregistersessioncode()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L68"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "registerdrawerpresentation_getcloseoutcloudregistersessionid",
+      "label": "getCloseoutCloudRegisterSessionId()",
+      "norm_label": "getcloseoutcloudregistersessionid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
       "source_location": "L50"
     },
     {
       "community": 202,
       "file_type": "code",
-      "id": "localpinverifier_bytestobase64",
-      "label": "bytesToBase64()",
-      "norm_label": "bytestobase64()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L38"
+      "id": "registerdrawerpresentation_getcloseoutlocalregistersessionid",
+      "label": "getCloseoutLocalRegisterSessionId()",
+      "norm_label": "getcloseoutlocalregistersessionid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L29"
     },
     {
       "community": 202,
       "file_type": "code",
-      "id": "localpinverifier_createlocalpinverifier",
-      "label": "createLocalPinVerifier()",
-      "norm_label": "createlocalpinverifier()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L131"
+      "id": "registerdrawerpresentation_getlatestlocalregisterlifecycleevent",
+      "label": "getLatestLocalRegisterLifecycleEvent()",
+      "norm_label": "getlatestlocalregisterlifecycleevent()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L207"
     },
     {
       "community": 202,
       "file_type": "code",
-      "id": "localpinverifier_cryptorefdecrypt",
-      "label": "cryptoRefDecrypt()",
-      "norm_label": "cryptorefdecrypt()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L268"
+      "id": "registerdrawerpresentation_getpendinglocalcashvoidapprovals",
+      "label": "getPendingLocalCashVoidApprovals()",
+      "norm_label": "getpendinglocalcashvoidapprovals()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L270"
     },
     {
       "community": 202,
       "file_type": "code",
-      "id": "localpinverifier_derivepinhash",
-      "label": "derivePinHash()",
-      "norm_label": "derivepinhash()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L76"
+      "id": "registerdrawerpresentation_getpendinglocalcloseoutregistersession",
+      "label": "getPendingLocalCloseoutRegisterSession()",
+      "norm_label": "getpendinglocalcloseoutregistersession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L234"
     },
     {
       "community": 202,
       "file_type": "code",
-      "id": "localpinverifier_derivewrappingkey",
-      "label": "deriveWrappingKey()",
-      "norm_label": "derivewrappingkey()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L103"
+      "id": "registerdrawerpresentation_isknowncloudregistersessionblockinglocalprojection",
+      "label": "isKnownCloudRegisterSessionBlockingLocalProjection()",
+      "norm_label": "isknowncloudregistersessionblockinglocalprojection()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L114"
     },
     {
       "community": 202,
       "file_type": "code",
-      "id": "localpinverifier_getcrypto",
-      "label": "getCrypto()",
-      "norm_label": "getcrypto()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L30"
+      "id": "registerdrawerpresentation_readlocalsyncstatus",
+      "label": "readLocalSyncStatus()",
+      "norm_label": "readlocalsyncstatus()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L146"
     },
     {
       "community": 202,
       "file_type": "code",
-      "id": "localpinverifier_islocalpinverifiermetadata",
-      "label": "isLocalPinVerifierMetadata()",
-      "norm_label": "islocalpinverifiermetadata()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L281"
-    },
-    {
-      "community": 202,
-      "file_type": "code",
-      "id": "localpinverifier_timingsafeequal",
-      "label": "timingSafeEqual()",
-      "norm_label": "timingsafeequal()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 202,
-      "file_type": "code",
-      "id": "localpinverifier_unwraplocalstaffprooftoken",
-      "label": "unwrapLocalStaffProofToken()",
-      "norm_label": "unwraplocalstaffprooftoken()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L221"
-    },
-    {
-      "community": 202,
-      "file_type": "code",
-      "id": "localpinverifier_verifylocalpin",
-      "label": "verifyLocalPin()",
-      "norm_label": "verifylocalpin()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L152"
-    },
-    {
-      "community": 202,
-      "file_type": "code",
-      "id": "localpinverifier_wraplocalstaffprooftoken",
-      "label": "wrapLocalStaffProofToken()",
-      "norm_label": "wraplocalstaffprooftoken()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L183"
-    },
-    {
-      "community": 202,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_security_localpinverifier_ts",
-      "label": "localPinVerifier.ts",
-      "norm_label": "localpinverifier.ts",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L1"
+      "id": "registerdrawerpresentation_stringfield",
+      "label": "stringField()",
+      "norm_label": "stringfield()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L334"
     },
     {
       "community": 2020,
@@ -220362,119 +220371,119 @@
     {
       "community": 203,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_reviews_ts",
-      "label": "reviews.ts",
-      "norm_label": "reviews.ts",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L1"
+      "id": "localpinverifier_base64tobytes",
+      "label": "base64ToBytes()",
+      "norm_label": "base64tobytes()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L50"
     },
     {
       "community": 203,
       "file_type": "code",
-      "id": "reviews_createreview",
-      "label": "createReview()",
-      "norm_label": "createreview()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L13"
+      "id": "localpinverifier_bytestobase64",
+      "label": "bytesToBase64()",
+      "norm_label": "bytestobase64()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L38"
     },
     {
       "community": 203,
       "file_type": "code",
-      "id": "reviews_deletereview",
-      "label": "deleteReview()",
-      "norm_label": "deletereview()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L69"
+      "id": "localpinverifier_createlocalpinverifier",
+      "label": "createLocalPinVerifier()",
+      "norm_label": "createlocalpinverifier()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L131"
     },
     {
       "community": 203,
       "file_type": "code",
-      "id": "reviews_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L4"
+      "id": "localpinverifier_cryptorefdecrypt",
+      "label": "cryptoRefDecrypt()",
+      "norm_label": "cryptorefdecrypt()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L268"
     },
     {
       "community": 203,
       "file_type": "code",
-      "id": "reviews_getreviewbyorderitem",
-      "label": "getReviewByOrderItem()",
-      "norm_label": "getreviewbyorderitem()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L32"
+      "id": "localpinverifier_derivepinhash",
+      "label": "derivePinHash()",
+      "norm_label": "derivepinhash()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L76"
     },
     {
       "community": 203,
       "file_type": "code",
-      "id": "reviews_getreviewsbyproductid",
-      "label": "getReviewsByProductId()",
-      "norm_label": "getreviewsbyproductid()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L132"
+      "id": "localpinverifier_derivewrappingkey",
+      "label": "deriveWrappingKey()",
+      "norm_label": "derivewrappingkey()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L103"
     },
     {
       "community": 203,
       "file_type": "code",
-      "id": "reviews_getreviewsbyproductskuid",
-      "label": "getReviewsByProductSkuId()",
-      "norm_label": "getreviewsbyproductskuid()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L83"
+      "id": "localpinverifier_getcrypto",
+      "label": "getCrypto()",
+      "norm_label": "getcrypto()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L30"
     },
     {
       "community": 203,
       "file_type": "code",
-      "id": "reviews_getuserreviews",
-      "label": "getUserReviews()",
-      "norm_label": "getuserreviews()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L99"
+      "id": "localpinverifier_islocalpinverifiermetadata",
+      "label": "isLocalPinVerifierMetadata()",
+      "norm_label": "islocalpinverifiermetadata()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L281"
     },
     {
       "community": 203,
       "file_type": "code",
-      "id": "reviews_getuserreviewsforproduct",
-      "label": "getUserReviewsForProduct()",
-      "norm_label": "getuserreviewsforproduct()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L113"
+      "id": "localpinverifier_timingsafeequal",
+      "label": "timingSafeEqual()",
+      "norm_label": "timingsafeequal()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L63"
     },
     {
       "community": 203,
       "file_type": "code",
-      "id": "reviews_hasreviewfororderitem",
-      "label": "hasReviewForOrderItem()",
-      "norm_label": "hasreviewfororderitem()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L164"
+      "id": "localpinverifier_unwraplocalstaffprooftoken",
+      "label": "unwrapLocalStaffProofToken()",
+      "norm_label": "unwraplocalstaffprooftoken()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L221"
     },
     {
       "community": 203,
       "file_type": "code",
-      "id": "reviews_hasuserreviewfororderitem",
-      "label": "hasUserReviewForOrderItem()",
-      "norm_label": "hasuserreviewfororderitem()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "id": "localpinverifier_verifylocalpin",
+      "label": "verifyLocalPin()",
+      "norm_label": "verifylocalpin()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L152"
+    },
+    {
+      "community": 203,
+      "file_type": "code",
+      "id": "localpinverifier_wraplocalstaffprooftoken",
+      "label": "wrapLocalStaffProofToken()",
+      "norm_label": "wraplocalstaffprooftoken()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
       "source_location": "L183"
     },
     {
       "community": 203,
       "file_type": "code",
-      "id": "reviews_markreviewhelpful",
-      "label": "markReviewHelpful()",
-      "norm_label": "markreviewhelpful()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L148"
-    },
-    {
-      "community": 203,
-      "file_type": "code",
-      "id": "reviews_updatereview",
-      "label": "updateReview()",
-      "norm_label": "updatereview()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L48"
+      "id": "packages_athena_webapp_src_lib_security_localpinverifier_ts",
+      "label": "localPinVerifier.ts",
+      "norm_label": "localpinverifier.ts",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L1"
     },
     {
       "community": 2030,
@@ -220569,119 +220578,119 @@
     {
       "community": 204,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "id": "packages_storefront_webapp_src_api_reviews_ts",
+      "label": "reviews.ts",
+      "norm_label": "reviews.ts",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L1"
     },
     {
       "community": 204,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
+      "id": "reviews_createreview",
+      "label": "createReview()",
+      "norm_label": "createreview()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L13"
     },
     {
       "community": 204,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L1"
+      "id": "reviews_deletereview",
+      "label": "deleteReview()",
+      "norm_label": "deletereview()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L69"
     },
     {
       "community": 204,
       "file_type": "code",
-      "id": "utils_formatdeliveryaddress",
-      "label": "formatDeliveryAddress()",
-      "norm_label": "formatdeliveryaddress()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L74"
+      "id": "reviews_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L4"
     },
     {
       "community": 204,
       "file_type": "code",
-      "id": "utils_getamountpaidfororder",
-      "label": "getAmountPaidForOrder()",
-      "norm_label": "getamountpaidfororder()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L191"
+      "id": "reviews_getreviewbyorderitem",
+      "label": "getReviewByOrderItem()",
+      "norm_label": "getreviewbyorderitem()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L32"
     },
     {
       "community": 204,
       "file_type": "code",
-      "id": "utils_getdiscountvalue",
-      "label": "getDiscountValue()",
-      "norm_label": "getdiscountvalue()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L17"
+      "id": "reviews_getreviewsbyproductid",
+      "label": "getReviewsByProductId()",
+      "norm_label": "getreviewsbyproductid()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L132"
     },
     {
       "community": 204,
       "file_type": "code",
-      "id": "utils_getonlineorderplacedat",
-      "label": "getOnlineOrderPlacedAt()",
-      "norm_label": "getonlineorderplacedat()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
+      "id": "reviews_getreviewsbyproductskuid",
+      "label": "getReviewsByProductSkuId()",
+      "norm_label": "getreviewsbyproductskuid()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L83"
     },
     {
       "community": 204,
       "file_type": "code",
-      "id": "utils_getorderamount",
-      "label": "getOrderAmount()",
-      "norm_label": "getorderamount()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L51"
+      "id": "reviews_getuserreviews",
+      "label": "getUserReviews()",
+      "norm_label": "getuserreviews()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L99"
     },
     {
       "community": 204,
       "file_type": "code",
-      "id": "utils_getorderstate",
-      "label": "getOrderState()",
-      "norm_label": "getorderstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L40"
+      "id": "reviews_getuserreviewsforproduct",
+      "label": "getUserReviewsForProduct()",
+      "norm_label": "getuserreviewsforproduct()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L113"
     },
     {
       "community": 204,
       "file_type": "code",
-      "id": "utils_getpickupactionstate",
-      "label": "getPickupActionState()",
-      "norm_label": "getpickupactionstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L102"
+      "id": "reviews_hasreviewfororderitem",
+      "label": "hasReviewForOrderItem()",
+      "norm_label": "hasreviewfororderitem()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L164"
     },
     {
       "community": 204,
       "file_type": "code",
-      "id": "utils_getpotentialpoints",
-      "label": "getPotentialPoints()",
-      "norm_label": "getpotentialpoints()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L107"
+      "id": "reviews_hasuserreviewfororderitem",
+      "label": "hasUserReviewForOrderItem()",
+      "norm_label": "hasuserreviewfororderitem()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L183"
     },
     {
       "community": 204,
       "file_type": "code",
-      "id": "utils_getproductdiscountvalue",
-      "label": "getProductDiscountValue()",
-      "norm_label": "getproductdiscountvalue()",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
-      "source_location": "L75"
+      "id": "reviews_markreviewhelpful",
+      "label": "markReviewHelpful()",
+      "norm_label": "markreviewhelpful()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L148"
     },
     {
       "community": 204,
       "file_type": "code",
-      "id": "utils_shouldshowpickupexceptionaction",
-      "label": "shouldShowPickupExceptionAction()",
-      "norm_label": "shouldshowpickupexceptionaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L116"
+      "id": "reviews_updatereview",
+      "label": "updateReview()",
+      "norm_label": "updatereview()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L48"
     },
     {
       "community": 2040,
@@ -230325,92 +230334,92 @@
     {
       "community": 247,
       "file_type": "code",
-      "id": "index_resolveverificationcoderecipient",
-      "label": "resolveVerificationCodeRecipient()",
-      "norm_label": "resolveverificationcoderecipient()",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "index_senddailymanagerreportemail",
-      "label": "sendDailyManagerReportEmail()",
-      "norm_label": "senddailymanagerreportemail()",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
-      "source_location": "L373"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "index_senddiscountcodeemail",
-      "label": "sendDiscountCodeEmail()",
-      "norm_label": "senddiscountcodeemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L255"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "index_senddiscountreminderemail",
-      "label": "sendDiscountReminderEmail()",
-      "norm_label": "senddiscountreminderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L334"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "index_sendfeedbackrequestemail",
-      "label": "sendFeedbackRequestEmail()",
-      "norm_label": "sendfeedbackrequestemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L167"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "index_sendneworderemail",
-      "label": "sendNewOrderEmail()",
-      "norm_label": "sendneworderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L117"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "index_sendorderemail",
-      "label": "sendOrderEmail()",
-      "norm_label": "sendorderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "index_sendverificationcode",
-      "label": "sendVerificationCode()",
-      "norm_label": "sendverificationcode()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "id": "packages_athena_webapp_convex_marketing_walkthroughconfig_ts",
+      "label": "walkthroughConfig.ts",
+      "norm_label": "walkthroughconfig.ts",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
       "source_location": "L1"
     },
     {
       "community": 247,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L1"
+      "id": "walkthroughconfig_landingfunnelhourlylimit",
+      "label": "landingFunnelHourlyLimit()",
+      "norm_label": "landingfunnelhourlylimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "walkthroughconfig_parseboundedpositiveinteger",
+      "label": "parseBoundedPositiveInteger()",
+      "norm_label": "parseboundedpositiveinteger()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "walkthroughconfig_resolvewalkthroughallowedorigins",
+      "label": "resolveWalkthroughAllowedOrigins()",
+      "norm_label": "resolvewalkthroughallowedorigins()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughallowedorigins",
+      "label": "walkthroughAllowedOrigins()",
+      "norm_label": "walkthroughallowedorigins()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughdailyperemaillimit",
+      "label": "walkthroughDailyPerEmailLimit()",
+      "norm_label": "walkthroughdailyperemaillimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughhourlygloballimit",
+      "label": "walkthroughHourlyGlobalLimit()",
+      "norm_label": "walkthroughhourlygloballimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughhourlynotificationlimit",
+      "label": "walkthroughHourlyNotificationLimit()",
+      "norm_label": "walkthroughhourlynotificationlimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughmaxbodybytes",
+      "label": "walkthroughMaxBodyBytes()",
+      "norm_label": "walkthroughmaxbodybytes()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughprivacycontact",
+      "label": "walkthroughPrivacyContact()",
+      "norm_label": "walkthroughprivacycontact()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L95"
     },
     {
       "community": 2470,
@@ -230505,92 +230514,92 @@
     {
       "community": 248,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_marketing_walkthroughconfig_ts",
-      "label": "walkthroughConfig.ts",
-      "norm_label": "walkthroughconfig.ts",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "id": "definitions_costoverlaystorewriteoperation",
+      "label": "costOverlayStoreWriteOperation()",
+      "norm_label": "costoverlaystorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L569"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "definitions_cyclecountdraftstorewriteoperation",
+      "label": "cycleCountDraftStoreWriteOperation()",
+      "norm_label": "cyclecountdraftstorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L383"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "definitions_defineoperation",
+      "label": "defineOperation()",
+      "norm_label": "defineoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "definitions_inventoryimportreviewpayloadwriteoperation",
+      "label": "inventoryImportReviewPayloadWriteOperation()",
+      "norm_label": "inventoryimportreviewpayloadwriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L544"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "definitions_notificationsubscriptionrowwriteoperation",
+      "label": "notificationSubscriptionRowWriteOperation()",
+      "norm_label": "notificationsubscriptionrowwriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L629"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "definitions_orderstorewriteoperation",
+      "label": "orderStoreWriteOperation()",
+      "norm_label": "orderstorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L155"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "definitions_storewriteoperation",
+      "label": "storeWriteOperation()",
+      "norm_label": "storewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L108"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "definitions_transactionstorewriteoperation",
+      "label": "transactionStoreWriteOperation()",
+      "norm_label": "transactionstorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "definitions_validateoperationdefinition",
+      "label": "validateOperationDefinition()",
+      "norm_label": "validateoperationdefinition()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L724"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operationadmission_definitions_ts",
+      "label": "definitions.ts",
+      "norm_label": "definitions.ts",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "walkthroughconfig_landingfunnelhourlylimit",
-      "label": "landingFunnelHourlyLimit()",
-      "norm_label": "landingfunnelhourlylimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "walkthroughconfig_parseboundedpositiveinteger",
-      "label": "parseBoundedPositiveInteger()",
-      "norm_label": "parseboundedpositiveinteger()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "walkthroughconfig_resolvewalkthroughallowedorigins",
-      "label": "resolveWalkthroughAllowedOrigins()",
-      "norm_label": "resolvewalkthroughallowedorigins()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughallowedorigins",
-      "label": "walkthroughAllowedOrigins()",
-      "norm_label": "walkthroughallowedorigins()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughdailyperemaillimit",
-      "label": "walkthroughDailyPerEmailLimit()",
-      "norm_label": "walkthroughdailyperemaillimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L55"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughhourlygloballimit",
-      "label": "walkthroughHourlyGlobalLimit()",
-      "norm_label": "walkthroughhourlygloballimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughhourlynotificationlimit",
-      "label": "walkthroughHourlyNotificationLimit()",
-      "norm_label": "walkthroughhourlynotificationlimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughmaxbodybytes",
-      "label": "walkthroughMaxBodyBytes()",
-      "norm_label": "walkthroughmaxbodybytes()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughprivacycontact",
-      "label": "walkthroughPrivacyContact()",
-      "norm_label": "walkthroughprivacycontact()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L95"
     },
     {
       "community": 2480,
@@ -230685,91 +230694,91 @@
     {
       "community": 249,
       "file_type": "code",
-      "id": "definitions_costoverlaystorewriteoperation",
-      "label": "costOverlayStoreWriteOperation()",
-      "norm_label": "costoverlaystorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L569"
+      "id": "adjustmentreports_adjustmentappliedat",
+      "label": "adjustmentAppliedAt()",
+      "norm_label": "adjustmentappliedat()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L101"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "definitions_cyclecountdraftstorewriteoperation",
-      "label": "cycleCountDraftStoreWriteOperation()",
-      "norm_label": "cyclecountdraftstorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L383"
+      "id": "adjustmentreports_adjustmentsalesdelta",
+      "label": "adjustmentSalesDelta()",
+      "norm_label": "adjustmentsalesdelta()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L116"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "definitions_defineoperation",
-      "label": "defineOperation()",
-      "norm_label": "defineoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L11"
+      "id": "adjustmentreports_adjustmentsettlementamount",
+      "label": "adjustmentSettlementAmount()",
+      "norm_label": "adjustmentsettlementamount()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L143"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "definitions_inventoryimportreviewpayloadwriteoperation",
-      "label": "inventoryImportReviewPayloadWriteOperation()",
-      "norm_label": "inventoryimportreviewpayloadwriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L544"
+      "id": "adjustmentreports_adjustmenttransactionid",
+      "label": "adjustmentTransactionId()",
+      "norm_label": "adjustmenttransactionid()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L110"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "definitions_notificationsubscriptionrowwriteoperation",
-      "label": "notificationSubscriptionRowWriteOperation()",
-      "norm_label": "notificationsubscriptionrowwriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L629"
+      "id": "adjustmentreports_buildadjustmentpaymenttotals",
+      "label": "buildAdjustmentPaymentTotals()",
+      "norm_label": "buildadjustmentpaymenttotals()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L242"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "definitions_orderstorewriteoperation",
-      "label": "orderStoreWriteOperation()",
-      "norm_label": "orderstorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L155"
+      "id": "adjustmentreports_buildadjustmentreporttotals",
+      "label": "buildAdjustmentReportTotals()",
+      "norm_label": "buildadjustmentreporttotals()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L275"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "definitions_storewriteoperation",
-      "label": "storeWriteOperation()",
-      "norm_label": "storewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L108"
+      "id": "adjustmentreports_listappliedtransactionadjustmentsforday",
+      "label": "listAppliedTransactionAdjustmentsForDay()",
+      "norm_label": "listappliedtransactionadjustmentsforday()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L229"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "definitions_transactionstorewriteoperation",
-      "label": "transactionStoreWriteOperation()",
-      "norm_label": "transactionstorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L128"
+      "id": "adjustmentreports_readappliedtransactionadjustmentsforday",
+      "label": "readAppliedTransactionAdjustmentsForDay()",
+      "norm_label": "readappliedtransactionadjustmentsforday()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L173"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "definitions_validateoperationdefinition",
-      "label": "validateOperationDefinition()",
-      "norm_label": "validateoperationdefinition()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L724"
+      "id": "adjustmentreports_sourcecompletenessentry",
+      "label": "sourceCompletenessEntry()",
+      "norm_label": "sourcecompletenessentry()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L76"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operationadmission_definitions_ts",
-      "label": "definitions.ts",
-      "norm_label": "definitions.ts",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "id": "packages_athena_webapp_convex_operations_dailyclose_adjustmentreports_ts",
+      "label": "adjustmentReports.ts",
+      "norm_label": "adjustmentreports.ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
       "source_location": "L1"
     },
     {
@@ -231216,91 +231225,91 @@
     {
       "community": 250,
       "file_type": "code",
-      "id": "adjustmentreports_adjustmentappliedat",
-      "label": "adjustmentAppliedAt()",
-      "norm_label": "adjustmentappliedat()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L101"
+      "id": "inventorymovements_assertnobusinesseventconflict",
+      "label": "assertNoBusinessEventConflict()",
+      "norm_label": "assertnobusinesseventconflict()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L178"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "adjustmentreports_adjustmentsalesdelta",
-      "label": "adjustmentSalesDelta()",
-      "norm_label": "adjustmentsalesdelta()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L116"
+      "id": "inventorymovements_buildinventorymovement",
+      "label": "buildInventoryMovement()",
+      "norm_label": "buildinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L124"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "adjustmentreports_adjustmentsettlementamount",
-      "label": "adjustmentSettlementAmount()",
-      "norm_label": "adjustmentsettlementamount()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L143"
+      "id": "inventorymovements_buildskuactivityforinventorymovement",
+      "label": "buildSkuActivityForInventoryMovement()",
+      "norm_label": "buildskuactivityforinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L66"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "adjustmentreports_adjustmenttransactionid",
-      "label": "adjustmentTransactionId()",
-      "norm_label": "adjustmenttransactionid()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L110"
+      "id": "inventorymovements_getskuactivitytypeformovement",
+      "label": "getSkuActivityTypeForMovement()",
+      "norm_label": "getskuactivitytypeformovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L49"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "adjustmentreports_buildadjustmentpaymenttotals",
-      "label": "buildAdjustmentPaymentTotals()",
-      "norm_label": "buildadjustmentpaymenttotals()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L242"
+      "id": "inventorymovements_matchesexistingmovement",
+      "label": "matchesExistingMovement()",
+      "norm_label": "matchesexistingmovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L150"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "adjustmentreports_buildadjustmentreporttotals",
-      "label": "buildAdjustmentReportTotals()",
-      "norm_label": "buildadjustmentreporttotals()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L275"
+      "id": "inventorymovements_recordinventorymovementwithctx",
+      "label": "recordInventoryMovementWithCtx()",
+      "norm_label": "recordinventorymovementwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L200"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "adjustmentreports_listappliedtransactionadjustmentsforday",
-      "label": "listAppliedTransactionAdjustmentsForDay()",
-      "norm_label": "listappliedtransactionadjustmentsforday()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L229"
+      "id": "inventorymovements_recordinventorymovementwithdispositionwithctx",
+      "label": "recordInventoryMovementWithDispositionWithCtx()",
+      "norm_label": "recordinventorymovementwithdispositionwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L245"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "adjustmentreports_readappliedtransactionadjustmentsforday",
-      "label": "readAppliedTransactionAdjustmentsForDay()",
-      "norm_label": "readappliedtransactionadjustmentsforday()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L173"
+      "id": "inventorymovements_recordskuactivityforinventorymovementwithctx",
+      "label": "recordSkuActivityForInventoryMovementWithCtx()",
+      "norm_label": "recordskuactivityforinventorymovementwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L111"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "adjustmentreports_sourcecompletenessentry",
-      "label": "sourceCompletenessEntry()",
-      "norm_label": "sourcecompletenessentry()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L76"
+      "id": "inventorymovements_summarizeinventorymovements",
+      "label": "summarizeInventoryMovements()",
+      "norm_label": "summarizeinventorymovements()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L135"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_dailyclose_adjustmentreports_ts",
-      "label": "adjustmentReports.ts",
-      "norm_label": "adjustmentreports.ts",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
+      "label": "inventoryMovements.ts",
+      "norm_label": "inventorymovements.ts",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
       "source_location": "L1"
     },
     {
@@ -231396,91 +231405,91 @@
     {
       "community": 251,
       "file_type": "code",
-      "id": "inventorymovements_assertnobusinesseventconflict",
-      "label": "assertNoBusinessEventConflict()",
-      "norm_label": "assertnobusinesseventconflict()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L178"
+      "id": "operationalevents_buildoperationalevent",
+      "label": "buildOperationalEvent()",
+      "norm_label": "buildoperationalevent()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L43"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "inventorymovements_buildinventorymovement",
-      "label": "buildInventoryMovement()",
-      "norm_label": "buildinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L124"
+      "id": "operationalevents_buildtracemetadata",
+      "label": "buildTraceMetadata()",
+      "norm_label": "buildtracemetadata()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L96"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "inventorymovements_buildskuactivityforinventorymovement",
-      "label": "buildSkuActivityForInventoryMovement()",
-      "norm_label": "buildskuactivityforinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L66"
+      "id": "operationalevents_isrecord",
+      "label": "isRecord()",
+      "norm_label": "isrecord()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L145"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "inventorymovements_getskuactivitytypeformovement",
-      "label": "getSkuActivityTypeForMovement()",
-      "norm_label": "getskuactivitytypeformovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L49"
+      "id": "operationalevents_listproductoperationaltimelinewithctx",
+      "label": "listProductOperationalTimelineWithCtx()",
+      "norm_label": "listproductoperationaltimelinewithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L246"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "inventorymovements_matchesexistingmovement",
-      "label": "matchesExistingMovement()",
-      "norm_label": "matchesexistingmovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L150"
+      "id": "operationalevents_matchesexistingevent",
+      "label": "matchesExistingEvent()",
+      "norm_label": "matchesexistingevent()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L149"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "inventorymovements_recordinventorymovementwithctx",
-      "label": "recordInventoryMovementWithCtx()",
-      "norm_label": "recordinventorymovementwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L200"
+      "id": "operationalevents_metadatadedupekeysmatch",
+      "label": "metadataDedupeKeysMatch()",
+      "norm_label": "metadatadedupekeysmatch()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L205"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "inventorymovements_recordinventorymovementwithdispositionwithctx",
-      "label": "recordInventoryMovementWithDispositionWithCtx()",
-      "norm_label": "recordinventorymovementwithdispositionwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L245"
+      "id": "operationalevents_normalizeoperationaleventtracefields",
+      "label": "normalizeOperationalEventTraceFields()",
+      "norm_label": "normalizeoperationaleventtracefields()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L60"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "inventorymovements_recordskuactivityforinventorymovementwithctx",
-      "label": "recordSkuActivityForInventoryMovementWithCtx()",
-      "norm_label": "recordskuactivityforinventorymovementwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L111"
+      "id": "operationalevents_recordoperationaleventwithctx",
+      "label": "recordOperationalEventWithCtx()",
+      "norm_label": "recordoperationaleventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L215"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "inventorymovements_summarizeinventorymovements",
-      "label": "summarizeInventoryMovements()",
-      "norm_label": "summarizeinventorymovements()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L135"
+      "id": "operationalevents_shouldnormalizepostrace",
+      "label": "shouldNormalizePosTrace()",
+      "norm_label": "shouldnormalizepostrace()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L118"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
-      "label": "inventoryMovements.ts",
-      "norm_label": "inventorymovements.ts",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
+      "label": "operationalEvents.ts",
+      "norm_label": "operationalevents.ts",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
       "source_location": "L1"
     },
     {
@@ -231576,91 +231585,91 @@
     {
       "community": 252,
       "file_type": "code",
-      "id": "operationalevents_buildoperationalevent",
-      "label": "buildOperationalEvent()",
-      "norm_label": "buildoperationalevent()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L43"
+      "id": "oversizedoperationalworkrepair_amendrepairwithctx",
+      "label": "amendRepairWithCtx()",
+      "norm_label": "amendrepairwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L430"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "operationalevents_buildtracemetadata",
-      "label": "buildTraceMetadata()",
-      "norm_label": "buildtracemetadata()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L96"
+      "id": "oversizedoperationalworkrepair_createrepairwithctx",
+      "label": "createRepairWithCtx()",
+      "norm_label": "createrepairwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L160"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "operationalevents_isrecord",
-      "label": "isRecord()",
-      "norm_label": "isrecord()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L145"
+      "id": "oversizedoperationalworkrepair_pauserepair",
+      "label": "pauseRepair()",
+      "norm_label": "pauserepair()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L231"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "operationalevents_listproductoperationaltimelinewithctx",
-      "label": "listProductOperationalTimelineWithCtx()",
-      "norm_label": "listproductoperationaltimelinewithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L246"
+      "id": "oversizedoperationalworkrepair_processrepairbatchwithctx",
+      "label": "processRepairBatchWithCtx()",
+      "norm_label": "processrepairbatchwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L249"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "operationalevents_matchesexistingevent",
-      "label": "matchesExistingEvent()",
-      "norm_label": "matchesexistingevent()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L149"
+      "id": "oversizedoperationalworkrepair_readcurrentgroup",
+      "label": "readCurrentGroup()",
+      "norm_label": "readcurrentgroup()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L49"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "operationalevents_metadatadedupekeysmatch",
-      "label": "metadataDedupeKeysMatch()",
-      "norm_label": "metadatadedupekeysmatch()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L205"
+      "id": "oversizedoperationalworkrepair_recordrepairauditevent",
+      "label": "recordRepairAuditEvent()",
+      "norm_label": "recordrepairauditevent()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L85"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "operationalevents_normalizeoperationaleventtracefields",
-      "label": "normalizeOperationalEventTraceFields()",
-      "norm_label": "normalizeoperationaleventtracefields()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L60"
+      "id": "oversizedoperationalworkrepair_requireevidence",
+      "label": "requireEvidence()",
+      "norm_label": "requireevidence()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L37"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "operationalevents_recordoperationaleventwithctx",
-      "label": "recordOperationalEventWithCtx()",
-      "norm_label": "recordoperationaleventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L215"
+      "id": "oversizedoperationalworkrepair_resumerepairwithctx",
+      "label": "resumeRepairWithCtx()",
+      "norm_label": "resumerepairwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L472"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "operationalevents_shouldnormalizepostrace",
-      "label": "shouldNormalizePosTrace()",
-      "norm_label": "shouldnormalizepostrace()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L118"
+      "id": "oversizedoperationalworkrepair_schedulenextbatch",
+      "label": "scheduleNextBatch()",
+      "norm_label": "schedulenextbatch()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L153"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
-      "label": "operationalEvents.ts",
-      "norm_label": "operationalevents.ts",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "id": "packages_athena_webapp_convex_operations_oversizedoperationalworkrepair_ts",
+      "label": "oversizedOperationalWorkRepair.ts",
+      "norm_label": "oversizedoperationalworkrepair.ts",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
       "source_location": "L1"
     },
     {
@@ -231756,92 +231765,92 @@
     {
       "community": 253,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_amendrepairwithctx",
-      "label": "amendRepairWithCtx()",
-      "norm_label": "amendrepairwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L430"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_createrepairwithctx",
-      "label": "createRepairWithCtx()",
-      "norm_label": "createrepairwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L160"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_pauserepair",
-      "label": "pauseRepair()",
-      "norm_label": "pauserepair()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L231"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_processrepairbatchwithctx",
-      "label": "processRepairBatchWithCtx()",
-      "norm_label": "processrepairbatchwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L249"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_readcurrentgroup",
-      "label": "readCurrentGroup()",
-      "norm_label": "readcurrentgroup()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_recordrepairauditevent",
-      "label": "recordRepairAuditEvent()",
-      "norm_label": "recordrepairauditevent()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_requireevidence",
-      "label": "requireEvidence()",
-      "norm_label": "requireevidence()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_resumerepairwithctx",
-      "label": "resumeRepairWithCtx()",
-      "norm_label": "resumerepairwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L472"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_schedulenextbatch",
-      "label": "scheduleNextBatch()",
-      "norm_label": "schedulenextbatch()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_oversizedoperationalworkrepair_ts",
-      "label": "oversizedOperationalWorkRepair.ts",
-      "norm_label": "oversizedoperationalworkrepair.ts",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "id": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
+      "label": "registerSessionTracing.ts",
+      "norm_label": "registersessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registersessiontracing_buildactorrefs",
+      "label": "buildActorRefs()",
+      "norm_label": "buildactorrefs()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registersessiontracing_buildtraceevent",
+      "label": "buildTraceEvent()",
+      "norm_label": "buildtraceevent()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L196"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registersessiontracing_buildtracerecord",
+      "label": "buildTraceRecord()",
+      "norm_label": "buildtracerecord()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L161"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registersessiontracing_displaytraceamount",
+      "label": "displayTraceAmount()",
+      "norm_label": "displaytraceamount()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L114"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registersessiontracing_formattransactionlabel",
+      "label": "formatTransactionLabel()",
+      "norm_label": "formattransactionlabel()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L132"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registersessiontracing_recordregistersessiontracebesteffort",
+      "label": "recordRegisterSessionTraceBestEffort()",
+      "norm_label": "recordregistersessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L407"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registersessiontracing_resolveoccurredat",
+      "label": "resolveOccurredAt()",
+      "norm_label": "resolveoccurredat()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registersessiontracing_resolvestorecurrency",
+      "label": "resolveStoreCurrency()",
+      "norm_label": "resolvestorecurrency()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L146"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registersessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L92"
     },
     {
       "community": 2530,
@@ -231936,92 +231945,92 @@
     {
       "community": 254,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
-      "label": "registerSessionTracing.ts",
-      "norm_label": "registersessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "id": "finalizedlineageremediation_classifyfinalizedlineagerepairconflicts",
+      "label": "classifyFinalizedLineageRepairConflicts()",
+      "norm_label": "classifyfinalizedlineagerepairconflicts()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L222"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_classifyrepaircandidate",
+      "label": "classifyRepairCandidate()",
+      "norm_label": "classifyrepaircandidate()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L164"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_countrepairablefinalizedlineagelines",
+      "label": "countRepairableFinalizedLineageLines()",
+      "norm_label": "countrepairablefinalizedlineagelines()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L284"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_getprovisionalimportsku",
+      "label": "getProvisionalImportSku()",
+      "norm_label": "getprovisionalimportsku()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L318"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_isclosedregisterrepairreplayconflict",
+      "label": "isClosedRegisterRepairReplayConflict()",
+      "norm_label": "isclosedregisterrepairreplayconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L273"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_isfinalizedlineagerepairconflict",
+      "label": "isFinalizedLineageRepairConflict()",
+      "norm_label": "isfinalizedlineagerepairconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L258"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_isprovisionalrowchangedconflict",
+      "label": "isProvisionalRowChangedConflict()",
+      "norm_label": "isprovisionalrowchangedconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L265"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_recordfinalizedlineagerepairevent",
+      "label": "recordFinalizedLineageRepairEvent()",
+      "norm_label": "recordfinalizedlineagerepairevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L358"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_skipped",
+      "label": "skipped()",
+      "norm_label": "skipped()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L346"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_sync_finalizedlineageremediation_ts",
+      "label": "finalizedLineageRemediation.ts",
+      "norm_label": "finalizedlineageremediation.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "registersessiontracing_buildactorrefs",
-      "label": "buildActorRefs()",
-      "norm_label": "buildactorrefs()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "registersessiontracing_buildtraceevent",
-      "label": "buildTraceEvent()",
-      "norm_label": "buildtraceevent()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L196"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "registersessiontracing_buildtracerecord",
-      "label": "buildTraceRecord()",
-      "norm_label": "buildtracerecord()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L161"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "registersessiontracing_displaytraceamount",
-      "label": "displayTraceAmount()",
-      "norm_label": "displaytraceamount()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L114"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "registersessiontracing_formattransactionlabel",
-      "label": "formatTransactionLabel()",
-      "norm_label": "formattransactionlabel()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L132"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "registersessiontracing_recordregistersessiontracebesteffort",
-      "label": "recordRegisterSessionTraceBestEffort()",
-      "norm_label": "recordregistersessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L407"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "registersessiontracing_resolveoccurredat",
-      "label": "resolveOccurredAt()",
-      "norm_label": "resolveoccurredat()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L76"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "registersessiontracing_resolvestorecurrency",
-      "label": "resolveStoreCurrency()",
-      "norm_label": "resolvestorecurrency()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L146"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "registersessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L92"
     },
     {
       "community": 2540,
@@ -232116,92 +232125,92 @@
     {
       "community": 255,
       "file_type": "code",
-      "id": "finalizedlineageremediation_classifyfinalizedlineagerepairconflicts",
-      "label": "classifyFinalizedLineageRepairConflicts()",
-      "norm_label": "classifyfinalizedlineagerepairconflicts()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_terminalrecoveryrepository_ts",
+      "label": "terminalRecoveryRepository.ts",
+      "norm_label": "terminalrecoveryrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_createterminalrecoverycommandreadrepository",
+      "label": "createTerminalRecoveryCommandReadRepository()",
+      "norm_label": "createterminalrecoverycommandreadrepository()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_createterminalrecoverycommandrepository",
+      "label": "createTerminalRecoveryCommandRepository()",
+      "norm_label": "createterminalrecoverycommandrepository()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L127"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_deduperecoverycommandsbyid",
+      "label": "dedupeRecoveryCommandsById()",
+      "norm_label": "deduperecoverycommandsbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L116"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_deduperecoveryconflictsbyid",
+      "label": "dedupeRecoveryConflictsById()",
+      "norm_label": "deduperecoveryconflictsbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L193"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_getterminalrecoverysourceevent",
+      "label": "getTerminalRecoverySourceEvent()",
+      "norm_label": "getterminalrecoverysourceevent()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
       "source_location": "L222"
     },
     {
       "community": 255,
       "file_type": "code",
-      "id": "finalizedlineageremediation_classifyrepaircandidate",
-      "label": "classifyRepairCandidate()",
-      "norm_label": "classifyrepaircandidate()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L164"
+      "id": "terminalrecoveryrepository_iscurrentterminalrecoveryconflict",
+      "label": "isCurrentTerminalRecoveryConflict()",
+      "norm_label": "iscurrentterminalrecoveryconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L206"
     },
     {
       "community": 255,
       "file_type": "code",
-      "id": "finalizedlineageremediation_countrepairablefinalizedlineagelines",
-      "label": "countRepairableFinalizedLineageLines()",
-      "norm_label": "countrepairablefinalizedlineagelines()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L284"
+      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsforrepair",
+      "label": "listTerminalRecoveryConflictsForRepair()",
+      "norm_label": "listterminalrecoveryconflictsforrepair()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L141"
     },
     {
       "community": 255,
       "file_type": "code",
-      "id": "finalizedlineageremediation_getprovisionalimportsku",
-      "label": "getProvisionalImportSku()",
-      "norm_label": "getprovisionalimportsku()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L318"
+      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsources",
+      "label": "listTerminalRecoveryConflictSources()",
+      "norm_label": "listterminalrecoveryconflictsources()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L162"
     },
     {
       "community": 255,
       "file_type": "code",
-      "id": "finalizedlineageremediation_isclosedregisterrepairreplayconflict",
-      "label": "isClosedRegisterRepairReplayConflict()",
-      "norm_label": "isclosedregisterrepairreplayconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L273"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_isfinalizedlineagerepairconflict",
-      "label": "isFinalizedLineageRepairConflict()",
-      "norm_label": "isfinalizedlineagerepairconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L258"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_isprovisionalrowchangedconflict",
-      "label": "isProvisionalRowChangedConflict()",
-      "norm_label": "isprovisionalrowchangedconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L265"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_recordfinalizedlineagerepairevent",
-      "label": "recordFinalizedLineageRepairEvent()",
-      "norm_label": "recordfinalizedlineagerepairevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L358"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_skipped",
-      "label": "skipped()",
-      "norm_label": "skipped()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L346"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sync_finalizedlineageremediation_ts",
-      "label": "finalizedLineageRemediation.ts",
-      "norm_label": "finalizedlineageremediation.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L1"
+      "id": "terminalrecoveryrepository_patchterminalrecoveryconflict",
+      "label": "patchTerminalRecoveryConflict()",
+      "norm_label": "patchterminalrecoveryconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L241"
     },
     {
       "community": 2550,
@@ -232296,92 +232305,92 @@
     {
       "community": 256,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_terminalrecoveryrepository_ts",
-      "label": "terminalRecoveryRepository.ts",
-      "norm_label": "terminalrecoveryrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "id": "contract_test_day",
+      "label": "day()",
+      "norm_label": "day()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L1308"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "contract_test_fieldsof",
+      "label": "fieldsOf()",
+      "norm_label": "fieldsof()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L86"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "contract_test_headerfor",
+      "label": "headerFor()",
+      "norm_label": "headerfor()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L972"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "contract_test_inclusivedays",
+      "label": "inclusiveDays()",
+      "norm_label": "inclusivedays()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L1216"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "contract_test_movementidentityargs",
+      "label": "movementIdentityArgs()",
+      "norm_label": "movementidentityargs()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L602"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "contract_test_probe",
+      "label": "probe()",
+      "norm_label": "probe()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L1312"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "contract_test_seedproductsku",
+      "label": "seedProductSku()",
+      "norm_label": "seedproductsku()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L561"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "contract_test_seedstore",
+      "label": "seedStore()",
+      "norm_label": "seedstore()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L542"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "contract_test_unionliterals",
+      "label": "unionLiterals()",
+      "norm_label": "unionliterals()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_reports_contract_test_ts",
+      "label": "contract.test.ts",
+      "norm_label": "contract.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_createterminalrecoverycommandreadrepository",
-      "label": "createTerminalRecoveryCommandReadRepository()",
-      "norm_label": "createterminalrecoverycommandreadrepository()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_createterminalrecoverycommandrepository",
-      "label": "createTerminalRecoveryCommandRepository()",
-      "norm_label": "createterminalrecoverycommandrepository()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L127"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_deduperecoverycommandsbyid",
-      "label": "dedupeRecoveryCommandsById()",
-      "norm_label": "deduperecoverycommandsbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_deduperecoveryconflictsbyid",
-      "label": "dedupeRecoveryConflictsById()",
-      "norm_label": "deduperecoveryconflictsbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L193"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_getterminalrecoverysourceevent",
-      "label": "getTerminalRecoverySourceEvent()",
-      "norm_label": "getterminalrecoverysourceevent()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L222"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_iscurrentterminalrecoveryconflict",
-      "label": "isCurrentTerminalRecoveryConflict()",
-      "norm_label": "iscurrentterminalrecoveryconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L206"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsforrepair",
-      "label": "listTerminalRecoveryConflictsForRepair()",
-      "norm_label": "listterminalrecoveryconflictsforrepair()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L141"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsources",
-      "label": "listTerminalRecoveryConflictSources()",
-      "norm_label": "listterminalrecoveryconflictsources()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L162"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_patchterminalrecoveryconflict",
-      "label": "patchTerminalRecoveryConflict()",
-      "norm_label": "patchterminalrecoveryconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L241"
     },
     {
       "community": 2560,
@@ -232476,91 +232485,91 @@
     {
       "community": 257,
       "file_type": "code",
-      "id": "contract_test_day",
-      "label": "day()",
-      "norm_label": "day()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L1308"
+      "id": "customrange_aggregateskudays",
+      "label": "aggregateSkuDays()",
+      "norm_label": "aggregateskudays()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L217"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "contract_test_fieldsof",
-      "label": "fieldsOf()",
-      "norm_label": "fieldsof()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L86"
+      "id": "customrange_computerange",
+      "label": "computeRange()",
+      "norm_label": "computerange()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L253"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "contract_test_headerfor",
-      "label": "headerFor()",
-      "norm_label": "headerfor()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L972"
+      "id": "customrange_computerequestkey",
+      "label": "computeRequestKey()",
+      "norm_label": "computerequestkey()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L84"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "contract_test_inclusivedays",
-      "label": "inclusiveDays()",
-      "norm_label": "inclusivedays()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L1216"
+      "id": "customrange_inclusivedayspan",
+      "label": "inclusiveDaySpan()",
+      "norm_label": "inclusivedayspan()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L52"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "contract_test_movementidentityargs",
-      "label": "movementIdentityArgs()",
-      "norm_label": "movementidentityargs()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L602"
+      "id": "customrange_isvalidoperatingdate",
+      "label": "isValidOperatingDate()",
+      "norm_label": "isvalidoperatingdate()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L35"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "contract_test_probe",
-      "label": "probe()",
-      "norm_label": "probe()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L1312"
+      "id": "customrange_requestrangecore",
+      "label": "requestRangeCore()",
+      "norm_label": "requestrangecore()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L112"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "contract_test_seedproductsku",
-      "label": "seedProductSku()",
-      "norm_label": "seedproductsku()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L561"
+      "id": "customrange_sumdays",
+      "label": "sumDays()",
+      "norm_label": "sumdays()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L189"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "contract_test_seedstore",
-      "label": "seedStore()",
-      "norm_label": "seedstore()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L542"
+      "id": "customrange_utcmillisforlabel",
+      "label": "utcMillisForLabel()",
+      "norm_label": "utcmillisforlabel()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L46"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "contract_test_unionliterals",
-      "label": "unionLiterals()",
-      "norm_label": "unionliterals()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L92"
+      "id": "customrange_validaterangeargs",
+      "label": "validateRangeArgs()",
+      "norm_label": "validaterangeargs()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L58"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_contract_test_ts",
-      "label": "contract.test.ts",
-      "norm_label": "contract.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "id": "packages_athena_webapp_convex_reports_customrange_ts",
+      "label": "customRange.ts",
+      "norm_label": "customrange.ts",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
       "source_location": "L1"
     },
     {
@@ -232656,92 +232665,92 @@
     {
       "community": 258,
       "file_type": "code",
-      "id": "customrange_aggregateskudays",
-      "label": "aggregateSkuDays()",
-      "norm_label": "aggregateskudays()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L217"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "customrange_computerange",
-      "label": "computeRange()",
-      "norm_label": "computerange()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L253"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "customrange_computerequestkey",
-      "label": "computeRequestKey()",
-      "norm_label": "computerequestkey()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L84"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "customrange_inclusivedayspan",
-      "label": "inclusiveDaySpan()",
-      "norm_label": "inclusivedayspan()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "customrange_isvalidoperatingdate",
-      "label": "isValidOperatingDate()",
-      "norm_label": "isvalidoperatingdate()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "customrange_requestrangecore",
-      "label": "requestRangeCore()",
-      "norm_label": "requestrangecore()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L112"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "customrange_sumdays",
-      "label": "sumDays()",
-      "norm_label": "sumdays()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L189"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "customrange_utcmillisforlabel",
-      "label": "utcMillisForLabel()",
-      "norm_label": "utcmillisforlabel()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "customrange_validaterangeargs",
-      "label": "validateRangeArgs()",
-      "norm_label": "validaterangeargs()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_customrange_ts",
-      "label": "customRange.ts",
-      "norm_label": "customrange.ts",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "id": "packages_athena_webapp_convex_reports_rangesnapshotlifecycle_test_ts",
+      "label": "rangeSnapshotLifecycle.test.ts",
+      "norm_label": "rangesnapshotlifecycle.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_allow",
+      "label": "allow()",
+      "norm_label": "allow()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_certifyday",
+      "label": "certifyDay()",
+      "norm_label": "certifyday()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L109"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_consume",
+      "label": "consume()",
+      "norm_label": "consume()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L296"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_drive",
+      "label": "drive()",
+      "norm_label": "drive()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L247"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_ensuresynthetic",
+      "label": "ensureSynthetic()",
+      "norm_label": "ensuresynthetic()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L208"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_headerbykey",
+      "label": "headerByKey()",
+      "norm_label": "headerbykey()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L230"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_insertkindedheader",
+      "label": "insertKindedHeader()",
+      "norm_label": "insertkindedheader()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L612"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_seedstore",
+      "label": "seedStore()",
+      "norm_label": "seedstore()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_synthetickind",
+      "label": "syntheticKind()",
+      "norm_label": "synthetickind()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L150"
     },
     {
       "community": 2580,
@@ -232836,92 +232845,92 @@
     {
       "community": 259,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_rangesnapshotlifecycle_test_ts",
-      "label": "rangeSnapshotLifecycle.test.ts",
-      "norm_label": "rangesnapshotlifecycle.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "id": "packages_athena_webapp_convex_reports_verificationclassify_ts",
+      "label": "verificationClassify.ts",
+      "norm_label": "verificationclassify.ts",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
       "source_location": "L1"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_allow",
-      "label": "allow()",
-      "norm_label": "allow()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L53"
+      "id": "verificationclassify_buildclassification",
+      "label": "buildClassification()",
+      "norm_label": "buildclassification()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L448"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_certifyday",
-      "label": "certifyDay()",
-      "norm_label": "certifyday()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L109"
+      "id": "verificationclassify_classifydayresult",
+      "label": "classifyDayResult()",
+      "norm_label": "classifydayresult()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L481"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_consume",
-      "label": "consume()",
-      "norm_label": "consume()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L296"
+      "id": "verificationclassify_classifyweekresult",
+      "label": "classifyWeekResult()",
+      "norm_label": "classifyweekresult()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L562"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_drive",
-      "label": "drive()",
-      "norm_label": "drive()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L247"
+      "id": "verificationclassify_confirmsclean",
+      "label": "confirmsClean()",
+      "norm_label": "confirmsclean()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L681"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_ensuresynthetic",
-      "label": "ensureSynthetic()",
-      "norm_label": "ensuresynthetic()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L208"
+      "id": "verificationclassify_explainmetricdifference",
+      "label": "explainMetricDifference()",
+      "norm_label": "explainmetricdifference()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L378"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_headerbykey",
-      "label": "headerByKey()",
-      "norm_label": "headerbykey()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L230"
+      "id": "verificationclassify_fingerprintdifferences",
+      "label": "fingerprintDifferences()",
+      "norm_label": "fingerprintdifferences()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L354"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_insertkindedheader",
-      "label": "insertKindedHeader()",
-      "norm_label": "insertkindedheader()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L612"
+      "id": "verificationclassify_initialstreakstate",
+      "label": "initialStreakState()",
+      "norm_label": "initialstreakstate()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L658"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_seedstore",
-      "label": "seedStore()",
-      "norm_label": "seedstore()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L73"
+      "id": "verificationclassify_nextstreakstate",
+      "label": "nextStreakState()",
+      "norm_label": "nextstreakstate()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L707"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_synthetickind",
-      "label": "syntheticKind()",
-      "norm_label": "synthetickind()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L150"
+      "id": "verificationclassify_partitiondifferences",
+      "label": "partitionDifferences()",
+      "norm_label": "partitiondifferences()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L434"
     },
     {
       "community": 2590,
@@ -233358,92 +233367,92 @@
     {
       "community": 260,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_verificationclassify_ts",
-      "label": "verificationClassify.ts",
-      "norm_label": "verificationclassify.ts",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "id": "index_resolveverificationcoderecipient",
+      "label": "resolveVerificationCodeRecipient()",
+      "norm_label": "resolveverificationcoderecipient()",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "index_senddailymanagerreportemail",
+      "label": "sendDailyManagerReportEmail()",
+      "norm_label": "senddailymanagerreportemail()",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "source_location": "L373"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "index_senddiscountcodeemail",
+      "label": "sendDiscountCodeEmail()",
+      "norm_label": "senddiscountcodeemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L255"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "index_senddiscountreminderemail",
+      "label": "sendDiscountReminderEmail()",
+      "norm_label": "senddiscountreminderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L334"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "index_sendfeedbackrequestemail",
+      "label": "sendFeedbackRequestEmail()",
+      "norm_label": "sendfeedbackrequestemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "index_sendneworderemail",
+      "label": "sendNewOrderEmail()",
+      "norm_label": "sendneworderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L117"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "index_sendorderemail",
+      "label": "sendOrderEmail()",
+      "norm_label": "sendorderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "index_sendverificationcode",
+      "label": "sendVerificationCode()",
+      "norm_label": "sendverificationcode()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
       "source_location": "L1"
     },
     {
       "community": 260,
       "file_type": "code",
-      "id": "verificationclassify_buildclassification",
-      "label": "buildClassification()",
-      "norm_label": "buildclassification()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L448"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "verificationclassify_classifydayresult",
-      "label": "classifyDayResult()",
-      "norm_label": "classifydayresult()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L481"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "verificationclassify_classifyweekresult",
-      "label": "classifyWeekResult()",
-      "norm_label": "classifyweekresult()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L562"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "verificationclassify_confirmsclean",
-      "label": "confirmsClean()",
-      "norm_label": "confirmsclean()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L681"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "verificationclassify_explainmetricdifference",
-      "label": "explainMetricDifference()",
-      "norm_label": "explainmetricdifference()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L378"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "verificationclassify_fingerprintdifferences",
-      "label": "fingerprintDifferences()",
-      "norm_label": "fingerprintdifferences()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L354"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "verificationclassify_initialstreakstate",
-      "label": "initialStreakState()",
-      "norm_label": "initialstreakstate()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L658"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "verificationclassify_nextstreakstate",
-      "label": "nextStreakState()",
-      "norm_label": "nextstreakstate()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L707"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "verificationclassify_partitiondifferences",
-      "label": "partitionDifferences()",
-      "norm_label": "partitiondifferences()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L434"
+      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L1"
     },
     {
       "community": 2600,
@@ -243159,87 +243168,6 @@
     {
       "community": 322,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontobservability_ts",
-      "label": "storefrontObservability.ts",
-      "norm_label": "storefrontobservability.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 322,
-      "file_type": "code",
-      "id": "storefrontobservability_createstorefrontobservabilitycontext",
-      "label": "createStorefrontObservabilityContext()",
-      "norm_label": "createstorefrontobservabilitycontext()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L182"
-    },
-    {
-      "community": 322,
-      "file_type": "code",
-      "id": "storefrontobservability_createstorefrontobservabilitypayload",
-      "label": "createStorefrontObservabilityPayload()",
-      "norm_label": "createstorefrontobservabilitypayload()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L229"
-    },
-    {
-      "community": 322,
-      "file_type": "code",
-      "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
-      "label": "getOrCreateStorefrontObservabilitySessionId()",
-      "norm_label": "getorcreatestorefrontobservabilitysessionid()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L157"
-    },
-    {
-      "community": 322,
-      "file_type": "code",
-      "id": "storefrontobservability_isbrowserautomationcontext",
-      "label": "isBrowserAutomationContext()",
-      "norm_label": "isbrowserautomationcontext()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L125"
-    },
-    {
-      "community": 322,
-      "file_type": "code",
-      "id": "storefrontobservability_issyntheticmonitororigin",
-      "label": "isSyntheticMonitorOrigin()",
-      "norm_label": "issyntheticmonitororigin()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L121"
-    },
-    {
-      "community": 322,
-      "file_type": "code",
-      "id": "storefrontobservability_resolvestorefrontanalyticsorigin",
-      "label": "resolveStorefrontAnalyticsOrigin()",
-      "norm_label": "resolvestorefrontanalyticsorigin()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L135"
-    },
-    {
-      "community": 322,
-      "file_type": "code",
-      "id": "storefrontobservability_resolveviewportbucket",
-      "label": "resolveViewportBucket()",
-      "norm_label": "resolveviewportbucket()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L211"
-    },
-    {
-      "community": 322,
-      "file_type": "code",
-      "id": "storefrontobservability_trackstorefrontevent",
-      "label": "trackStorefrontEvent()",
-      "norm_label": "trackstorefrontevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L265"
-    },
-    {
-      "community": 323,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
       "norm_label": "versionchecker.ts",
@@ -243247,7 +243175,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 322,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -243256,7 +243184,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 322,
       "file_type": "code",
       "id": "versionchecker_buildidfromscripts",
       "label": "buildIdFromScripts()",
@@ -243265,7 +243193,7 @@
       "source_location": "L192"
     },
     {
-      "community": 323,
+      "community": 322,
       "file_type": "code",
       "id": "versionchecker_createversionchecker",
       "label": "createVersionChecker()",
@@ -243274,7 +243202,7 @@
       "source_location": "L16"
     },
     {
-      "community": 323,
+      "community": 322,
       "file_type": "code",
       "id": "versionchecker_getinitialdeploybuildid",
       "label": "getInitialDeployBuildId()",
@@ -243283,7 +243211,7 @@
       "source_location": "L135"
     },
     {
-      "community": 323,
+      "community": 322,
       "file_type": "code",
       "id": "versionchecker_readdeploybuildid",
       "label": "readDeployBuildId()",
@@ -243292,7 +243220,7 @@
       "source_location": "L141"
     },
     {
-      "community": 323,
+      "community": 322,
       "file_type": "code",
       "id": "versionchecker_readdocumentscriptsources",
       "label": "readDocumentScriptSources()",
@@ -243301,7 +243229,7 @@
       "source_location": "L174"
     },
     {
-      "community": 323,
+      "community": 322,
       "file_type": "code",
       "id": "versionchecker_readentryhtmlscripts",
       "label": "readEntryHtmlScripts()",
@@ -243310,13 +243238,94 @@
       "source_location": "L151"
     },
     {
-      "community": 323,
+      "community": 322,
       "file_type": "code",
       "id": "versionchecker_readscriptsources",
       "label": "readScriptSources()",
       "norm_label": "readscriptsources()",
       "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
       "source_location": "L182"
+    },
+    {
+      "community": 323,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_storefrontobservability_ts",
+      "label": "storefrontObservability.ts",
+      "norm_label": "storefrontobservability.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 323,
+      "file_type": "code",
+      "id": "storefrontobservability_createstorefrontobservabilitycontext",
+      "label": "createStorefrontObservabilityContext()",
+      "norm_label": "createstorefrontobservabilitycontext()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L182"
+    },
+    {
+      "community": 323,
+      "file_type": "code",
+      "id": "storefrontobservability_createstorefrontobservabilitypayload",
+      "label": "createStorefrontObservabilityPayload()",
+      "norm_label": "createstorefrontobservabilitypayload()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L229"
+    },
+    {
+      "community": 323,
+      "file_type": "code",
+      "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
+      "label": "getOrCreateStorefrontObservabilitySessionId()",
+      "norm_label": "getorcreatestorefrontobservabilitysessionid()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L157"
+    },
+    {
+      "community": 323,
+      "file_type": "code",
+      "id": "storefrontobservability_isbrowserautomationcontext",
+      "label": "isBrowserAutomationContext()",
+      "norm_label": "isbrowserautomationcontext()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L125"
+    },
+    {
+      "community": 323,
+      "file_type": "code",
+      "id": "storefrontobservability_issyntheticmonitororigin",
+      "label": "isSyntheticMonitorOrigin()",
+      "norm_label": "issyntheticmonitororigin()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L121"
+    },
+    {
+      "community": 323,
+      "file_type": "code",
+      "id": "storefrontobservability_resolvestorefrontanalyticsorigin",
+      "label": "resolveStorefrontAnalyticsOrigin()",
+      "norm_label": "resolvestorefrontanalyticsorigin()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 323,
+      "file_type": "code",
+      "id": "storefrontobservability_resolveviewportbucket",
+      "label": "resolveViewportBucket()",
+      "norm_label": "resolveviewportbucket()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L211"
+    },
+    {
+      "community": 323,
+      "file_type": "code",
+      "id": "storefrontobservability_trackstorefrontevent",
+      "label": "trackStorefrontEvent()",
+      "norm_label": "trackstorefrontevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L265"
     },
     {
       "community": 324,
@@ -244459,7 +244468,7 @@
       "label": "candidatesForPolicies()",
       "norm_label": "candidatesforpolicies()",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L196"
+      "source_location": "L191"
     },
     {
       "community": 335,
@@ -244468,7 +244477,7 @@
       "label": "completedOperatingDatesForStore()",
       "norm_label": "completedoperatingdatesforstore()",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L171"
+      "source_location": "L166"
     },
     {
       "community": 335,
@@ -244477,7 +244486,7 @@
       "label": "dailyCloseSweepResultSettled()",
       "norm_label": "dailyclosesweepresultsettled()",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L79"
+      "source_location": "L77"
     },
     {
       "community": 335,
@@ -244486,7 +244495,7 @@
       "label": "daysBetweenOperatingDates()",
       "norm_label": "daysbetweenoperatingdates()",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L490"
+      "source_location": "L485"
     },
     {
       "community": 335,
@@ -244495,7 +244504,7 @@
       "label": "runOwedDailyCloseSweepWithCtx()",
       "norm_label": "runoweddailyclosesweepwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L360"
+      "source_location": "L355"
     },
     {
       "community": 335,
@@ -244504,7 +244513,7 @@
       "label": "selectOwedDailyCloseDates()",
       "norm_label": "selectoweddailyclosedates()",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L117"
+      "source_location": "L115"
     },
     {
       "community": 335,
@@ -244513,7 +244522,7 @@
       "label": "selectRotatingOwedDailyCloseAttempt()",
       "norm_label": "selectrotatingoweddailycloseattempt()",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L90"
+      "source_location": "L88"
     },
     {
       "community": 335,
@@ -274767,6 +274776,42 @@
     {
       "community": 695,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_register_test_ts",
+      "label": "register.test.ts",
+      "norm_label": "register.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 695,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_public_register_test_ts",
+      "label": "register.test.ts",
+      "norm_label": "register.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 695,
+      "file_type": "code",
+      "id": "register_test_buildctx",
+      "label": "buildCtx()",
+      "norm_label": "buildctx()",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 695,
+      "file_type": "code",
+      "id": "register_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 696,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
       "label": "register.ts",
       "norm_label": "register.ts",
@@ -274774,7 +274819,7 @@
       "source_location": "L1"
     },
     {
-      "community": 695,
+      "community": 696,
       "file_type": "code",
       "id": "register_mapopendrawerusererror",
       "label": "mapOpenDrawerUserError()",
@@ -274783,7 +274828,7 @@
       "source_location": "L34"
     },
     {
-      "community": 695,
+      "community": 696,
       "file_type": "code",
       "id": "register_normalizeregisternumber",
       "label": "normalizeRegisterNumber()",
@@ -274792,7 +274837,7 @@
       "source_location": "L29"
     },
     {
-      "community": 695,
+      "community": 696,
       "file_type": "code",
       "id": "register_opendrawer",
       "label": "openDrawer()",
@@ -274801,7 +274846,7 @@
       "source_location": "L56"
     },
     {
-      "community": 696,
+      "community": 697,
       "file_type": "code",
       "id": "opendrawer_test_createdbgetmock",
       "label": "createDbGetMock()",
@@ -274810,7 +274855,7 @@
       "source_location": "L39"
     },
     {
-      "community": 696,
+      "community": 697,
       "file_type": "code",
       "id": "opendrawer_test_createdbmock",
       "label": "createDbMock()",
@@ -274819,7 +274864,7 @@
       "source_location": "L99"
     },
     {
-      "community": 696,
+      "community": 697,
       "file_type": "code",
       "id": "opendrawer_test_createdbquerymock",
       "label": "createDbQueryMock()",
@@ -274828,7 +274873,7 @@
       "source_location": "L74"
     },
     {
-      "community": 696,
+      "community": 697,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_opendrawer_test_ts",
       "label": "openDrawer.test.ts",
@@ -274837,7 +274882,7 @@
       "source_location": "L1"
     },
     {
-      "community": 697,
+      "community": 698,
       "file_type": "code",
       "id": "getregisterstate_buildregisterstate",
       "label": "buildRegisterState()",
@@ -274846,7 +274891,7 @@
       "source_location": "L21"
     },
     {
-      "community": 697,
+      "community": 698,
       "file_type": "code",
       "id": "getregisterstate_getactivesessionconflictforregisterstate",
       "label": "getActiveSessionConflictForRegisterState()",
@@ -274855,7 +274900,7 @@
       "source_location": "L42"
     },
     {
-      "community": 697,
+      "community": 698,
       "file_type": "code",
       "id": "getregisterstate_getregisterstate",
       "label": "getRegisterState()",
@@ -274864,7 +274909,7 @@
       "source_location": "L80"
     },
     {
-      "community": 697,
+      "community": 698,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
       "label": "getRegisterState.ts",
@@ -274873,7 +274918,7 @@
       "source_location": "L1"
     },
     {
-      "community": 698,
+      "community": 699,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_storepulse_test_ts",
       "label": "storePulse.test.ts",
@@ -274882,7 +274927,7 @@
       "source_location": "L1"
     },
     {
-      "community": 698,
+      "community": 699,
       "file_type": "code",
       "id": "storepulse_test_createdb",
       "label": "createDb()",
@@ -274891,7 +274936,7 @@
       "source_location": "L12"
     },
     {
-      "community": 698,
+      "community": 699,
       "file_type": "code",
       "id": "storepulse_test_item",
       "label": "item()",
@@ -274900,49 +274945,13 @@
       "source_location": "L127"
     },
     {
-      "community": 698,
+      "community": 699,
       "file_type": "code",
       "id": "storepulse_test_transaction",
       "label": "transaction()",
       "norm_label": "transaction()",
       "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.test.ts",
       "source_location": "L99"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sync_posregistersessionactivity_test_ts",
-      "label": "posRegisterSessionActivity.test.ts",
-      "norm_label": "posregistersessionactivity.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "posregistersessionactivity_test_buildactivity",
-      "label": "buildActivity()",
-      "norm_label": "buildactivity()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
-      "source_location": "L457"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "posregistersessionactivity_test_buildreport",
-      "label": "buildReport()",
-      "norm_label": "buildreport()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
-      "source_location": "L436"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "posregistersessionactivity_test_createfakerepository",
-      "label": "createFakeRepository()",
-      "norm_label": "createfakerepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
-      "source_location": "L476"
     },
     {
       "community": 7,
@@ -275793,6 +275802,42 @@
     {
       "community": 700,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_sync_posregistersessionactivity_test_ts",
+      "label": "posRegisterSessionActivity.test.ts",
+      "norm_label": "posregistersessionactivity.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 700,
+      "file_type": "code",
+      "id": "posregistersessionactivity_test_buildactivity",
+      "label": "buildActivity()",
+      "norm_label": "buildactivity()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
+      "source_location": "L457"
+    },
+    {
+      "community": 700,
+      "file_type": "code",
+      "id": "posregistersessionactivity_test_buildreport",
+      "label": "buildReport()",
+      "norm_label": "buildreport()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
+      "source_location": "L436"
+    },
+    {
+      "community": 700,
+      "file_type": "code",
+      "id": "posregistersessionactivity_test_createfakerepository",
+      "label": "createFakeRepository()",
+      "norm_label": "createfakerepository()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
+      "source_location": "L476"
+    },
+    {
+      "community": 701,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_registercatalogrevision_ts",
       "label": "registerCatalogRevision.ts",
       "norm_label": "registercatalogrevision.ts",
@@ -275800,7 +275845,7 @@
       "source_location": "L1"
     },
     {
-      "community": 700,
+      "community": 701,
       "file_type": "code",
       "id": "registercatalogrevision_advanceregistercatalogrevision",
       "label": "advanceRegisterCatalogRevision()",
@@ -275809,7 +275854,7 @@
       "source_location": "L24"
     },
     {
-      "community": 700,
+      "community": 701,
       "file_type": "code",
       "id": "registercatalogrevision_readregistercatalogrevision",
       "label": "readRegisterCatalogRevision()",
@@ -275818,7 +275863,7 @@
       "source_location": "L16"
     },
     {
-      "community": 700,
+      "community": 701,
       "file_type": "code",
       "id": "registercatalogrevision_readregistercatalogrevisionrow",
       "label": "readRegisterCatalogRevisionRow()",
@@ -275827,7 +275872,7 @@
       "source_location": "L6"
     },
     {
-      "community": 701,
+      "community": 702,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_sequencegappolicy_ts",
       "label": "sequenceGapPolicy.ts",
@@ -275836,7 +275881,7 @@
       "source_location": "L1"
     },
     {
-      "community": 701,
+      "community": 702,
       "file_type": "code",
       "id": "sequencegappolicy_decidesequencegapaction",
       "label": "decideSequenceGapAction()",
@@ -275845,7 +275890,7 @@
       "source_location": "L115"
     },
     {
-      "community": 701,
+      "community": 702,
       "file_type": "code",
       "id": "sequencegappolicy_issequencegapresolved",
       "label": "isSequenceGapResolved()",
@@ -275854,7 +275899,7 @@
       "source_location": "L219"
     },
     {
-      "community": 701,
+      "community": 702,
       "file_type": "code",
       "id": "sequencegappolicy_recordsequencegapobservation",
       "label": "recordSequenceGapObservation()",
@@ -275863,7 +275908,7 @@
       "source_location": "L190"
     },
     {
-      "community": 702,
+      "community": 703,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_staffproof_ts",
       "label": "staffProof.ts",
@@ -275872,7 +275917,7 @@
       "source_location": "L1"
     },
     {
-      "community": 702,
+      "community": 703,
       "file_type": "code",
       "id": "staffproof_createposlocalstaffprooftoken",
       "label": "createPosLocalStaffProofToken()",
@@ -275881,7 +275926,7 @@
       "source_location": "L10"
     },
     {
-      "community": 702,
+      "community": 703,
       "file_type": "code",
       "id": "staffproof_hashposlocalstaffprooftoken",
       "label": "hashPosLocalStaffProofToken()",
@@ -275890,7 +275935,7 @@
       "source_location": "L16"
     },
     {
-      "community": 702,
+      "community": 703,
       "file_type": "code",
       "id": "staffproof_tohex",
       "label": "toHex()",
@@ -275899,7 +275944,7 @@
       "source_location": "L4"
     },
     {
-      "community": 703,
+      "community": 704,
       "file_type": "code",
       "id": "cloudrepairpolicy_test_buildconflict",
       "label": "buildConflict()",
@@ -275908,7 +275953,7 @@
       "source_location": "L387"
     },
     {
-      "community": 703,
+      "community": 704,
       "file_type": "code",
       "id": "cloudrepairpolicy_test_buildevent",
       "label": "buildEvent()",
@@ -275917,7 +275962,7 @@
       "source_location": "L407"
     },
     {
-      "community": 703,
+      "community": 704,
       "file_type": "code",
       "id": "cloudrepairpolicy_test_createrepairprojectionrepository",
       "label": "createRepairProjectionRepository()",
@@ -275926,7 +275971,7 @@
       "source_location": "L282"
     },
     {
-      "community": 703,
+      "community": 704,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_cloudrepairpolicy_test_ts",
       "label": "cloudRepairPolicy.test.ts",
@@ -275935,7 +275980,7 @@
       "source_location": "L1"
     },
     {
-      "community": 704,
+      "community": 705,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_terminalcommandservice_test_ts",
       "label": "terminalCommandService.test.ts",
@@ -275944,7 +275989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 704,
+      "community": 705,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildcommand",
       "label": "buildCommand()",
@@ -275953,7 +275998,7 @@
       "source_location": "L1731"
     },
     {
-      "community": 704,
+      "community": 705,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildrepository",
       "label": "buildRepository()",
@@ -275962,7 +276007,7 @@
       "source_location": "L1666"
     },
     {
-      "community": 704,
+      "community": 705,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildruntimestatus",
       "label": "buildRuntimeStatus()",
@@ -275971,7 +276016,7 @@
       "source_location": "L1755"
     },
     {
-      "community": 705,
+      "community": 706,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
       "label": "sessionCommandRepository.ts",
@@ -275980,7 +276025,7 @@
       "source_location": "L1"
     },
     {
-      "community": 705,
+      "community": 706,
       "file_type": "code",
       "id": "sessioncommandrepository_collectsessionitemsfrompages",
       "label": "collectSessionItemsFromPages()",
@@ -275989,7 +276034,7 @@
       "source_location": "L177"
     },
     {
-      "community": 705,
+      "community": 706,
       "file_type": "code",
       "id": "sessioncommandrepository_createsessioncommandrepository",
       "label": "createSessionCommandRepository()",
@@ -275998,49 +276043,13 @@
       "source_location": "L68"
     },
     {
-      "community": 705,
+      "community": 706,
       "file_type": "code",
       "id": "sessioncommandrepository_scansessionitembyskuinpages",
       "label": "scanSessionItemBySkuInPages()",
       "norm_label": "scansessionitembyskuinpages()",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
       "source_location": "L195"
-    },
-    {
-      "community": 706,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_register_test_ts",
-      "label": "register.test.ts",
-      "norm_label": "register.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 706,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_public_register_test_ts",
-      "label": "register.test.ts",
-      "norm_label": "register.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 706,
-      "file_type": "code",
-      "id": "register_test_buildctx",
-      "label": "buildCtx()",
-      "norm_label": "buildctx()",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 706,
-      "file_type": "code",
-      "id": "register_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L38"
     },
     {
       "community": 707,

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -34187,7 +34187,7 @@
       "relation": "calls",
       "source": "oweddailyclosesweep_completedoperatingdatesforstore",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L209",
+      "source_location": "L210",
       "target": "oweddailyclosesweep_candidatesforpolicies",
       "weight": 1
     },
@@ -34199,8 +34199,32 @@
       "relation": "calls",
       "source": "oweddailyclosesweep_selectoweddailyclosedates",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L221",
+      "source_location": "L222",
       "target": "oweddailyclosesweep_candidatesforpolicies",
+      "weight": 1
+    },
+    {
+      "_src": "oweddailyclosesweep_runoweddailyclosesweepwithctx",
+      "_tgt": "oweddailyclosesweep_daysbetweenoperatingdates",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "oweddailyclosesweep_runoweddailyclosesweepwithctx",
+      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
+      "source_location": "L456",
+      "target": "oweddailyclosesweep_daysbetweenoperatingdates",
+      "weight": 1
+    },
+    {
+      "_src": "oweddailyclosesweep_runoweddailyclosesweepwithctx",
+      "_tgt": "oweddailyclosesweep_selectrotatingoweddailycloseattempt",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "oweddailyclosesweep_selectrotatingoweddailycloseattempt",
+      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
+      "source_location": "L406",
+      "target": "oweddailyclosesweep_runoweddailyclosesweepwithctx",
       "weight": 1
     },
     {
@@ -55355,7 +55379,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.test.ts",
-      "source_location": "L14",
+      "source_location": "L15",
       "target": "oweddailyclosesweep_test_fullwindow",
       "weight": 1
     },
@@ -55367,7 +55391,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L195",
+      "source_location": "L196",
       "target": "oweddailyclosesweep_candidatesforpolicies",
       "weight": 1
     },
@@ -55379,7 +55403,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L170",
+      "source_location": "L171",
       "target": "oweddailyclosesweep_completedoperatingdatesforstore",
       "weight": 1
     },
@@ -55391,7 +55415,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L78",
+      "source_location": "L79",
       "target": "oweddailyclosesweep_dailyclosesweepresultsettled",
       "weight": 1
     },
@@ -55403,8 +55427,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L474",
+      "source_location": "L490",
       "target": "oweddailyclosesweep_daysbetweenoperatingdates",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
+      "_tgt": "oweddailyclosesweep_runoweddailyclosesweepwithctx",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
+      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
+      "source_location": "L360",
+      "target": "oweddailyclosesweep_runoweddailyclosesweepwithctx",
       "weight": 1
     },
     {
@@ -55415,7 +55451,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L116",
+      "source_location": "L117",
       "target": "oweddailyclosesweep_selectoweddailyclosedates",
       "weight": 1
     },
@@ -55427,7 +55463,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L89",
+      "source_location": "L90",
       "target": "oweddailyclosesweep_selectrotatingoweddailycloseattempt",
       "weight": 1
     },
@@ -192124,7 +192160,7 @@
       "label": "fullWindow()",
       "norm_label": "fullwindow()",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.test.ts",
-      "source_location": "L14"
+      "source_location": "L15"
     },
     {
       "community": 1196,
@@ -230208,92 +230244,92 @@
     {
       "community": 247,
       "file_type": "code",
-      "id": "index_resolveverificationcoderecipient",
-      "label": "resolveVerificationCodeRecipient()",
-      "norm_label": "resolveverificationcoderecipient()",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "index_senddailymanagerreportemail",
-      "label": "sendDailyManagerReportEmail()",
-      "norm_label": "senddailymanagerreportemail()",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
-      "source_location": "L373"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "index_senddiscountcodeemail",
-      "label": "sendDiscountCodeEmail()",
-      "norm_label": "senddiscountcodeemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L255"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "index_senddiscountreminderemail",
-      "label": "sendDiscountReminderEmail()",
-      "norm_label": "senddiscountreminderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L334"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "index_sendfeedbackrequestemail",
-      "label": "sendFeedbackRequestEmail()",
-      "norm_label": "sendfeedbackrequestemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L167"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "index_sendneworderemail",
-      "label": "sendNewOrderEmail()",
-      "norm_label": "sendneworderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L117"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "index_sendorderemail",
-      "label": "sendOrderEmail()",
-      "norm_label": "sendorderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "index_sendverificationcode",
-      "label": "sendVerificationCode()",
-      "norm_label": "sendverificationcode()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "id": "packages_athena_webapp_convex_marketing_walkthroughconfig_ts",
+      "label": "walkthroughConfig.ts",
+      "norm_label": "walkthroughconfig.ts",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
       "source_location": "L1"
     },
     {
       "community": 247,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L1"
+      "id": "walkthroughconfig_landingfunnelhourlylimit",
+      "label": "landingFunnelHourlyLimit()",
+      "norm_label": "landingfunnelhourlylimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "walkthroughconfig_parseboundedpositiveinteger",
+      "label": "parseBoundedPositiveInteger()",
+      "norm_label": "parseboundedpositiveinteger()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "walkthroughconfig_resolvewalkthroughallowedorigins",
+      "label": "resolveWalkthroughAllowedOrigins()",
+      "norm_label": "resolvewalkthroughallowedorigins()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughallowedorigins",
+      "label": "walkthroughAllowedOrigins()",
+      "norm_label": "walkthroughallowedorigins()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughdailyperemaillimit",
+      "label": "walkthroughDailyPerEmailLimit()",
+      "norm_label": "walkthroughdailyperemaillimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughhourlygloballimit",
+      "label": "walkthroughHourlyGlobalLimit()",
+      "norm_label": "walkthroughhourlygloballimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughhourlynotificationlimit",
+      "label": "walkthroughHourlyNotificationLimit()",
+      "norm_label": "walkthroughhourlynotificationlimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughmaxbodybytes",
+      "label": "walkthroughMaxBodyBytes()",
+      "norm_label": "walkthroughmaxbodybytes()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughprivacycontact",
+      "label": "walkthroughPrivacyContact()",
+      "norm_label": "walkthroughprivacycontact()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L95"
     },
     {
       "community": 2470,
@@ -230388,92 +230424,92 @@
     {
       "community": 248,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_marketing_walkthroughconfig_ts",
-      "label": "walkthroughConfig.ts",
-      "norm_label": "walkthroughconfig.ts",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "id": "definitions_costoverlaystorewriteoperation",
+      "label": "costOverlayStoreWriteOperation()",
+      "norm_label": "costoverlaystorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L569"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "definitions_cyclecountdraftstorewriteoperation",
+      "label": "cycleCountDraftStoreWriteOperation()",
+      "norm_label": "cyclecountdraftstorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L383"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "definitions_defineoperation",
+      "label": "defineOperation()",
+      "norm_label": "defineoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "definitions_inventoryimportreviewpayloadwriteoperation",
+      "label": "inventoryImportReviewPayloadWriteOperation()",
+      "norm_label": "inventoryimportreviewpayloadwriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L544"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "definitions_notificationsubscriptionrowwriteoperation",
+      "label": "notificationSubscriptionRowWriteOperation()",
+      "norm_label": "notificationsubscriptionrowwriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L629"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "definitions_orderstorewriteoperation",
+      "label": "orderStoreWriteOperation()",
+      "norm_label": "orderstorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L155"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "definitions_storewriteoperation",
+      "label": "storeWriteOperation()",
+      "norm_label": "storewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L108"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "definitions_transactionstorewriteoperation",
+      "label": "transactionStoreWriteOperation()",
+      "norm_label": "transactionstorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "definitions_validateoperationdefinition",
+      "label": "validateOperationDefinition()",
+      "norm_label": "validateoperationdefinition()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L724"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operationadmission_definitions_ts",
+      "label": "definitions.ts",
+      "norm_label": "definitions.ts",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "walkthroughconfig_landingfunnelhourlylimit",
-      "label": "landingFunnelHourlyLimit()",
-      "norm_label": "landingfunnelhourlylimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "walkthroughconfig_parseboundedpositiveinteger",
-      "label": "parseBoundedPositiveInteger()",
-      "norm_label": "parseboundedpositiveinteger()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "walkthroughconfig_resolvewalkthroughallowedorigins",
-      "label": "resolveWalkthroughAllowedOrigins()",
-      "norm_label": "resolvewalkthroughallowedorigins()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughallowedorigins",
-      "label": "walkthroughAllowedOrigins()",
-      "norm_label": "walkthroughallowedorigins()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughdailyperemaillimit",
-      "label": "walkthroughDailyPerEmailLimit()",
-      "norm_label": "walkthroughdailyperemaillimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L55"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughhourlygloballimit",
-      "label": "walkthroughHourlyGlobalLimit()",
-      "norm_label": "walkthroughhourlygloballimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughhourlynotificationlimit",
-      "label": "walkthroughHourlyNotificationLimit()",
-      "norm_label": "walkthroughhourlynotificationlimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughmaxbodybytes",
-      "label": "walkthroughMaxBodyBytes()",
-      "norm_label": "walkthroughmaxbodybytes()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughprivacycontact",
-      "label": "walkthroughPrivacyContact()",
-      "norm_label": "walkthroughprivacycontact()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L95"
     },
     {
       "community": 2480,
@@ -230568,91 +230604,91 @@
     {
       "community": 249,
       "file_type": "code",
-      "id": "definitions_costoverlaystorewriteoperation",
-      "label": "costOverlayStoreWriteOperation()",
-      "norm_label": "costoverlaystorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L569"
+      "id": "adjustmentreports_adjustmentappliedat",
+      "label": "adjustmentAppliedAt()",
+      "norm_label": "adjustmentappliedat()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L101"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "definitions_cyclecountdraftstorewriteoperation",
-      "label": "cycleCountDraftStoreWriteOperation()",
-      "norm_label": "cyclecountdraftstorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L383"
+      "id": "adjustmentreports_adjustmentsalesdelta",
+      "label": "adjustmentSalesDelta()",
+      "norm_label": "adjustmentsalesdelta()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L116"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "definitions_defineoperation",
-      "label": "defineOperation()",
-      "norm_label": "defineoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L11"
+      "id": "adjustmentreports_adjustmentsettlementamount",
+      "label": "adjustmentSettlementAmount()",
+      "norm_label": "adjustmentsettlementamount()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L143"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "definitions_inventoryimportreviewpayloadwriteoperation",
-      "label": "inventoryImportReviewPayloadWriteOperation()",
-      "norm_label": "inventoryimportreviewpayloadwriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L544"
+      "id": "adjustmentreports_adjustmenttransactionid",
+      "label": "adjustmentTransactionId()",
+      "norm_label": "adjustmenttransactionid()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L110"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "definitions_notificationsubscriptionrowwriteoperation",
-      "label": "notificationSubscriptionRowWriteOperation()",
-      "norm_label": "notificationsubscriptionrowwriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L629"
+      "id": "adjustmentreports_buildadjustmentpaymenttotals",
+      "label": "buildAdjustmentPaymentTotals()",
+      "norm_label": "buildadjustmentpaymenttotals()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L242"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "definitions_orderstorewriteoperation",
-      "label": "orderStoreWriteOperation()",
-      "norm_label": "orderstorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L155"
+      "id": "adjustmentreports_buildadjustmentreporttotals",
+      "label": "buildAdjustmentReportTotals()",
+      "norm_label": "buildadjustmentreporttotals()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L275"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "definitions_storewriteoperation",
-      "label": "storeWriteOperation()",
-      "norm_label": "storewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L108"
+      "id": "adjustmentreports_listappliedtransactionadjustmentsforday",
+      "label": "listAppliedTransactionAdjustmentsForDay()",
+      "norm_label": "listappliedtransactionadjustmentsforday()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L229"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "definitions_transactionstorewriteoperation",
-      "label": "transactionStoreWriteOperation()",
-      "norm_label": "transactionstorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L128"
+      "id": "adjustmentreports_readappliedtransactionadjustmentsforday",
+      "label": "readAppliedTransactionAdjustmentsForDay()",
+      "norm_label": "readappliedtransactionadjustmentsforday()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L173"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "definitions_validateoperationdefinition",
-      "label": "validateOperationDefinition()",
-      "norm_label": "validateoperationdefinition()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L724"
+      "id": "adjustmentreports_sourcecompletenessentry",
+      "label": "sourceCompletenessEntry()",
+      "norm_label": "sourcecompletenessentry()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L76"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operationadmission_definitions_ts",
-      "label": "definitions.ts",
-      "norm_label": "definitions.ts",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "id": "packages_athena_webapp_convex_operations_dailyclose_adjustmentreports_ts",
+      "label": "adjustmentReports.ts",
+      "norm_label": "adjustmentreports.ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
       "source_location": "L1"
     },
     {
@@ -231099,91 +231135,91 @@
     {
       "community": 250,
       "file_type": "code",
-      "id": "adjustmentreports_adjustmentappliedat",
-      "label": "adjustmentAppliedAt()",
-      "norm_label": "adjustmentappliedat()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L101"
+      "id": "inventorymovements_assertnobusinesseventconflict",
+      "label": "assertNoBusinessEventConflict()",
+      "norm_label": "assertnobusinesseventconflict()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L178"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "adjustmentreports_adjustmentsalesdelta",
-      "label": "adjustmentSalesDelta()",
-      "norm_label": "adjustmentsalesdelta()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L116"
+      "id": "inventorymovements_buildinventorymovement",
+      "label": "buildInventoryMovement()",
+      "norm_label": "buildinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L124"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "adjustmentreports_adjustmentsettlementamount",
-      "label": "adjustmentSettlementAmount()",
-      "norm_label": "adjustmentsettlementamount()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L143"
+      "id": "inventorymovements_buildskuactivityforinventorymovement",
+      "label": "buildSkuActivityForInventoryMovement()",
+      "norm_label": "buildskuactivityforinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L66"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "adjustmentreports_adjustmenttransactionid",
-      "label": "adjustmentTransactionId()",
-      "norm_label": "adjustmenttransactionid()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L110"
+      "id": "inventorymovements_getskuactivitytypeformovement",
+      "label": "getSkuActivityTypeForMovement()",
+      "norm_label": "getskuactivitytypeformovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L49"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "adjustmentreports_buildadjustmentpaymenttotals",
-      "label": "buildAdjustmentPaymentTotals()",
-      "norm_label": "buildadjustmentpaymenttotals()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L242"
+      "id": "inventorymovements_matchesexistingmovement",
+      "label": "matchesExistingMovement()",
+      "norm_label": "matchesexistingmovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L150"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "adjustmentreports_buildadjustmentreporttotals",
-      "label": "buildAdjustmentReportTotals()",
-      "norm_label": "buildadjustmentreporttotals()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L275"
+      "id": "inventorymovements_recordinventorymovementwithctx",
+      "label": "recordInventoryMovementWithCtx()",
+      "norm_label": "recordinventorymovementwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L200"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "adjustmentreports_listappliedtransactionadjustmentsforday",
-      "label": "listAppliedTransactionAdjustmentsForDay()",
-      "norm_label": "listappliedtransactionadjustmentsforday()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L229"
+      "id": "inventorymovements_recordinventorymovementwithdispositionwithctx",
+      "label": "recordInventoryMovementWithDispositionWithCtx()",
+      "norm_label": "recordinventorymovementwithdispositionwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L245"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "adjustmentreports_readappliedtransactionadjustmentsforday",
-      "label": "readAppliedTransactionAdjustmentsForDay()",
-      "norm_label": "readappliedtransactionadjustmentsforday()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L173"
+      "id": "inventorymovements_recordskuactivityforinventorymovementwithctx",
+      "label": "recordSkuActivityForInventoryMovementWithCtx()",
+      "norm_label": "recordskuactivityforinventorymovementwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L111"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "adjustmentreports_sourcecompletenessentry",
-      "label": "sourceCompletenessEntry()",
-      "norm_label": "sourcecompletenessentry()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L76"
+      "id": "inventorymovements_summarizeinventorymovements",
+      "label": "summarizeInventoryMovements()",
+      "norm_label": "summarizeinventorymovements()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L135"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_dailyclose_adjustmentreports_ts",
-      "label": "adjustmentReports.ts",
-      "norm_label": "adjustmentreports.ts",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
+      "label": "inventoryMovements.ts",
+      "norm_label": "inventorymovements.ts",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
       "source_location": "L1"
     },
     {
@@ -231279,91 +231315,91 @@
     {
       "community": 251,
       "file_type": "code",
-      "id": "inventorymovements_assertnobusinesseventconflict",
-      "label": "assertNoBusinessEventConflict()",
-      "norm_label": "assertnobusinesseventconflict()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L178"
+      "id": "operationalevents_buildoperationalevent",
+      "label": "buildOperationalEvent()",
+      "norm_label": "buildoperationalevent()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L43"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "inventorymovements_buildinventorymovement",
-      "label": "buildInventoryMovement()",
-      "norm_label": "buildinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L124"
+      "id": "operationalevents_buildtracemetadata",
+      "label": "buildTraceMetadata()",
+      "norm_label": "buildtracemetadata()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L96"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "inventorymovements_buildskuactivityforinventorymovement",
-      "label": "buildSkuActivityForInventoryMovement()",
-      "norm_label": "buildskuactivityforinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L66"
+      "id": "operationalevents_isrecord",
+      "label": "isRecord()",
+      "norm_label": "isrecord()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L145"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "inventorymovements_getskuactivitytypeformovement",
-      "label": "getSkuActivityTypeForMovement()",
-      "norm_label": "getskuactivitytypeformovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L49"
+      "id": "operationalevents_listproductoperationaltimelinewithctx",
+      "label": "listProductOperationalTimelineWithCtx()",
+      "norm_label": "listproductoperationaltimelinewithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L246"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "inventorymovements_matchesexistingmovement",
-      "label": "matchesExistingMovement()",
-      "norm_label": "matchesexistingmovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L150"
+      "id": "operationalevents_matchesexistingevent",
+      "label": "matchesExistingEvent()",
+      "norm_label": "matchesexistingevent()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L149"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "inventorymovements_recordinventorymovementwithctx",
-      "label": "recordInventoryMovementWithCtx()",
-      "norm_label": "recordinventorymovementwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L200"
+      "id": "operationalevents_metadatadedupekeysmatch",
+      "label": "metadataDedupeKeysMatch()",
+      "norm_label": "metadatadedupekeysmatch()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L205"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "inventorymovements_recordinventorymovementwithdispositionwithctx",
-      "label": "recordInventoryMovementWithDispositionWithCtx()",
-      "norm_label": "recordinventorymovementwithdispositionwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L245"
+      "id": "operationalevents_normalizeoperationaleventtracefields",
+      "label": "normalizeOperationalEventTraceFields()",
+      "norm_label": "normalizeoperationaleventtracefields()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L60"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "inventorymovements_recordskuactivityforinventorymovementwithctx",
-      "label": "recordSkuActivityForInventoryMovementWithCtx()",
-      "norm_label": "recordskuactivityforinventorymovementwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L111"
+      "id": "operationalevents_recordoperationaleventwithctx",
+      "label": "recordOperationalEventWithCtx()",
+      "norm_label": "recordoperationaleventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L215"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "inventorymovements_summarizeinventorymovements",
-      "label": "summarizeInventoryMovements()",
-      "norm_label": "summarizeinventorymovements()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L135"
+      "id": "operationalevents_shouldnormalizepostrace",
+      "label": "shouldNormalizePosTrace()",
+      "norm_label": "shouldnormalizepostrace()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L118"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
-      "label": "inventoryMovements.ts",
-      "norm_label": "inventorymovements.ts",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
+      "label": "operationalEvents.ts",
+      "norm_label": "operationalevents.ts",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
       "source_location": "L1"
     },
     {
@@ -231459,91 +231495,91 @@
     {
       "community": 252,
       "file_type": "code",
-      "id": "operationalevents_buildoperationalevent",
-      "label": "buildOperationalEvent()",
-      "norm_label": "buildoperationalevent()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L43"
+      "id": "oversizedoperationalworkrepair_amendrepairwithctx",
+      "label": "amendRepairWithCtx()",
+      "norm_label": "amendrepairwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L430"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "operationalevents_buildtracemetadata",
-      "label": "buildTraceMetadata()",
-      "norm_label": "buildtracemetadata()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L96"
+      "id": "oversizedoperationalworkrepair_createrepairwithctx",
+      "label": "createRepairWithCtx()",
+      "norm_label": "createrepairwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L160"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "operationalevents_isrecord",
-      "label": "isRecord()",
-      "norm_label": "isrecord()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L145"
+      "id": "oversizedoperationalworkrepair_pauserepair",
+      "label": "pauseRepair()",
+      "norm_label": "pauserepair()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L231"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "operationalevents_listproductoperationaltimelinewithctx",
-      "label": "listProductOperationalTimelineWithCtx()",
-      "norm_label": "listproductoperationaltimelinewithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L246"
+      "id": "oversizedoperationalworkrepair_processrepairbatchwithctx",
+      "label": "processRepairBatchWithCtx()",
+      "norm_label": "processrepairbatchwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L249"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "operationalevents_matchesexistingevent",
-      "label": "matchesExistingEvent()",
-      "norm_label": "matchesexistingevent()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L149"
+      "id": "oversizedoperationalworkrepair_readcurrentgroup",
+      "label": "readCurrentGroup()",
+      "norm_label": "readcurrentgroup()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L49"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "operationalevents_metadatadedupekeysmatch",
-      "label": "metadataDedupeKeysMatch()",
-      "norm_label": "metadatadedupekeysmatch()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L205"
+      "id": "oversizedoperationalworkrepair_recordrepairauditevent",
+      "label": "recordRepairAuditEvent()",
+      "norm_label": "recordrepairauditevent()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L85"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "operationalevents_normalizeoperationaleventtracefields",
-      "label": "normalizeOperationalEventTraceFields()",
-      "norm_label": "normalizeoperationaleventtracefields()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L60"
+      "id": "oversizedoperationalworkrepair_requireevidence",
+      "label": "requireEvidence()",
+      "norm_label": "requireevidence()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L37"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "operationalevents_recordoperationaleventwithctx",
-      "label": "recordOperationalEventWithCtx()",
-      "norm_label": "recordoperationaleventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L215"
+      "id": "oversizedoperationalworkrepair_resumerepairwithctx",
+      "label": "resumeRepairWithCtx()",
+      "norm_label": "resumerepairwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L472"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "operationalevents_shouldnormalizepostrace",
-      "label": "shouldNormalizePosTrace()",
-      "norm_label": "shouldnormalizepostrace()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L118"
+      "id": "oversizedoperationalworkrepair_schedulenextbatch",
+      "label": "scheduleNextBatch()",
+      "norm_label": "schedulenextbatch()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L153"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
-      "label": "operationalEvents.ts",
-      "norm_label": "operationalevents.ts",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "id": "packages_athena_webapp_convex_operations_oversizedoperationalworkrepair_ts",
+      "label": "oversizedOperationalWorkRepair.ts",
+      "norm_label": "oversizedoperationalworkrepair.ts",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
       "source_location": "L1"
     },
     {
@@ -231639,92 +231675,92 @@
     {
       "community": 253,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_amendrepairwithctx",
-      "label": "amendRepairWithCtx()",
-      "norm_label": "amendrepairwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L430"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_createrepairwithctx",
-      "label": "createRepairWithCtx()",
-      "norm_label": "createrepairwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L160"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_pauserepair",
-      "label": "pauseRepair()",
-      "norm_label": "pauserepair()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L231"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_processrepairbatchwithctx",
-      "label": "processRepairBatchWithCtx()",
-      "norm_label": "processrepairbatchwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L249"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_readcurrentgroup",
-      "label": "readCurrentGroup()",
-      "norm_label": "readcurrentgroup()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_recordrepairauditevent",
-      "label": "recordRepairAuditEvent()",
-      "norm_label": "recordrepairauditevent()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_requireevidence",
-      "label": "requireEvidence()",
-      "norm_label": "requireevidence()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_resumerepairwithctx",
-      "label": "resumeRepairWithCtx()",
-      "norm_label": "resumerepairwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L472"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_schedulenextbatch",
-      "label": "scheduleNextBatch()",
-      "norm_label": "schedulenextbatch()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_oversizedoperationalworkrepair_ts",
-      "label": "oversizedOperationalWorkRepair.ts",
-      "norm_label": "oversizedoperationalworkrepair.ts",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "id": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
+      "label": "registerSessionTracing.ts",
+      "norm_label": "registersessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registersessiontracing_buildactorrefs",
+      "label": "buildActorRefs()",
+      "norm_label": "buildactorrefs()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registersessiontracing_buildtraceevent",
+      "label": "buildTraceEvent()",
+      "norm_label": "buildtraceevent()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L196"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registersessiontracing_buildtracerecord",
+      "label": "buildTraceRecord()",
+      "norm_label": "buildtracerecord()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L161"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registersessiontracing_displaytraceamount",
+      "label": "displayTraceAmount()",
+      "norm_label": "displaytraceamount()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L114"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registersessiontracing_formattransactionlabel",
+      "label": "formatTransactionLabel()",
+      "norm_label": "formattransactionlabel()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L132"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registersessiontracing_recordregistersessiontracebesteffort",
+      "label": "recordRegisterSessionTraceBestEffort()",
+      "norm_label": "recordregistersessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L407"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registersessiontracing_resolveoccurredat",
+      "label": "resolveOccurredAt()",
+      "norm_label": "resolveoccurredat()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registersessiontracing_resolvestorecurrency",
+      "label": "resolveStoreCurrency()",
+      "norm_label": "resolvestorecurrency()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L146"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registersessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L92"
     },
     {
       "community": 2530,
@@ -231819,92 +231855,92 @@
     {
       "community": 254,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
-      "label": "registerSessionTracing.ts",
-      "norm_label": "registersessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "id": "finalizedlineageremediation_classifyfinalizedlineagerepairconflicts",
+      "label": "classifyFinalizedLineageRepairConflicts()",
+      "norm_label": "classifyfinalizedlineagerepairconflicts()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L222"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_classifyrepaircandidate",
+      "label": "classifyRepairCandidate()",
+      "norm_label": "classifyrepaircandidate()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L164"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_countrepairablefinalizedlineagelines",
+      "label": "countRepairableFinalizedLineageLines()",
+      "norm_label": "countrepairablefinalizedlineagelines()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L284"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_getprovisionalimportsku",
+      "label": "getProvisionalImportSku()",
+      "norm_label": "getprovisionalimportsku()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L318"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_isclosedregisterrepairreplayconflict",
+      "label": "isClosedRegisterRepairReplayConflict()",
+      "norm_label": "isclosedregisterrepairreplayconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L273"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_isfinalizedlineagerepairconflict",
+      "label": "isFinalizedLineageRepairConflict()",
+      "norm_label": "isfinalizedlineagerepairconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L258"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_isprovisionalrowchangedconflict",
+      "label": "isProvisionalRowChangedConflict()",
+      "norm_label": "isprovisionalrowchangedconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L265"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_recordfinalizedlineagerepairevent",
+      "label": "recordFinalizedLineageRepairEvent()",
+      "norm_label": "recordfinalizedlineagerepairevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L358"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_skipped",
+      "label": "skipped()",
+      "norm_label": "skipped()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L346"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_sync_finalizedlineageremediation_ts",
+      "label": "finalizedLineageRemediation.ts",
+      "norm_label": "finalizedlineageremediation.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "registersessiontracing_buildactorrefs",
-      "label": "buildActorRefs()",
-      "norm_label": "buildactorrefs()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "registersessiontracing_buildtraceevent",
-      "label": "buildTraceEvent()",
-      "norm_label": "buildtraceevent()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L196"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "registersessiontracing_buildtracerecord",
-      "label": "buildTraceRecord()",
-      "norm_label": "buildtracerecord()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L161"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "registersessiontracing_displaytraceamount",
-      "label": "displayTraceAmount()",
-      "norm_label": "displaytraceamount()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L114"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "registersessiontracing_formattransactionlabel",
-      "label": "formatTransactionLabel()",
-      "norm_label": "formattransactionlabel()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L132"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "registersessiontracing_recordregistersessiontracebesteffort",
-      "label": "recordRegisterSessionTraceBestEffort()",
-      "norm_label": "recordregistersessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L407"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "registersessiontracing_resolveoccurredat",
-      "label": "resolveOccurredAt()",
-      "norm_label": "resolveoccurredat()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L76"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "registersessiontracing_resolvestorecurrency",
-      "label": "resolveStoreCurrency()",
-      "norm_label": "resolvestorecurrency()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L146"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "registersessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L92"
     },
     {
       "community": 2540,
@@ -231999,92 +232035,92 @@
     {
       "community": 255,
       "file_type": "code",
-      "id": "finalizedlineageremediation_classifyfinalizedlineagerepairconflicts",
-      "label": "classifyFinalizedLineageRepairConflicts()",
-      "norm_label": "classifyfinalizedlineagerepairconflicts()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_terminalrecoveryrepository_ts",
+      "label": "terminalRecoveryRepository.ts",
+      "norm_label": "terminalrecoveryrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_createterminalrecoverycommandreadrepository",
+      "label": "createTerminalRecoveryCommandReadRepository()",
+      "norm_label": "createterminalrecoverycommandreadrepository()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_createterminalrecoverycommandrepository",
+      "label": "createTerminalRecoveryCommandRepository()",
+      "norm_label": "createterminalrecoverycommandrepository()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L127"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_deduperecoverycommandsbyid",
+      "label": "dedupeRecoveryCommandsById()",
+      "norm_label": "deduperecoverycommandsbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L116"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_deduperecoveryconflictsbyid",
+      "label": "dedupeRecoveryConflictsById()",
+      "norm_label": "deduperecoveryconflictsbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L193"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_getterminalrecoverysourceevent",
+      "label": "getTerminalRecoverySourceEvent()",
+      "norm_label": "getterminalrecoverysourceevent()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
       "source_location": "L222"
     },
     {
       "community": 255,
       "file_type": "code",
-      "id": "finalizedlineageremediation_classifyrepaircandidate",
-      "label": "classifyRepairCandidate()",
-      "norm_label": "classifyrepaircandidate()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L164"
+      "id": "terminalrecoveryrepository_iscurrentterminalrecoveryconflict",
+      "label": "isCurrentTerminalRecoveryConflict()",
+      "norm_label": "iscurrentterminalrecoveryconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L206"
     },
     {
       "community": 255,
       "file_type": "code",
-      "id": "finalizedlineageremediation_countrepairablefinalizedlineagelines",
-      "label": "countRepairableFinalizedLineageLines()",
-      "norm_label": "countrepairablefinalizedlineagelines()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L284"
+      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsforrepair",
+      "label": "listTerminalRecoveryConflictsForRepair()",
+      "norm_label": "listterminalrecoveryconflictsforrepair()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L141"
     },
     {
       "community": 255,
       "file_type": "code",
-      "id": "finalizedlineageremediation_getprovisionalimportsku",
-      "label": "getProvisionalImportSku()",
-      "norm_label": "getprovisionalimportsku()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L318"
+      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsources",
+      "label": "listTerminalRecoveryConflictSources()",
+      "norm_label": "listterminalrecoveryconflictsources()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L162"
     },
     {
       "community": 255,
       "file_type": "code",
-      "id": "finalizedlineageremediation_isclosedregisterrepairreplayconflict",
-      "label": "isClosedRegisterRepairReplayConflict()",
-      "norm_label": "isclosedregisterrepairreplayconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L273"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_isfinalizedlineagerepairconflict",
-      "label": "isFinalizedLineageRepairConflict()",
-      "norm_label": "isfinalizedlineagerepairconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L258"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_isprovisionalrowchangedconflict",
-      "label": "isProvisionalRowChangedConflict()",
-      "norm_label": "isprovisionalrowchangedconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L265"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_recordfinalizedlineagerepairevent",
-      "label": "recordFinalizedLineageRepairEvent()",
-      "norm_label": "recordfinalizedlineagerepairevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L358"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_skipped",
-      "label": "skipped()",
-      "norm_label": "skipped()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L346"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sync_finalizedlineageremediation_ts",
-      "label": "finalizedLineageRemediation.ts",
-      "norm_label": "finalizedlineageremediation.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L1"
+      "id": "terminalrecoveryrepository_patchterminalrecoveryconflict",
+      "label": "patchTerminalRecoveryConflict()",
+      "norm_label": "patchterminalrecoveryconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L241"
     },
     {
       "community": 2550,
@@ -232179,92 +232215,92 @@
     {
       "community": 256,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_terminalrecoveryrepository_ts",
-      "label": "terminalRecoveryRepository.ts",
-      "norm_label": "terminalrecoveryrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "id": "contract_test_day",
+      "label": "day()",
+      "norm_label": "day()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L1308"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "contract_test_fieldsof",
+      "label": "fieldsOf()",
+      "norm_label": "fieldsof()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L86"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "contract_test_headerfor",
+      "label": "headerFor()",
+      "norm_label": "headerfor()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L972"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "contract_test_inclusivedays",
+      "label": "inclusiveDays()",
+      "norm_label": "inclusivedays()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L1216"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "contract_test_movementidentityargs",
+      "label": "movementIdentityArgs()",
+      "norm_label": "movementidentityargs()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L602"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "contract_test_probe",
+      "label": "probe()",
+      "norm_label": "probe()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L1312"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "contract_test_seedproductsku",
+      "label": "seedProductSku()",
+      "norm_label": "seedproductsku()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L561"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "contract_test_seedstore",
+      "label": "seedStore()",
+      "norm_label": "seedstore()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L542"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "contract_test_unionliterals",
+      "label": "unionLiterals()",
+      "norm_label": "unionliterals()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_reports_contract_test_ts",
+      "label": "contract.test.ts",
+      "norm_label": "contract.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_createterminalrecoverycommandreadrepository",
-      "label": "createTerminalRecoveryCommandReadRepository()",
-      "norm_label": "createterminalrecoverycommandreadrepository()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_createterminalrecoverycommandrepository",
-      "label": "createTerminalRecoveryCommandRepository()",
-      "norm_label": "createterminalrecoverycommandrepository()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L127"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_deduperecoverycommandsbyid",
-      "label": "dedupeRecoveryCommandsById()",
-      "norm_label": "deduperecoverycommandsbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_deduperecoveryconflictsbyid",
-      "label": "dedupeRecoveryConflictsById()",
-      "norm_label": "deduperecoveryconflictsbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L193"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_getterminalrecoverysourceevent",
-      "label": "getTerminalRecoverySourceEvent()",
-      "norm_label": "getterminalrecoverysourceevent()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L222"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_iscurrentterminalrecoveryconflict",
-      "label": "isCurrentTerminalRecoveryConflict()",
-      "norm_label": "iscurrentterminalrecoveryconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L206"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsforrepair",
-      "label": "listTerminalRecoveryConflictsForRepair()",
-      "norm_label": "listterminalrecoveryconflictsforrepair()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L141"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsources",
-      "label": "listTerminalRecoveryConflictSources()",
-      "norm_label": "listterminalrecoveryconflictsources()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L162"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_patchterminalrecoveryconflict",
-      "label": "patchTerminalRecoveryConflict()",
-      "norm_label": "patchterminalrecoveryconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L241"
     },
     {
       "community": 2560,
@@ -232359,91 +232395,91 @@
     {
       "community": 257,
       "file_type": "code",
-      "id": "contract_test_day",
-      "label": "day()",
-      "norm_label": "day()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L1308"
+      "id": "customrange_aggregateskudays",
+      "label": "aggregateSkuDays()",
+      "norm_label": "aggregateskudays()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L217"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "contract_test_fieldsof",
-      "label": "fieldsOf()",
-      "norm_label": "fieldsof()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L86"
+      "id": "customrange_computerange",
+      "label": "computeRange()",
+      "norm_label": "computerange()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L253"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "contract_test_headerfor",
-      "label": "headerFor()",
-      "norm_label": "headerfor()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L972"
+      "id": "customrange_computerequestkey",
+      "label": "computeRequestKey()",
+      "norm_label": "computerequestkey()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L84"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "contract_test_inclusivedays",
-      "label": "inclusiveDays()",
-      "norm_label": "inclusivedays()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L1216"
+      "id": "customrange_inclusivedayspan",
+      "label": "inclusiveDaySpan()",
+      "norm_label": "inclusivedayspan()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L52"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "contract_test_movementidentityargs",
-      "label": "movementIdentityArgs()",
-      "norm_label": "movementidentityargs()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L602"
+      "id": "customrange_isvalidoperatingdate",
+      "label": "isValidOperatingDate()",
+      "norm_label": "isvalidoperatingdate()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L35"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "contract_test_probe",
-      "label": "probe()",
-      "norm_label": "probe()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L1312"
+      "id": "customrange_requestrangecore",
+      "label": "requestRangeCore()",
+      "norm_label": "requestrangecore()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L112"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "contract_test_seedproductsku",
-      "label": "seedProductSku()",
-      "norm_label": "seedproductsku()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L561"
+      "id": "customrange_sumdays",
+      "label": "sumDays()",
+      "norm_label": "sumdays()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L189"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "contract_test_seedstore",
-      "label": "seedStore()",
-      "norm_label": "seedstore()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L542"
+      "id": "customrange_utcmillisforlabel",
+      "label": "utcMillisForLabel()",
+      "norm_label": "utcmillisforlabel()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L46"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "contract_test_unionliterals",
-      "label": "unionLiterals()",
-      "norm_label": "unionliterals()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L92"
+      "id": "customrange_validaterangeargs",
+      "label": "validateRangeArgs()",
+      "norm_label": "validaterangeargs()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L58"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_contract_test_ts",
-      "label": "contract.test.ts",
-      "norm_label": "contract.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "id": "packages_athena_webapp_convex_reports_customrange_ts",
+      "label": "customRange.ts",
+      "norm_label": "customrange.ts",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
       "source_location": "L1"
     },
     {
@@ -232539,92 +232575,92 @@
     {
       "community": 258,
       "file_type": "code",
-      "id": "customrange_aggregateskudays",
-      "label": "aggregateSkuDays()",
-      "norm_label": "aggregateskudays()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L217"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "customrange_computerange",
-      "label": "computeRange()",
-      "norm_label": "computerange()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L253"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "customrange_computerequestkey",
-      "label": "computeRequestKey()",
-      "norm_label": "computerequestkey()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L84"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "customrange_inclusivedayspan",
-      "label": "inclusiveDaySpan()",
-      "norm_label": "inclusivedayspan()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "customrange_isvalidoperatingdate",
-      "label": "isValidOperatingDate()",
-      "norm_label": "isvalidoperatingdate()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "customrange_requestrangecore",
-      "label": "requestRangeCore()",
-      "norm_label": "requestrangecore()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L112"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "customrange_sumdays",
-      "label": "sumDays()",
-      "norm_label": "sumdays()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L189"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "customrange_utcmillisforlabel",
-      "label": "utcMillisForLabel()",
-      "norm_label": "utcmillisforlabel()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "customrange_validaterangeargs",
-      "label": "validateRangeArgs()",
-      "norm_label": "validaterangeargs()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_customrange_ts",
-      "label": "customRange.ts",
-      "norm_label": "customrange.ts",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "id": "packages_athena_webapp_convex_reports_rangesnapshotlifecycle_test_ts",
+      "label": "rangeSnapshotLifecycle.test.ts",
+      "norm_label": "rangesnapshotlifecycle.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_allow",
+      "label": "allow()",
+      "norm_label": "allow()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_certifyday",
+      "label": "certifyDay()",
+      "norm_label": "certifyday()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L109"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_consume",
+      "label": "consume()",
+      "norm_label": "consume()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L296"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_drive",
+      "label": "drive()",
+      "norm_label": "drive()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L247"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_ensuresynthetic",
+      "label": "ensureSynthetic()",
+      "norm_label": "ensuresynthetic()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L208"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_headerbykey",
+      "label": "headerByKey()",
+      "norm_label": "headerbykey()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L230"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_insertkindedheader",
+      "label": "insertKindedHeader()",
+      "norm_label": "insertkindedheader()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L612"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_seedstore",
+      "label": "seedStore()",
+      "norm_label": "seedstore()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_synthetickind",
+      "label": "syntheticKind()",
+      "norm_label": "synthetickind()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L150"
     },
     {
       "community": 2580,
@@ -232719,92 +232755,92 @@
     {
       "community": 259,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_rangesnapshotlifecycle_test_ts",
-      "label": "rangeSnapshotLifecycle.test.ts",
-      "norm_label": "rangesnapshotlifecycle.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "id": "packages_athena_webapp_convex_reports_verificationclassify_ts",
+      "label": "verificationClassify.ts",
+      "norm_label": "verificationclassify.ts",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
       "source_location": "L1"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_allow",
-      "label": "allow()",
-      "norm_label": "allow()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L53"
+      "id": "verificationclassify_buildclassification",
+      "label": "buildClassification()",
+      "norm_label": "buildclassification()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L448"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_certifyday",
-      "label": "certifyDay()",
-      "norm_label": "certifyday()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L109"
+      "id": "verificationclassify_classifydayresult",
+      "label": "classifyDayResult()",
+      "norm_label": "classifydayresult()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L481"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_consume",
-      "label": "consume()",
-      "norm_label": "consume()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L296"
+      "id": "verificationclassify_classifyweekresult",
+      "label": "classifyWeekResult()",
+      "norm_label": "classifyweekresult()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L562"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_drive",
-      "label": "drive()",
-      "norm_label": "drive()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L247"
+      "id": "verificationclassify_confirmsclean",
+      "label": "confirmsClean()",
+      "norm_label": "confirmsclean()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L681"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_ensuresynthetic",
-      "label": "ensureSynthetic()",
-      "norm_label": "ensuresynthetic()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L208"
+      "id": "verificationclassify_explainmetricdifference",
+      "label": "explainMetricDifference()",
+      "norm_label": "explainmetricdifference()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L378"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_headerbykey",
-      "label": "headerByKey()",
-      "norm_label": "headerbykey()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L230"
+      "id": "verificationclassify_fingerprintdifferences",
+      "label": "fingerprintDifferences()",
+      "norm_label": "fingerprintdifferences()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L354"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_insertkindedheader",
-      "label": "insertKindedHeader()",
-      "norm_label": "insertkindedheader()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L612"
+      "id": "verificationclassify_initialstreakstate",
+      "label": "initialStreakState()",
+      "norm_label": "initialstreakstate()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L658"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_seedstore",
-      "label": "seedStore()",
-      "norm_label": "seedstore()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L73"
+      "id": "verificationclassify_nextstreakstate",
+      "label": "nextStreakState()",
+      "norm_label": "nextstreakstate()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L707"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_synthetickind",
-      "label": "syntheticKind()",
-      "norm_label": "synthetickind()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L150"
+      "id": "verificationclassify_partitiondifferences",
+      "label": "partitionDifferences()",
+      "norm_label": "partitiondifferences()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L434"
     },
     {
       "community": 2590,
@@ -233241,92 +233277,92 @@
     {
       "community": 260,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_verificationclassify_ts",
-      "label": "verificationClassify.ts",
-      "norm_label": "verificationclassify.ts",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "id": "index_resolveverificationcoderecipient",
+      "label": "resolveVerificationCodeRecipient()",
+      "norm_label": "resolveverificationcoderecipient()",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "index_senddailymanagerreportemail",
+      "label": "sendDailyManagerReportEmail()",
+      "norm_label": "senddailymanagerreportemail()",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "source_location": "L373"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "index_senddiscountcodeemail",
+      "label": "sendDiscountCodeEmail()",
+      "norm_label": "senddiscountcodeemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L255"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "index_senddiscountreminderemail",
+      "label": "sendDiscountReminderEmail()",
+      "norm_label": "senddiscountreminderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L334"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "index_sendfeedbackrequestemail",
+      "label": "sendFeedbackRequestEmail()",
+      "norm_label": "sendfeedbackrequestemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "index_sendneworderemail",
+      "label": "sendNewOrderEmail()",
+      "norm_label": "sendneworderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L117"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "index_sendorderemail",
+      "label": "sendOrderEmail()",
+      "norm_label": "sendorderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "index_sendverificationcode",
+      "label": "sendVerificationCode()",
+      "norm_label": "sendverificationcode()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
       "source_location": "L1"
     },
     {
       "community": 260,
       "file_type": "code",
-      "id": "verificationclassify_buildclassification",
-      "label": "buildClassification()",
-      "norm_label": "buildclassification()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L448"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "verificationclassify_classifydayresult",
-      "label": "classifyDayResult()",
-      "norm_label": "classifydayresult()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L481"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "verificationclassify_classifyweekresult",
-      "label": "classifyWeekResult()",
-      "norm_label": "classifyweekresult()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L562"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "verificationclassify_confirmsclean",
-      "label": "confirmsClean()",
-      "norm_label": "confirmsclean()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L681"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "verificationclassify_explainmetricdifference",
-      "label": "explainMetricDifference()",
-      "norm_label": "explainmetricdifference()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L378"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "verificationclassify_fingerprintdifferences",
-      "label": "fingerprintDifferences()",
-      "norm_label": "fingerprintdifferences()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L354"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "verificationclassify_initialstreakstate",
-      "label": "initialStreakState()",
-      "norm_label": "initialstreakstate()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L658"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "verificationclassify_nextstreakstate",
-      "label": "nextStreakState()",
-      "norm_label": "nextstreakstate()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L707"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "verificationclassify_partitiondifferences",
-      "label": "partitionDifferences()",
-      "norm_label": "partitiondifferences()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L434"
+      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L1"
     },
     {
       "community": 2600,
@@ -242394,87 +242430,6 @@
     {
       "community": 318,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "productutils_getpreferredsku",
-      "label": "getPreferredSku()",
-      "norm_label": "getpreferredsku()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L82"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "productutils_sortskusbyavailabilitythenlength",
-      "label": "sortSkusByAvailabilityThenLength()",
-      "norm_label": "sortskusbyavailabilitythenlength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
       "id": "applyremoteassistcontrolintent_applyacceptedcontrolresult",
       "label": "applyAcceptedControlResult()",
       "norm_label": "applyacceptedcontrolresult()",
@@ -242482,7 +242437,7 @@
       "source_location": "L84"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_applykeyevent",
       "label": "applyKeyEvent()",
@@ -242491,7 +242446,7 @@
       "source_location": "L155"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_applypointerevent",
       "label": "applyPointerEvent()",
@@ -242500,7 +242455,7 @@
       "source_location": "L116"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_applyremoteassistcontrolintent",
       "label": "applyRemoteAssistControlIntent()",
@@ -242509,7 +242464,7 @@
       "source_location": "L17"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_getrecentcontrolresult",
       "label": "getRecentControlResult()",
@@ -242518,7 +242473,7 @@
       "source_location": "L95"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_getremoteassistcontroltarget",
       "label": "getRemoteAssistControlTarget()",
@@ -242527,7 +242482,7 @@
       "source_location": "L145"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_prepareremoteassistcontrolintent",
       "label": "prepareRemoteAssistControlIntent()",
@@ -242536,7 +242491,7 @@
       "source_location": "L27"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_remembercontrolresult",
       "label": "rememberControlResult()",
@@ -242545,13 +242500,94 @@
       "source_location": "L101"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_remote_assist_runtime_applyremoteassistcontrolintent_ts",
       "label": "applyRemoteAssistControlIntent.ts",
       "norm_label": "applyremoteassistcontrolintent.ts",
       "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_offline_posofflinereadiness_ts",
+      "label": "posOfflineReadiness.ts",
+      "norm_label": "posofflinereadiness.ts",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "posofflinereadiness_buildposofflinereadinesssummary",
+      "label": "buildPosOfflineReadinessSummary()",
+      "norm_label": "buildposofflinereadinesssummary()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L152"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "posofflinereadiness_buildsignal",
+      "label": "buildSignal()",
+      "norm_label": "buildsignal()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L178"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "posofflinereadiness_formatage",
+      "label": "formatAge()",
+      "norm_label": "formatage()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L290"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsignaldescription",
+      "label": "getSignalDescription()",
+      "norm_label": "getsignaldescription()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L221"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsignalstatus",
+      "label": "getSignalStatus()",
+      "norm_label": "getsignalstatus()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L201"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsummarydescription",
+      "label": "getSummaryDescription()",
+      "norm_label": "getsummarydescription()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L262"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsummarytitle",
+      "label": "getSummaryTitle()",
+      "norm_label": "getsummarytitle()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L256"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "posofflinereadiness_isreadylike",
+      "label": "isReadyLike()",
+      "norm_label": "isreadylike()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L286"
     },
     {
       "community": 32,
@@ -242880,87 +242916,6 @@
     {
       "community": 320,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_offline_posofflinereadiness_ts",
-      "label": "posOfflineReadiness.ts",
-      "norm_label": "posofflinereadiness.ts",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "posofflinereadiness_buildposofflinereadinesssummary",
-      "label": "buildPosOfflineReadinessSummary()",
-      "norm_label": "buildposofflinereadinesssummary()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L152"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "posofflinereadiness_buildsignal",
-      "label": "buildSignal()",
-      "norm_label": "buildsignal()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L178"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "posofflinereadiness_formatage",
-      "label": "formatAge()",
-      "norm_label": "formatage()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L290"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsignaldescription",
-      "label": "getSignalDescription()",
-      "norm_label": "getsignaldescription()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L221"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsignalstatus",
-      "label": "getSignalStatus()",
-      "norm_label": "getsignalstatus()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L201"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsummarydescription",
-      "label": "getSummaryDescription()",
-      "norm_label": "getsummarydescription()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L262"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsummarytitle",
-      "label": "getSummaryTitle()",
-      "norm_label": "getsummarytitle()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L256"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "posofflinereadiness_isreadylike",
-      "label": "isReadyLike()",
-      "norm_label": "isreadylike()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L286"
-    },
-    {
-      "community": 321,
-      "file_type": "code",
       "id": "foundations_content_colorrolecard",
       "label": "ColorRoleCard()",
       "norm_label": "colorrolecard()",
@@ -242968,7 +242923,7 @@
       "source_location": "L222"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "foundations_content_densitycard",
       "label": "DensityCard()",
@@ -242977,7 +242932,7 @@
       "source_location": "L283"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "foundations_content_detailviewrolecard",
       "label": "DetailViewRoleCard()",
@@ -242986,7 +242941,7 @@
       "source_location": "L363"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "foundations_content_hslvar",
       "label": "hslVar()",
@@ -242995,7 +242950,7 @@
       "source_location": "L214"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "foundations_content_motioncard",
       "label": "MotionCard()",
@@ -243004,7 +242959,7 @@
       "source_location": "L342"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "foundations_content_spacetokenrow",
       "label": "SpaceTokenRow()",
@@ -243013,7 +242968,7 @@
       "source_location": "L265"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "foundations_content_textvar",
       "label": "textVar()",
@@ -243022,7 +242977,7 @@
       "source_location": "L218"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "foundations_content_typespecimencard",
       "label": "TypeSpecimenCard()",
@@ -243031,13 +242986,94 @@
       "source_location": "L246"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_foundations_content_tsx",
       "label": "foundations-content.tsx",
       "norm_label": "foundations-content.tsx",
       "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "productutils_getpreferredsku",
+      "label": "getPreferredSku()",
+      "norm_label": "getpreferredsku()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L82"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "productutils_sortskusbyavailabilitythenlength",
+      "label": "sortSkusByAvailabilityThenLength()",
+      "norm_label": "sortskusbyavailabilitythenlength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L59"
     },
     {
       "community": 322,
@@ -244338,6 +244374,78 @@
     {
       "community": 335,
       "file_type": "code",
+      "id": "oweddailyclosesweep_candidatesforpolicies",
+      "label": "candidatesForPolicies()",
+      "norm_label": "candidatesforpolicies()",
+      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
+      "source_location": "L196"
+    },
+    {
+      "community": 335,
+      "file_type": "code",
+      "id": "oweddailyclosesweep_completedoperatingdatesforstore",
+      "label": "completedOperatingDatesForStore()",
+      "norm_label": "completedoperatingdatesforstore()",
+      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
+      "source_location": "L171"
+    },
+    {
+      "community": 335,
+      "file_type": "code",
+      "id": "oweddailyclosesweep_dailyclosesweepresultsettled",
+      "label": "dailyCloseSweepResultSettled()",
+      "norm_label": "dailyclosesweepresultsettled()",
+      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
+      "source_location": "L79"
+    },
+    {
+      "community": 335,
+      "file_type": "code",
+      "id": "oweddailyclosesweep_daysbetweenoperatingdates",
+      "label": "daysBetweenOperatingDates()",
+      "norm_label": "daysbetweenoperatingdates()",
+      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
+      "source_location": "L490"
+    },
+    {
+      "community": 335,
+      "file_type": "code",
+      "id": "oweddailyclosesweep_runoweddailyclosesweepwithctx",
+      "label": "runOwedDailyCloseSweepWithCtx()",
+      "norm_label": "runoweddailyclosesweepwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
+      "source_location": "L360"
+    },
+    {
+      "community": 335,
+      "file_type": "code",
+      "id": "oweddailyclosesweep_selectoweddailyclosedates",
+      "label": "selectOwedDailyCloseDates()",
+      "norm_label": "selectoweddailyclosedates()",
+      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
+      "source_location": "L117"
+    },
+    {
+      "community": 335,
+      "file_type": "code",
+      "id": "oweddailyclosesweep_selectrotatingoweddailycloseattempt",
+      "label": "selectRotatingOwedDailyCloseAttempt()",
+      "norm_label": "selectrotatingoweddailycloseattempt()",
+      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 335,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
+      "label": "owedDailyCloseSweep.ts",
+      "norm_label": "oweddailyclosesweep.ts",
+      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 336,
+      "file_type": "code",
       "id": "capabilitycatalog_classifyathenapublicwrite",
       "label": "classifyAthenaPublicWrite()",
       "norm_label": "classifyathenapublicwrite()",
@@ -244345,7 +244453,7 @@
       "source_location": "L303"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "capabilitycatalog_hascompletedweeklyobservedatverification",
       "label": "hasCompletedWeeklyObservedAtVerification()",
@@ -244354,7 +244462,7 @@
       "source_location": "L65"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "capabilitycatalog_hascompletedweeklyreportingcycleanchorverification",
       "label": "hasCompletedWeeklyReportingCycleAnchorVerification()",
@@ -244363,7 +244471,7 @@
       "source_location": "L83"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "capabilitycatalog_isclosewithinweeklyacceptancefloor",
       "label": "isCloseWithinWeeklyAcceptanceFloor()",
@@ -244372,7 +244480,7 @@
       "source_location": "L100"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "capabilitycatalog_isshareddemocapabilityallowed",
       "label": "isSharedDemoCapabilityAllowed()",
@@ -244381,7 +244489,7 @@
       "source_location": "L324"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "capabilitycatalog_isweeklyreportingenabledforstore",
       "label": "isWeeklyReportingEnabledForStore()",
@@ -244390,7 +244498,7 @@
       "source_location": "L118"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "capabilitycatalog_isweeklyreportingenabledforstoredoc",
       "label": "isWeeklyReportingEnabledForStoreDoc()",
@@ -244399,7 +244507,7 @@
       "source_location": "L137"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_platform_capabilitycatalog_ts",
       "label": "capabilityCatalog.ts",
@@ -244408,7 +244516,7 @@
       "source_location": "L1"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
       "label": "posSessionTracing.ts",
@@ -244417,7 +244525,7 @@
       "source_location": "L1"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "possessiontracing_buildpossessiontraceevent",
       "label": "buildPosSessionTraceEvent()",
@@ -244426,7 +244534,7 @@
       "source_location": "L226"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "possessiontracing_buildpossessiontracerecord",
       "label": "buildPosSessionTraceRecord()",
@@ -244435,7 +244543,7 @@
       "source_location": "L142"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "possessiontracing_buildtracesummary",
       "label": "buildTraceSummary()",
@@ -244444,7 +244552,7 @@
       "source_location": "L105"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "possessiontracing_createpossessiontracerecorder",
       "label": "createPosSessionTraceRecorder()",
@@ -244453,7 +244561,7 @@
       "source_location": "L559"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "possessiontracing_formatpaymentmethod",
       "label": "formatPaymentMethod()",
@@ -244462,7 +244570,7 @@
       "source_location": "L218"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "possessiontracing_recordpossessiontracebesteffort",
       "label": "recordPosSessionTraceBestEffort()",
@@ -244471,7 +244579,7 @@
       "source_location": "L532"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "possessiontracing_safetracewrite",
       "label": "safeTraceWrite()",
@@ -244480,7 +244588,7 @@
       "source_location": "L524"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "expensesessioncommands_test_builditem",
       "label": "buildItem()",
@@ -244489,7 +244597,7 @@
       "source_location": "L1083"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "expensesessioncommands_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -244498,7 +244606,7 @@
       "source_location": "L1077"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "expensesessioncommands_test_buildsession",
       "label": "buildSession()",
@@ -244507,7 +244615,7 @@
       "source_location": "L1073"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "expensesessioncommands_test_createcommandservice",
       "label": "createCommandService()",
@@ -244516,7 +244624,7 @@
       "source_location": "L1093"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "expensesessioncommands_test_createdependencies",
       "label": "createDependencies()",
@@ -244525,7 +244633,7 @@
       "source_location": "L813"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "expensesessioncommands_test_createfakerepository",
       "label": "createFakeRepository()",
@@ -244534,7 +244642,7 @@
       "source_location": "L900"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "expensesessioncommands_test_loadcommandservice",
       "label": "loadCommandService()",
@@ -244543,7 +244651,7 @@
       "source_location": "L793"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_expensesessioncommands_test_ts",
       "label": "expenseSessionCommands.test.ts",
@@ -244552,7 +244660,7 @@
       "source_location": "L1"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "label": "sessionCommands.test.ts",
@@ -244561,7 +244669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "sessioncommands_test_builditem",
       "label": "buildItem()",
@@ -244570,7 +244678,7 @@
       "source_location": "L3408"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "sessioncommands_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -244579,7 +244687,7 @@
       "source_location": "L3402"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "sessioncommands_test_buildsession",
       "label": "buildSession()",
@@ -244588,7 +244696,7 @@
       "source_location": "L3398"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "sessioncommands_test_createcommandservice",
       "label": "createCommandService()",
@@ -244597,7 +244705,7 @@
       "source_location": "L3418"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "sessioncommands_test_createdependencies",
       "label": "createDependencies()",
@@ -244606,7 +244714,7 @@
       "source_location": "L3125"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "sessioncommands_test_createfakerepository",
       "label": "createFakeRepository()",
@@ -244615,85 +244723,13 @@
       "source_location": "L3222"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "sessioncommands_test_loadcommandservice",
       "label": "loadCommandService()",
       "norm_label": "loadcommandservice()",
       "source_file": "packages/athena-webapp/convex/pos/application/sessionCommands.test.ts",
       "source_location": "L3107"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sync_projectlocalevents_test_ts",
-      "label": "projectLocalEvents.test.ts",
-      "norm_label": "projectlocalevents.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "projectlocalevents_test_buildexpenserecordedevent",
-      "label": "buildExpenseRecordedEvent()",
-      "norm_label": "buildexpenserecordedevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts",
-      "source_location": "L8009"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "projectlocalevents_test_buildpendingcheckoutitemdefinedevent",
-      "label": "buildPendingCheckoutItemDefinedEvent()",
-      "norm_label": "buildpendingcheckoutitemdefinedevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts",
-      "source_location": "L8092"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "projectlocalevents_test_buildregistercloseoutreviewfact",
-      "label": "buildRegisterCloseoutReviewFact()",
-      "norm_label": "buildregistercloseoutreviewfact()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts",
-      "source_location": "L9150"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "projectlocalevents_test_buildsaleclearedevent",
-      "label": "buildSaleClearedEvent()",
-      "norm_label": "buildsaleclearedevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts",
-      "source_location": "L8145"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "projectlocalevents_test_buildsalecompletedevent",
-      "label": "buildSaleCompletedEvent()",
-      "norm_label": "buildsalecompletedevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts",
-      "source_location": "L8046"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "projectlocalevents_test_buildserviceline",
-      "label": "buildServiceLine()",
-      "norm_label": "buildserviceline()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts",
-      "source_location": "L8125"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "projectlocalevents_test_createprojectionrepository",
-      "label": "createProjectionRepository()",
-      "norm_label": "createprojectionrepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts",
-      "source_location": "L8164"
     },
     {
       "community": 34,
@@ -245004,6 +245040,78 @@
     {
       "community": 340,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_sync_projectlocalevents_test_ts",
+      "label": "projectLocalEvents.test.ts",
+      "norm_label": "projectlocalevents.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "projectlocalevents_test_buildexpenserecordedevent",
+      "label": "buildExpenseRecordedEvent()",
+      "norm_label": "buildexpenserecordedevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts",
+      "source_location": "L8009"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "projectlocalevents_test_buildpendingcheckoutitemdefinedevent",
+      "label": "buildPendingCheckoutItemDefinedEvent()",
+      "norm_label": "buildpendingcheckoutitemdefinedevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts",
+      "source_location": "L8092"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "projectlocalevents_test_buildregistercloseoutreviewfact",
+      "label": "buildRegisterCloseoutReviewFact()",
+      "norm_label": "buildregistercloseoutreviewfact()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts",
+      "source_location": "L9150"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "projectlocalevents_test_buildsaleclearedevent",
+      "label": "buildSaleClearedEvent()",
+      "norm_label": "buildsaleclearedevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts",
+      "source_location": "L8145"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "projectlocalevents_test_buildsalecompletedevent",
+      "label": "buildSaleCompletedEvent()",
+      "norm_label": "buildsalecompletedevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts",
+      "source_location": "L8046"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "projectlocalevents_test_buildserviceline",
+      "label": "buildServiceLine()",
+      "norm_label": "buildserviceline()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts",
+      "source_location": "L8125"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "projectlocalevents_test_createprojectionrepository",
+      "label": "createProjectionRepository()",
+      "norm_label": "createprojectionrepository()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts",
+      "source_location": "L8164"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_resolveterminalcloudrepair_test_ts",
       "label": "resolveTerminalCloudRepair.test.ts",
       "norm_label": "resolveterminalcloudrepair.test.ts",
@@ -245011,7 +245119,7 @@
       "source_location": "L1"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "resolveterminalcloudrepair_test_buildconflict",
       "label": "buildConflict()",
@@ -245020,7 +245128,7 @@
       "source_location": "L587"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "resolveterminalcloudrepair_test_buildctx",
       "label": "buildCtx()",
@@ -245029,7 +245137,7 @@
       "source_location": "L440"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "resolveterminalcloudrepair_test_buildevent",
       "label": "buildEvent()",
@@ -245038,7 +245146,7 @@
       "source_location": "L607"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "resolveterminalcloudrepair_test_buildquery",
       "label": "buildQuery()",
@@ -245047,7 +245155,7 @@
       "source_location": "L499"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "resolveterminalcloudrepair_test_buildstaffprofile",
       "label": "buildStaffProfile()",
@@ -245056,7 +245164,7 @@
       "source_location": "L566"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "resolveterminalcloudrepair_test_buildstore",
       "label": "buildStore()",
@@ -245065,7 +245173,7 @@
       "source_location": "L578"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "resolveterminalcloudrepair_test_buildterminal",
       "label": "buildTerminal()",
@@ -245074,7 +245182,7 @@
       "source_location": "L553"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "livekitremoteassisttransportprovider_buildgrant",
       "label": "buildGrant()",
@@ -245083,7 +245191,7 @@
       "source_location": "L93"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "livekitremoteassisttransportprovider_getlivekitconfig",
       "label": "getLiveKitConfig()",
@@ -245092,7 +245200,7 @@
       "source_location": "L77"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "livekitremoteassisttransportprovider_isalreadyexistserror",
       "label": "isAlreadyExistsError()",
@@ -245101,7 +245209,7 @@
       "source_location": "L106"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "livekitremoteassisttransportprovider_livekitremoteassisttransportprovider",
       "label": "LiveKitRemoteAssistTransportProvider",
@@ -245110,7 +245218,7 @@
       "source_location": "L27"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "livekitremoteassisttransportprovider_livekitremoteassisttransportprovider_constructor",
       "label": ".constructor()",
@@ -245119,7 +245227,7 @@
       "source_location": "L30"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "livekitremoteassisttransportprovider_livekitremoteassisttransportprovider_ensureroom",
       "label": ".ensureRoom()",
@@ -245128,7 +245236,7 @@
       "source_location": "L54"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "livekitremoteassisttransportprovider_livekitremoteassisttransportprovider_issuecredential",
       "label": ".issueCredential()",
@@ -245137,7 +245245,7 @@
       "source_location": "L32"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_infrastructure_transport_livekitremoteassisttransportprovider_ts",
       "label": "LiveKitRemoteAssistTransportProvider.ts",
@@ -245146,7 +245254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "foldversionrepair_boundedlimit",
       "label": "boundedLimit()",
@@ -245155,7 +245263,7 @@
       "source_location": "L99"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "foldversionrepair_countstalefoldversiondayswithctx",
       "label": "countStaleFoldVersionDaysWithCtx()",
@@ -245164,7 +245272,7 @@
       "source_location": "L240"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "foldversionrepair_countuncertifieddayswithctx",
       "label": "countUncertifiedDaysWithCtx()",
@@ -245173,7 +245281,7 @@
       "source_location": "L271"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "foldversionrepair_daypage",
       "label": "dayPage()",
@@ -245182,7 +245290,7 @@
       "source_location": "L113"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "foldversionrepair_markstalefoldversiondayswithctx",
       "label": "markStaleFoldVersionDaysWithCtx()",
@@ -245191,7 +245299,7 @@
       "source_location": "L126"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "foldversionrepair_needscertifiedrefold",
       "label": "needsCertifiedRefold()",
@@ -245200,7 +245308,7 @@
       "source_location": "L65"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "foldversionrepair_skudayrowcountbackfillneeded",
       "label": "skuDayRowCountBackfillNeeded()",
@@ -245209,7 +245317,7 @@
       "source_location": "L90"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_foldversionrepair_ts",
       "label": "foldVersionRepair.ts",
@@ -245218,7 +245326,7 @@
       "source_location": "L1"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_skumixrange_ts",
       "label": "skuMixRange.ts",
@@ -245227,7 +245335,7 @@
       "source_location": "L1"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "skumixrange_aggregatemixsourceday",
       "label": "aggregateMixSourceDay()",
@@ -245236,7 +245344,7 @@
       "source_location": "L203"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "skumixrange_ensuremixrangecore",
       "label": "ensureMixRangeCore()",
@@ -245245,7 +245353,7 @@
       "source_location": "L381"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "skumixrange_mixretrybackoffms",
       "label": "mixRetryBackoffMs()",
@@ -245254,7 +245362,7 @@
       "source_location": "L479"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "skumixrange_readablemixheader",
       "label": "readableMixHeader()",
@@ -245263,7 +245371,7 @@
       "source_location": "L564"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "skumixrange_recordmixworkerfailurecore",
       "label": "recordMixWorkerFailureCore()",
@@ -245272,7 +245380,7 @@
       "source_location": "L486"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "skumixrange_retryterminalmixrequest",
       "label": "retryTerminalMixRequest()",
@@ -245281,7 +245389,7 @@
       "source_location": "L427"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "skumixrange_runmixbatchcore",
       "label": "runMixBatchCore()",
@@ -245290,7 +245398,7 @@
       "source_location": "L458"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_weeklyacceptedrepair_test_ts",
       "label": "weeklyAcceptedRepair.test.ts",
@@ -245299,7 +245407,7 @@
       "source_location": "L1"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "weeklyacceptedrepair_test_apply",
       "label": "apply()",
@@ -245308,7 +245416,7 @@
       "source_location": "L617"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "weeklyacceptedrepair_test_daystart",
       "label": "dayStart()",
@@ -245317,7 +245425,7 @@
       "source_location": "L192"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "weeklyacceptedrepair_test_evidencecoverage",
       "label": "evidenceCoverage()",
@@ -245326,7 +245434,7 @@
       "source_location": "L211"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "weeklyacceptedrepair_test_fixture",
       "label": "fixture()",
@@ -245335,7 +245443,7 @@
       "source_location": "L23"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "weeklyacceptedrepair_test_preview",
       "label": "preview()",
@@ -245344,7 +245452,7 @@
       "source_location": "L610"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "weeklyacceptedrepair_test_seedwigclubweek",
       "label": "seedWigclubWeek()",
@@ -245353,7 +245461,7 @@
       "source_location": "L294"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "weeklyacceptedrepair_test_snapshotstate",
       "label": "snapshotState()",
@@ -245362,7 +245470,7 @@
       "source_location": "L581"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_weeklyscale_test_ts",
       "label": "weeklyScale.test.ts",
@@ -245371,7 +245479,7 @@
       "source_location": "L1"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "weeklyscale_test_countprojectionreads",
       "label": "countProjectionReads()",
@@ -245380,7 +245488,7 @@
       "source_location": "L260"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "weeklyscale_test_handlerof",
       "label": "handlerOf()",
@@ -245389,7 +245497,7 @@
       "source_location": "L84"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "weeklyscale_test_ledgeridentity",
       "label": "ledgerIdentity()",
@@ -245398,7 +245506,7 @@
       "source_location": "L680"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "weeklyscale_test_measurepublicprojectionread",
       "label": "measurePublicProjectionRead()",
@@ -245407,7 +245515,7 @@
       "source_location": "L328"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "weeklyscale_test_percentile95",
       "label": "percentile95()",
@@ -245416,7 +245524,7 @@
       "source_location": "L323"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "weeklyscale_test_seedacceptedfactscalefixture",
       "label": "seedAcceptedFactScaleFixture()",
@@ -245425,7 +245533,7 @@
       "source_location": "L137"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "weeklyscale_test_seedstore",
       "label": "seedStore()",
@@ -245434,7 +245542,7 @@
       "source_location": "L94"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_weeklyverify_test_ts",
       "label": "weeklyVerify.test.ts",
@@ -245443,7 +245551,7 @@
       "source_location": "L1"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "weeklyverify_test_closerow",
       "label": "closeRow()",
@@ -245452,7 +245560,7 @@
       "source_location": "L97"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "weeklyverify_test_currentrow",
       "label": "currentRow()",
@@ -245461,7 +245569,7 @@
       "source_location": "L1176"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "weeklyverify_test_dayrow",
       "label": "dayRow()",
@@ -245470,7 +245578,7 @@
       "source_location": "L68"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "weeklyverify_test_lanemix",
       "label": "laneMix()",
@@ -245479,7 +245587,7 @@
       "source_location": "L1388"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "weeklyverify_test_seedevidenceweek",
       "label": "seedEvidenceWeek()",
@@ -245488,7 +245596,7 @@
       "source_location": "L1111"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "weeklyverify_test_seedscheduledstore",
       "label": "seedScheduledStore()",
@@ -245497,7 +245605,7 @@
       "source_location": "L24"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "weeklyverify_test_seedsettledpaymentweek",
       "label": "seedSettledPaymentWeek()",
@@ -245506,7 +245614,7 @@
       "source_location": "L659"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "offers_buildofferproductemailitem",
       "label": "buildOfferProductEmailItem()",
@@ -245515,7 +245623,7 @@
       "source_location": "L45"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "offers_createoffer",
       "label": "createOffer()",
@@ -245524,7 +245632,7 @@
       "source_location": "L129"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "offers_formatofferproductprice",
       "label": "formatOfferProductPrice()",
@@ -245533,7 +245641,7 @@
       "source_location": "L31"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "offers_getdiscountedofferproductprice",
       "label": "getDiscountedOfferProductPrice()",
@@ -245542,7 +245650,7 @@
       "source_location": "L38"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "offers_getupsellproducts",
       "label": "getUpsellProducts()",
@@ -245551,7 +245659,7 @@
       "source_location": "L793"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "offers_isduplicate",
       "label": "isDuplicate()",
@@ -245560,7 +245668,7 @@
       "source_location": "L75"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "offers_updatestorefrontactoremail",
       "label": "updateStoreFrontActorEmail()",
@@ -245569,7 +245677,7 @@
       "source_location": "L100"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_offers_ts",
       "label": "offers.ts",
@@ -245578,7 +245686,7 @@
       "source_location": "L1"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_public_ts",
       "label": "public.ts",
@@ -245587,7 +245695,7 @@
       "source_location": "L1"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "public_assertdefaultworkflowtraceaccess",
       "label": "assertDefaultWorkflowTraceAccess()",
@@ -245596,7 +245704,7 @@
       "source_location": "L112"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "public_assertworkflowtraceaccess",
       "label": "assertWorkflowTraceAccess()",
@@ -245605,7 +245713,7 @@
       "source_location": "L84"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "public_getregistersessiontraceidentity",
       "label": "getRegisterSessionTraceIdentity()",
@@ -245614,7 +245722,7 @@
       "source_location": "L127"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbyidwithctx",
       "label": "getWorkflowTraceViewByIdWithCtx()",
@@ -245623,7 +245731,7 @@
       "source_location": "L191"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbylookupwithctx",
       "label": "getWorkflowTraceViewByLookupWithCtx()",
@@ -245632,7 +245740,7 @@
       "source_location": "L267"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "public_requireadminworkflowtraceaccess",
       "label": "requireAdminWorkflowTraceAccess()",
@@ -245641,85 +245749,13 @@
       "source_location": "L44"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "public_requirefulladminormanagerelevationtraceaccess",
       "label": "requireFullAdminOrManagerElevationTraceAccess()",
       "norm_label": "requirefulladminormanagerelevationtraceaccess()",
       "source_file": "packages/athena-webapp/convex/workflowTraces/public.ts",
       "source_location": "L52"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "data_table_row_actions_datatablerowactions",
-      "label": "DataTableRowActions()",
-      "norm_label": "datatablerowactions()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-row-actions.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-row-actions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-row-actions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-row-actions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-row-actions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-row-actions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-row-actions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_row_actions_tsx",
-      "label": "data-table-row-actions.tsx",
-      "norm_label": "data-table-row-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-row-actions.tsx",
-      "source_location": "L1"
     },
     {
       "community": 35,
@@ -246021,6 +246057,78 @@
     {
       "community": 350,
       "file_type": "code",
+      "id": "data_table_row_actions_datatablerowactions",
+      "label": "DataTableRowActions()",
+      "norm_label": "datatablerowactions()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-row-actions.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-row-actions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-row-actions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-row-actions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-row-actions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-row-actions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-row-actions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_row_actions_tsx",
+      "label": "data-table-row-actions.tsx",
+      "norm_label": "data-table-row-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-row-actions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
       "id": "app_sidebar_appsidebar",
       "label": "AppSidebar()",
       "norm_label": "appsidebar()",
@@ -246028,7 +246136,7 @@
       "source_location": "L177"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "app_sidebar_cn",
       "label": "cn()",
@@ -246037,7 +246145,7 @@
       "source_location": "L366"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "app_sidebar_containedsidebartoggle",
       "label": "ContainedSidebarToggle()",
@@ -246046,7 +246154,7 @@
       "source_location": "L107"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "app_sidebar_getsidebarsubmenuopenstate",
       "label": "getSidebarSubmenuOpenState()",
@@ -246055,7 +246163,7 @@
       "source_location": "L90"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "app_sidebar_resetappsidebarsubmenustatefortests",
       "label": "resetAppSidebarSubmenuStateForTests()",
@@ -246064,7 +246172,7 @@
       "source_location": "L86"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "app_sidebar_sidebarmenucollapsible",
       "label": "SidebarMenuCollapsible()",
@@ -246073,7 +246181,7 @@
       "source_location": "L136"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "app_sidebar_sidebarmenumetadata",
       "label": "SidebarMenuMetadata()",
@@ -246082,7 +246190,7 @@
       "source_location": "L128"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_sidebar_tsx",
       "label": "app-sidebar.tsx",
@@ -246091,7 +246199,7 @@
       "source_location": "L1"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "authsynchandoff_clearathenaauthsynchandoff",
       "label": "clearAthenaAuthSyncHandoff()",
@@ -246100,7 +246208,7 @@
       "source_location": "L87"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "authsynchandoff_failathenaauthsynchandoff",
       "label": "failAthenaAuthSyncHandoff()",
@@ -246109,7 +246217,7 @@
       "source_location": "L95"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "authsynchandoff_getathenaauthsynchandoffstatus",
       "label": "getAthenaAuthSyncHandoffStatus()",
@@ -246118,7 +246226,7 @@
       "source_location": "L62"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "authsynchandoff_normalizeauthsyncredirect",
       "label": "normalizeAuthSyncRedirect()",
@@ -246127,7 +246235,7 @@
       "source_location": "L25"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "authsynchandoff_parsehandoff",
       "label": "parseHandoff()",
@@ -246136,7 +246244,7 @@
       "source_location": "L41"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "authsynchandoff_readrawhandoff",
       "label": "readRawHandoff()",
@@ -246145,7 +246253,7 @@
       "source_location": "L33"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "authsynchandoff_startathenaauthsynchandoff",
       "label": "startAthenaAuthSyncHandoff()",
@@ -246154,7 +246262,7 @@
       "source_location": "L100"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_authsynchandoff_ts",
       "label": "authSyncHandoff.ts",
@@ -246163,7 +246271,7 @@
       "source_location": "L1"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "landingworkspaceshot_apply",
       "label": "apply()",
@@ -246172,7 +246280,7 @@
       "source_location": "L151"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "landingworkspaceshot_beginpan",
       "label": "beginPan()",
@@ -246181,7 +246289,7 @@
       "source_location": "L160"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "landingworkspaceshot_distance",
       "label": "distance()",
@@ -246190,7 +246298,7 @@
       "source_location": "L157"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "landingworkspaceshot_onend",
       "label": "onEnd()",
@@ -246199,7 +246307,7 @@
       "source_location": "L221"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "landingworkspaceshot_onkeydown",
       "label": "onKeyDown()",
@@ -246208,7 +246316,7 @@
       "source_location": "L97"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "landingworkspaceshot_onmove",
       "label": "onMove()",
@@ -246217,7 +246325,7 @@
       "source_location": "L200"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "landingworkspaceshot_onstart",
       "label": "onStart()",
@@ -246226,7 +246334,7 @@
       "source_location": "L167"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_landing_story_landingworkspaceshot_tsx",
       "label": "LandingWorkspaceShot.tsx",
@@ -246235,7 +246343,7 @@
       "source_location": "L1"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "customerinfopanel_clearcustomer",
       "label": "clearCustomer()",
@@ -246244,7 +246352,7 @@
       "source_location": "L166"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "customerinfopanel_handlecanceledit",
       "label": "handleCancelEdit()",
@@ -246253,7 +246361,7 @@
       "source_location": "L157"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "customerinfopanel_handlecreatecustomer",
       "label": "handleCreateCustomer()",
@@ -246262,7 +246370,7 @@
       "source_location": "L84"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "customerinfopanel_handlesaveedit",
       "label": "handleSaveEdit()",
@@ -246271,7 +246379,7 @@
       "source_location": "L124"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "customerinfopanel_handleselectcustomer",
       "label": "handleSelectCustomer()",
@@ -246280,7 +246388,7 @@
       "source_location": "L68"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "customerinfopanel_handlestartedit",
       "label": "handleStartEdit()",
@@ -246289,7 +246397,7 @@
       "source_location": "L114"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "customerinfopanel_showcommanderror",
       "label": "showCommandError()",
@@ -246298,7 +246406,7 @@
       "source_location": "L64"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_customerinfopanel_tsx",
       "label": "CustomerInfoPanel.tsx",
@@ -246307,7 +246415,7 @@
       "source_location": "L1"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productentry_test_tsx",
       "label": "ProductEntry.test.tsx",
@@ -246316,7 +246424,7 @@
       "source_location": "L1"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "productentry_test_buildquickaddedproduct",
       "label": "buildQuickAddedProduct()",
@@ -246325,7 +246433,7 @@
       "source_location": "L53"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "productentry_test_function",
       "label": "function()",
@@ -246334,7 +246442,7 @@
       "source_location": "L134"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "productentry_test_harness",
       "label": "Harness()",
@@ -246343,7 +246451,7 @@
       "source_location": "L76"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "productentry_test_resizeobserverstub",
       "label": "ResizeObserverStub",
@@ -246352,7 +246460,7 @@
       "source_location": "L23"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "productentry_test_resizeobserverstub_disconnect",
       "label": ".disconnect()",
@@ -246361,7 +246469,7 @@
       "source_location": "L26"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "productentry_test_resizeobserverstub_observe",
       "label": ".observe()",
@@ -246370,7 +246478,7 @@
       "source_location": "L24"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "productentry_test_resizeobserverstub_unobserve",
       "label": ".unobserve()",
@@ -246379,7 +246487,7 @@
       "source_location": "L25"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_receipt_posreceiptsharecontrol_tsx",
       "label": "PosReceiptShareControl.tsx",
@@ -246388,7 +246496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "posreceiptsharecontrol_formatdeliverystatus",
       "label": "formatDeliveryStatus()",
@@ -246397,7 +246505,7 @@
       "source_location": "L76"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "posreceiptsharecontrol_formatdeliverytimestamp",
       "label": "formatDeliveryTimestamp()",
@@ -246406,7 +246514,7 @@
       "source_location": "L97"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "posreceiptsharecontrol_getdeliverytimestamp",
       "label": "getDeliveryTimestamp()",
@@ -246415,7 +246523,7 @@
       "source_location": "L93"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "posreceiptsharecontrol_getlatestreceiptdelivery",
       "label": "getLatestReceiptDelivery()",
@@ -246424,7 +246532,7 @@
       "source_location": "L110"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "posreceiptsharecontrol_getsendreceiptlinkaction",
       "label": "getSendReceiptLinkAction()",
@@ -246433,7 +246541,7 @@
       "source_location": "L60"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "posreceiptsharecontrol_handlesendreceiptlink",
       "label": "handleSendReceiptLink()",
@@ -246442,7 +246550,7 @@
       "source_location": "L144"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "posreceiptsharecontrol_normalizephone",
       "label": "normalizePhone()",
@@ -246451,7 +246559,7 @@
       "source_location": "L72"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_welcome_offer_modal_tsx",
       "label": "welcome-offer-modal.tsx",
@@ -246460,7 +246568,7 @@
       "source_location": "L1"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "welcome_offer_modal_handlechange",
       "label": "handleChange()",
@@ -246469,7 +246577,7 @@
       "source_location": "L76"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "welcome_offer_modal_handlecolorchange",
       "label": "handleColorChange()",
@@ -246478,7 +246586,7 @@
       "source_location": "L92"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "welcome_offer_modal_handlenumberchange",
       "label": "handleNumberChange()",
@@ -246487,7 +246595,7 @@
       "source_location": "L83"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "welcome_offer_modal_handleselectchange",
       "label": "handleSelectChange()",
@@ -246496,7 +246604,7 @@
       "source_location": "L96"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "welcome_offer_modal_handlesubmit",
       "label": "handleSubmit()",
@@ -246505,7 +246613,7 @@
       "source_location": "L104"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "welcome_offer_modal_handleswitchchange",
       "label": "handleSwitchChange()",
@@ -246514,7 +246622,7 @@
       "source_location": "L88"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "welcome_offer_modal_updateimages",
       "label": "updateImages()",
@@ -246523,7 +246631,7 @@
       "source_location": "L100"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_remote_assist_posremoteassistruntimehost_tsx",
       "label": "PosRemoteAssistRuntimeHost.tsx",
@@ -246532,7 +246640,7 @@
       "source_location": "L1"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "posremoteassistruntimehost_claimruntimehostforterminal",
       "label": "claimRuntimeHostForTerminal()",
@@ -246541,7 +246649,7 @@
       "source_location": "L144"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "posremoteassistruntimehost_createruntimehostownerid",
       "label": "createRuntimeHostOwnerId()",
@@ -246550,7 +246658,7 @@
       "source_location": "L220"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "posremoteassistruntimehost_getremoteassistruntimestate",
       "label": "getRemoteAssistRuntimeState()",
@@ -246559,7 +246667,7 @@
       "source_location": "L262"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "posremoteassistruntimehost_getruntimehostclaimstorage",
       "label": "getRuntimeHostClaimStorage()",
@@ -246568,7 +246676,7 @@
       "source_location": "L203"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "posremoteassistruntimehost_posremoteassistruntimehost",
       "label": "PosRemoteAssistRuntimeHost()",
@@ -246577,7 +246685,7 @@
       "source_location": "L28"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "posremoteassistruntimehost_releaseruntimehostclaim",
       "label": "releaseRuntimeHostClaim()",
@@ -246586,7 +246694,7 @@
       "source_location": "L182"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "posremoteassistruntimehost_withruntimetransportstate",
       "label": "withRuntimeTransportState()",
@@ -246595,7 +246703,7 @@
       "source_location": "L227"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemoreportsfixture_test_ts",
       "label": "sharedDemoReportsFixture.test.ts",
@@ -246604,7 +246712,7 @@
       "source_location": "L1"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "shareddemoreportsfixture_test_adddaystodate",
       "label": "addDaysToDate()",
@@ -246613,7 +246721,7 @@
       "source_location": "L53"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "shareddemoreportsfixture_test_expectfinitenumbers",
       "label": "expectFiniteNumbers()",
@@ -246622,7 +246730,7 @@
       "source_location": "L75"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "shareddemoreportsfixture_test_historydates",
       "label": "historyDates()",
@@ -246631,7 +246739,7 @@
       "source_location": "L68"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "shareddemoreportsfixture_test_isoweekstart",
       "label": "isoWeekStart()",
@@ -246640,7 +246748,7 @@
       "source_location": "L59"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "shareddemoreportsfixture_test_liveday",
       "label": "liveDay()",
@@ -246649,7 +246757,7 @@
       "source_location": "L1073"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "shareddemoreportsfixture_test_quickaddday",
       "label": "quickAddDay()",
@@ -246658,85 +246766,13 @@
       "source_location": "L1138"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "shareddemoreportsfixture_test_skuidfor",
       "label": "skuIdFor()",
       "norm_label": "skuidfor()",
       "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoReportsFixture.test.ts",
       "source_location": "L64"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
-      "label": "sidebar.tsx",
-      "norm_label": "sidebar.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "sidebar_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L178"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "sidebar_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L135"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "sidebar_handleonhover",
-      "label": "handleOnHover()",
-      "norm_label": "handleonhover()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L254"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "sidebar_handleonmouseleave",
-      "label": "handleOnMouseLeave()",
-      "norm_label": "handleonmouseleave()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L258"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "sidebar_readpersistedsidebaropenstate",
-      "label": "readPersistedSidebarOpenState()",
-      "norm_label": "readpersistedsidebaropenstate()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "sidebar_useoptionalsidebar",
-      "label": "useOptionalSidebar()",
-      "norm_label": "useoptionalsidebar()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L71"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "sidebar_usesidebar",
-      "label": "useSidebar()",
-      "norm_label": "usesidebar()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L62"
     },
     {
       "community": 36,
@@ -247038,6 +247074,78 @@
     {
       "community": 360,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
+      "label": "sidebar.tsx",
+      "norm_label": "sidebar.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "sidebar_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L178"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "sidebar_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L135"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "sidebar_handleonhover",
+      "label": "handleOnHover()",
+      "norm_label": "handleonhover()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L254"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "sidebar_handleonmouseleave",
+      "label": "handleOnMouseLeave()",
+      "norm_label": "handleonmouseleave()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L258"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "sidebar_readpersistedsidebaropenstate",
+      "label": "readPersistedSidebarOpenState()",
+      "norm_label": "readpersistedsidebaropenstate()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "sidebar_useoptionalsidebar",
+      "label": "useOptionalSidebar()",
+      "norm_label": "useoptionalsidebar()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L71"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "sidebar_usesidebar",
+      "label": "useSidebar()",
+      "norm_label": "usesidebar()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L62"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
       "id": "onlineordersessionoverlay_applyshareddemosessionorderpatches",
       "label": "applySharedDemoSessionOrderPatches()",
       "norm_label": "applyshareddemosessionorderpatches()",
@@ -247045,7 +247153,7 @@
       "source_location": "L108"
     },
     {
-      "community": 360,
+      "community": 361,
       "file_type": "code",
       "id": "onlineordersessionoverlay_getsessionstorage",
       "label": "getSessionStorage()",
@@ -247054,7 +247162,7 @@
       "source_location": "L17"
     },
     {
-      "community": 360,
+      "community": 361,
       "file_type": "code",
       "id": "onlineordersessionoverlay_getshareddemosessionorderstoragekey",
       "label": "getSharedDemoSessionOrderStorageKey()",
@@ -247063,7 +247171,7 @@
       "source_location": "L27"
     },
     {
-      "community": 360,
+      "community": 361,
       "file_type": "code",
       "id": "onlineordersessionoverlay_getshareddemosessionorderstorageprefix",
       "label": "getSharedDemoSessionOrderStoragePrefix()",
@@ -247072,7 +247180,7 @@
       "source_location": "L35"
     },
     {
-      "community": 360,
+      "community": 361,
       "file_type": "code",
       "id": "onlineordersessionoverlay_readshareddemosessionorderpatch",
       "label": "readSharedDemoSessionOrderPatch()",
@@ -247081,7 +247189,7 @@
       "source_location": "L42"
     },
     {
-      "community": 360,
+      "community": 361,
       "file_type": "code",
       "id": "onlineordersessionoverlay_readshareddemosessionorderpatches",
       "label": "readSharedDemoSessionOrderPatches()",
@@ -247090,7 +247198,7 @@
       "source_location": "L77"
     },
     {
-      "community": 360,
+      "community": 361,
       "file_type": "code",
       "id": "onlineordersessionoverlay_writeshareddemosessionorderpatch",
       "label": "writeSharedDemoSessionOrderPatch()",
@@ -247099,7 +247207,7 @@
       "source_location": "L60"
     },
     {
-      "community": 360,
+      "community": 361,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_onlineordersessionoverlay_ts",
       "label": "onlineOrderSessionOverlay.ts",
@@ -247108,7 +247216,7 @@
       "source_location": "L1"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
       "label": "useBulkOperations.ts",
@@ -247117,7 +247225,7 @@
       "source_location": "L1"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "usebulkoperations_applyoperation",
       "label": "applyOperation()",
@@ -247126,7 +247234,7 @@
       "source_location": "L58"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "usebulkoperations_calculatepricewithfee",
       "label": "calculatePriceWithFee()",
@@ -247135,7 +247243,7 @@
       "source_location": "L88"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "usebulkoperations_computepreview",
       "label": "computePreview()",
@@ -247144,7 +247252,7 @@
       "source_location": "L128"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "usebulkoperations_ismoneyoperation",
       "label": "isMoneyOperation()",
@@ -247153,7 +247261,7 @@
       "source_location": "L101"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "usebulkoperations_parseoperationvalue",
       "label": "parseOperationValue()",
@@ -247162,7 +247270,7 @@
       "source_location": "L109"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "usebulkoperations_usebulkoperations",
       "label": "useBulkOperations()",
@@ -247171,7 +247279,7 @@
       "source_location": "L190"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "usebulkoperations_validateoperationvalue",
       "label": "validateOperationValue()",
@@ -247180,7 +247288,7 @@
       "source_location": "L167"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
       "label": "useExpenseOperations.ts",
@@ -247189,7 +247297,7 @@
       "source_location": "L1"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "useexpenseoperations_clonecartitems",
       "label": "cloneCartItems()",
@@ -247198,7 +247306,7 @@
       "source_location": "L16"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "useexpenseoperations_createoptimisticexpenseitemid",
       "label": "createOptimisticExpenseItemId()",
@@ -247207,7 +247315,7 @@
       "source_location": "L74"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "useexpenseoperations_expensecartitemsourcekey",
       "label": "expenseCartItemSourceKey()",
@@ -247216,7 +247324,7 @@
       "source_location": "L56"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "useexpenseoperations_expenselinematchesproduct",
       "label": "expenseLineMatchesProduct()",
@@ -247225,7 +247333,7 @@
       "source_location": "L67"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "useexpenseoperations_expenselinesourcekey",
       "label": "expenseLineSourceKey()",
@@ -247234,7 +247342,7 @@
       "source_location": "L43"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "useexpenseoperations_mapproducttoexpensecartitem",
       "label": "mapProductToExpenseCartItem()",
@@ -247243,7 +247351,7 @@
       "source_location": "L20"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "useexpenseoperations_useexpenseoperations",
       "label": "useExpenseOperations()",
@@ -247252,7 +247360,7 @@
       "source_location": "L84"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_syncstatus_ts",
       "label": "syncStatus.ts",
@@ -247261,7 +247369,7 @@
       "source_location": "L1"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "syncstatus_deriveposlocalsyncstatus",
       "label": "derivePosLocalSyncStatus()",
@@ -247270,7 +247378,7 @@
       "source_location": "L67"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "syncstatus_getcontiguoussyncedsequence",
       "label": "getContiguousSyncedSequence()",
@@ -247279,7 +247387,7 @@
       "source_location": "L115"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "syncstatus_getsyncstate",
       "label": "getSyncState()",
@@ -247288,7 +247396,7 @@
       "source_location": "L159"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "syncstatus_islocallysettledsyncstatus",
       "label": "isLocallySettledSyncStatus()",
@@ -247297,7 +247405,7 @@
       "source_location": "L128"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "syncstatus_isserverconfirmedlocalresolution",
       "label": "isServerConfirmedLocalResolution()",
@@ -247306,7 +247414,7 @@
       "source_location": "L139"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "syncstatus_isserverconvergedsyncevent",
       "label": "isServerConvergedSyncEvent()",
@@ -247315,7 +247423,7 @@
       "source_location": "L151"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "syncstatus_mapserversettlementoutcometolocalstate",
       "label": "mapServerSettlementOutcomeToLocalState()",
@@ -247324,7 +247432,7 @@
       "source_location": "L33"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_useregisterlifecycleauthorityruntime_test_ts",
       "label": "useRegisterLifecycleAuthorityRuntime.test.ts",
@@ -247333,7 +247441,7 @@
       "source_location": "L1"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_test_appliedauthorityvalue",
       "label": "appliedAuthorityValue()",
@@ -247342,7 +247450,7 @@
       "source_location": "L103"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_test_createstore",
       "label": "createStore()",
@@ -247351,7 +247459,7 @@
       "source_location": "L85"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_test_releasefirst",
       "label": "releaseFirst()",
@@ -247360,7 +247468,7 @@
       "source_location": "L584"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_test_releaseolder",
       "label": "releaseOlder()",
@@ -247369,7 +247477,7 @@
       "source_location": "L800"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_test_renderruntime",
       "label": "renderRuntime()",
@@ -247378,7 +247486,7 @@
       "source_location": "L117"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_test_rerenderprojection",
       "label": "rerenderProjection()",
@@ -247387,7 +247495,7 @@
       "source_location": "L322"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_test_snapshot",
       "label": "snapshot()",
@@ -247396,7 +247504,7 @@
       "source_location": "L62"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_registercashierpresence_ts",
       "label": "registerCashierPresence.ts",
@@ -247405,7 +247513,7 @@
       "source_location": "L1"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "registercashierpresence_canoperateregister",
       "label": "canOperateRegister()",
@@ -247414,7 +247522,7 @@
       "source_location": "L188"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "registercashierpresence_getstaffdisplaynamefromauthresult",
       "label": "getStaffDisplayNameFromAuthResult()",
@@ -247423,7 +247531,7 @@
       "source_location": "L107"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "registercashierpresence_hasregistermanagerrole",
       "label": "hasRegisterManagerRole()",
@@ -247432,7 +247540,7 @@
       "source_location": "L203"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "registercashierpresence_hasregisteroperatorrole",
       "label": "hasRegisterOperatorRole()",
@@ -247441,7 +247549,7 @@
       "source_location": "L197"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "registercashierpresence_iscashierpresenceblockingsale",
       "label": "isCashierPresenceBlockingSale()",
@@ -247450,7 +247558,7 @@
       "source_location": "L182"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "registercashierpresence_readstaffprooffromauthresult",
       "label": "readStaffProofFromAuthResult()",
@@ -247459,7 +247567,7 @@
       "source_location": "L88"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "registercashierpresence_validaterestoredcashierpresence",
       "label": "validateRestoredCashierPresence()",
@@ -247468,7 +247576,7 @@
       "source_location": "L118"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "packages_athena_webapp_src_offline_posappshellreadiness_ts",
       "label": "posAppShellReadiness.ts",
@@ -247477,7 +247585,7 @@
       "source_location": "L1"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "posappshellreadiness_islocaldevappshelldisabled",
       "label": "isLocalDevAppShellDisabled()",
@@ -247486,7 +247594,7 @@
       "source_location": "L169"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "posappshellreadiness_readcachedposappshellreadiness",
       "label": "readCachedPosAppShellReadiness()",
@@ -247495,7 +247603,7 @@
       "source_location": "L38"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "posappshellreadiness_readposappshellreadiness",
       "label": "readPosAppShellReadiness()",
@@ -247504,7 +247612,7 @@
       "source_location": "L12"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "posappshellreadiness_resolveregisterpath",
       "label": "resolveRegisterPath()",
@@ -247513,7 +247621,7 @@
       "source_location": "L190"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "posappshellreadiness_towarmresult",
       "label": "toWarmResult()",
@@ -247522,7 +247630,7 @@
       "source_location": "L177"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "posappshellreadiness_waitforactiveserviceworker",
       "label": "waitForActiveServiceWorker()",
@@ -247531,7 +247639,7 @@
       "source_location": "L146"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "posappshellreadiness_warmposappshellreadiness",
       "label": "warmPosAppShellReadiness()",
@@ -247540,7 +247648,7 @@
       "source_location": "L84"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "bag_additemtobag",
       "label": "addItemToBag()",
@@ -247549,7 +247657,7 @@
       "source_location": "L27"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "bag_clearbag",
       "label": "clearBag()",
@@ -247558,7 +247666,7 @@
       "source_location": "L106"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "bag_getactivebag",
       "label": "getActiveBag()",
@@ -247567,7 +247675,7 @@
       "source_location": "L12"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "bag_getbaseurl",
       "label": "getBaseUrl()",
@@ -247576,7 +247684,7 @@
       "source_location": "L10"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "bag_removeitemfrombag",
       "label": "removeItemFromBag()",
@@ -247585,7 +247693,7 @@
       "source_location": "L90"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "bag_updatebagitem",
       "label": "updateBagItem()",
@@ -247594,7 +247702,7 @@
       "source_location": "L63"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "bag_updatebagowner",
       "label": "updateBagOwner()",
@@ -247603,7 +247711,7 @@
       "source_location": "L118"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_bag_ts",
       "label": "bag.ts",
@@ -247612,7 +247720,7 @@
       "source_location": "L1"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_product_ts",
       "label": "product.ts",
@@ -247621,7 +247729,7 @@
       "source_location": "L1"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "product_buildquerystring",
       "label": "buildQueryString()",
@@ -247630,7 +247738,7 @@
       "source_location": "L5"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "product_getallproducts",
       "label": "getAllProducts()",
@@ -247639,7 +247747,7 @@
       "source_location": "L20"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "product_getbaseurl",
       "label": "getBaseUrl()",
@@ -247648,7 +247756,7 @@
       "source_location": "L18"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "product_getbestsellers",
       "label": "getBestSellers()",
@@ -247657,7 +247765,7 @@
       "source_location": "L59"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "product_getfeatured",
       "label": "getFeatured()",
@@ -247666,7 +247774,7 @@
       "source_location": "L73"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "product_getinventorybyskuids",
       "label": "getInventoryBySkuIds()",
@@ -247675,85 +247783,13 @@
       "source_location": "L93"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "product_getproduct",
       "label": "getProduct()",
       "norm_label": "getproduct()",
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L40"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_tsx",
-      "label": "ShoppingBag.tsx",
-      "norm_label": "shoppingbag.tsx",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "shoppingbag_handleclickondiscountcode",
-      "label": "handleClickOnDiscountCode()",
-      "norm_label": "handleclickondiscountcode()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L554"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "shoppingbag_handledeleteitem",
-      "label": "handleDeleteItem()",
-      "norm_label": "handledeleteitem()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L595"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "shoppingbag_handlemovetosaved",
-      "label": "handleMoveToSaved()",
-      "norm_label": "handlemovetosaved()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L581"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "shoppingbag_handleoncheckoutclick",
-      "label": "handleOnCheckoutClick()",
-      "norm_label": "handleoncheckoutclick()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L505"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "shoppingbag_isskuunavailable",
-      "label": "isSkuUnavailable()",
-      "norm_label": "isskuunavailable()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L566"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "shoppingbag_pendingitem",
-      "label": "PendingItem()",
-      "norm_label": "pendingitem()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L62"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "shoppingbag_shoppingbagcheckoutbutton",
-      "label": "ShoppingBagCheckoutButton()",
-      "norm_label": "shoppingbagcheckoutbutton()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
-      "source_location": "L110"
     },
     {
       "community": 37,
@@ -248055,6 +248091,78 @@
     {
       "community": 370,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_tsx",
+      "label": "ShoppingBag.tsx",
+      "norm_label": "shoppingbag.tsx",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "shoppingbag_handleclickondiscountcode",
+      "label": "handleClickOnDiscountCode()",
+      "norm_label": "handleclickondiscountcode()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L554"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "shoppingbag_handledeleteitem",
+      "label": "handleDeleteItem()",
+      "norm_label": "handledeleteitem()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L595"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "shoppingbag_handlemovetosaved",
+      "label": "handleMoveToSaved()",
+      "norm_label": "handlemovetosaved()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L581"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "shoppingbag_handleoncheckoutclick",
+      "label": "handleOnCheckoutClick()",
+      "norm_label": "handleoncheckoutclick()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L505"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "shoppingbag_isskuunavailable",
+      "label": "isSkuUnavailable()",
+      "norm_label": "isskuunavailable()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L566"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "shoppingbag_pendingitem",
+      "label": "PendingItem()",
+      "norm_label": "pendingitem()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L62"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "shoppingbag_shoppingbagcheckoutbutton",
+      "label": "ShoppingBagCheckoutButton()",
+      "norm_label": "shoppingbagcheckoutbutton()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
+      "source_location": "L110"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
       "id": "coverage_toolchain_parity_test_createfixtureroot",
       "label": "createFixtureRoot()",
       "norm_label": "createfixtureroot()",
@@ -248062,7 +248170,7 @@
       "source_location": "L14"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "coverage_toolchain_parity_test_createpackage",
       "label": "createPackage()",
@@ -248071,7 +248179,7 @@
       "source_location": "L26"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "coverage_toolchain_parity_test_installfixturetoolchain",
       "label": "installFixtureToolchain()",
@@ -248080,7 +248188,7 @@
       "source_location": "L64"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "coverage_toolchain_parity_test_linkworkspacepackage",
       "label": "linkWorkspacePackage()",
@@ -248089,7 +248197,7 @@
       "source_location": "L33"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "coverage_toolchain_parity_test_writefixtureinstaller",
       "label": "writeFixtureInstaller()",
@@ -248098,7 +248206,7 @@
       "source_location": "L75"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "coverage_toolchain_parity_test_writefixturemanifests",
       "label": "writeFixtureManifests()",
@@ -248107,7 +248215,7 @@
       "source_location": "L43"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "coverage_toolchain_parity_test_writejson",
       "label": "writeJson()",
@@ -248116,7 +248224,7 @@
       "source_location": "L20"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "scripts_coverage_toolchain_parity_test_ts",
       "label": "coverage-toolchain-parity.test.ts",
@@ -248125,7 +248233,7 @@
       "source_location": "L1"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "harness_behavior_test_createbrowser",
       "label": "createBrowser()",
@@ -248134,7 +248242,7 @@
       "source_location": "L55"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "harness_behavior_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -248143,7 +248251,7 @@
       "source_location": "L25"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "harness_behavior_test_createplaywrightmodule",
       "label": "createPlaywrightModule()",
@@ -248152,7 +248260,7 @@
       "source_location": "L47"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "harness_behavior_test_islistening",
       "label": "isListening()",
@@ -248161,7 +248269,7 @@
       "source_location": "L664"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "harness_behavior_test_reservefreeport",
       "label": "reserveFreePort()",
@@ -248170,7 +248278,7 @@
       "source_location": "L652"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "harness_behavior_test_reservefreeportforreclaim",
       "label": "reserveFreePortForReclaim()",
@@ -248179,7 +248287,7 @@
       "source_location": "L828"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "harness_behavior_test_write",
       "label": "write()",
@@ -248188,7 +248296,7 @@
       "source_location": "L19"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "scripts_harness_behavior_test_ts",
       "label": "harness-behavior.test.ts",
@@ -248197,7 +248305,7 @@
       "source_location": "L1"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "harness_review_identity_test_createspawn",
       "label": "createSpawn()",
@@ -248206,7 +248314,7 @@
       "source_location": "L24"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "harness_review_identity_test_entryfor",
       "label": "entryFor()",
@@ -248215,7 +248323,7 @@
       "source_location": "L263"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "harness_review_identity_test_git",
       "label": "git()",
@@ -248224,7 +248332,7 @@
       "source_location": "L304"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "harness_review_identity_test_gitfixture",
       "label": "gitFixture()",
@@ -248233,7 +248341,7 @@
       "source_location": "L320"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "harness_review_identity_test_headtreeidentity",
       "label": "headTreeIdentity()",
@@ -248242,7 +248350,7 @@
       "source_location": "L343"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "harness_review_identity_test_identityfor",
       "label": "identityFor()",
@@ -248251,7 +248359,7 @@
       "source_location": "L42"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "harness_review_identity_test_lstreeoutput",
       "label": "lsTreeOutput()",
@@ -248260,7 +248368,7 @@
       "source_location": "L17"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "scripts_harness_review_identity_test_ts",
       "label": "harness-review-identity.test.ts",
@@ -248269,7 +248377,7 @@
       "source_location": "L1"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "pr_athena_prepare_blocked",
       "label": "blocked()",
@@ -248278,7 +248386,7 @@
       "source_location": "L238"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "pr_athena_prepare_computeprathenapreparationfingerprint",
       "label": "computePrAthenaPreparationFingerprint()",
@@ -248287,7 +248395,7 @@
       "source_location": "L111"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "pr_athena_prepare_evaluateprathenapreparationreceipt",
       "label": "evaluatePrAthenaPreparationReceipt()",
@@ -248296,7 +248404,7 @@
       "source_location": "L252"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "pr_athena_prepare_isreceipt",
       "label": "isReceipt()",
@@ -248305,7 +248413,7 @@
       "source_location": "L134"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "pr_athena_prepare_publishreceipt",
       "label": "publishReceipt()",
@@ -248314,7 +248422,7 @@
       "source_location": "L150"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "pr_athena_prepare_resolvepreparationreceiptpath",
       "label": "resolvePreparationReceiptPath()",
@@ -248323,7 +248431,7 @@
       "source_location": "L91"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "pr_athena_prepare_runprathenapreparation",
       "label": "runPrAthenaPreparation()",
@@ -248332,7 +248440,7 @@
       "source_location": "L168"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "scripts_pr_athena_prepare_ts",
       "label": "pr-athena-prepare.ts",
@@ -248341,7 +248449,7 @@
       "source_location": "L1"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "deposits_test_createauthorizedregisterdepositctx",
       "label": "createAuthorizedRegisterDepositCtx()",
@@ -248350,7 +248458,7 @@
       "source_location": "L293"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "deposits_test_createmissingmappingrepairseed",
       "label": "createMissingMappingRepairSeed()",
@@ -248359,7 +248467,7 @@
       "source_location": "L332"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "deposits_test_createprojectedinventoryreviewqueryctx",
       "label": "createProjectedInventoryReviewQueryCtx()",
@@ -248368,7 +248476,7 @@
       "source_location": "L194"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "deposits_test_createqueryctx",
       "label": "createQueryCtx()",
@@ -248377,7 +248485,7 @@
       "source_location": "L46"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "deposits_test_gethandler",
       "label": "getHandler()",
@@ -248386,7 +248494,7 @@
       "source_location": "L42"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "deposits_test_getsource",
       "label": "getSource()",
@@ -248395,7 +248503,7 @@
       "source_location": "L38"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_deposits_test_ts",
       "label": "deposits.test.ts",
@@ -248404,7 +248512,7 @@
       "source_location": "L1"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "eventdefinitions_containssensitivetext",
       "label": "containsSensitiveText()",
@@ -248413,7 +248521,7 @@
       "source_location": "L267"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "eventdefinitions_findregisteredcontextevent",
       "label": "findRegisteredContextEvent()",
@@ -248422,7 +248530,7 @@
       "source_location": "L196"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "eventdefinitions_invalidpayloadmessage",
       "label": "invalidPayloadMessage()",
@@ -248431,7 +248539,7 @@
       "source_location": "L231"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "eventdefinitions_ispubliccontextvalue",
       "label": "isPublicContextValue()",
@@ -248440,7 +248548,7 @@
       "source_location": "L237"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "eventdefinitions_validatepayloadvalue",
       "label": "validatePayloadValue()",
@@ -248449,7 +248557,7 @@
       "source_location": "L247"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "eventdefinitions_validateregisteredcontexteventpayload",
       "label": "validateRegisteredContextEventPayload()",
@@ -248458,7 +248566,7 @@
       "source_location": "L209"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_contexttracking_eventdefinitions_ts",
       "label": "eventDefinitions.ts",
@@ -248467,7 +248575,7 @@
       "source_location": "L1"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_contexttracking_shareddemoactivity_ts",
       "label": "sharedDemoActivity.ts",
@@ -248476,7 +248584,7 @@
       "source_location": "L1"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "shareddemoactivity_addto",
       "label": "addTo()",
@@ -248485,7 +248593,7 @@
       "source_location": "L193"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "shareddemoactivity_byvisitorsthen",
       "label": "byVisitorsThen()",
@@ -248494,7 +248602,7 @@
       "source_location": "L203"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "shareddemoactivity_foldshareddemoactivity",
       "label": "foldSharedDemoActivity()",
@@ -248503,7 +248611,7 @@
       "source_location": "L29"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "shareddemoactivity_increment",
       "label": "increment()",
@@ -248512,7 +248620,7 @@
       "source_location": "L199"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "shareddemoactivity_median",
       "label": "median()",
@@ -248521,7 +248629,7 @@
       "source_location": "L210"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "shareddemoactivity_readtext",
       "label": "readText()",
@@ -248530,7 +248638,7 @@
       "source_location": "L219"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_whatsappconfig_ts",
       "label": "whatsappConfig.ts",
@@ -248539,7 +248647,7 @@
       "source_location": "L1"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "whatsappconfig_buildreceiptshareurl",
       "label": "buildReceiptShareUrl()",
@@ -248548,7 +248656,7 @@
       "source_location": "L43"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "whatsappconfig_getwhatsappreceiptconfig",
       "label": "getWhatsAppReceiptConfig()",
@@ -248557,7 +248665,7 @@
       "source_location": "L23"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "whatsappconfig_getwhatsappwebhookappsecret",
       "label": "getWhatsAppWebhookAppSecret()",
@@ -248566,7 +248674,7 @@
       "source_location": "L39"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "whatsappconfig_getwhatsappwebhookverifytoken",
       "label": "getWhatsAppWebhookVerifyToken()",
@@ -248575,7 +248683,7 @@
       "source_location": "L35"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "whatsappconfig_optionalenv",
       "label": "optionalEnv()",
@@ -248584,7 +248692,7 @@
       "source_location": "L11"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "whatsappconfig_requiredenv",
       "label": "requiredEnv()",
@@ -248593,7 +248701,7 @@
       "source_location": "L15"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "expensetransactions_createexpensetransactionfromsessionhandler",
       "label": "createExpenseTransactionFromSessionHandler()",
@@ -248602,7 +248710,7 @@
       "source_location": "L72"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "expensetransactions_expenseitemhastrustedavailabilityhold",
       "label": "expenseItemHasTrustedAvailabilityHold()",
@@ -248611,7 +248719,7 @@
       "source_location": "L49"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "expensetransactions_expenseitemusestrustedinventory",
       "label": "expenseItemUsesTrustedInventory()",
@@ -248620,7 +248728,7 @@
       "source_location": "L42"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "expensetransactions_expensetransactionerror",
       "label": "expenseTransactionError()",
@@ -248629,7 +248737,7 @@
       "source_location": "L28"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "expensetransactions_formatexpensestaffprofilename",
       "label": "formatExpenseStaffProfileName()",
@@ -248638,7 +248746,7 @@
       "source_location": "L59"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "expensetransactions_voidexpensetransactionhandler",
       "label": "voidExpenseTransactionHandler()",
@@ -248647,76 +248755,13 @@
       "source_location": "L446"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensetransactions_ts",
       "label": "expenseTransactions.ts",
       "norm_label": "expensetransactions.ts",
       "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_marketing_walkthroughhmac_ts",
-      "label": "walkthroughHmac.ts",
-      "norm_label": "walkthroughhmac.ts",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughHmac.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "walkthroughhmac_createwalkthroughdedupehmac",
-      "label": "createWalkthroughDedupeHmac()",
-      "norm_label": "createwalkthroughdedupehmac()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughHmac.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "walkthroughhmac_getactivewalkthroughhmackey",
-      "label": "getActiveWalkthroughHmacKey()",
-      "norm_label": "getactivewalkthroughhmackey()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughHmac.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "walkthroughhmac_getwalkthroughhmacsecret",
-      "label": "getWalkthroughHmacSecret()",
-      "norm_label": "getwalkthroughhmacsecret()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughHmac.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "walkthroughhmac_getwalkthroughhmacverificationkeys",
-      "label": "getWalkthroughHmacVerificationKeys()",
-      "norm_label": "getwalkthroughhmacverificationkeys()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughHmac.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "walkthroughhmac_matcheswalkthroughtombstone",
-      "label": "matchesWalkthroughTombstone()",
-      "norm_label": "matcheswalkthroughtombstone()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughHmac.ts",
-      "source_location": "L92"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "walkthroughhmac_priorkeyring",
-      "label": "priorKeyring()",
-      "norm_label": "priorkeyring()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughHmac.ts",
-      "source_location": "L8"
     },
     {
       "community": 38,
@@ -249009,6 +249054,69 @@
     {
       "community": 380,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_marketing_walkthroughhmac_ts",
+      "label": "walkthroughHmac.ts",
+      "norm_label": "walkthroughhmac.ts",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughHmac.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "walkthroughhmac_createwalkthroughdedupehmac",
+      "label": "createWalkthroughDedupeHmac()",
+      "norm_label": "createwalkthroughdedupehmac()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughHmac.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "walkthroughhmac_getactivewalkthroughhmackey",
+      "label": "getActiveWalkthroughHmacKey()",
+      "norm_label": "getactivewalkthroughhmackey()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughHmac.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "walkthroughhmac_getwalkthroughhmacsecret",
+      "label": "getWalkthroughHmacSecret()",
+      "norm_label": "getwalkthroughhmacsecret()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughHmac.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "walkthroughhmac_getwalkthroughhmacverificationkeys",
+      "label": "getWalkthroughHmacVerificationKeys()",
+      "norm_label": "getwalkthroughhmacverificationkeys()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughHmac.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "walkthroughhmac_matcheswalkthroughtombstone",
+      "label": "matchesWalkthroughTombstone()",
+      "norm_label": "matcheswalkthroughtombstone()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughHmac.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "walkthroughhmac_priorkeyring",
+      "label": "priorKeyring()",
+      "norm_label": "priorkeyring()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughHmac.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
       "id": "backfillathenausernormalizedemail_backfillathenausernormalizedemailbatchwithctx",
       "label": "backfillAthenaUserNormalizedEmailBatchWithCtx()",
       "norm_label": "backfillathenausernormalizedemailbatchwithctx()",
@@ -249016,7 +249124,7 @@
       "source_location": "L72"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "backfillathenausernormalizedemail_boundedlimit",
       "label": "boundedLimit()",
@@ -249025,7 +249133,7 @@
       "source_location": "L21"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "backfillathenausernormalizedemail_candidateforuserwithctx",
       "label": "candidateForUserWithCtx()",
@@ -249034,7 +249142,7 @@
       "source_location": "L42"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "backfillathenausernormalizedemail_normalizedidentityfingerprint",
       "label": "normalizedIdentityFingerprint()",
@@ -249043,7 +249151,7 @@
       "source_location": "L34"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "backfillathenausernormalizedemail_recordidentityconflictwithctx",
       "label": "recordIdentityConflictWithCtx()",
@@ -249052,7 +249160,7 @@
       "source_location": "L59"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "backfillathenausernormalizedemail_tohex",
       "label": "toHex()",
@@ -249061,7 +249169,7 @@
       "source_location": "L28"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_backfillathenausernormalizedemail_ts",
       "label": "backfillAthenaUserNormalizedEmail.ts",
@@ -249070,7 +249178,7 @@
       "source_location": "L1"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "backfillreportfactobservedat_backfillreportfactobservedatwithctx",
       "label": "backfillReportFactObservedAtWithCtx()",
@@ -249079,7 +249187,7 @@
       "source_location": "L66"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "backfillreportfactobservedat_boundedlimit",
       "label": "boundedLimit()",
@@ -249088,7 +249196,7 @@
       "source_location": "L34"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "backfillreportfactobservedat_factpage",
       "label": "factPage()",
@@ -249097,7 +249205,7 @@
       "source_location": "L41"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "backfillreportfactobservedat_storefactpage",
       "label": "storeFactPage()",
@@ -249106,7 +249214,7 @@
       "source_location": "L51"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "backfillreportfactobservedat_verifyreportfactobservedatwithctx",
       "label": "verifyReportFactObservedAtWithCtx()",
@@ -249115,7 +249223,7 @@
       "source_location": "L142"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "backfillreportfactobservedat_verifystorereportfactobservedatwithctx",
       "label": "verifyStoreReportFactObservedAtWithCtx()",
@@ -249124,7 +249232,7 @@
       "source_location": "L161"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_backfillreportfactobservedat_ts",
       "label": "backfillReportFactObservedAt.ts",
@@ -249133,7 +249241,7 @@
       "source_location": "L1"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "backfillreportingcyclestart_backfillreportingcyclestartwithctx",
       "label": "backfillReportingCycleStartWithCtx()",
@@ -249142,7 +249250,7 @@
       "source_location": "L50"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "backfillreportingcyclestart_boundedlimit",
       "label": "boundedLimit()",
@@ -249151,7 +249259,7 @@
       "source_location": "L33"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "backfillreportingcyclestart_schedulepage",
       "label": "schedulePage()",
@@ -249160,7 +249268,7 @@
       "source_location": "L40"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "backfillreportingcyclestart_storeschedulepage",
       "label": "storeSchedulePage()",
@@ -249169,7 +249277,7 @@
       "source_location": "L140"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "backfillreportingcyclestart_verifyreportingcyclestartwithctx",
       "label": "verifyReportingCycleStartWithCtx()",
@@ -249178,7 +249286,7 @@
       "source_location": "L125"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "backfillreportingcyclestart_verifystorereportingcyclestartwithctx",
       "label": "verifyStoreReportingCycleStartWithCtx()",
@@ -249187,7 +249295,7 @@
       "source_location": "L164"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_backfillreportingcyclestart_ts",
       "label": "backfillReportingCycleStart.ts",
@@ -249196,7 +249304,7 @@
       "source_location": "L1"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "client_buildheaders",
       "label": "buildHeaders()",
@@ -249205,7 +249313,7 @@
       "source_location": "L20"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "client_createcollectionsaccesstoken",
       "label": "createCollectionsAccessToken()",
@@ -249214,7 +249322,7 @@
       "source_location": "L30"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "client_encodebasicauth",
       "label": "encodeBasicAuth()",
@@ -249223,7 +249331,7 @@
       "source_location": "L9"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "client_getrequesttopaystatus",
       "label": "getRequestToPayStatus()",
@@ -249232,7 +249340,7 @@
       "source_location": "L115"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "client_requesttopay",
       "label": "requestToPay()",
@@ -249241,7 +249349,7 @@
       "source_location": "L65"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "client_toerror",
       "label": "toError()",
@@ -249250,7 +249358,7 @@
       "source_location": "L13"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_client_ts",
       "label": "client.ts",
@@ -249259,7 +249367,7 @@
       "source_location": "L1"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "dailyopening_test_completeddailyclose",
       "label": "completedDailyClose()",
@@ -249268,7 +249376,7 @@
       "source_location": "L250"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "dailyopening_test_createdb",
       "label": "createDb()",
@@ -249277,7 +249385,7 @@
       "source_location": "L38"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "dailyopening_test_gethandler",
       "label": "getHandler()",
@@ -249286,7 +249394,7 @@
       "source_location": "L277"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "dailyopening_test_inventoryreview",
       "label": "inventoryReview()",
@@ -249295,7 +249403,7 @@
       "source_location": "L687"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "dailyopening_test_openingapprovalproof",
       "label": "openingApprovalProof()",
@@ -249304,7 +249412,7 @@
       "source_location": "L233"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "dailyopening_test_workitem",
       "label": "workItem()",
@@ -249313,7 +249421,7 @@
       "source_location": "L1305"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_dailyopening_test_ts",
       "label": "dailyOpening.test.ts",
@@ -249322,7 +249430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "linking_buildcustomerprofiledraft",
       "label": "buildCustomerProfileDraft()",
@@ -249331,7 +249439,7 @@
       "source_location": "L110"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "linking_buildfullname",
       "label": "buildFullName()",
@@ -249340,7 +249448,7 @@
       "source_location": "L85"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "linking_findmatchingcustomerprofile",
       "label": "findMatchingCustomerProfile()",
@@ -249349,7 +249457,7 @@
       "source_location": "L172"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "linking_normalizelookupvalue",
       "label": "normalizeLookupValue()",
@@ -249358,7 +249466,7 @@
       "source_location": "L58"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "linking_normalizephonenumber",
       "label": "normalizePhoneNumber()",
@@ -249367,7 +249475,7 @@
       "source_location": "L62"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "linking_splitfullname",
       "label": "splitFullName()",
@@ -249376,75 +249484,12 @@
       "source_location": "L66"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_helpers_linking_ts",
       "label": "linking.ts",
       "norm_label": "linking.ts",
       "source_file": "packages/athena-webapp/convex/operations/helpers/linking.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 386,
-      "file_type": "code",
-      "id": "oweddailyclosesweep_candidatesforpolicies",
-      "label": "candidatesForPolicies()",
-      "norm_label": "candidatesforpolicies()",
-      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L195"
-    },
-    {
-      "community": 386,
-      "file_type": "code",
-      "id": "oweddailyclosesweep_completedoperatingdatesforstore",
-      "label": "completedOperatingDatesForStore()",
-      "norm_label": "completedoperatingdatesforstore()",
-      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L170"
-    },
-    {
-      "community": 386,
-      "file_type": "code",
-      "id": "oweddailyclosesweep_dailyclosesweepresultsettled",
-      "label": "dailyCloseSweepResultSettled()",
-      "norm_label": "dailyclosesweepresultsettled()",
-      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 386,
-      "file_type": "code",
-      "id": "oweddailyclosesweep_daysbetweenoperatingdates",
-      "label": "daysBetweenOperatingDates()",
-      "norm_label": "daysbetweenoperatingdates()",
-      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L474"
-    },
-    {
-      "community": 386,
-      "file_type": "code",
-      "id": "oweddailyclosesweep_selectoweddailyclosedates",
-      "label": "selectOwedDailyCloseDates()",
-      "norm_label": "selectoweddailyclosedates()",
-      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 386,
-      "file_type": "code",
-      "id": "oweddailyclosesweep_selectrotatingoweddailycloseattempt",
-      "label": "selectRotatingOwedDailyCloseAttempt()",
-      "norm_label": "selectrotatingoweddailycloseattempt()",
-      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L89"
-    },
-    {
-      "community": 386,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
-      "label": "owedDailyCloseSweep.ts",
-      "norm_label": "oweddailyclosesweep.ts",
-      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
       "source_location": "L1"
     },
     {
@@ -261078,6 +261123,60 @@
     {
       "community": 507,
       "file_type": "code",
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L101"
+    },
+    {
+      "community": 507,
+      "file_type": "code",
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 507,
+      "file_type": "code",
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 507,
+      "file_type": "code",
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 507,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 507,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 508,
+      "file_type": "code",
       "id": "config_derivestorefrontfromadminhost",
       "label": "deriveStoreFrontFromAdminHost()",
       "norm_label": "derivestorefrontfromadminhost()",
@@ -261085,7 +261184,7 @@
       "source_location": "L29"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "config_getruntimeorigin",
       "label": "getRuntimeOrigin()",
@@ -261094,7 +261193,7 @@
       "source_location": "L12"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "config_islocalhost",
       "label": "isLocalHost()",
@@ -261103,7 +261202,7 @@
       "source_location": "L20"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "config_resolvestorefronturl",
       "label": "resolveStoreFrontUrl()",
@@ -261112,7 +261211,7 @@
       "source_location": "L51"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "config_trimtrailingslash",
       "label": "trimTrailingSlash()",
@@ -261121,7 +261220,7 @@
       "source_location": "L8"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "packages_athena_webapp_src_config_ts",
       "label": "config.ts",
@@ -261130,7 +261229,7 @@
       "source_location": "L1"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "managerelevationcontext_getstaffdisplayname",
       "label": "getStaffDisplayName()",
@@ -261139,7 +261238,7 @@
       "source_location": "L64"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "managerelevationcontext_managerelevationprovider",
       "label": "ManagerElevationProvider()",
@@ -261148,7 +261247,7 @@
       "source_location": "L87"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "managerelevationcontext_tostaffauthenticationresult",
       "label": "toStaffAuthenticationResult()",
@@ -261157,7 +261256,7 @@
       "source_location": "L74"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "managerelevationcontext_usemanagerelevation",
       "label": "useManagerElevation()",
@@ -261166,7 +261265,7 @@
       "source_location": "L242"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "managerelevationcontext_useoptionalmanagerelevation",
       "label": "useOptionalManagerElevation()",
@@ -261175,67 +261274,13 @@
       "source_location": "L251"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_managerelevationcontext_tsx",
       "label": "ManagerElevationContext.tsx",
       "norm_label": "managerelevationcontext.tsx",
       "source_file": "packages/athena-webapp/src/contexts/ManagerElevationContext.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
-      "label": "useExpenseSessions.ts",
-      "norm_label": "useexpensesessions.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpenseactivesession",
-      "label": "useExpenseActiveSession()",
-      "norm_label": "useexpenseactivesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesession",
-      "label": "useExpenseSession()",
-      "norm_label": "useexpensesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesessioncreate",
-      "label": "useExpenseSessionCreate()",
-      "norm_label": "useexpensesessioncreate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesessionupdate",
-      "label": "useExpenseSessionUpdate()",
-      "norm_label": "useexpensesessionupdate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensestoresessions",
-      "label": "useExpenseStoreSessions()",
-      "norm_label": "useexpensestoresessions()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L10"
     },
     {
       "community": 51,
@@ -261501,6 +261546,60 @@
     {
       "community": 510,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
+      "label": "useExpenseSessions.ts",
+      "norm_label": "useexpensesessions.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpenseactivesession",
+      "label": "useExpenseActiveSession()",
+      "norm_label": "useexpenseactivesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesession",
+      "label": "useExpenseSession()",
+      "norm_label": "useexpensesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesessioncreate",
+      "label": "useExpenseSessionCreate()",
+      "norm_label": "useexpensesessioncreate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesessionupdate",
+      "label": "useExpenseSessionUpdate()",
+      "norm_label": "useexpensesessionupdate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensestoresessions",
+      "label": "useExpenseStoreSessions()",
+      "norm_label": "useexpensestoresessions()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
       "id": "capabilities_canaccesscashcontrolssurface",
       "label": "canAccessCashControlsSurface()",
       "norm_label": "canaccesscashcontrolssurface()",
@@ -261508,7 +261607,7 @@
       "source_location": "L54"
     },
     {
-      "community": 510,
+      "community": 511,
       "file_type": "code",
       "id": "capabilities_canaccessfulladminsurface",
       "label": "canAccessFullAdminSurface()",
@@ -261517,7 +261616,7 @@
       "source_location": "L41"
     },
     {
-      "community": 510,
+      "community": 511,
       "file_type": "code",
       "id": "capabilities_canaccessstoredaysurface",
       "label": "canAccessStoreDaySurface()",
@@ -261526,7 +261625,7 @@
       "source_location": "L47"
     },
     {
-      "community": 510,
+      "community": 511,
       "file_type": "code",
       "id": "capabilities_canviewfinancialdetails",
       "label": "canViewFinancialDetails()",
@@ -261535,7 +261634,7 @@
       "source_location": "L61"
     },
     {
-      "community": 510,
+      "community": 511,
       "file_type": "code",
       "id": "capabilities_getsurfaceaccess",
       "label": "getSurfaceAccess()",
@@ -261544,7 +261643,7 @@
       "source_location": "L68"
     },
     {
-      "community": 510,
+      "community": 511,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_access_capabilities_ts",
       "label": "capabilities.ts",
@@ -261553,7 +261652,7 @@
       "source_location": "L1"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "behaviorutils_calculateengagementmetrics",
       "label": "calculateEngagementMetrics()",
@@ -261562,7 +261661,7 @@
       "source_location": "L173"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "behaviorutils_calculateriskindicators",
       "label": "calculateRiskIndicators()",
@@ -261571,7 +261670,7 @@
       "source_location": "L71"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "behaviorutils_getactivitypriority",
       "label": "getActivityPriority()",
@@ -261580,7 +261679,7 @@
       "source_location": "L251"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "behaviorutils_getcustomerjourneystage",
       "label": "getCustomerJourneyStage()",
@@ -261589,7 +261688,7 @@
       "source_location": "L36"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "behaviorutils_getjourneystageinfo",
       "label": "getJourneyStageInfo()",
@@ -261598,7 +261697,7 @@
       "source_location": "L277"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
       "label": "behaviorUtils.ts",
@@ -261607,7 +261706,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
       "label": "results.ts",
@@ -261616,7 +261715,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "results_isposusecasesuccess",
       "label": "isPosUseCaseSuccess()",
@@ -261625,7 +261724,7 @@
       "source_location": "L134"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "results_mapcommandoutcome",
       "label": "mapCommandOutcome()",
@@ -261634,7 +261733,7 @@
       "source_location": "L69"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "results_mapcommandresult",
       "label": "mapCommandResult()",
@@ -261643,7 +261742,7 @@
       "source_location": "L86"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "results_maplegacymutationresult",
       "label": "mapLegacyMutationResult()",
@@ -261652,7 +261751,7 @@
       "source_location": "L52"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "results_mapthrownerror",
       "label": "mapThrownError()",
@@ -261661,7 +261760,7 @@
       "source_location": "L103"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registerlifecycleauthoritycandidates_ts",
       "label": "registerLifecycleAuthorityCandidates.ts",
@@ -261670,7 +261769,7 @@
       "source_location": "L1"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_deriveregisterlifecycleauthoritycandidates",
       "label": "deriveRegisterLifecycleAuthorityCandidates()",
@@ -261679,7 +261778,7 @@
       "source_location": "L45"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_isboundedidentifier",
       "label": "isBoundedIdentifier()",
@@ -261688,7 +261787,7 @@
       "source_location": "L220"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_iseligibleregistermapping",
       "label": "isEligibleRegisterMapping()",
@@ -261697,7 +261796,7 @@
       "source_location": "L167"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_legacymappingmatchesactivesession",
       "label": "legacyMappingMatchesActiveSession()",
@@ -261706,7 +261805,7 @@
       "source_location": "L182"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_mappingcandidate",
       "label": "mappingCandidate()",
@@ -261715,7 +261814,7 @@
       "source_location": "L194"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_useposlocalsyncruntime_test_ts",
       "label": "usePosLocalSyncRuntime.test.ts",
@@ -261724,7 +261823,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_buildlocalevent",
       "label": "buildLocalEvent()",
@@ -261733,7 +261832,7 @@
       "source_location": "L7449"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_buildrecoverycommand",
       "label": "buildRecoveryCommand()",
@@ -261742,7 +261841,7 @@
       "source_location": "L7472"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_buildrecoverycommandstore",
       "label": "buildRecoveryCommandStore()",
@@ -261751,7 +261850,7 @@
       "source_location": "L7491"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_deferred",
       "label": "deferred()",
@@ -261760,7 +261859,7 @@
       "source_location": "L108"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_storefactory",
       "label": "storeFactory()",
@@ -261769,7 +261868,7 @@
       "source_location": "L352"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
       "label": "selectors.ts",
@@ -261778,7 +261877,7 @@
       "source_location": "L1"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "selectors_buildregisterheaderstate",
       "label": "buildRegisterHeaderState()",
@@ -261787,7 +261886,7 @@
       "source_location": "L28"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "selectors_buildregisterinfostate",
       "label": "buildRegisterInfoState()",
@@ -261796,7 +261895,7 @@
       "source_location": "L37"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "selectors_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -261805,7 +261904,7 @@
       "source_location": "L12"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "selectors_getregistercustomerinfo",
       "label": "getRegisterCustomerInfo()",
@@ -261814,7 +261913,7 @@
       "source_location": "L6"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "selectors_isregistersessionactive",
       "label": "isRegisterSessionActive()",
@@ -261823,7 +261922,7 @@
       "source_location": "L49"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
       "label": "toastService.ts",
@@ -261832,7 +261931,7 @@
       "source_location": "L1"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "toastservice_handleposoperation",
       "label": "handlePOSOperation()",
@@ -261841,7 +261940,7 @@
       "source_location": "L171"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "toastservice_showinventoryerror",
       "label": "showInventoryError()",
@@ -261850,7 +261949,7 @@
       "source_location": "L302"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "toastservice_shownoactivesessionerror",
       "label": "showNoActiveSessionError()",
@@ -261859,7 +261958,7 @@
       "source_location": "L319"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "toastservice_showsessionexpirederror",
       "label": "showSessionExpiredError()",
@@ -261868,7 +261967,7 @@
       "source_location": "L312"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "toastservice_showvalidationerror",
       "label": "showValidationError()",
@@ -261877,7 +261976,7 @@
       "source_location": "L293"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_sheetreturn_ts",
       "label": "sheetReturn.ts",
@@ -261886,7 +261985,7 @@
       "source_location": "L1"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "sheetreturn_decodesheetreturn",
       "label": "decodeSheetReturn()",
@@ -261895,7 +261994,7 @@
       "source_location": "L85"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "sheetreturn_encodefocuskey",
       "label": "encodeFocusKey()",
@@ -261904,7 +262003,7 @@
       "source_location": "L74"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "sheetreturn_encodesheetreturn",
       "label": "encodeSheetReturn()",
@@ -261913,7 +262012,7 @@
       "source_location": "L55"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "sheetreturn_sheetreturnfocusselector",
       "label": "sheetReturnFocusSelector()",
@@ -261922,7 +262021,7 @@
       "source_location": "L126"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "sheetreturn_sheetreturntargetprops",
       "label": "sheetReturnTargetProps()",
@@ -261931,7 +262030,7 @@
       "source_location": "L131"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_skusearch_productskusearchadapters_ts",
       "label": "productSkuSearchAdapters.ts",
@@ -261940,7 +262039,7 @@
       "source_location": "L1"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "productskusearchadapters_buildadminskusearchoption",
       "label": "buildAdminSkuSearchOption()",
@@ -261949,7 +262048,7 @@
       "source_location": "L80"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "productskusearchadapters_buildadminskusearchoptions",
       "label": "buildAdminSkuSearchOptions()",
@@ -261958,7 +262057,7 @@
       "source_location": "L132"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "productskusearchadapters_compactjoin",
       "label": "compactJoin()",
@@ -261967,7 +262066,7 @@
       "source_location": "L73"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "productskusearchadapters_groupadminskusearchoptionsbyproduct",
       "label": "groupAdminSkuSearchOptionsByProduct()",
@@ -261976,67 +262075,13 @@
       "source_location": "L138"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "productskusearchadapters_presentationtext",
       "label": "presentationText()",
       "norm_label": "presentationtext()",
       "source_file": "packages/athena-webapp/src/lib/skuSearch/productSkuSearchAdapters.ts",
       "source_location": "L66"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_stockops_skusearch_ts",
-      "label": "skuSearch.ts",
-      "norm_label": "skusearch.ts",
-      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "skusearch_isbarcodeshapedsearchquery",
-      "label": "isBarcodeShapedSearchQuery()",
-      "norm_label": "isbarcodeshapedsearchquery()",
-      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "skusearch_matchesskusearchterms",
-      "label": "matchesSkuSearchTerms()",
-      "norm_label": "matchesskusearchterms()",
-      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "skusearch_normalizeidentifier",
-      "label": "normalizeIdentifier()",
-      "norm_label": "normalizeidentifier()",
-      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
-      "source_location": "L53"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "skusearch_normalizeskusearchquery",
-      "label": "normalizeSkuSearchQuery()",
-      "norm_label": "normalizeskusearchquery()",
-      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "skusearch_scoreskusearchterms",
-      "label": "scoreSkuSearchTerms()",
-      "norm_label": "scoreskusearchterms()",
-      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
-      "source_location": "L18"
     },
     {
       "community": 52,
@@ -262302,6 +262347,60 @@
     {
       "community": 520,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_stockops_skusearch_ts",
+      "label": "skuSearch.ts",
+      "norm_label": "skusearch.ts",
+      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "skusearch_isbarcodeshapedsearchquery",
+      "label": "isBarcodeShapedSearchQuery()",
+      "norm_label": "isbarcodeshapedsearchquery()",
+      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "skusearch_matchesskusearchterms",
+      "label": "matchesSkuSearchTerms()",
+      "norm_label": "matchesskusearchterms()",
+      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "skusearch_normalizeidentifier",
+      "label": "normalizeIdentifier()",
+      "norm_label": "normalizeidentifier()",
+      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "skusearch_normalizeskusearchquery",
+      "label": "normalizeSkuSearchQuery()",
+      "norm_label": "normalizeskusearchquery()",
+      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "skusearch_scoreskusearchterms",
+      "label": "scoreSkuSearchTerms()",
+      "norm_label": "scoreskusearchterms()",
+      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_offline_posappshellroutes_ts",
       "label": "posAppShellRoutes.ts",
       "norm_label": "posappshellroutes.ts",
@@ -262309,7 +262408,7 @@
       "source_location": "L1"
     },
     {
-      "community": 520,
+      "community": 521,
       "file_type": "code",
       "id": "posappshellroutes_isexcludedfromposappshellcache",
       "label": "isExcludedFromPosAppShellCache()",
@@ -262318,7 +262417,7 @@
       "source_location": "L53"
     },
     {
-      "community": 520,
+      "community": 521,
       "file_type": "code",
       "id": "posappshellroutes_isposappshellnavigationrequest",
       "label": "isPosAppShellNavigationRequest()",
@@ -262327,7 +262426,7 @@
       "source_location": "L71"
     },
     {
-      "community": 520,
+      "community": 521,
       "file_type": "code",
       "id": "posappshellroutes_isposappshellroutepath",
       "label": "isPosAppShellRoutePath()",
@@ -262336,7 +262435,7 @@
       "source_location": "L48"
     },
     {
-      "community": 520,
+      "community": 521,
       "file_type": "code",
       "id": "posappshellroutes_isposappshellstaticassetrequest",
       "label": "isPosAppShellStaticAssetRequest()",
@@ -262345,7 +262444,7 @@
       "source_location": "L88"
     },
     {
-      "community": 520,
+      "community": 521,
       "file_type": "code",
       "id": "posappshellroutes_readheader",
       "label": "readHeader()",
@@ -262354,7 +262453,7 @@
       "source_location": "L107"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "packages_athena_webapp_src_offline_posappshellserviceworkerstaging_test_ts",
       "label": "posAppShellServiceWorkerStaging.test.ts",
@@ -262363,7 +262462,7 @@
       "source_location": "L1"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_createserviceworkerfixture",
       "label": "createServiceWorkerFixture()",
@@ -262372,7 +262471,7 @@
       "source_location": "L32"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_memorycache",
       "label": "MemoryCache",
@@ -262381,7 +262480,7 @@
       "source_location": "L14"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_memorycache_keys",
       "label": ".keys()",
@@ -262390,7 +262489,7 @@
       "source_location": "L27"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_memorycache_match",
       "label": ".match()",
@@ -262399,7 +262498,7 @@
       "source_location": "L17"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_memorycache_put",
       "label": ".put()",
@@ -262408,7 +262507,7 @@
       "source_location": "L22"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "docs_shared_companionsection",
       "label": "CompanionSection()",
@@ -262417,7 +262516,7 @@
       "source_location": "L81"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "docs_shared_formatcategorylabel",
       "label": "formatCategoryLabel()",
@@ -262426,7 +262525,7 @@
       "source_location": "L7"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "docs_shared_formatdocdate",
       "label": "formatDocDate()",
@@ -262435,7 +262534,7 @@
       "source_location": "L11"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "docs_shared_severityindicator",
       "label": "SeverityIndicator()",
@@ -262444,7 +262543,7 @@
       "source_location": "L32"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "docs_shared_solutiondoccard",
       "label": "SolutionDocCard()",
@@ -262453,7 +262552,7 @@
       "source_location": "L48"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_docs_shared_tsx",
       "label": "-docs-shared.tsx",
@@ -262462,7 +262561,7 @@
       "source_location": "L1"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "index_route_view_democtabutton",
       "label": "DemoCtaButton()",
@@ -262471,7 +262570,7 @@
       "source_location": "L192"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "index_route_view_herogrid",
       "label": "HeroGrid()",
@@ -262480,7 +262579,7 @@
       "source_location": "L178"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "index_route_view_rest",
       "label": "rest()",
@@ -262489,7 +262588,7 @@
       "source_location": "L246"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "index_route_view_useheroshotrevealref",
       "label": "useHeroShotRevealRef()",
@@ -262498,7 +262597,7 @@
       "source_location": "L54"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "index_route_view_useheroshottiltref",
       "label": "useHeroShotTiltRef()",
@@ -262507,7 +262606,7 @@
       "source_location": "L107"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_route_view_tsx",
       "label": "-index-route-view.tsx",
@@ -262516,7 +262615,7 @@
       "source_location": "L1"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
       "label": "procurement.index.tsx",
@@ -262525,7 +262624,7 @@
       "source_location": "L1"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementmodesearch",
       "label": "getNextProcurementModeSearch()",
@@ -262534,7 +262633,7 @@
       "source_location": "L19"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementpagesearch",
       "label": "getNextProcurementPageSearch()",
@@ -262543,7 +262642,7 @@
       "source_location": "L37"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementquerysearch",
       "label": "getNextProcurementQuerySearch()",
@@ -262552,7 +262651,7 @@
       "source_location": "L47"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementselectedskusearch",
       "label": "getNextProcurementSelectedSkuSearch()",
@@ -262561,7 +262660,7 @@
       "source_location": "L62"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "procurement_index_procurementroute",
       "label": "ProcurementRoute()",
@@ -262570,7 +262669,7 @@
       "source_location": "L88"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_weekly_lifecycle_test_tsx",
       "label": "weekly.lifecycle.test.tsx",
@@ -262579,7 +262678,7 @@
       "source_location": "L1"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "weekly_lifecycle_test_installcompletedmovement",
       "label": "installCompletedMovement()",
@@ -262588,7 +262687,7 @@
       "source_location": "L283"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "weekly_lifecycle_test_isshareddemostandingread",
       "label": "isSharedDemoStandingRead()",
@@ -262597,7 +262696,7 @@
       "source_location": "L102"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "weekly_lifecycle_test_movementrow",
       "label": "movementRow()",
@@ -262606,7 +262705,7 @@
       "source_location": "L268"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "weekly_lifecycle_test_params",
       "label": "params()",
@@ -262615,7 +262714,7 @@
       "source_location": "L40"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "weekly_lifecycle_test_stubensuremutation",
       "label": "stubEnsureMutation()",
@@ -262624,7 +262723,7 @@
       "source_location": "L81"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "login_layout_completependingauthsync",
       "label": "completePendingAuthSync()",
@@ -262633,7 +262732,7 @@
       "source_location": "L145"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "login_layout_handlependingauthsync",
       "label": "handlePendingAuthSync()",
@@ -262642,7 +262741,7 @@
       "source_location": "L95"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "login_layout_navigationtargetforredirect",
       "label": "navigationTargetForRedirect()",
@@ -262651,7 +262750,7 @@
       "source_location": "L33"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "login_layout_sleep",
       "label": "sleep()",
@@ -262660,7 +262759,7 @@
       "source_location": "L29"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "login_layout_usedocumentscrolllock",
       "label": "useDocumentScrollLock()",
@@ -262669,7 +262768,7 @@
       "source_location": "L45"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_login_layout_tsx",
       "label": "-login-layout.tsx",
@@ -262678,7 +262777,7 @@
       "source_location": "L1"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "organizationsettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -262687,7 +262786,7 @@
       "source_location": "L155"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "organizationsettingsview_navigation",
       "label": "Navigation()",
@@ -262696,7 +262795,7 @@
       "source_location": "L197"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "organizationsettingsview_onsubmit",
       "label": "onSubmit()",
@@ -262705,7 +262804,7 @@
       "source_location": "L104"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "organizationsettingsview_organizationsettings",
       "label": "OrganizationSettings()",
@@ -262714,7 +262813,7 @@
       "source_location": "L25"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "organizationsettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -262723,7 +262822,7 @@
       "source_location": "L72"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
       "label": "OrganizationSettingsView.tsx",
@@ -262732,7 +262831,7 @@
       "source_location": "L1"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
       "label": "StoreSettingsView.tsx",
@@ -262741,7 +262840,7 @@
       "source_location": "L1"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "storesettingsview_handledeleteallproductsinstore",
       "label": "handleDeleteAllProductsInStore()",
@@ -262750,7 +262849,7 @@
       "source_location": "L231"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "storesettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -262759,7 +262858,7 @@
       "source_location": "L167"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "storesettingsview_onsubmit",
       "label": "onSubmit()",
@@ -262768,7 +262867,7 @@
       "source_location": "L116"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "storesettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -262777,67 +262876,13 @@
       "source_location": "L83"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "storesettingsview_storesettings",
       "label": "StoreSettings()",
       "norm_label": "storesettings()",
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L29"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "devfixtureactivation_usedailyclosefixture",
-      "label": "useDailyCloseFixture()",
-      "norm_label": "usedailyclosefixture()",
-      "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "devfixtureactivation_usedailyopeningfixture",
-      "label": "useDailyOpeningFixture()",
-      "norm_label": "usedailyopeningfixture()",
-      "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "devfixtureactivation_usedailyoperationsfixture",
-      "label": "useDailyOperationsFixture()",
-      "norm_label": "usedailyoperationsfixture()",
-      "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "devfixtureactivation_useposhubfixture",
-      "label": "usePosHubFixture()",
-      "norm_label": "useposhubfixture()",
-      "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
-      "source_location": "L108"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "devfixtureactivation_useworkspacefixture",
-      "label": "useWorkspaceFixture()",
-      "norm_label": "useworkspacefixture()",
-      "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_operations_devfixtureactivation_ts",
-      "label": "devFixtureActivation.ts",
-      "norm_label": "devfixtureactivation.ts",
-      "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
-      "source_location": "L1"
     },
     {
       "community": 53,
@@ -263103,6 +263148,60 @@
     {
       "community": 530,
       "file_type": "code",
+      "id": "devfixtureactivation_usedailyclosefixture",
+      "label": "useDailyCloseFixture()",
+      "norm_label": "usedailyclosefixture()",
+      "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
+      "source_location": "L102"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "devfixtureactivation_usedailyopeningfixture",
+      "label": "useDailyOpeningFixture()",
+      "norm_label": "usedailyopeningfixture()",
+      "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "devfixtureactivation_usedailyoperationsfixture",
+      "label": "useDailyOperationsFixture()",
+      "norm_label": "usedailyoperationsfixture()",
+      "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "devfixtureactivation_useposhubfixture",
+      "label": "usePosHubFixture()",
+      "norm_label": "useposhubfixture()",
+      "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
+      "source_location": "L108"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "devfixtureactivation_useworkspacefixture",
+      "label": "useWorkspaceFixture()",
+      "norm_label": "useworkspacefixture()",
+      "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_operations_devfixtureactivation_ts",
+      "label": "devFixtureActivation.ts",
+      "norm_label": "devfixtureactivation.ts",
+      "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
       "label": "storybook-shell.tsx",
       "norm_label": "storybook-shell.tsx",
@@ -263110,7 +263209,7 @@
       "source_location": "L1"
     },
     {
-      "community": 530,
+      "community": 531,
       "file_type": "code",
       "id": "storybook_shell_storybookcallout",
       "label": "StorybookCallout()",
@@ -263119,7 +263218,7 @@
       "source_location": "L76"
     },
     {
-      "community": 530,
+      "community": 531,
       "file_type": "code",
       "id": "storybook_shell_storybooklist",
       "label": "StorybookList()",
@@ -263128,7 +263227,7 @@
       "source_location": "L55"
     },
     {
-      "community": 530,
+      "community": 531,
       "file_type": "code",
       "id": "storybook_shell_storybookpillrow",
       "label": "StorybookPillRow()",
@@ -263137,7 +263236,7 @@
       "source_location": "L88"
     },
     {
-      "community": 530,
+      "community": 531,
       "file_type": "code",
       "id": "storybook_shell_storybooksection",
       "label": "StorybookSection()",
@@ -263146,7 +263245,7 @@
       "source_location": "L34"
     },
     {
-      "community": 530,
+      "community": 531,
       "file_type": "code",
       "id": "storybook_shell_storybookshell",
       "label": "StorybookShell()",
@@ -263155,7 +263254,7 @@
       "source_location": "L13"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_postransaction_ts",
       "label": "posTransaction.ts",
@@ -263164,7 +263263,7 @@
       "source_location": "L1"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "postransaction_fetchpostransaction",
       "label": "fetchPosTransaction()",
@@ -263173,7 +263272,7 @@
       "source_location": "L69"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "postransaction_getbaseurl",
       "label": "getBaseUrl()",
@@ -263182,7 +263281,7 @@
       "source_location": "L57"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "postransaction_getpostransactionbyreceipttoken",
       "label": "getPosTransactionByReceiptToken()",
@@ -263191,7 +263290,7 @@
       "source_location": "L90"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "postransaction_postransactionreceipterror",
       "label": "PosTransactionReceiptError",
@@ -263200,7 +263299,7 @@
       "source_location": "L59"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "postransaction_postransactionreceipterror_constructor",
       "label": ".constructor()",
@@ -263209,7 +263308,7 @@
       "source_location": "L62"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_promocodes_ts",
       "label": "promoCodes.ts",
@@ -263218,7 +263317,7 @@
       "source_location": "L1"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "promocodes_getbaseurl",
       "label": "getBaseUrl()",
@@ -263227,7 +263326,7 @@
       "source_location": "L4"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "promocodes_getpromocodeitems",
       "label": "getPromoCodeItems()",
@@ -263236,7 +263335,7 @@
       "source_location": "L49"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "promocodes_getpromocodes",
       "label": "getPromoCodes()",
@@ -263245,7 +263344,7 @@
       "source_location": "L34"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "promocodes_getredeemedpromocodes",
       "label": "getRedeemedPromoCodes()",
@@ -263254,7 +263353,7 @@
       "source_location": "L74"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "promocodes_redeempromocode",
       "label": "redeemPromoCode()",
@@ -263263,7 +263362,7 @@
       "source_location": "L6"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "billingdetails_clearform",
       "label": "clearForm()",
@@ -263272,7 +263371,7 @@
       "source_location": "L173"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "billingdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -263281,7 +263380,7 @@
       "source_location": "L102"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "billingdetails_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -263290,7 +263389,7 @@
       "source_location": "L201"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "billingdetails_onsubmit",
       "label": "onSubmit()",
@@ -263299,7 +263398,7 @@
       "source_location": "L150"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "billingdetails_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -263308,7 +263407,7 @@
       "source_location": "L155"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
       "label": "BillingDetails.tsx",
@@ -263317,7 +263416,7 @@
       "source_location": "L1"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "homehero_test_attachmedia",
       "label": "attachMedia()",
@@ -263326,7 +263425,7 @@
       "source_location": "L22"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "homehero_test_destroy",
       "label": "destroy()",
@@ -263335,7 +263434,7 @@
       "source_location": "L24"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "homehero_test_issupported",
       "label": "isSupported()",
@@ -263344,7 +263443,7 @@
       "source_location": "L18"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "homehero_test_loadsource",
       "label": "loadSource()",
@@ -263353,7 +263452,7 @@
       "source_location": "L21"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "homehero_test_on",
       "label": "on()",
@@ -263362,7 +263461,7 @@
       "source_location": "L23"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homehero_test_tsx",
       "label": "HomeHero.test.tsx",
@@ -263371,7 +263470,7 @@
       "source_location": "L1"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "mobileproductactions_collapseonpageclick",
       "label": "collapseOnPageClick()",
@@ -263380,7 +263479,7 @@
       "source_location": "L76"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "mobileproductactions_handleconfirm",
       "label": "handleConfirm()",
@@ -263389,7 +263488,7 @@
       "source_location": "L120"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "mobileproductactions_handleprimaryaction",
       "label": "handlePrimaryAction()",
@@ -263398,7 +263497,7 @@
       "source_location": "L129"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "mobileproductactions_handlesecondaryaction",
       "label": "handleSecondaryAction()",
@@ -263407,7 +263506,7 @@
       "source_location": "L133"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "mobileproductactions_updateposition",
       "label": "updatePosition()",
@@ -263416,7 +263515,7 @@
       "source_location": "L44"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
       "label": "MobileProductActions.tsx",
@@ -263425,7 +263524,7 @@
       "source_location": "L1"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "checkoutexpired_checkoutexpired",
       "label": "CheckoutExpired()",
@@ -263434,7 +263533,7 @@
       "source_location": "L9"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessiongeneric",
       "label": "CheckoutSessionGeneric()",
@@ -263443,7 +263542,7 @@
       "source_location": "L73"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessionnotfound",
       "label": "CheckoutSessionNotFound()",
@@ -263452,7 +263551,7 @@
       "source_location": "L54"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "checkoutexpired_handlesendemail",
       "label": "handleSendEmail()",
@@ -263461,7 +263560,7 @@
       "source_location": "L98"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "checkoutexpired_nocheckoutsession",
       "label": "NoCheckoutSession()",
@@ -263470,66 +263569,12 @@
       "source_location": "L33"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
       "label": "CheckoutExpired.tsx",
       "norm_label": "checkoutexpired.tsx",
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 537,
-      "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L101"
-    },
-    {
-      "community": 537,
-      "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 537,
-      "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 537,
-      "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 537,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 537,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1"
     },
     {
@@ -274641,42 +274686,6 @@
     {
       "community": 695,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_register_test_ts",
-      "label": "register.test.ts",
-      "norm_label": "register.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 695,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_public_register_test_ts",
-      "label": "register.test.ts",
-      "norm_label": "register.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 695,
-      "file_type": "code",
-      "id": "register_test_buildctx",
-      "label": "buildCtx()",
-      "norm_label": "buildctx()",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 695,
-      "file_type": "code",
-      "id": "register_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 696,
-      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
       "label": "register.ts",
       "norm_label": "register.ts",
@@ -274684,7 +274693,7 @@
       "source_location": "L1"
     },
     {
-      "community": 696,
+      "community": 695,
       "file_type": "code",
       "id": "register_mapopendrawerusererror",
       "label": "mapOpenDrawerUserError()",
@@ -274693,7 +274702,7 @@
       "source_location": "L34"
     },
     {
-      "community": 696,
+      "community": 695,
       "file_type": "code",
       "id": "register_normalizeregisternumber",
       "label": "normalizeRegisterNumber()",
@@ -274702,7 +274711,7 @@
       "source_location": "L29"
     },
     {
-      "community": 696,
+      "community": 695,
       "file_type": "code",
       "id": "register_opendrawer",
       "label": "openDrawer()",
@@ -274711,7 +274720,7 @@
       "source_location": "L56"
     },
     {
-      "community": 697,
+      "community": 696,
       "file_type": "code",
       "id": "opendrawer_test_createdbgetmock",
       "label": "createDbGetMock()",
@@ -274720,7 +274729,7 @@
       "source_location": "L39"
     },
     {
-      "community": 697,
+      "community": 696,
       "file_type": "code",
       "id": "opendrawer_test_createdbmock",
       "label": "createDbMock()",
@@ -274729,7 +274738,7 @@
       "source_location": "L99"
     },
     {
-      "community": 697,
+      "community": 696,
       "file_type": "code",
       "id": "opendrawer_test_createdbquerymock",
       "label": "createDbQueryMock()",
@@ -274738,7 +274747,7 @@
       "source_location": "L74"
     },
     {
-      "community": 697,
+      "community": 696,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_opendrawer_test_ts",
       "label": "openDrawer.test.ts",
@@ -274747,7 +274756,7 @@
       "source_location": "L1"
     },
     {
-      "community": 698,
+      "community": 697,
       "file_type": "code",
       "id": "getregisterstate_buildregisterstate",
       "label": "buildRegisterState()",
@@ -274756,7 +274765,7 @@
       "source_location": "L21"
     },
     {
-      "community": 698,
+      "community": 697,
       "file_type": "code",
       "id": "getregisterstate_getactivesessionconflictforregisterstate",
       "label": "getActiveSessionConflictForRegisterState()",
@@ -274765,7 +274774,7 @@
       "source_location": "L42"
     },
     {
-      "community": 698,
+      "community": 697,
       "file_type": "code",
       "id": "getregisterstate_getregisterstate",
       "label": "getRegisterState()",
@@ -274774,7 +274783,7 @@
       "source_location": "L80"
     },
     {
-      "community": 698,
+      "community": 697,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
       "label": "getRegisterState.ts",
@@ -274783,7 +274792,7 @@
       "source_location": "L1"
     },
     {
-      "community": 699,
+      "community": 698,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_storepulse_test_ts",
       "label": "storePulse.test.ts",
@@ -274792,7 +274801,7 @@
       "source_location": "L1"
     },
     {
-      "community": 699,
+      "community": 698,
       "file_type": "code",
       "id": "storepulse_test_createdb",
       "label": "createDb()",
@@ -274801,7 +274810,7 @@
       "source_location": "L12"
     },
     {
-      "community": 699,
+      "community": 698,
       "file_type": "code",
       "id": "storepulse_test_item",
       "label": "item()",
@@ -274810,13 +274819,49 @@
       "source_location": "L127"
     },
     {
-      "community": 699,
+      "community": 698,
       "file_type": "code",
       "id": "storepulse_test_transaction",
       "label": "transaction()",
       "norm_label": "transaction()",
       "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.test.ts",
       "source_location": "L99"
+    },
+    {
+      "community": 699,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_sync_posregistersessionactivity_test_ts",
+      "label": "posRegisterSessionActivity.test.ts",
+      "norm_label": "posregistersessionactivity.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 699,
+      "file_type": "code",
+      "id": "posregistersessionactivity_test_buildactivity",
+      "label": "buildActivity()",
+      "norm_label": "buildactivity()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
+      "source_location": "L457"
+    },
+    {
+      "community": 699,
+      "file_type": "code",
+      "id": "posregistersessionactivity_test_buildreport",
+      "label": "buildReport()",
+      "norm_label": "buildreport()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
+      "source_location": "L436"
+    },
+    {
+      "community": 699,
+      "file_type": "code",
+      "id": "posregistersessionactivity_test_createfakerepository",
+      "label": "createFakeRepository()",
+      "norm_label": "createfakerepository()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
+      "source_location": "L476"
     },
     {
       "community": 7,
@@ -275667,42 +275712,6 @@
     {
       "community": 700,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sync_posregistersessionactivity_test_ts",
-      "label": "posRegisterSessionActivity.test.ts",
-      "norm_label": "posregistersessionactivity.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 700,
-      "file_type": "code",
-      "id": "posregistersessionactivity_test_buildactivity",
-      "label": "buildActivity()",
-      "norm_label": "buildactivity()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
-      "source_location": "L457"
-    },
-    {
-      "community": 700,
-      "file_type": "code",
-      "id": "posregistersessionactivity_test_buildreport",
-      "label": "buildReport()",
-      "norm_label": "buildreport()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
-      "source_location": "L436"
-    },
-    {
-      "community": 700,
-      "file_type": "code",
-      "id": "posregistersessionactivity_test_createfakerepository",
-      "label": "createFakeRepository()",
-      "norm_label": "createfakerepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
-      "source_location": "L476"
-    },
-    {
-      "community": 701,
-      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_registercatalogrevision_ts",
       "label": "registerCatalogRevision.ts",
       "norm_label": "registercatalogrevision.ts",
@@ -275710,7 +275719,7 @@
       "source_location": "L1"
     },
     {
-      "community": 701,
+      "community": 700,
       "file_type": "code",
       "id": "registercatalogrevision_advanceregistercatalogrevision",
       "label": "advanceRegisterCatalogRevision()",
@@ -275719,7 +275728,7 @@
       "source_location": "L24"
     },
     {
-      "community": 701,
+      "community": 700,
       "file_type": "code",
       "id": "registercatalogrevision_readregistercatalogrevision",
       "label": "readRegisterCatalogRevision()",
@@ -275728,7 +275737,7 @@
       "source_location": "L16"
     },
     {
-      "community": 701,
+      "community": 700,
       "file_type": "code",
       "id": "registercatalogrevision_readregistercatalogrevisionrow",
       "label": "readRegisterCatalogRevisionRow()",
@@ -275737,7 +275746,7 @@
       "source_location": "L6"
     },
     {
-      "community": 702,
+      "community": 701,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_sequencegappolicy_ts",
       "label": "sequenceGapPolicy.ts",
@@ -275746,7 +275755,7 @@
       "source_location": "L1"
     },
     {
-      "community": 702,
+      "community": 701,
       "file_type": "code",
       "id": "sequencegappolicy_decidesequencegapaction",
       "label": "decideSequenceGapAction()",
@@ -275755,7 +275764,7 @@
       "source_location": "L115"
     },
     {
-      "community": 702,
+      "community": 701,
       "file_type": "code",
       "id": "sequencegappolicy_issequencegapresolved",
       "label": "isSequenceGapResolved()",
@@ -275764,7 +275773,7 @@
       "source_location": "L219"
     },
     {
-      "community": 702,
+      "community": 701,
       "file_type": "code",
       "id": "sequencegappolicy_recordsequencegapobservation",
       "label": "recordSequenceGapObservation()",
@@ -275773,7 +275782,7 @@
       "source_location": "L190"
     },
     {
-      "community": 703,
+      "community": 702,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_staffproof_ts",
       "label": "staffProof.ts",
@@ -275782,7 +275791,7 @@
       "source_location": "L1"
     },
     {
-      "community": 703,
+      "community": 702,
       "file_type": "code",
       "id": "staffproof_createposlocalstaffprooftoken",
       "label": "createPosLocalStaffProofToken()",
@@ -275791,7 +275800,7 @@
       "source_location": "L10"
     },
     {
-      "community": 703,
+      "community": 702,
       "file_type": "code",
       "id": "staffproof_hashposlocalstaffprooftoken",
       "label": "hashPosLocalStaffProofToken()",
@@ -275800,7 +275809,7 @@
       "source_location": "L16"
     },
     {
-      "community": 703,
+      "community": 702,
       "file_type": "code",
       "id": "staffproof_tohex",
       "label": "toHex()",
@@ -275809,7 +275818,7 @@
       "source_location": "L4"
     },
     {
-      "community": 704,
+      "community": 703,
       "file_type": "code",
       "id": "cloudrepairpolicy_test_buildconflict",
       "label": "buildConflict()",
@@ -275818,7 +275827,7 @@
       "source_location": "L387"
     },
     {
-      "community": 704,
+      "community": 703,
       "file_type": "code",
       "id": "cloudrepairpolicy_test_buildevent",
       "label": "buildEvent()",
@@ -275827,7 +275836,7 @@
       "source_location": "L407"
     },
     {
-      "community": 704,
+      "community": 703,
       "file_type": "code",
       "id": "cloudrepairpolicy_test_createrepairprojectionrepository",
       "label": "createRepairProjectionRepository()",
@@ -275836,7 +275845,7 @@
       "source_location": "L282"
     },
     {
-      "community": 704,
+      "community": 703,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_cloudrepairpolicy_test_ts",
       "label": "cloudRepairPolicy.test.ts",
@@ -275845,7 +275854,7 @@
       "source_location": "L1"
     },
     {
-      "community": 705,
+      "community": 704,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_terminalcommandservice_test_ts",
       "label": "terminalCommandService.test.ts",
@@ -275854,7 +275863,7 @@
       "source_location": "L1"
     },
     {
-      "community": 705,
+      "community": 704,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildcommand",
       "label": "buildCommand()",
@@ -275863,7 +275872,7 @@
       "source_location": "L1731"
     },
     {
-      "community": 705,
+      "community": 704,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildrepository",
       "label": "buildRepository()",
@@ -275872,7 +275881,7 @@
       "source_location": "L1666"
     },
     {
-      "community": 705,
+      "community": 704,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildruntimestatus",
       "label": "buildRuntimeStatus()",
@@ -275881,7 +275890,7 @@
       "source_location": "L1755"
     },
     {
-      "community": 706,
+      "community": 705,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
       "label": "sessionCommandRepository.ts",
@@ -275890,7 +275899,7 @@
       "source_location": "L1"
     },
     {
-      "community": 706,
+      "community": 705,
       "file_type": "code",
       "id": "sessioncommandrepository_collectsessionitemsfrompages",
       "label": "collectSessionItemsFromPages()",
@@ -275899,7 +275908,7 @@
       "source_location": "L177"
     },
     {
-      "community": 706,
+      "community": 705,
       "file_type": "code",
       "id": "sessioncommandrepository_createsessioncommandrepository",
       "label": "createSessionCommandRepository()",
@@ -275908,13 +275917,49 @@
       "source_location": "L68"
     },
     {
-      "community": 706,
+      "community": 705,
       "file_type": "code",
       "id": "sessioncommandrepository_scansessionitembyskuinpages",
       "label": "scanSessionItemBySkuInPages()",
       "norm_label": "scansessionitembyskuinpages()",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
       "source_location": "L195"
+    },
+    {
+      "community": 706,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_register_test_ts",
+      "label": "register.test.ts",
+      "norm_label": "register.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 706,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_public_register_test_ts",
+      "label": "register.test.ts",
+      "norm_label": "register.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 706,
+      "file_type": "code",
+      "id": "register_test_buildctx",
+      "label": "buildCtx()",
+      "norm_label": "buildctx()",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 706,
+      "file_type": "code",
+      "id": "register_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L38"
     },
     {
       "community": 707,

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -47615,7 +47615,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_registry_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/registry.test.ts",
-      "source_location": "L641",
+      "source_location": "L665",
       "target": "registry_test_dedupekey",
       "weight": 1
     },
@@ -47627,7 +47627,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_registry_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/registry.test.ts",
-      "source_location": "L826",
+      "source_location": "L850",
       "target": "registry_test_keyfor",
       "weight": 1
     },
@@ -47663,7 +47663,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_registry_ts",
       "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
-      "source_location": "L420",
+      "source_location": "L421",
       "target": "registry_findnotificationkind",
       "weight": 1
     },
@@ -47675,7 +47675,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_registry_ts",
       "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
-      "source_location": "L430",
+      "source_location": "L431",
       "target": "registry_getnotificationkind",
       "weight": 1
     },
@@ -47699,7 +47699,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_registry_ts",
       "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
-      "source_location": "L438",
+      "source_location": "L439",
       "target": "registry_listnotificationkinds",
       "weight": 1
     },
@@ -47711,7 +47711,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_registry_ts",
       "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
-      "source_location": "L101",
+      "source_location": "L102",
       "target": "registry_requirestaledailyclosepayload",
       "weight": 1
     },
@@ -55343,7 +55343,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L177",
+      "source_location": "L182",
       "target": "oweddailyclosesweep_completedoperatingdatesforstore",
       "weight": 1
     },
@@ -55367,7 +55367,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L416",
+      "source_location": "L421",
       "target": "oweddailyclosesweep_daysbetweenoperatingdates",
       "weight": 1
     },
@@ -55379,7 +55379,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L163",
+      "source_location": "L168",
       "target": "oweddailyclosesweep_listenabledeodpolicies",
       "weight": 1
     },
@@ -55391,7 +55391,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L111",
+      "source_location": "L116",
       "target": "oweddailyclosesweep_selectoweddailyclosedates",
       "weight": 1
     },
@@ -55403,7 +55403,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L84",
+      "source_location": "L89",
       "target": "oweddailyclosesweep_selectrotatingoweddailycloseattempt",
       "weight": 1
     },
@@ -147467,7 +147467,7 @@
       "relation": "calls",
       "source": "registry_findnotificationkind",
       "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
-      "source_location": "L431",
+      "source_location": "L432",
       "target": "registry_getnotificationkind",
       "weight": 1
     },
@@ -147539,7 +147539,7 @@
       "relation": "calls",
       "source": "registry_isstaledailyclosepayload",
       "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
-      "source_location": "L104",
+      "source_location": "L105",
       "target": "registry_requirestaledailyclosepayload",
       "weight": 1
     },
@@ -147551,7 +147551,7 @@
       "relation": "calls",
       "source": "registry_test_dedupekey",
       "source_file": "packages/athena-webapp/convex/notifications/registry.test.ts",
-      "source_location": "L827",
+      "source_location": "L851",
       "target": "registry_test_keyfor",
       "weight": 1
     },
@@ -249367,7 +249367,7 @@
       "label": "completedOperatingDatesForStore()",
       "norm_label": "completedoperatingdatesforstore()",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L177"
+      "source_location": "L182"
     },
     {
       "community": 386,
@@ -249385,7 +249385,7 @@
       "label": "daysBetweenOperatingDates()",
       "norm_label": "daysbetweenoperatingdates()",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L416"
+      "source_location": "L421"
     },
     {
       "community": 386,
@@ -249394,7 +249394,7 @@
       "label": "listEnabledEodPolicies()",
       "norm_label": "listenabledeodpolicies()",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L163"
+      "source_location": "L168"
     },
     {
       "community": 386,
@@ -249403,7 +249403,7 @@
       "label": "selectOwedDailyCloseDates()",
       "norm_label": "selectoweddailyclosedates()",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L111"
+      "source_location": "L116"
     },
     {
       "community": 386,
@@ -249412,7 +249412,7 @@
       "label": "selectRotatingOwedDailyCloseAttempt()",
       "norm_label": "selectrotatingoweddailycloseattempt()",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L84"
+      "source_location": "L89"
     },
     {
       "community": 386,
@@ -256036,7 +256036,7 @@
       "label": "findNotificationKind()",
       "norm_label": "findnotificationkind()",
       "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
-      "source_location": "L420"
+      "source_location": "L421"
     },
     {
       "community": 451,
@@ -256045,7 +256045,7 @@
       "label": "getNotificationKind()",
       "norm_label": "getnotificationkind()",
       "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
-      "source_location": "L430"
+      "source_location": "L431"
     },
     {
       "community": 451,
@@ -256063,7 +256063,7 @@
       "label": "listNotificationKinds()",
       "norm_label": "listnotificationkinds()",
       "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
-      "source_location": "L438"
+      "source_location": "L439"
     },
     {
       "community": 451,
@@ -256072,7 +256072,7 @@
       "label": "requireStaleDailyClosePayload()",
       "norm_label": "requirestaledailyclosepayload()",
       "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
-      "source_location": "L101"
+      "source_location": "L102"
     },
     {
       "community": 452,
@@ -265468,7 +265468,7 @@
       "label": "dedupeKey()",
       "norm_label": "dedupekey()",
       "source_file": "packages/athena-webapp/convex/notifications/registry.test.ts",
-      "source_location": "L641"
+      "source_location": "L665"
     },
     {
       "community": 563,
@@ -265477,7 +265477,7 @@
       "label": "keyFor()",
       "norm_label": "keyfor()",
       "source_file": "packages/athena-webapp/convex/notifications/registry.test.ts",
-      "source_location": "L826"
+      "source_location": "L850"
     },
     {
       "community": 563,

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -34180,6 +34180,30 @@
       "weight": 1
     },
     {
+      "_src": "oweddailyclosesweep_candidatesforpolicies",
+      "_tgt": "oweddailyclosesweep_completedoperatingdatesforstore",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "oweddailyclosesweep_completedoperatingdatesforstore",
+      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
+      "source_location": "L209",
+      "target": "oweddailyclosesweep_candidatesforpolicies",
+      "weight": 1
+    },
+    {
+      "_src": "oweddailyclosesweep_candidatesforpolicies",
+      "_tgt": "oweddailyclosesweep_selectoweddailyclosedates",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "oweddailyclosesweep_selectoweddailyclosedates",
+      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
+      "source_location": "L221",
+      "target": "oweddailyclosesweep_candidatesforpolicies",
+      "weight": 1
+    },
+    {
       "_src": "packages_athena_webapp_convex_auth_shareddemoticket_ts",
       "_tgt": "shareddemoticket_authorizeshareddemoticket",
       "confidence": "EXTRACTED",
@@ -47459,7 +47483,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_rail_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L2602",
+      "source_location": "L2612",
       "target": "rail_test_emitapprovalrequestcreated",
       "weight": 1
     },
@@ -47471,7 +47495,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_rail_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L2911",
+      "source_location": "L2921",
       "target": "rail_test_emitverificationdiscrepancy",
       "weight": 1
     },
@@ -47483,7 +47507,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_rail_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L1659",
+      "source_location": "L1669",
       "target": "rail_test_insertdelivery",
       "weight": 1
     },
@@ -47531,7 +47555,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_rail_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L1037",
+      "source_location": "L1047",
       "target": "rail_test_reserveone",
       "weight": 1
     },
@@ -47555,7 +47579,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_rail_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L2573",
+      "source_location": "L2583",
       "target": "rail_test_seedpendingapprovalrequest",
       "weight": 1
     },
@@ -47567,7 +47591,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_rail_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L1687",
+      "source_location": "L1697",
       "target": "rail_test_seedsweeperfixture",
       "weight": 1
     },
@@ -47591,7 +47615,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_rail_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L2859",
+      "source_location": "L2869",
       "target": "rail_test_seedverificationrun",
       "weight": 1
     },
@@ -47603,7 +47627,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_rail_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L2842",
+      "source_location": "L2852",
       "target": "rail_test_stubprodtransport",
       "weight": 1
     },
@@ -55337,13 +55361,25 @@
     },
     {
       "_src": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
+      "_tgt": "oweddailyclosesweep_candidatesforpolicies",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
+      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
+      "source_location": "L195",
+      "target": "oweddailyclosesweep_candidatesforpolicies",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "_tgt": "oweddailyclosesweep_completedoperatingdatesforstore",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L182",
+      "source_location": "L170",
       "target": "oweddailyclosesweep_completedoperatingdatesforstore",
       "weight": 1
     },
@@ -55367,20 +55403,8 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L421",
+      "source_location": "L474",
       "target": "oweddailyclosesweep_daysbetweenoperatingdates",
-      "weight": 1
-    },
-    {
-      "_src": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
-      "_tgt": "oweddailyclosesweep_listenabledeodpolicies",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "contains",
-      "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
-      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L168",
-      "target": "oweddailyclosesweep_listenabledeodpolicies",
       "weight": 1
     },
     {
@@ -210829,7 +210853,7 @@
       "label": "emitApprovalRequestCreated()",
       "norm_label": "emitapprovalrequestcreated()",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L2602"
+      "source_location": "L2612"
     },
     {
       "community": 170,
@@ -210838,7 +210862,7 @@
       "label": "emitVerificationDiscrepancy()",
       "norm_label": "emitverificationdiscrepancy()",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L2911"
+      "source_location": "L2921"
     },
     {
       "community": 170,
@@ -210847,7 +210871,7 @@
       "label": "insertDelivery()",
       "norm_label": "insertdelivery()",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L1659"
+      "source_location": "L1669"
     },
     {
       "community": 170,
@@ -210883,7 +210907,7 @@
       "label": "reserveOne()",
       "norm_label": "reserveone()",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L1037"
+      "source_location": "L1047"
     },
     {
       "community": 170,
@@ -210901,7 +210925,7 @@
       "label": "seedPendingApprovalRequest()",
       "norm_label": "seedpendingapprovalrequest()",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L2573"
+      "source_location": "L2583"
     },
     {
       "community": 170,
@@ -210910,7 +210934,7 @@
       "label": "seedSweeperFixture()",
       "norm_label": "seedsweeperfixture()",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L1687"
+      "source_location": "L1697"
     },
     {
       "community": 170,
@@ -210928,7 +210952,7 @@
       "label": "seedVerificationRun()",
       "norm_label": "seedverificationrun()",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L2859"
+      "source_location": "L2869"
     },
     {
       "community": 170,
@@ -210937,7 +210961,7 @@
       "label": "stubProdTransport()",
       "norm_label": "stubprodtransport()",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L1228"
+      "source_location": "L1238"
     },
     {
       "community": 1700,
@@ -249363,11 +249387,20 @@
     {
       "community": 386,
       "file_type": "code",
+      "id": "oweddailyclosesweep_candidatesforpolicies",
+      "label": "candidatesForPolicies()",
+      "norm_label": "candidatesforpolicies()",
+      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
+      "source_location": "L195"
+    },
+    {
+      "community": 386,
+      "file_type": "code",
       "id": "oweddailyclosesweep_completedoperatingdatesforstore",
       "label": "completedOperatingDatesForStore()",
       "norm_label": "completedoperatingdatesforstore()",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L182"
+      "source_location": "L170"
     },
     {
       "community": 386,
@@ -249385,16 +249418,7 @@
       "label": "daysBetweenOperatingDates()",
       "norm_label": "daysbetweenoperatingdates()",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L421"
-    },
-    {
-      "community": 386,
-      "file_type": "code",
-      "id": "oweddailyclosesweep_listenabledeodpolicies",
-      "label": "listEnabledEodPolicies()",
-      "norm_label": "listenabledeodpolicies()",
-      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L168"
+      "source_location": "L474"
     },
     {
       "community": 386,

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -11807,7 +11807,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildcashmetrics",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1086",
+      "source_location": "L1095",
       "target": "dailymanagerreportemail_comparisonfromsummary",
       "weight": 1
     },
@@ -11819,7 +11819,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildcashmetrics",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1074",
+      "source_location": "L1083",
       "target": "dailymanagerreportemail_numberfromsummary",
       "weight": 1
     },
@@ -11831,7 +11831,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildcashmetrics",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1076",
+      "source_location": "L1085",
       "target": "dailymanagerreportemail_numberfromsummarywithfallback",
       "weight": 1
     },
@@ -11843,7 +11843,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_builddailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L636",
+      "source_location": "L645",
       "target": "dailymanagerreportemail_buildblockers",
       "weight": 1
     },
@@ -11855,7 +11855,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_builddailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L635",
+      "source_location": "L644",
       "target": "dailymanagerreportemail_buildcarryforwarditems",
       "weight": 1
     },
@@ -11867,7 +11867,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_builddailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L643",
+      "source_location": "L652",
       "target": "dailymanagerreportemail_buildcashmetrics",
       "weight": 1
     },
@@ -11879,7 +11879,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_builddailytopmoversurl",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L630",
+      "source_location": "L639",
       "target": "dailymanagerreportemail_builddailymanagerreportpayload",
       "weight": 1
     },
@@ -11891,7 +11891,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_builddailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L644",
+      "source_location": "L653",
       "target": "dailymanagerreportemail_buildpaymenttotals",
       "weight": 1
     },
@@ -11903,7 +11903,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_builddailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L634",
+      "source_location": "L643",
       "target": "dailymanagerreportemail_buildrevieweditems",
       "weight": 1
     },
@@ -11915,7 +11915,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_builddailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L637",
+      "source_location": "L646",
       "target": "dailymanagerreportemail_buildsummarymetrics",
       "weight": 1
     },
@@ -11927,7 +11927,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_builddailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L613",
+      "source_location": "L622",
       "target": "dailymanagerreportemail_formatcompletedat",
       "weight": 1
     },
@@ -11939,7 +11939,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_builddailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L612",
+      "source_location": "L621",
       "target": "dailymanagerreportemail_formatoperatingdate",
       "weight": 1
     },
@@ -11951,7 +11951,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_builddailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L600",
+      "source_location": "L609",
       "target": "dailymanagerreportemail_moneyformatter",
       "weight": 1
     },
@@ -11963,7 +11963,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_builddailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L599",
+      "source_location": "L608",
       "target": "dailymanagerreportemail_normalizecurrency",
       "weight": 1
     },
@@ -11975,7 +11975,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_builddailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L607",
+      "source_location": "L616",
       "target": "dailymanagerreportemail_resolveappurl",
       "weight": 1
     },
@@ -11987,7 +11987,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_builddailytopmoversurl",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L586",
+      "source_location": "L595",
       "target": "dailymanagerreportemail_resolveappurl",
       "weight": 1
     },
@@ -11999,7 +11999,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildopendailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L696",
+      "source_location": "L705",
       "target": "dailymanagerreportemail_buildcashmetrics",
       "weight": 1
     },
@@ -12011,7 +12011,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildopendailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L697",
+      "source_location": "L706",
       "target": "dailymanagerreportemail_buildpaymenttotals",
       "weight": 1
     },
@@ -12023,7 +12023,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildopendailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L694",
+      "source_location": "L703",
       "target": "dailymanagerreportemail_buildpreparedblockers",
       "weight": 1
     },
@@ -12035,7 +12035,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildopendailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L693",
+      "source_location": "L702",
       "target": "dailymanagerreportemail_buildpreparedcarryforwarditems",
       "weight": 1
     },
@@ -12047,7 +12047,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildopendailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L692",
+      "source_location": "L701",
       "target": "dailymanagerreportemail_buildpreparedreviewitems",
       "weight": 1
     },
@@ -12059,7 +12059,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildopendailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L695",
+      "source_location": "L704",
       "target": "dailymanagerreportemail_buildsummarymetrics",
       "weight": 1
     },
@@ -12071,7 +12071,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildopendailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L687",
+      "source_location": "L696",
       "target": "dailymanagerreportemail_formatcompletedat",
       "weight": 1
     },
@@ -12083,7 +12083,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildopendailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L686",
+      "source_location": "L695",
       "target": "dailymanagerreportemail_formatoperatingdate",
       "weight": 1
     },
@@ -12095,7 +12095,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildopendailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L675",
+      "source_location": "L684",
       "target": "dailymanagerreportemail_moneyformatter",
       "weight": 1
     },
@@ -12107,7 +12107,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildopendailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L674",
+      "source_location": "L683",
       "target": "dailymanagerreportemail_normalizecurrency",
       "weight": 1
     },
@@ -12119,7 +12119,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildopendailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L681",
+      "source_location": "L690",
       "target": "dailymanagerreportemail_resolveappurl",
       "weight": 1
     },
@@ -12131,7 +12131,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildprepareddailymanagerreportpayload",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L656",
+      "source_location": "L665",
       "target": "dailymanagerreportemail_buildopendailymanagerreportpayload",
       "weight": 1
     },
@@ -12143,7 +12143,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildrevieweditems",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L820",
+      "source_location": "L829",
       "target": "dailymanagerreportemail_comparisonfromsummary",
       "weight": 1
     },
@@ -12155,7 +12155,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildrevieweditems",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L799",
+      "source_location": "L808",
       "target": "dailymanagerreportemail_numberfromsummary",
       "weight": 1
     },
@@ -12167,7 +12167,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildrevieweditems",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L807",
+      "source_location": "L816",
       "target": "dailymanagerreportemail_numberfromsummarywithfallback",
       "weight": 1
     },
@@ -12179,7 +12179,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildsummarymetrics",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1002",
+      "source_location": "L1011",
       "target": "dailymanagerreportemail_comparisonfromsummary",
       "weight": 1
     },
@@ -12191,7 +12191,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildsummarymetrics",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1007",
+      "source_location": "L1016",
       "target": "dailymanagerreportemail_countlabel",
       "weight": 1
     },
@@ -12203,7 +12203,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildsummarymetrics",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1027",
+      "source_location": "L1036",
       "target": "dailymanagerreportemail_formatpriordaycomparison",
       "weight": 1
     },
@@ -12215,7 +12215,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildsummarymetrics",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1024",
+      "source_location": "L1033",
       "target": "dailymanagerreportemail_formatunitcount",
       "weight": 1
     },
@@ -12227,7 +12227,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_buildsummarymetrics",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L993",
+      "source_location": "L1002",
       "target": "dailymanagerreportemail_numberfromsummary",
       "weight": 1
     },
@@ -12239,7 +12239,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_readunitssoldforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L548",
+      "source_location": "L557",
       "target": "dailymanagerreportemail_buildunitssoldsummary",
       "weight": 1
     },
@@ -12251,7 +12251,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_comparisonfromsummary",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1155",
+      "source_location": "L1164",
       "target": "dailymanagerreportemail_formatpriordaycomparison",
       "weight": 1
     },
@@ -12263,7 +12263,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_numberfromsummary",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1157",
+      "source_location": "L1166",
       "target": "dailymanagerreportemail_comparisonfromsummary",
       "weight": 1
     },
@@ -12275,7 +12275,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_formatblockermessage",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L932",
+      "source_location": "L941",
       "target": "dailymanagerreportemail_optionalmetadatalabel",
       "weight": 1
     },
@@ -12287,7 +12287,7 @@
       "relation": "calls",
       "source": "dailymanagerreportemail_resolveappurl",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1240",
+      "source_location": "L1249",
       "target": "dailymanagerreportemail_trimtrailingslash",
       "weight": 1
     },
@@ -47459,7 +47459,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_rail_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L2462",
+      "source_location": "L2524",
       "target": "rail_test_emitapprovalrequestcreated",
       "weight": 1
     },
@@ -47471,7 +47471,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_rail_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L2771",
+      "source_location": "L2833",
       "target": "rail_test_emitverificationdiscrepancy",
       "weight": 1
     },
@@ -47483,7 +47483,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_rail_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L1519",
+      "source_location": "L1581",
       "target": "rail_test_insertdelivery",
       "weight": 1
     },
@@ -47531,7 +47531,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_rail_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L897",
+      "source_location": "L959",
       "target": "rail_test_reserveone",
       "weight": 1
     },
@@ -47555,7 +47555,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_rail_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L2433",
+      "source_location": "L2495",
       "target": "rail_test_seedpendingapprovalrequest",
       "weight": 1
     },
@@ -47567,7 +47567,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_rail_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L1547",
+      "source_location": "L1609",
       "target": "rail_test_seedsweeperfixture",
       "weight": 1
     },
@@ -47591,7 +47591,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_rail_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L2719",
+      "source_location": "L2781",
       "target": "rail_test_seedverificationrun",
       "weight": 1
     },
@@ -47603,7 +47603,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_rail_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L2702",
+      "source_location": "L2764",
       "target": "rail_test_stubprodtransport",
       "weight": 1
     },
@@ -47663,7 +47663,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_registry_ts",
       "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
-      "source_location": "L395",
+      "source_location": "L420",
       "target": "registry_findnotificationkind",
       "weight": 1
     },
@@ -47675,8 +47675,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_registry_ts",
       "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
-      "source_location": "L405",
+      "source_location": "L430",
       "target": "registry_getnotificationkind",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_notifications_registry_ts",
+      "_tgt": "registry_isstaledailyclosepayload",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_notifications_registry_ts",
+      "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
+      "source_location": "L88",
+      "target": "registry_isstaledailyclosepayload",
       "weight": 1
     },
     {
@@ -47687,8 +47699,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_registry_ts",
       "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
-      "source_location": "L413",
+      "source_location": "L438",
       "target": "registry_listnotificationkinds",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_notifications_registry_ts",
+      "_tgt": "registry_requirestaledailyclosepayload",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_notifications_registry_ts",
+      "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
+      "source_location": "L101",
+      "target": "registry_requirestaledailyclosepayload",
       "weight": 1
     },
     {
@@ -50687,7 +50711,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L425",
+      "source_location": "L510",
       "target": "dailymanagerreportemail_test_ask",
       "weight": 1
     },
@@ -50699,7 +50723,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L632",
+      "source_location": "L749",
       "target": "dailymanagerreportemail_test_askforday",
       "weight": 1
     },
@@ -50711,7 +50735,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L485",
+      "source_location": "L602",
       "target": "dailymanagerreportemail_test_insertcompletedclose",
       "weight": 1
     },
@@ -50735,8 +50759,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L535",
+      "source_location": "L652",
       "target": "dailymanagerreportemail_test_insertreportday",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_operations_dailymanagerreportemail_test_ts",
+      "_tgt": "dailymanagerreportemail_test_insertrun",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_test_ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
+      "source_location": "L484",
+      "target": "dailymanagerreportemail_test_insertrun",
       "weight": 1
     },
     {
@@ -50747,7 +50783,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L569",
+      "source_location": "L686",
       "target": "dailymanagerreportemail_test_insertskuday",
       "weight": 1
     },
@@ -50771,7 +50807,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L465",
+      "source_location": "L582",
       "target": "dailymanagerreportemail_test_seedstore",
       "weight": 1
     },
@@ -50795,7 +50831,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L623",
+      "source_location": "L740",
       "target": "dailymanagerreportemail_test_unitsmetric",
       "weight": 1
     },
@@ -50807,7 +50843,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L903",
+      "source_location": "L912",
       "target": "dailymanagerreportemail_buildblockers",
       "weight": 1
     },
@@ -50819,7 +50855,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L879",
+      "source_location": "L888",
       "target": "dailymanagerreportemail_buildcarryforwarditems",
       "weight": 1
     },
@@ -50831,7 +50867,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1069",
+      "source_location": "L1078",
       "target": "dailymanagerreportemail_buildcashmetrics",
       "weight": 1
     },
@@ -50843,7 +50879,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L589",
+      "source_location": "L598",
       "target": "dailymanagerreportemail_builddailymanagerreportpayload",
       "weight": 1
     },
@@ -50855,7 +50891,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L574",
+      "source_location": "L583",
       "target": "dailymanagerreportemail_builddailytopmoversurl",
       "weight": 1
     },
@@ -50867,7 +50903,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L666",
+      "source_location": "L675",
       "target": "dailymanagerreportemail_buildopendailymanagerreportpayload",
       "weight": 1
     },
@@ -50879,7 +50915,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L947",
+      "source_location": "L956",
       "target": "dailymanagerreportemail_buildpaymenttotals",
       "weight": 1
     },
@@ -50891,7 +50927,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L917",
+      "source_location": "L926",
       "target": "dailymanagerreportemail_buildpreparedblockers",
       "weight": 1
     },
@@ -50903,7 +50939,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L892",
+      "source_location": "L901",
       "target": "dailymanagerreportemail_buildpreparedcarryforwarditems",
       "weight": 1
     },
@@ -50915,7 +50951,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L649",
+      "source_location": "L658",
       "target": "dailymanagerreportemail_buildprepareddailymanagerreportpayload",
       "weight": 1
     },
@@ -50927,7 +50963,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L868",
+      "source_location": "L877",
       "target": "dailymanagerreportemail_buildpreparedreviewitems",
       "weight": 1
     },
@@ -50939,7 +50975,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L705",
+      "source_location": "L714",
       "target": "dailymanagerreportemail_buildregistercashpositionsummary",
       "weight": 1
     },
@@ -50951,7 +50987,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L792",
+      "source_location": "L801",
       "target": "dailymanagerreportemail_buildrevieweditems",
       "weight": 1
     },
@@ -50963,7 +50999,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L987",
+      "source_location": "L996",
       "target": "dailymanagerreportemail_buildsummarymetrics",
       "weight": 1
     },
@@ -50975,7 +51011,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L562",
+      "source_location": "L571",
       "target": "dailymanagerreportemail_buildtopitemsforday",
       "weight": 1
     },
@@ -50987,7 +51023,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L544",
+      "source_location": "L553",
       "target": "dailymanagerreportemail_buildunitssoldsummary",
       "weight": 1
     },
@@ -50999,7 +51035,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1147",
+      "source_location": "L1156",
       "target": "dailymanagerreportemail_comparisonfromsummary",
       "weight": 1
     },
@@ -51011,7 +51047,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1183",
+      "source_location": "L1192",
       "target": "dailymanagerreportemail_countlabel",
       "weight": 1
     },
@@ -51023,7 +51059,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L927",
+      "source_location": "L936",
       "target": "dailymanagerreportemail_formatblockermessage",
       "weight": 1
     },
@@ -51035,7 +51071,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1227",
+      "source_location": "L1236",
       "target": "dailymanagerreportemail_formatcompletedat",
       "weight": 1
     },
@@ -51047,7 +51083,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1206",
+      "source_location": "L1215",
       "target": "dailymanagerreportemail_formatoperatingdate",
       "weight": 1
     },
@@ -51059,7 +51095,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1193",
+      "source_location": "L1202",
       "target": "dailymanagerreportemail_formatpaymentmethod",
       "weight": 1
     },
@@ -51071,7 +51107,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1162",
+      "source_location": "L1171",
       "target": "dailymanagerreportemail_formatpriordaycomparison",
       "weight": 1
     },
@@ -51083,7 +51119,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1179",
+      "source_location": "L1188",
       "target": "dailymanagerreportemail_formatunitcount",
       "weight": 1
     },
@@ -51095,7 +51131,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1114",
+      "source_location": "L1123",
       "target": "dailymanagerreportemail_ispaymenttotal",
       "weight": 1
     },
@@ -51107,7 +51143,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1127",
+      "source_location": "L1136",
       "target": "dailymanagerreportemail_moneyformatter",
       "weight": 1
     },
@@ -51119,7 +51155,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1187",
+      "source_location": "L1196",
       "target": "dailymanagerreportemail_normalizecurrency",
       "weight": 1
     },
@@ -51131,7 +51167,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1199",
+      "source_location": "L1208",
       "target": "dailymanagerreportemail_normalizepaymentmethod",
       "weight": 1
     },
@@ -51143,7 +51179,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1133",
+      "source_location": "L1142",
       "target": "dailymanagerreportemail_numberfromsummary",
       "weight": 1
     },
@@ -51155,7 +51191,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1138",
+      "source_location": "L1147",
       "target": "dailymanagerreportemail_numberfromsummarywithfallback",
       "weight": 1
     },
@@ -51167,7 +51203,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L939",
+      "source_location": "L948",
       "target": "dailymanagerreportemail_optionalmetadatalabel",
       "weight": 1
     },
@@ -51179,7 +51215,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L526",
+      "source_location": "L535",
       "target": "dailymanagerreportemail_readunitssoldforday",
       "weight": 1
     },
@@ -51191,7 +51227,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1235",
+      "source_location": "L1244",
       "target": "dailymanagerreportemail_resolveappurl",
       "weight": 1
     },
@@ -51203,7 +51239,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L504",
+      "source_location": "L513",
       "target": "dailymanagerreportemail_resolvestaffname",
       "weight": 1
     },
@@ -51215,7 +51251,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L483",
+      "source_location": "L492",
       "target": "dailymanagerreportemail_resolvestore",
       "weight": 1
     },
@@ -51227,7 +51263,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1219",
+      "source_location": "L1228",
       "target": "dailymanagerreportemail_resolvestorescheduletimezoneforat",
       "weight": 1
     },
@@ -51239,7 +51275,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1248",
+      "source_location": "L1257",
       "target": "dailymanagerreportemail_trimtrailingslash",
       "weight": 1
     },
@@ -55295,7 +55331,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.test.ts",
-      "source_location": "L12",
+      "source_location": "L13",
       "target": "oweddailyclosesweep_test_fullwindow",
       "weight": 1
     },
@@ -55307,8 +55343,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L151",
+      "source_location": "L155",
       "target": "oweddailyclosesweep_completedoperatingdatesforstore",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
+      "_tgt": "oweddailyclosesweep_dailyclosesweepresultsettled",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
+      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
+      "source_location": "L78",
+      "target": "oweddailyclosesweep_dailyclosesweepresultsettled",
       "weight": 1
     },
     {
@@ -55319,7 +55367,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L369",
+      "source_location": "L388",
       "target": "oweddailyclosesweep_daysbetweenoperatingdates",
       "weight": 1
     },
@@ -55331,7 +55379,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L137",
+      "source_location": "L141",
       "target": "oweddailyclosesweep_listenabledeodpolicies",
       "weight": 1
     },
@@ -55343,7 +55391,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L85",
+      "source_location": "L89",
       "target": "oweddailyclosesweep_selectoweddailyclosedates",
       "weight": 1
     },
@@ -147407,7 +147455,7 @@
       "relation": "calls",
       "source": "registry_findnotificationkind",
       "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
-      "source_location": "L406",
+      "source_location": "L431",
       "target": "registry_getnotificationkind",
       "weight": 1
     },
@@ -147469,6 +147517,18 @@
       "source_file": "packages/athena-webapp/convex/intelligence/registry.ts",
       "source_location": "L212",
       "target": "registry_isjsonvalue",
+      "weight": 1
+    },
+    {
+      "_src": "registry_requirestaledailyclosepayload",
+      "_tgt": "registry_isstaledailyclosepayload",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "registry_isstaledailyclosepayload",
+      "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
+      "source_location": "L104",
+      "target": "registry_requirestaledailyclosepayload",
       "weight": 1
     },
     {
@@ -192028,7 +192088,7 @@
       "label": "fullWindow()",
       "norm_label": "fullwindow()",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.test.ts",
-      "source_location": "L12"
+      "source_location": "L13"
     },
     {
       "community": 1196,
@@ -210757,7 +210817,7 @@
       "label": "emitApprovalRequestCreated()",
       "norm_label": "emitapprovalrequestcreated()",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L2462"
+      "source_location": "L2524"
     },
     {
       "community": 170,
@@ -210766,7 +210826,7 @@
       "label": "emitVerificationDiscrepancy()",
       "norm_label": "emitverificationdiscrepancy()",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L2771"
+      "source_location": "L2833"
     },
     {
       "community": 170,
@@ -210775,7 +210835,7 @@
       "label": "insertDelivery()",
       "norm_label": "insertdelivery()",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L1519"
+      "source_location": "L1581"
     },
     {
       "community": 170,
@@ -210811,7 +210871,7 @@
       "label": "reserveOne()",
       "norm_label": "reserveone()",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L897"
+      "source_location": "L959"
     },
     {
       "community": 170,
@@ -210829,7 +210889,7 @@
       "label": "seedPendingApprovalRequest()",
       "norm_label": "seedpendingapprovalrequest()",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L2433"
+      "source_location": "L2495"
     },
     {
       "community": 170,
@@ -210838,7 +210898,7 @@
       "label": "seedSweeperFixture()",
       "norm_label": "seedsweeperfixture()",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L1547"
+      "source_location": "L1609"
     },
     {
       "community": 170,
@@ -210856,7 +210916,7 @@
       "label": "seedVerificationRun()",
       "norm_label": "seedverificationrun()",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L2719"
+      "source_location": "L2781"
     },
     {
       "community": 170,
@@ -210865,7 +210925,7 @@
       "label": "stubProdTransport()",
       "norm_label": "stubprodtransport()",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L1088"
+      "source_location": "L1150"
     },
     {
       "community": 1700,
@@ -221382,109 +221442,109 @@
     {
       "community": 209,
       "file_type": "code",
-      "id": "dailyoperationsautomation_test_closedregistersession",
-      "label": "closedRegisterSession()",
-      "norm_label": "closedregistersession()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts",
-      "source_location": "L286"
+      "id": "dailymanagerreportemail_test_ask",
+      "label": "ask()",
+      "norm_label": "ask()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
+      "source_location": "L425"
     },
     {
       "community": 209,
       "file_type": "code",
-      "id": "dailyoperationsautomation_test_completeddailyclose",
-      "label": "completedDailyClose()",
-      "norm_label": "completeddailyclose()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts",
-      "source_location": "L340"
+      "id": "dailymanagerreportemail_test_askforday",
+      "label": "askForDay()",
+      "norm_label": "askforday()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
+      "source_location": "L749"
     },
     {
       "community": 209,
       "file_type": "code",
-      "id": "dailyoperationsautomation_test_completedtransaction",
-      "label": "completedTransaction()",
-      "norm_label": "completedtransaction()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts",
-      "source_location": "L300"
+      "id": "dailymanagerreportemail_test_insertcompletedclose",
+      "label": "insertCompletedClose()",
+      "norm_label": "insertcompletedclose()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
+      "source_location": "L602"
     },
     {
       "community": 209,
       "file_type": "code",
-      "id": "dailyoperationsautomation_test_createdb",
-      "label": "createDb()",
-      "norm_label": "createdb()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts",
-      "source_location": "L79"
+      "id": "dailymanagerreportemail_test_insertlegacydelivery",
+      "label": "insertLegacyDelivery()",
+      "norm_label": "insertlegacydelivery()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
+      "source_location": "L396"
     },
     {
       "community": 209,
       "file_type": "code",
-      "id": "dailyoperationsautomation_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts",
-      "source_location": "L255"
+      "id": "dailymanagerreportemail_test_insertreportday",
+      "label": "insertReportDay()",
+      "norm_label": "insertreportday()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
+      "source_location": "L652"
     },
     {
       "community": 209,
       "file_type": "code",
-      "id": "dailyoperationsautomation_test_insertlegacysentdelivery",
-      "label": "insertLegacySentDelivery()",
-      "norm_label": "insertlegacysentdelivery()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts",
-      "source_location": "L1432"
+      "id": "dailymanagerreportemail_test_insertrun",
+      "label": "insertRun()",
+      "norm_label": "insertrun()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
+      "source_location": "L484"
     },
     {
       "community": 209,
       "file_type": "code",
-      "id": "dailyoperationsautomation_test_makeemitctx",
-      "label": "makeEmitCtx()",
-      "norm_label": "makeemitctx()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts",
-      "source_location": "L1459"
+      "id": "dailymanagerreportemail_test_insertskuday",
+      "label": "insertSkuDay()",
+      "norm_label": "insertskuday()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
+      "source_location": "L686"
     },
     {
       "community": 209,
       "file_type": "code",
-      "id": "dailyoperationsautomation_test_policy",
-      "label": "policy()",
-      "norm_label": "policy()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts",
-      "source_location": "L268"
+      "id": "dailymanagerreportemail_test_money",
+      "label": "money()",
+      "norm_label": "money()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
+      "source_location": "L77"
     },
     {
       "community": 209,
       "file_type": "code",
-      "id": "dailyoperationsautomation_test_resultforrun",
-      "label": "resultForRun()",
-      "norm_label": "resultforrun()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts",
-      "source_location": "L1331"
+      "id": "dailymanagerreportemail_test_seedstore",
+      "label": "seedStore()",
+      "norm_label": "seedstore()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
+      "source_location": "L464"
     },
     {
       "community": 209,
       "file_type": "code",
-      "id": "dailyoperationsautomation_test_seedcutoverfixture",
-      "label": "seedCutoverFixture()",
-      "norm_label": "seedcutoverfixture()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts",
-      "source_location": "L1383"
+      "id": "dailymanagerreportemail_test_seedstoreandrun",
+      "label": "seedStoreAndRun()",
+      "norm_label": "seedstoreandrun()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
+      "source_location": "L358"
     },
     {
       "community": 209,
       "file_type": "code",
-      "id": "dailyoperationsautomation_test_storeschedule",
-      "label": "storeSchedule()",
-      "norm_label": "storeschedule()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts",
-      "source_location": "L316"
+      "id": "dailymanagerreportemail_test_unitsmetric",
+      "label": "unitsMetric()",
+      "norm_label": "unitsmetric()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
+      "source_location": "L740"
     },
     {
       "community": 209,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_dailyoperationsautomation_test_ts",
-      "label": "dailyOperationsAutomation.test.ts",
-      "norm_label": "dailyoperationsautomation.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts",
+      "id": "packages_athena_webapp_convex_operations_dailymanagerreportemail_test_ts",
+      "label": "dailyManagerReportEmail.test.ts",
+      "norm_label": "dailymanagerreportemail.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
       "source_location": "L1"
     },
     {
@@ -221949,110 +222009,110 @@
     {
       "community": 210,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_transactionadjustmentplanner_ts",
-      "label": "transactionAdjustmentPlanner.ts",
-      "norm_label": "transactionadjustmentplanner.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/transactionAdjustmentPlanner.ts",
+      "id": "dailyoperationsautomation_test_closedregistersession",
+      "label": "closedRegisterSession()",
+      "norm_label": "closedregistersession()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts",
+      "source_location": "L286"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "dailyoperationsautomation_test_completeddailyclose",
+      "label": "completedDailyClose()",
+      "norm_label": "completeddailyclose()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts",
+      "source_location": "L340"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "dailyoperationsautomation_test_completedtransaction",
+      "label": "completedTransaction()",
+      "norm_label": "completedtransaction()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts",
+      "source_location": "L300"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "dailyoperationsautomation_test_createdb",
+      "label": "createDb()",
+      "norm_label": "createdb()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts",
+      "source_location": "L79"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "dailyoperationsautomation_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts",
+      "source_location": "L255"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "dailyoperationsautomation_test_insertlegacysentdelivery",
+      "label": "insertLegacySentDelivery()",
+      "norm_label": "insertlegacysentdelivery()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts",
+      "source_location": "L1432"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "dailyoperationsautomation_test_makeemitctx",
+      "label": "makeEmitCtx()",
+      "norm_label": "makeemitctx()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts",
+      "source_location": "L1459"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "dailyoperationsautomation_test_policy",
+      "label": "policy()",
+      "norm_label": "policy()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts",
+      "source_location": "L268"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "dailyoperationsautomation_test_resultforrun",
+      "label": "resultForRun()",
+      "norm_label": "resultforrun()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts",
+      "source_location": "L1331"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "dailyoperationsautomation_test_seedcutoverfixture",
+      "label": "seedCutoverFixture()",
+      "norm_label": "seedcutoverfixture()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts",
+      "source_location": "L1383"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "dailyoperationsautomation_test_storeschedule",
+      "label": "storeSchedule()",
+      "norm_label": "storeschedule()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts",
+      "source_location": "L316"
+    },
+    {
+      "community": 210,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_dailyoperationsautomation_test_ts",
+      "label": "dailyOperationsAutomation.test.ts",
+      "norm_label": "dailyoperationsautomation.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 210,
-      "file_type": "code",
-      "id": "transactionadjustmentplanner_buildfingerprintpayload",
-      "label": "buildFingerprintPayload()",
-      "norm_label": "buildfingerprintpayload()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/transactionAdjustmentPlanner.ts",
-      "source_location": "L224"
-    },
-    {
-      "community": 210,
-      "file_type": "code",
-      "id": "transactionadjustmentplanner_getskudisplayname",
-      "label": "getSkuDisplayName()",
-      "norm_label": "getskudisplayname()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/transactionAdjustmentPlanner.ts",
-      "source_location": "L201"
-    },
-    {
-      "community": 210,
-      "file_type": "code",
-      "id": "transactionadjustmentplanner_getskudisplaysku",
-      "label": "getSkuDisplaySku()",
-      "norm_label": "getskudisplaysku()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/transactionAdjustmentPlanner.ts",
-      "source_location": "L197"
-    },
-    {
-      "community": 210,
-      "file_type": "code",
-      "id": "transactionadjustmentplanner_getskuprice",
-      "label": "getSkuPrice()",
-      "norm_label": "getskuprice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/transactionAdjustmentPlanner.ts",
-      "source_location": "L205"
-    },
-    {
-      "community": 210,
-      "file_type": "code",
-      "id": "transactionadjustmentplanner_hasownvalue",
-      "label": "hasOwnValue()",
-      "norm_label": "hasownvalue()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/transactionAdjustmentPlanner.ts",
-      "source_location": "L156"
-    },
-    {
-      "community": 210,
-      "file_type": "code",
-      "id": "transactionadjustmentplanner_hasunsupportedmanualfields",
-      "label": "hasUnsupportedManualFields()",
-      "norm_label": "hasunsupportedmanualfields()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/transactionAdjustmentPlanner.ts",
-      "source_location": "L160"
-    },
-    {
-      "community": 210,
-      "file_type": "code",
-      "id": "transactionadjustmentplanner_isskuavailableforaddition",
-      "label": "isSkuAvailableForAddition()",
-      "norm_label": "isskuavailableforaddition()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/transactionAdjustmentPlanner.ts",
-      "source_location": "L209"
-    },
-    {
-      "community": 210,
-      "file_type": "code",
-      "id": "transactionadjustmentplanner_iswholequantity",
-      "label": "isWholeQuantity()",
-      "norm_label": "iswholequantity()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/transactionAdjustmentPlanner.ts",
-      "source_location": "L152"
-    },
-    {
-      "community": 210,
-      "file_type": "code",
-      "id": "transactionadjustmentplanner_plantransactionadjustment",
-      "label": "planTransactionAdjustment()",
-      "norm_label": "plantransactionadjustment()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/transactionAdjustmentPlanner.ts",
-      "source_location": "L251"
-    },
-    {
-      "community": 210,
-      "file_type": "code",
-      "id": "transactionadjustmentplanner_roundstoredamount",
-      "label": "roundStoredAmount()",
-      "norm_label": "roundstoredamount()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/transactionAdjustmentPlanner.ts",
-      "source_location": "L148"
-    },
-    {
-      "community": 210,
-      "file_type": "code",
-      "id": "transactionadjustmentplanner_stablestringify",
-      "label": "stableStringify()",
-      "norm_label": "stablestringify()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/transactionAdjustmentPlanner.ts",
-      "source_location": "L181"
     },
     {
       "community": 2100,
@@ -222147,110 +222207,110 @@
     {
       "community": 211,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_public_transactions_test_ts",
-      "label": "transactions.test.ts",
-      "norm_label": "transactions.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
+      "id": "packages_athena_webapp_convex_pos_application_commands_transactionadjustmentplanner_ts",
+      "label": "transactionAdjustmentPlanner.ts",
+      "norm_label": "transactionadjustmentplanner.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/transactionAdjustmentPlanner.ts",
       "source_location": "L1"
     },
     {
       "community": 211,
       "file_type": "code",
-      "id": "transactions_test_createauthorizeditemadjustmentctx",
-      "label": "createAuthorizedItemAdjustmentCtx()",
-      "norm_label": "createauthorizeditemadjustmentctx()",
-      "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
-      "source_location": "L1783"
+      "id": "transactionadjustmentplanner_buildfingerprintpayload",
+      "label": "buildFingerprintPayload()",
+      "norm_label": "buildfingerprintpayload()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/transactionAdjustmentPlanner.ts",
+      "source_location": "L224"
     },
     {
       "community": 211,
       "file_type": "code",
-      "id": "transactions_test_createauthorizedsessioncompletionctx",
-      "label": "createAuthorizedSessionCompletionCtx()",
-      "norm_label": "createauthorizedsessioncompletionctx()",
-      "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
-      "source_location": "L1662"
+      "id": "transactionadjustmentplanner_getskudisplayname",
+      "label": "getSkuDisplayName()",
+      "norm_label": "getskudisplayname()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/transactionAdjustmentPlanner.ts",
+      "source_location": "L201"
     },
     {
       "community": 211,
       "file_type": "code",
-      "id": "transactions_test_createauthorizedvoidctx",
-      "label": "createAuthorizedVoidCtx()",
-      "norm_label": "createauthorizedvoidctx()",
-      "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
-      "source_location": "L1348"
+      "id": "transactionadjustmentplanner_getskudisplaysku",
+      "label": "getSkuDisplaySku()",
+      "norm_label": "getskudisplaysku()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/transactionAdjustmentPlanner.ts",
+      "source_location": "L197"
     },
     {
       "community": 211,
       "file_type": "code",
-      "id": "transactions_test_createctx",
-      "label": "createCtx()",
-      "norm_label": "createctx()",
-      "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
-      "source_location": "L1056"
+      "id": "transactionadjustmentplanner_getskuprice",
+      "label": "getSkuPrice()",
+      "norm_label": "getskuprice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/transactionAdjustmentPlanner.ts",
+      "source_location": "L205"
     },
     {
       "community": 211,
       "file_type": "code",
-      "id": "transactions_test_createmembership",
-      "label": "createMembership()",
-      "norm_label": "createmembership()",
-      "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
-      "source_location": "L547"
+      "id": "transactionadjustmentplanner_hasownvalue",
+      "label": "hasOwnValue()",
+      "norm_label": "hasownvalue()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/transactionAdjustmentPlanner.ts",
+      "source_location": "L156"
     },
     {
       "community": 211,
       "file_type": "code",
-      "id": "transactions_test_createstorepulsesummary",
-      "label": "createStorePulseSummary()",
-      "norm_label": "createstorepulsesummary()",
-      "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
-      "source_location": "L557"
+      "id": "transactionadjustmentplanner_hasunsupportedmanualfields",
+      "label": "hasUnsupportedManualFields()",
+      "norm_label": "hasunsupportedmanualfields()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/transactionAdjustmentPlanner.ts",
+      "source_location": "L160"
     },
     {
       "community": 211,
       "file_type": "code",
-      "id": "transactions_test_createtransactionauthctx",
-      "label": "createTransactionAuthCtx()",
-      "norm_label": "createtransactionauthctx()",
-      "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
-      "source_location": "L436"
+      "id": "transactionadjustmentplanner_isskuavailableforaddition",
+      "label": "isSkuAvailableForAddition()",
+      "norm_label": "isskuavailableforaddition()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/transactionAdjustmentPlanner.ts",
+      "source_location": "L209"
     },
     {
       "community": 211,
       "file_type": "code",
-      "id": "transactions_test_exportreturns",
-      "label": "exportReturns()",
-      "norm_label": "exportreturns()",
-      "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
-      "source_location": "L86"
+      "id": "transactionadjustmentplanner_iswholequantity",
+      "label": "isWholeQuantity()",
+      "norm_label": "iswholequantity()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/transactionAdjustmentPlanner.ts",
+      "source_location": "L152"
     },
     {
       "community": 211,
       "file_type": "code",
-      "id": "transactions_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
-      "source_location": "L121"
+      "id": "transactionadjustmentplanner_plantransactionadjustment",
+      "label": "planTransactionAdjustment()",
+      "norm_label": "plantransactionadjustment()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/transactionAdjustmentPlanner.ts",
+      "source_location": "L251"
     },
     {
       "community": 211,
       "file_type": "code",
-      "id": "transactions_test_mockadmissionawareauth",
-      "label": "mockAdmissionAwareAuth()",
-      "norm_label": "mockadmissionawareauth()",
-      "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
-      "source_location": "L101"
+      "id": "transactionadjustmentplanner_roundstoredamount",
+      "label": "roundStoredAmount()",
+      "norm_label": "roundstoredamount()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/transactionAdjustmentPlanner.ts",
+      "source_location": "L148"
     },
     {
       "community": 211,
       "file_type": "code",
-      "id": "transactions_test_parsevalidator",
-      "label": "parseValidator()",
-      "norm_label": "parsevalidator()",
-      "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
-      "source_location": "L90"
+      "id": "transactionadjustmentplanner_stablestringify",
+      "label": "stableStringify()",
+      "norm_label": "stablestringify()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/transactionAdjustmentPlanner.ts",
+      "source_location": "L181"
     },
     {
       "community": 2110,
@@ -222345,110 +222405,110 @@
     {
       "community": 212,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_rollups_ts",
-      "label": "rollups.ts",
-      "norm_label": "rollups.ts",
-      "source_file": "packages/athena-webapp/convex/reports/rollups.ts",
+      "id": "packages_athena_webapp_convex_pos_public_transactions_test_ts",
+      "label": "transactions.test.ts",
+      "norm_label": "transactions.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
       "source_location": "L1"
     },
     {
       "community": 212,
       "file_type": "code",
-      "id": "rollups_adddaystodate",
-      "label": "addDaysToDate()",
-      "norm_label": "adddaystodate()",
-      "source_file": "packages/athena-webapp/convex/reports/rollups.ts",
-      "source_location": "L45"
+      "id": "transactions_test_createauthorizeditemadjustmentctx",
+      "label": "createAuthorizedItemAdjustmentCtx()",
+      "norm_label": "createauthorizeditemadjustmentctx()",
+      "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
+      "source_location": "L1783"
     },
     {
       "community": 212,
       "file_type": "code",
-      "id": "rollups_affectedperiodkeys",
-      "label": "affectedPeriodKeys()",
-      "norm_label": "affectedperiodkeys()",
-      "source_file": "packages/athena-webapp/convex/reports/rollups.ts",
-      "source_location": "L100"
+      "id": "transactions_test_createauthorizedsessioncompletionctx",
+      "label": "createAuthorizedSessionCompletionCtx()",
+      "norm_label": "createauthorizedsessioncompletionctx()",
+      "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
+      "source_location": "L1662"
     },
     {
       "community": 212,
       "file_type": "code",
-      "id": "rollups_aggregateskudays",
-      "label": "aggregateSkuDays()",
-      "norm_label": "aggregateskudays()",
-      "source_file": "packages/athena-webapp/convex/reports/rollups.ts",
-      "source_location": "L135"
+      "id": "transactions_test_createauthorizedvoidctx",
+      "label": "createAuthorizedVoidCtx()",
+      "norm_label": "createauthorizedvoidctx()",
+      "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
+      "source_location": "L1348"
     },
     {
       "community": 212,
       "file_type": "code",
-      "id": "rollups_formatoperatingdate",
-      "label": "formatOperatingDate()",
-      "norm_label": "formatoperatingdate()",
-      "source_file": "packages/athena-webapp/convex/reports/rollups.ts",
-      "source_location": "L41"
+      "id": "transactions_test_createctx",
+      "label": "createCtx()",
+      "norm_label": "createctx()",
+      "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
+      "source_location": "L1056"
     },
     {
       "community": 212,
       "file_type": "code",
-      "id": "rollups_isoweekstart",
-      "label": "isoWeekStart()",
-      "norm_label": "isoweekstart()",
-      "source_file": "packages/athena-webapp/convex/reports/rollups.ts",
-      "source_location": "L52"
+      "id": "transactions_test_createmembership",
+      "label": "createMembership()",
+      "norm_label": "createmembership()",
+      "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
+      "source_location": "L547"
     },
     {
       "community": 212,
       "file_type": "code",
-      "id": "rollups_measuresequal",
-      "label": "measuresEqual()",
-      "norm_label": "measuresequal()",
-      "source_file": "packages/athena-webapp/convex/reports/rollups.ts",
-      "source_location": "L164"
+      "id": "transactions_test_createstorepulsesummary",
+      "label": "createStorePulseSummary()",
+      "norm_label": "createstorepulsesummary()",
+      "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
+      "source_location": "L557"
     },
     {
       "community": 212,
       "file_type": "code",
-      "id": "rollups_perioddaterange",
-      "label": "periodDateRange()",
-      "norm_label": "perioddaterange()",
-      "source_file": "packages/athena-webapp/convex/reports/rollups.ts",
-      "source_location": "L63"
+      "id": "transactions_test_createtransactionauthctx",
+      "label": "createTransactionAuthCtx()",
+      "norm_label": "createtransactionauthctx()",
+      "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
+      "source_location": "L436"
     },
     {
       "community": 212,
       "file_type": "code",
-      "id": "rollups_rebuildperiodrollup",
-      "label": "rebuildPeriodRollup()",
-      "norm_label": "rebuildperiodrollup()",
-      "source_file": "packages/athena-webapp/convex/reports/rollups.ts",
-      "source_location": "L186"
+      "id": "transactions_test_exportreturns",
+      "label": "exportReturns()",
+      "norm_label": "exportreturns()",
+      "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
+      "source_location": "L86"
     },
     {
       "community": 212,
       "file_type": "code",
-      "id": "rollups_rebuildrollupsfordates",
-      "label": "rebuildRollupsForDates()",
-      "norm_label": "rebuildrollupsfordates()",
-      "source_file": "packages/athena-webapp/convex/reports/rollups.ts",
-      "source_location": "L261"
+      "id": "transactions_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
+      "source_location": "L121"
     },
     {
       "community": 212,
       "file_type": "code",
-      "id": "rollups_toutcdate",
-      "label": "toUtcDate()",
-      "norm_label": "toutcdate()",
-      "source_file": "packages/athena-webapp/convex/reports/rollups.ts",
-      "source_location": "L37"
+      "id": "transactions_test_mockadmissionawareauth",
+      "label": "mockAdmissionAwareAuth()",
+      "norm_label": "mockadmissionawareauth()",
+      "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
+      "source_location": "L101"
     },
     {
       "community": 212,
       "file_type": "code",
-      "id": "rollups_zeromeasures",
-      "label": "zeroMeasures()",
-      "norm_label": "zeromeasures()",
-      "source_file": "packages/athena-webapp/convex/reports/rollups.ts",
-      "source_location": "L116"
+      "id": "transactions_test_parsevalidator",
+      "label": "parseValidator()",
+      "norm_label": "parsevalidator()",
+      "source_file": "packages/athena-webapp/convex/pos/public/transactions.test.ts",
+      "source_location": "L90"
     },
     {
       "community": 2120,
@@ -222543,110 +222603,110 @@
     {
       "community": 213,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_skumovementrange_ts",
-      "label": "skuMovementRange.ts",
-      "norm_label": "skumovementrange.ts",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.ts",
+      "id": "packages_athena_webapp_convex_reports_rollups_ts",
+      "label": "rollups.ts",
+      "norm_label": "rollups.ts",
+      "source_file": "packages/athena-webapp/convex/reports/rollups.ts",
       "source_location": "L1"
     },
     {
       "community": 213,
       "file_type": "code",
-      "id": "skumovementrange_aggregatemovementsourceday",
-      "label": "aggregateMovementSourceDay()",
-      "norm_label": "aggregatemovementsourceday()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.ts",
-      "source_location": "L183"
+      "id": "rollups_adddaystodate",
+      "label": "addDaysToDate()",
+      "norm_label": "adddaystodate()",
+      "source_file": "packages/athena-webapp/convex/reports/rollups.ts",
+      "source_location": "L45"
     },
     {
       "community": 213,
       "file_type": "code",
-      "id": "skumovementrange_ensuremovementrangecore",
-      "label": "ensureMovementRangeCore()",
-      "norm_label": "ensuremovementrangecore()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.ts",
-      "source_location": "L480"
+      "id": "rollups_affectedperiodkeys",
+      "label": "affectedPeriodKeys()",
+      "norm_label": "affectedperiodkeys()",
+      "source_file": "packages/athena-webapp/convex/reports/rollups.ts",
+      "source_location": "L100"
     },
     {
       "community": 213,
       "file_type": "code",
-      "id": "skumovementrange_movementretrybackoffms",
-      "label": "movementRetryBackoffMs()",
-      "norm_label": "movementretrybackoffms()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.ts",
-      "source_location": "L585"
+      "id": "rollups_aggregateskudays",
+      "label": "aggregateSkuDays()",
+      "norm_label": "aggregateskudays()",
+      "source_file": "packages/athena-webapp/convex/reports/rollups.ts",
+      "source_location": "L135"
     },
     {
       "community": 213,
       "file_type": "code",
-      "id": "skumovementrange_readablemovementheader",
-      "label": "readableMovementHeader()",
-      "norm_label": "readablemovementheader()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.ts",
-      "source_location": "L673"
+      "id": "rollups_formatoperatingdate",
+      "label": "formatOperatingDate()",
+      "norm_label": "formatoperatingdate()",
+      "source_file": "packages/athena-webapp/convex/reports/rollups.ts",
+      "source_location": "L41"
     },
     {
       "community": 213,
       "file_type": "code",
-      "id": "skumovementrange_readmovementrevisionvector",
-      "label": "readMovementRevisionVector()",
-      "norm_label": "readmovementrevisionvector()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.ts",
-      "source_location": "L427"
+      "id": "rollups_isoweekstart",
+      "label": "isoWeekStart()",
+      "norm_label": "isoweekstart()",
+      "source_file": "packages/athena-webapp/convex/reports/rollups.ts",
+      "source_location": "L52"
     },
     {
       "community": 213,
       "file_type": "code",
-      "id": "skumovementrange_recordmovementworkerfailurecore",
-      "label": "recordMovementWorkerFailureCore()",
-      "norm_label": "recordmovementworkerfailurecore()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.ts",
-      "source_location": "L595"
+      "id": "rollups_measuresequal",
+      "label": "measuresEqual()",
+      "norm_label": "measuresequal()",
+      "source_file": "packages/athena-webapp/convex/reports/rollups.ts",
+      "source_location": "L164"
     },
     {
       "community": 213,
       "file_type": "code",
-      "id": "skumovementrange_requirevalidmovementpage",
-      "label": "requireValidMovementPage()",
-      "norm_label": "requirevalidmovementpage()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.ts",
-      "source_location": "L722"
+      "id": "rollups_perioddaterange",
+      "label": "periodDateRange()",
+      "norm_label": "perioddaterange()",
+      "source_file": "packages/athena-webapp/convex/reports/rollups.ts",
+      "source_location": "L63"
     },
     {
       "community": 213,
       "file_type": "code",
-      "id": "skumovementrange_retryterminalmovementrequest",
-      "label": "retryTerminalMovementRequest()",
-      "norm_label": "retryterminalmovementrequest()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.ts",
-      "source_location": "L533"
+      "id": "rollups_rebuildperiodrollup",
+      "label": "rebuildPeriodRollup()",
+      "norm_label": "rebuildperiodrollup()",
+      "source_file": "packages/athena-webapp/convex/reports/rollups.ts",
+      "source_location": "L186"
     },
     {
       "community": 213,
       "file_type": "code",
-      "id": "skumovementrange_runmovementbatchcore",
-      "label": "runMovementBatchCore()",
-      "norm_label": "runmovementbatchcore()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.ts",
-      "source_location": "L564"
+      "id": "rollups_rebuildrollupsfordates",
+      "label": "rebuildRollupsForDates()",
+      "norm_label": "rebuildrollupsfordates()",
+      "source_file": "packages/athena-webapp/convex/reports/rollups.ts",
+      "source_location": "L261"
     },
     {
       "community": 213,
       "file_type": "code",
-      "id": "skumovementrange_runmovementrankingbatch",
-      "label": "runMovementRankingBatch()",
-      "norm_label": "runmovementrankingbatch()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.ts",
-      "source_location": "L246"
+      "id": "rollups_toutcdate",
+      "label": "toUtcDate()",
+      "norm_label": "toutcdate()",
+      "source_file": "packages/athena-webapp/convex/reports/rollups.ts",
+      "source_location": "L37"
     },
     {
       "community": 213,
       "file_type": "code",
-      "id": "skumovementrange_tryconsumemovementadmission",
-      "label": "tryConsumeMovementAdmission()",
-      "norm_label": "tryconsumemovementadmission()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.ts",
-      "source_location": "L446"
+      "id": "rollups_zeromeasures",
+      "label": "zeroMeasures()",
+      "norm_label": "zeromeasures()",
+      "source_file": "packages/athena-webapp/convex/reports/rollups.ts",
+      "source_location": "L116"
     },
     {
       "community": 2130,
@@ -222741,110 +222801,110 @@
     {
       "community": 214,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productstock_tsx",
-      "label": "ProductStock.tsx",
-      "norm_label": "productstock.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
+      "id": "packages_athena_webapp_convex_reports_skumovementrange_ts",
+      "label": "skuMovementRange.ts",
+      "norm_label": "skumovementrange.ts",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.ts",
       "source_location": "L1"
     },
     {
       "community": 214,
       "file_type": "code",
-      "id": "productstock_getconversionrequestid",
-      "label": "getConversionRequestId()",
-      "norm_label": "getconversionrequestid()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
-      "source_location": "L453"
+      "id": "skumovementrange_aggregatemovementsourceday",
+      "label": "aggregateMovementSourceDay()",
+      "norm_label": "aggregatemovementsourceday()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.ts",
+      "source_location": "L183"
     },
     {
       "community": 214,
       "file_type": "code",
-      "id": "productstock_getreservationtype",
-      "label": "getReservationType()",
-      "norm_label": "getreservationtype()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
-      "source_location": "L300"
+      "id": "skumovementrange_ensuremovementrangecore",
+      "label": "ensureMovementRangeCore()",
+      "norm_label": "ensuremovementrangecore()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.ts",
+      "source_location": "L480"
     },
     {
       "community": 214,
       "file_type": "code",
-      "id": "productstock_handleclick",
-      "label": "handleClick()",
-      "norm_label": "handleclick()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
-      "source_location": "L526"
+      "id": "skumovementrange_movementretrybackoffms",
+      "label": "movementRetryBackoffMs()",
+      "norm_label": "movementretrybackoffms()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.ts",
+      "source_location": "L585"
     },
     {
       "community": 214,
       "file_type": "code",
-      "id": "productstock_handlefinalize",
-      "label": "handleFinalize()",
-      "norm_label": "handlefinalize()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
-      "source_location": "L476"
+      "id": "skumovementrange_readablemovementheader",
+      "label": "readableMovementHeader()",
+      "norm_label": "readablemovementheader()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.ts",
+      "source_location": "L673"
     },
     {
       "community": 214,
       "file_type": "code",
-      "id": "productstock_handlelink",
-      "label": "handleLink()",
-      "norm_label": "handlelink()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
-      "source_location": "L866"
+      "id": "skumovementrange_readmovementrevisionvector",
+      "label": "readMovementRevisionVector()",
+      "norm_label": "readmovementrevisionvector()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.ts",
+      "source_location": "L427"
     },
     {
       "community": 214,
       "file_type": "code",
-      "id": "productstock_if",
-      "label": "if()",
-      "norm_label": "if()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
-      "source_location": "L1347"
+      "id": "skumovementrange_recordmovementworkerfailurecore",
+      "label": "recordMovementWorkerFailureCore()",
+      "norm_label": "recordmovementworkerfailurecore()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.ts",
+      "source_location": "L595"
     },
     {
       "community": 214,
       "file_type": "code",
-      "id": "productstock_isskureserved",
-      "label": "isSkuReserved()",
-      "norm_label": "isskureserved()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
-      "source_location": "L296"
+      "id": "skumovementrange_requirevalidmovementpage",
+      "label": "requireValidMovementPage()",
+      "norm_label": "requirevalidmovementpage()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.ts",
+      "source_location": "L722"
     },
     {
       "community": 214,
       "file_type": "code",
-      "id": "productstock_normalizecommandmessage",
-      "label": "normalizeCommandMessage()",
-      "norm_label": "normalizecommandmessage()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
-      "source_location": "L468"
+      "id": "skumovementrange_retryterminalmovementrequest",
+      "label": "retryTerminalMovementRequest()",
+      "norm_label": "retryterminalmovementrequest()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.ts",
+      "source_location": "L533"
     },
     {
       "community": 214,
       "file_type": "code",
-      "id": "productstock_patchvariantvisibility",
-      "label": "patchVariantVisibility()",
-      "norm_label": "patchvariantvisibility()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
-      "source_location": "L1390"
+      "id": "skumovementrange_runmovementbatchcore",
+      "label": "runMovementBatchCore()",
+      "norm_label": "runmovementbatchcore()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.ts",
+      "source_location": "L564"
     },
     {
       "community": 214,
       "file_type": "code",
-      "id": "productstock_resolvetrustedinventoryfinalizationpricingpolicy",
-      "label": "resolveTrustedInventoryFinalizationPricingPolicy()",
-      "norm_label": "resolvetrustedinventoryfinalizationpricingpolicy()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
-      "source_location": "L2145"
+      "id": "skumovementrange_runmovementrankingbatch",
+      "label": "runMovementRankingBatch()",
+      "norm_label": "runmovementrankingbatch()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.ts",
+      "source_location": "L246"
     },
     {
       "community": 214,
       "file_type": "code",
-      "id": "productstock_restock",
-      "label": "restock()",
-      "norm_label": "restock()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
-      "source_location": "L229"
+      "id": "skumovementrange_tryconsumemovementadmission",
+      "label": "tryConsumeMovementAdmission()",
+      "norm_label": "tryconsumemovementadmission()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.ts",
+      "source_location": "L446"
     },
     {
       "community": 2140,
@@ -222939,110 +222999,110 @@
     {
       "community": 215,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_skuactivityuntrustedsalesadapter_ts",
-      "label": "skuActivityUntrustedSalesAdapter.ts",
-      "norm_label": "skuactivityuntrustedsalesadapter.ts",
-      "source_file": "packages/athena-webapp/src/components/operations/skuActivityUntrustedSalesAdapter.ts",
+      "id": "packages_athena_webapp_src_components_add_product_productstock_tsx",
+      "label": "ProductStock.tsx",
+      "norm_label": "productstock.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L1"
     },
     {
       "community": 215,
       "file_type": "code",
-      "id": "skuactivityuntrustedsalesadapter_buildskuactivityuntrustedsalesviewmodel",
-      "label": "buildSkuActivityUntrustedSalesViewModel()",
-      "norm_label": "buildskuactivityuntrustedsalesviewmodel()",
-      "source_file": "packages/athena-webapp/src/components/operations/skuActivityUntrustedSalesAdapter.ts",
-      "source_location": "L260"
+      "id": "productstock_getconversionrequestid",
+      "label": "getConversionRequestId()",
+      "norm_label": "getconversionrequestid()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
+      "source_location": "L453"
     },
     {
       "community": 215,
       "file_type": "code",
-      "id": "skuactivityuntrustedsalesadapter_buildsourcerow",
-      "label": "buildSourceRow()",
-      "norm_label": "buildsourcerow()",
-      "source_file": "packages/athena-webapp/src/components/operations/skuActivityUntrustedSalesAdapter.ts",
-      "source_location": "L197"
+      "id": "productstock_getreservationtype",
+      "label": "getReservationType()",
+      "norm_label": "getreservationtype()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
+      "source_location": "L300"
     },
     {
       "community": 215,
       "file_type": "code",
-      "id": "skuactivityuntrustedsalesadapter_buildtransactionrow",
-      "label": "buildTransactionRow()",
-      "norm_label": "buildtransactionrow()",
-      "source_file": "packages/athena-webapp/src/components/operations/skuActivityUntrustedSalesAdapter.ts",
-      "source_location": "L220"
+      "id": "productstock_handleclick",
+      "label": "handleClick()",
+      "norm_label": "handleclick()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
+      "source_location": "L526"
     },
     {
       "community": 215,
       "file_type": "code",
-      "id": "skuactivityuntrustedsalesadapter_capitalizewords",
-      "label": "capitalizeWords()",
-      "norm_label": "capitalizewords()",
-      "source_file": "packages/athena-webapp/src/components/operations/skuActivityUntrustedSalesAdapter.ts",
-      "source_location": "L138"
+      "id": "productstock_handlefinalize",
+      "label": "handleFinalize()",
+      "norm_label": "handlefinalize()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
+      "source_location": "L476"
     },
     {
       "community": 215,
       "file_type": "code",
-      "id": "skuactivityuntrustedsalesadapter_formatevidencelabel",
-      "label": "formatEvidenceLabel()",
-      "norm_label": "formatevidencelabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/skuActivityUntrustedSalesAdapter.ts",
-      "source_location": "L152"
+      "id": "productstock_handlelink",
+      "label": "handleLink()",
+      "norm_label": "handlelink()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
+      "source_location": "L866"
     },
     {
       "community": 215,
       "file_type": "code",
-      "id": "skuactivityuntrustedsalesadapter_formatproductname",
-      "label": "formatProductName()",
-      "norm_label": "formatproductname()",
-      "source_file": "packages/athena-webapp/src/components/operations/skuActivityUntrustedSalesAdapter.ts",
-      "source_location": "L193"
+      "id": "productstock_if",
+      "label": "if()",
+      "norm_label": "if()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
+      "source_location": "L1347"
     },
     {
       "community": 215,
       "file_type": "code",
-      "id": "skuactivityuntrustedsalesadapter_getemptymessage",
-      "label": "getEmptyMessage()",
-      "norm_label": "getemptymessage()",
-      "source_file": "packages/athena-webapp/src/components/operations/skuActivityUntrustedSalesAdapter.ts",
-      "source_location": "L249"
+      "id": "productstock_isskureserved",
+      "label": "isSkuReserved()",
+      "norm_label": "isskureserved()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
+      "source_location": "L296"
     },
     {
       "community": 215,
       "file_type": "code",
-      "id": "skuactivityuntrustedsalesadapter_getlookuplabel",
-      "label": "getLookupLabel()",
-      "norm_label": "getlookuplabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/skuActivityUntrustedSalesAdapter.ts",
-      "source_location": "L185"
+      "id": "productstock_normalizecommandmessage",
+      "label": "normalizeCommandMessage()",
+      "norm_label": "normalizecommandmessage()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
+      "source_location": "L468"
     },
     {
       "community": 215,
       "file_type": "code",
-      "id": "skuactivityuntrustedsalesadapter_getuntrustedsourcetypelabel",
-      "label": "getUntrustedSourceTypeLabel()",
-      "norm_label": "getuntrustedsourcetypelabel()",
-      "source_file": "packages/athena-webapp/src/components/operations/skuActivityUntrustedSalesAdapter.ts",
-      "source_location": "L177"
+      "id": "productstock_patchvariantvisibility",
+      "label": "patchVariantVisibility()",
+      "norm_label": "patchvariantvisibility()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
+      "source_location": "L1390"
     },
     {
       "community": 215,
       "file_type": "code",
-      "id": "skuactivityuntrustedsalesadapter_pluralize",
-      "label": "pluralize()",
-      "norm_label": "pluralize()",
-      "source_file": "packages/athena-webapp/src/components/operations/skuActivityUntrustedSalesAdapter.ts",
-      "source_location": "L148"
+      "id": "productstock_resolvetrustedinventoryfinalizationpricingpolicy",
+      "label": "resolveTrustedInventoryFinalizationPricingPolicy()",
+      "norm_label": "resolvetrustedinventoryfinalizationpricingpolicy()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
+      "source_location": "L2145"
     },
     {
       "community": 215,
       "file_type": "code",
-      "id": "skuactivityuntrustedsalesadapter_sourcematchesfilter",
-      "label": "sourceMatchesFilter()",
-      "norm_label": "sourcematchesfilter()",
-      "source_file": "packages/athena-webapp/src/components/operations/skuActivityUntrustedSalesAdapter.ts",
-      "source_location": "L162"
+      "id": "productstock_restock",
+      "label": "restock()",
+      "norm_label": "restock()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
+      "source_location": "L229"
     },
     {
       "community": 2150,
@@ -223137,110 +223197,110 @@
     {
       "community": 216,
       "file_type": "code",
-      "id": "ordersummary_clearattemptedordersummaryautoprintreceiptkeysfortest",
-      "label": "clearAttemptedOrderSummaryAutoPrintReceiptKeysForTest()",
-      "norm_label": "clearattemptedordersummaryautoprintreceiptkeysfortest()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L175"
-    },
-    {
-      "community": 216,
-      "file_type": "code",
-      "id": "ordersummary_formatproductlinemeta",
-      "label": "formatProductLineMeta()",
-      "norm_label": "formatproductlinemeta()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L91"
-    },
-    {
-      "community": 216,
-      "file_type": "code",
-      "id": "ordersummary_formatreceiptwebsite",
-      "label": "formatReceiptWebsite()",
-      "norm_label": "formatreceiptwebsite()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L35"
-    },
-    {
-      "community": 216,
-      "file_type": "code",
-      "id": "ordersummary_formatregistersummaryvalue",
-      "label": "formatRegisterSummaryValue()",
-      "norm_label": "formatregistersummaryvalue()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L179"
-    },
-    {
-      "community": 216,
-      "file_type": "code",
-      "id": "ordersummary_formatservicelabel",
-      "label": "formatServiceLabel()",
-      "norm_label": "formatservicelabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L72"
-    },
-    {
-      "community": 216,
-      "file_type": "code",
-      "id": "ordersummary_formatservicelinemeta",
-      "label": "formatServiceLineMeta()",
-      "norm_label": "formatservicelinemeta()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L77"
-    },
-    {
-      "community": 216,
-      "file_type": "code",
-      "id": "ordersummary_handlecompletetransaction",
-      "label": "handleCompleteTransaction()",
-      "norm_label": "handlecompletetransaction()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L546"
-    },
-    {
-      "community": 216,
-      "file_type": "code",
-      "id": "ordersummary_handleeditingpaymentidchange",
-      "label": "handleEditingPaymentIdChange()",
-      "norm_label": "handleeditingpaymentidchange()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L579"
-    },
-    {
-      "community": 216,
-      "file_type": "code",
-      "id": "ordersummary_handleselectedpaymentmethodchange",
-      "label": "handleSelectedPaymentMethodChange()",
-      "norm_label": "handleselectedpaymentmethodchange()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L569"
-    },
-    {
-      "community": 216,
-      "file_type": "code",
-      "id": "ordersummary_handlestartnewtransaction",
-      "label": "handleStartNewTransaction()",
-      "norm_label": "handlestartnewtransaction()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L563"
-    },
-    {
-      "community": 216,
-      "file_type": "code",
-      "id": "ordersummary_parsereceiptlocation",
-      "label": "parseReceiptLocation()",
-      "norm_label": "parsereceiptlocation()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L41"
-    },
-    {
-      "community": 216,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
-      "label": "OrderSummary.tsx",
-      "norm_label": "ordersummary.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "id": "packages_athena_webapp_src_components_operations_skuactivityuntrustedsalesadapter_ts",
+      "label": "skuActivityUntrustedSalesAdapter.ts",
+      "norm_label": "skuactivityuntrustedsalesadapter.ts",
+      "source_file": "packages/athena-webapp/src/components/operations/skuActivityUntrustedSalesAdapter.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 216,
+      "file_type": "code",
+      "id": "skuactivityuntrustedsalesadapter_buildskuactivityuntrustedsalesviewmodel",
+      "label": "buildSkuActivityUntrustedSalesViewModel()",
+      "norm_label": "buildskuactivityuntrustedsalesviewmodel()",
+      "source_file": "packages/athena-webapp/src/components/operations/skuActivityUntrustedSalesAdapter.ts",
+      "source_location": "L260"
+    },
+    {
+      "community": 216,
+      "file_type": "code",
+      "id": "skuactivityuntrustedsalesadapter_buildsourcerow",
+      "label": "buildSourceRow()",
+      "norm_label": "buildsourcerow()",
+      "source_file": "packages/athena-webapp/src/components/operations/skuActivityUntrustedSalesAdapter.ts",
+      "source_location": "L197"
+    },
+    {
+      "community": 216,
+      "file_type": "code",
+      "id": "skuactivityuntrustedsalesadapter_buildtransactionrow",
+      "label": "buildTransactionRow()",
+      "norm_label": "buildtransactionrow()",
+      "source_file": "packages/athena-webapp/src/components/operations/skuActivityUntrustedSalesAdapter.ts",
+      "source_location": "L220"
+    },
+    {
+      "community": 216,
+      "file_type": "code",
+      "id": "skuactivityuntrustedsalesadapter_capitalizewords",
+      "label": "capitalizeWords()",
+      "norm_label": "capitalizewords()",
+      "source_file": "packages/athena-webapp/src/components/operations/skuActivityUntrustedSalesAdapter.ts",
+      "source_location": "L138"
+    },
+    {
+      "community": 216,
+      "file_type": "code",
+      "id": "skuactivityuntrustedsalesadapter_formatevidencelabel",
+      "label": "formatEvidenceLabel()",
+      "norm_label": "formatevidencelabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/skuActivityUntrustedSalesAdapter.ts",
+      "source_location": "L152"
+    },
+    {
+      "community": 216,
+      "file_type": "code",
+      "id": "skuactivityuntrustedsalesadapter_formatproductname",
+      "label": "formatProductName()",
+      "norm_label": "formatproductname()",
+      "source_file": "packages/athena-webapp/src/components/operations/skuActivityUntrustedSalesAdapter.ts",
+      "source_location": "L193"
+    },
+    {
+      "community": 216,
+      "file_type": "code",
+      "id": "skuactivityuntrustedsalesadapter_getemptymessage",
+      "label": "getEmptyMessage()",
+      "norm_label": "getemptymessage()",
+      "source_file": "packages/athena-webapp/src/components/operations/skuActivityUntrustedSalesAdapter.ts",
+      "source_location": "L249"
+    },
+    {
+      "community": 216,
+      "file_type": "code",
+      "id": "skuactivityuntrustedsalesadapter_getlookuplabel",
+      "label": "getLookupLabel()",
+      "norm_label": "getlookuplabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/skuActivityUntrustedSalesAdapter.ts",
+      "source_location": "L185"
+    },
+    {
+      "community": 216,
+      "file_type": "code",
+      "id": "skuactivityuntrustedsalesadapter_getuntrustedsourcetypelabel",
+      "label": "getUntrustedSourceTypeLabel()",
+      "norm_label": "getuntrustedsourcetypelabel()",
+      "source_file": "packages/athena-webapp/src/components/operations/skuActivityUntrustedSalesAdapter.ts",
+      "source_location": "L177"
+    },
+    {
+      "community": 216,
+      "file_type": "code",
+      "id": "skuactivityuntrustedsalesadapter_pluralize",
+      "label": "pluralize()",
+      "norm_label": "pluralize()",
+      "source_file": "packages/athena-webapp/src/components/operations/skuActivityUntrustedSalesAdapter.ts",
+      "source_location": "L148"
+    },
+    {
+      "community": 216,
+      "file_type": "code",
+      "id": "skuactivityuntrustedsalesadapter_sourcematchesfilter",
+      "label": "sourceMatchesFilter()",
+      "norm_label": "sourcematchesfilter()",
+      "source_file": "packages/athena-webapp/src/components/operations/skuActivityUntrustedSalesAdapter.ts",
+      "source_location": "L162"
     },
     {
       "community": 2160,
@@ -223335,110 +223395,110 @@
     {
       "community": 217,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reports_reportunitsmovedchartsheet_tsx",
-      "label": "ReportUnitsMovedChartSheet.tsx",
-      "norm_label": "reportunitsmovedchartsheet.tsx",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
+      "id": "ordersummary_clearattemptedordersummaryautoprintreceiptkeysfortest",
+      "label": "clearAttemptedOrderSummaryAutoPrintReceiptKeysForTest()",
+      "norm_label": "clearattemptedordersummaryautoprintreceiptkeysfortest()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L175"
+    },
+    {
+      "community": 217,
+      "file_type": "code",
+      "id": "ordersummary_formatproductlinemeta",
+      "label": "formatProductLineMeta()",
+      "norm_label": "formatproductlinemeta()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L91"
+    },
+    {
+      "community": 217,
+      "file_type": "code",
+      "id": "ordersummary_formatreceiptwebsite",
+      "label": "formatReceiptWebsite()",
+      "norm_label": "formatreceiptwebsite()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L35"
+    },
+    {
+      "community": 217,
+      "file_type": "code",
+      "id": "ordersummary_formatregistersummaryvalue",
+      "label": "formatRegisterSummaryValue()",
+      "norm_label": "formatregistersummaryvalue()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L179"
+    },
+    {
+      "community": 217,
+      "file_type": "code",
+      "id": "ordersummary_formatservicelabel",
+      "label": "formatServiceLabel()",
+      "norm_label": "formatservicelabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L72"
+    },
+    {
+      "community": 217,
+      "file_type": "code",
+      "id": "ordersummary_formatservicelinemeta",
+      "label": "formatServiceLineMeta()",
+      "norm_label": "formatservicelinemeta()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L77"
+    },
+    {
+      "community": 217,
+      "file_type": "code",
+      "id": "ordersummary_handlecompletetransaction",
+      "label": "handleCompleteTransaction()",
+      "norm_label": "handlecompletetransaction()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L546"
+    },
+    {
+      "community": 217,
+      "file_type": "code",
+      "id": "ordersummary_handleeditingpaymentidchange",
+      "label": "handleEditingPaymentIdChange()",
+      "norm_label": "handleeditingpaymentidchange()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L579"
+    },
+    {
+      "community": 217,
+      "file_type": "code",
+      "id": "ordersummary_handleselectedpaymentmethodchange",
+      "label": "handleSelectedPaymentMethodChange()",
+      "norm_label": "handleselectedpaymentmethodchange()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L569"
+    },
+    {
+      "community": 217,
+      "file_type": "code",
+      "id": "ordersummary_handlestartnewtransaction",
+      "label": "handleStartNewTransaction()",
+      "norm_label": "handlestartnewtransaction()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L563"
+    },
+    {
+      "community": 217,
+      "file_type": "code",
+      "id": "ordersummary_parsereceiptlocation",
+      "label": "parseReceiptLocation()",
+      "norm_label": "parsereceiptlocation()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L41"
+    },
+    {
+      "community": 217,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
+      "label": "OrderSummary.tsx",
+      "norm_label": "ordersummary.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 217,
-      "file_type": "code",
-      "id": "reportunitsmovedchartsheet_capturescrollposition",
-      "label": "captureScrollPosition()",
-      "norm_label": "capturescrollposition()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
-      "source_location": "L339"
-    },
-    {
-      "community": 217,
-      "file_type": "code",
-      "id": "reportunitsmovedchartsheet_formatnetunitsmoved",
-      "label": "formatNetUnitsMoved()",
-      "norm_label": "formatnetunitsmoved()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
-      "source_location": "L85"
-    },
-    {
-      "community": 217,
-      "file_type": "code",
-      "id": "reportunitsmovedchartsheet_handleretry",
-      "label": "handleRetry()",
-      "norm_label": "handleretry()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
-      "source_location": "L529"
-    },
-    {
-      "community": 217,
-      "file_type": "code",
-      "id": "reportunitsmovedchartsheet_handleskulinkclick",
-      "label": "handleSkuLinkClick()",
-      "norm_label": "handleskulinkclick()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
-      "source_location": "L597"
-    },
-    {
-      "community": 217,
-      "file_type": "code",
-      "id": "reportunitsmovedchartsheet_movementbarradius",
-      "label": "movementBarRadius()",
-      "norm_label": "movementbarradius()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
-      "source_location": "L102"
-    },
-    {
-      "community": 217,
-      "file_type": "code",
-      "id": "reportunitsmovedchartsheet_movementchartdomain",
-      "label": "movementChartDomain()",
-      "norm_label": "movementchartdomain()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
-      "source_location": "L109"
-    },
-    {
-      "community": 217,
-      "file_type": "code",
-      "id": "reportunitsmovedchartsheet_netunitsmovedaccessiblephrase",
-      "label": "netUnitsMovedAccessiblePhrase()",
-      "norm_label": "netunitsmovedaccessiblephrase()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
-      "source_location": "L92"
-    },
-    {
-      "community": 217,
-      "file_type": "code",
-      "id": "reportunitsmovedchartsheet_setactivetab",
-      "label": "setActiveTab()",
-      "norm_label": "setactivetab()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
-      "source_location": "L331"
-    },
-    {
-      "community": 217,
-      "file_type": "code",
-      "id": "reportunitsmovedchartsheet_setgranularpage",
-      "label": "setGranularPage()",
-      "norm_label": "setgranularpage()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
-      "source_location": "L335"
-    },
-    {
-      "community": 217,
-      "file_type": "code",
-      "id": "reportunitsmovedchartsheet_setisopen",
-      "label": "setIsOpen()",
-      "norm_label": "setisopen()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
-      "source_location": "L317"
-    },
-    {
-      "community": 217,
-      "file_type": "code",
-      "id": "reportunitsmovedchartsheet_unitmovementmetadata",
-      "label": "unitMovementMetadata()",
-      "norm_label": "unitmovementmetadata()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
-      "source_location": "L132"
     },
     {
       "community": 2170,
@@ -223533,110 +223593,110 @@
     {
       "community": 218,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_servicesworkspaceview_tsx",
-      "label": "ServicesWorkspaceView.tsx",
-      "norm_label": "servicesworkspaceview.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
+      "id": "packages_athena_webapp_src_components_reports_reportunitsmovedchartsheet_tsx",
+      "label": "ReportUnitsMovedChartSheet.tsx",
+      "norm_label": "reportunitsmovedchartsheet.tsx",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
       "source_location": "L1"
     },
     {
       "community": 218,
       "file_type": "code",
-      "id": "servicesworkspaceview_detailrow",
-      "label": "DetailRow()",
-      "norm_label": "detailrow()",
-      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
-      "source_location": "L106"
+      "id": "reportunitsmovedchartsheet_capturescrollposition",
+      "label": "captureScrollPosition()",
+      "norm_label": "capturescrollposition()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
+      "source_location": "L339"
     },
     {
       "community": 218,
       "file_type": "code",
-      "id": "servicesworkspaceview_formatdeposit",
-      "label": "formatDeposit()",
-      "norm_label": "formatdeposit()",
-      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
-      "source_location": "L77"
+      "id": "reportunitsmovedchartsheet_formatnetunitsmoved",
+      "label": "formatNetUnitsMoved()",
+      "norm_label": "formatnetunitsmoved()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
+      "source_location": "L85"
     },
     {
       "community": 218,
       "file_type": "code",
-      "id": "servicesworkspaceview_formatmoney",
-      "label": "formatMoney()",
-      "norm_label": "formatmoney()",
-      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
-      "source_location": "L67"
+      "id": "reportunitsmovedchartsheet_handleretry",
+      "label": "handleRetry()",
+      "norm_label": "handleretry()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
+      "source_location": "L529"
     },
     {
       "community": 218,
       "file_type": "code",
-      "id": "servicesworkspaceview_handlecanceledit",
-      "label": "handleCancelEdit()",
-      "norm_label": "handlecanceledit()",
-      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
-      "source_location": "L464"
+      "id": "reportunitsmovedchartsheet_handleskulinkclick",
+      "label": "handleSkuLinkClick()",
+      "norm_label": "handleskulinkclick()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
+      "source_location": "L597"
     },
     {
       "community": 218,
       "file_type": "code",
-      "id": "servicesworkspaceview_handlechange",
-      "label": "handleChange()",
-      "norm_label": "handlechange()",
-      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
-      "source_location": "L441"
+      "id": "reportunitsmovedchartsheet_movementbarradius",
+      "label": "movementBarRadius()",
+      "norm_label": "movementbarradius()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
+      "source_location": "L102"
     },
     {
       "community": 218,
       "file_type": "code",
-      "id": "servicesworkspaceview_handleedit",
-      "label": "handleEdit()",
-      "norm_label": "handleedit()",
-      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
-      "source_location": "L454"
+      "id": "reportunitsmovedchartsheet_movementchartdomain",
+      "label": "movementChartDomain()",
+      "norm_label": "movementchartdomain()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
+      "source_location": "L109"
     },
     {
       "community": 218,
       "file_type": "code",
-      "id": "servicesworkspaceview_handlesaveedit",
-      "label": "handleSaveEdit()",
-      "norm_label": "handlesaveedit()",
-      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
-      "source_location": "L470"
+      "id": "reportunitsmovedchartsheet_netunitsmovedaccessiblephrase",
+      "label": "netUnitsMovedAccessiblePhrase()",
+      "norm_label": "netunitsmovedaccessiblephrase()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
+      "source_location": "L92"
     },
     {
       "community": 218,
       "file_type": "code",
-      "id": "servicesworkspaceview_handleselectservice",
-      "label": "handleSelectService()",
-      "norm_label": "handleselectservice()",
-      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
-      "source_location": "L437"
+      "id": "reportunitsmovedchartsheet_setactivetab",
+      "label": "setActiveTab()",
+      "norm_label": "setactivetab()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
+      "source_location": "L331"
     },
     {
       "community": 218,
       "file_type": "code",
-      "id": "servicesworkspaceview_serviceeditform",
-      "label": "ServiceEditForm()",
-      "norm_label": "serviceeditform()",
-      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
-      "source_location": "L117"
+      "id": "reportunitsmovedchartsheet_setgranularpage",
+      "label": "setGranularPage()",
+      "norm_label": "setgranularpage()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
+      "source_location": "L335"
     },
     {
       "community": 218,
       "file_type": "code",
-      "id": "servicesworkspaceview_sortservices",
-      "label": "sortServices()",
-      "norm_label": "sortservices()",
-      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
-      "source_location": "L98"
+      "id": "reportunitsmovedchartsheet_setisopen",
+      "label": "setIsOpen()",
+      "norm_label": "setisopen()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
+      "source_location": "L317"
     },
     {
       "community": 218,
       "file_type": "code",
-      "id": "servicesworkspaceview_summarizeservice",
-      "label": "summarizeService()",
-      "norm_label": "summarizeservice()",
-      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
-      "source_location": "L89"
+      "id": "reportunitsmovedchartsheet_unitmovementmetadata",
+      "label": "unitMovementMetadata()",
+      "norm_label": "unitmovementmetadata()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportUnitsMovedChartSheet.tsx",
+      "source_location": "L132"
     },
     {
       "community": 2180,
@@ -223731,110 +223791,110 @@
     {
       "community": 219,
       "file_type": "code",
-      "id": "inventoryimportparser_normalizekey",
-      "label": "normalizeKey()",
-      "norm_label": "normalizekey()",
-      "source_file": "packages/athena-webapp/src/lib/inventory-import/inventoryImportParser.ts",
-      "source_location": "L212"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "inventoryimportparser_normalizelegacyrow",
-      "label": "normalizeLegacyRow()",
-      "norm_label": "normalizelegacyrow()",
-      "source_file": "packages/athena-webapp/src/lib/inventory-import/inventoryImportParser.ts",
-      "source_location": "L108"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "inventoryimportparser_normalizelegacyrows",
-      "label": "normalizeLegacyRows()",
-      "norm_label": "normalizelegacyrows()",
-      "source_file": "packages/athena-webapp/src/lib/inventory-import/inventoryImportParser.ts",
-      "source_location": "L91"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "inventoryimportparser_parseinventoryimportcontent",
-      "label": "parseInventoryImportContent()",
-      "norm_label": "parseinventoryimportcontent()",
-      "source_file": "packages/athena-webapp/src/lib/inventory-import/inventoryImportParser.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "inventoryimportparser_readinteger",
-      "label": "readInteger()",
-      "norm_label": "readinteger()",
-      "source_file": "packages/athena-webapp/src/lib/inventory-import/inventoryImportParser.ts",
-      "source_location": "L174"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "inventoryimportparser_readmoney",
-      "label": "readMoney()",
-      "norm_label": "readmoney()",
-      "source_file": "packages/athena-webapp/src/lib/inventory-import/inventoryImportParser.ts",
-      "source_location": "L162"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "inventoryimportparser_readoptionalmoney",
-      "label": "readOptionalMoney()",
-      "norm_label": "readoptionalmoney()",
-      "source_file": "packages/athena-webapp/src/lib/inventory-import/inventoryImportParser.ts",
-      "source_location": "L168"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "inventoryimportparser_readoptionalnumber",
-      "label": "readOptionalNumber()",
-      "norm_label": "readoptionalnumber()",
-      "source_file": "packages/athena-webapp/src/lib/inventory-import/inventoryImportParser.ts",
-      "source_location": "L182"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "inventoryimportparser_readstatus",
-      "label": "readStatus()",
-      "norm_label": "readstatus()",
-      "source_file": "packages/athena-webapp/src/lib/inventory-import/inventoryImportParser.ts",
-      "source_location": "L189"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "inventoryimportparser_readstring",
-      "label": "readString()",
-      "norm_label": "readstring()",
-      "source_file": "packages/athena-webapp/src/lib/inventory-import/inventoryImportParser.ts",
-      "source_location": "L141"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "inventoryimportparser_readvalue",
-      "label": "readValue()",
-      "norm_label": "readvalue()",
-      "source_file": "packages/athena-webapp/src/lib/inventory-import/inventoryImportParser.ts",
-      "source_location": "L147"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_inventory_import_inventoryimportparser_ts",
-      "label": "inventoryImportParser.ts",
-      "norm_label": "inventoryimportparser.ts",
-      "source_file": "packages/athena-webapp/src/lib/inventory-import/inventoryImportParser.ts",
+      "id": "packages_athena_webapp_src_components_services_servicesworkspaceview_tsx",
+      "label": "ServicesWorkspaceView.tsx",
+      "norm_label": "servicesworkspaceview.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 219,
+      "file_type": "code",
+      "id": "servicesworkspaceview_detailrow",
+      "label": "DetailRow()",
+      "norm_label": "detailrow()",
+      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
+      "source_location": "L106"
+    },
+    {
+      "community": 219,
+      "file_type": "code",
+      "id": "servicesworkspaceview_formatdeposit",
+      "label": "formatDeposit()",
+      "norm_label": "formatdeposit()",
+      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
+      "source_location": "L77"
+    },
+    {
+      "community": 219,
+      "file_type": "code",
+      "id": "servicesworkspaceview_formatmoney",
+      "label": "formatMoney()",
+      "norm_label": "formatmoney()",
+      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
+      "source_location": "L67"
+    },
+    {
+      "community": 219,
+      "file_type": "code",
+      "id": "servicesworkspaceview_handlecanceledit",
+      "label": "handleCancelEdit()",
+      "norm_label": "handlecanceledit()",
+      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
+      "source_location": "L464"
+    },
+    {
+      "community": 219,
+      "file_type": "code",
+      "id": "servicesworkspaceview_handlechange",
+      "label": "handleChange()",
+      "norm_label": "handlechange()",
+      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
+      "source_location": "L441"
+    },
+    {
+      "community": 219,
+      "file_type": "code",
+      "id": "servicesworkspaceview_handleedit",
+      "label": "handleEdit()",
+      "norm_label": "handleedit()",
+      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
+      "source_location": "L454"
+    },
+    {
+      "community": 219,
+      "file_type": "code",
+      "id": "servicesworkspaceview_handlesaveedit",
+      "label": "handleSaveEdit()",
+      "norm_label": "handlesaveedit()",
+      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
+      "source_location": "L470"
+    },
+    {
+      "community": 219,
+      "file_type": "code",
+      "id": "servicesworkspaceview_handleselectservice",
+      "label": "handleSelectService()",
+      "norm_label": "handleselectservice()",
+      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
+      "source_location": "L437"
+    },
+    {
+      "community": 219,
+      "file_type": "code",
+      "id": "servicesworkspaceview_serviceeditform",
+      "label": "ServiceEditForm()",
+      "norm_label": "serviceeditform()",
+      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
+      "source_location": "L117"
+    },
+    {
+      "community": 219,
+      "file_type": "code",
+      "id": "servicesworkspaceview_sortservices",
+      "label": "sortServices()",
+      "norm_label": "sortservices()",
+      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
+      "source_location": "L98"
+    },
+    {
+      "community": 219,
+      "file_type": "code",
+      "id": "servicesworkspaceview_summarizeservice",
+      "label": "summarizeService()",
+      "norm_label": "summarizeservice()",
+      "source_file": "packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx",
+      "source_location": "L89"
     },
     {
       "community": 2190,
@@ -224289,110 +224349,110 @@
     {
       "community": 220,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoragehealth_ts",
-      "label": "posLocalStorageHealth.ts",
-      "norm_label": "poslocalstoragehealth.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageHealth.ts",
-      "source_location": "L1"
+      "id": "inventoryimportparser_normalizekey",
+      "label": "normalizeKey()",
+      "norm_label": "normalizekey()",
+      "source_file": "packages/athena-webapp/src/lib/inventory-import/inventoryImportParser.ts",
+      "source_location": "L212"
     },
     {
       "community": 220,
       "file_type": "code",
-      "id": "poslocalstoragehealth_allowvalue",
-      "label": "allowValue()",
-      "norm_label": "allowvalue()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageHealth.ts",
-      "source_location": "L213"
+      "id": "inventoryimportparser_normalizelegacyrow",
+      "label": "normalizeLegacyRow()",
+      "norm_label": "normalizelegacyrow()",
+      "source_file": "packages/athena-webapp/src/lib/inventory-import/inventoryImportParser.ts",
+      "source_location": "L108"
     },
     {
       "community": 220,
       "file_type": "code",
-      "id": "poslocalstoragehealth_classifyposlocalledgerpressure",
-      "label": "classifyPosLocalLedgerPressure()",
-      "norm_label": "classifyposlocalledgerpressure()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageHealth.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 220,
-      "file_type": "code",
-      "id": "poslocalstoragehealth_classifypressure",
-      "label": "classifyPressure()",
-      "norm_label": "classifypressure()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageHealth.ts",
-      "source_location": "L43"
-    },
-    {
-      "community": 220,
-      "file_type": "code",
-      "id": "poslocalstoragehealth_observeposlocalstoragehealth",
-      "label": "observePosLocalStorageHealth()",
-      "norm_label": "observeposlocalstoragehealth()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageHealth.ts",
+      "id": "inventoryimportparser_normalizelegacyrows",
+      "label": "normalizeLegacyRows()",
+      "norm_label": "normalizelegacyrows()",
+      "source_file": "packages/athena-webapp/src/lib/inventory-import/inventoryImportParser.ts",
       "source_location": "L91"
     },
     {
       "community": 220,
       "file_type": "code",
-      "id": "poslocalstoragehealth_requestposlocalpersistentstorage",
-      "label": "requestPosLocalPersistentStorage()",
-      "norm_label": "requestposlocalpersistentstorage()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageHealth.ts",
-      "source_location": "L243"
+      "id": "inventoryimportparser_parseinventoryimportcontent",
+      "label": "parseInventoryImportContent()",
+      "norm_label": "parseinventoryimportcontent()",
+      "source_file": "packages/athena-webapp/src/lib/inventory-import/inventoryImportParser.ts",
+      "source_location": "L71"
     },
     {
       "community": 220,
       "file_type": "code",
-      "id": "poslocalstoragehealth_safecapacity",
-      "label": "safeCapacity()",
-      "norm_label": "safecapacity()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageHealth.ts",
-      "source_location": "L229"
+      "id": "inventoryimportparser_readinteger",
+      "label": "readInteger()",
+      "norm_label": "readinteger()",
+      "source_file": "packages/athena-webapp/src/lib/inventory-import/inventoryImportParser.ts",
+      "source_location": "L174"
     },
     {
       "community": 220,
       "file_type": "code",
-      "id": "poslocalstoragehealth_safeeventcount",
-      "label": "safeEventCount()",
-      "norm_label": "safeeventcount()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageHealth.ts",
-      "source_location": "L235"
+      "id": "inventoryimportparser_readmoney",
+      "label": "readMoney()",
+      "norm_label": "readmoney()",
+      "source_file": "packages/athena-webapp/src/lib/inventory-import/inventoryImportParser.ts",
+      "source_location": "L162"
     },
     {
       "community": 220,
       "file_type": "code",
-      "id": "poslocalstoragehealth_safetimestamp",
-      "label": "safeTimestamp()",
-      "norm_label": "safetimestamp()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageHealth.ts",
-      "source_location": "L223"
+      "id": "inventoryimportparser_readoptionalmoney",
+      "label": "readOptionalMoney()",
+      "norm_label": "readoptionalmoney()",
+      "source_file": "packages/athena-webapp/src/lib/inventory-import/inventoryImportParser.ts",
+      "source_location": "L168"
     },
     {
       "community": 220,
       "file_type": "code",
-      "id": "poslocalstoragehealth_storagehealthfreshness",
-      "label": "storageHealthFreshness()",
-      "norm_label": "storagehealthfreshness()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageHealth.ts",
-      "source_location": "L202"
+      "id": "inventoryimportparser_readoptionalnumber",
+      "label": "readOptionalNumber()",
+      "norm_label": "readoptionalnumber()",
+      "source_file": "packages/athena-webapp/src/lib/inventory-import/inventoryImportParser.ts",
+      "source_location": "L182"
     },
     {
       "community": 220,
       "file_type": "code",
-      "id": "poslocalstoragehealth_tosafeposlocalstoragehealthdiagnostic",
-      "label": "toSafePosLocalStorageHealthDiagnostic()",
-      "norm_label": "tosafeposlocalstoragehealthdiagnostic()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageHealth.ts",
-      "source_location": "L134"
+      "id": "inventoryimportparser_readstatus",
+      "label": "readStatus()",
+      "norm_label": "readstatus()",
+      "source_file": "packages/athena-webapp/src/lib/inventory-import/inventoryImportParser.ts",
+      "source_location": "L189"
     },
     {
       "community": 220,
       "file_type": "code",
-      "id": "poslocalstoragehealth_unknownenginehealth",
-      "label": "unknownEngineHealth()",
-      "norm_label": "unknownenginehealth()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageHealth.ts",
-      "source_location": "L190"
+      "id": "inventoryimportparser_readstring",
+      "label": "readString()",
+      "norm_label": "readstring()",
+      "source_file": "packages/athena-webapp/src/lib/inventory-import/inventoryImportParser.ts",
+      "source_location": "L141"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "inventoryimportparser_readvalue",
+      "label": "readValue()",
+      "norm_label": "readvalue()",
+      "source_file": "packages/athena-webapp/src/lib/inventory-import/inventoryImportParser.ts",
+      "source_location": "L147"
+    },
+    {
+      "community": 220,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_inventory_import_inventoryimportparser_ts",
+      "label": "inventoryImportParser.ts",
+      "norm_label": "inventoryimportparser.ts",
+      "source_file": "packages/athena-webapp/src/lib/inventory-import/inventoryImportParser.ts",
+      "source_location": "L1"
     },
     {
       "community": 2200,
@@ -224487,110 +224547,110 @@
     {
       "community": 221,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_ts",
-      "label": "useExpenseRegisterViewModel.ts",
-      "norm_label": "useexpenseregisterviewmodel.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoragehealth_ts",
+      "label": "posLocalStorageHealth.ts",
+      "norm_label": "poslocalstoragehealth.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageHealth.ts",
       "source_location": "L1"
     },
     {
       "community": 221,
       "file_type": "code",
-      "id": "useexpenseregisterviewmodel_createlocalexpenseeventid",
-      "label": "createLocalExpenseEventId()",
-      "norm_label": "createlocalexpenseeventid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
-      "source_location": "L65"
+      "id": "poslocalstoragehealth_allowvalue",
+      "label": "allowValue()",
+      "norm_label": "allowvalue()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageHealth.ts",
+      "source_location": "L213"
     },
     {
       "community": 221,
       "file_type": "code",
-      "id": "useexpenseregisterviewmodel_expenseitemsourcekey",
-      "label": "expenseItemSourceKey()",
-      "norm_label": "expenseitemsourcekey()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
-      "source_location": "L108"
+      "id": "poslocalstoragehealth_classifyposlocalledgerpressure",
+      "label": "classifyPosLocalLedgerPressure()",
+      "norm_label": "classifyposlocalledgerpressure()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageHealth.ts",
+      "source_location": "L62"
     },
     {
       "community": 221,
       "file_type": "code",
-      "id": "useexpenseregisterviewmodel_getcashierdisplayname",
-      "label": "getCashierDisplayName()",
-      "norm_label": "getcashierdisplayname()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
-      "source_location": "L44"
+      "id": "poslocalstoragehealth_classifypressure",
+      "label": "classifyPressure()",
+      "norm_label": "classifypressure()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageHealth.ts",
+      "source_location": "L43"
     },
     {
       "community": 221,
       "file_type": "code",
-      "id": "useexpenseregisterviewmodel_hasunrepresentedoptimisticexpensecartitem",
-      "label": "hasUnrepresentedOptimisticExpenseCartItem()",
-      "norm_label": "hasunrepresentedoptimisticexpensecartitem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
-      "source_location": "L146"
+      "id": "poslocalstoragehealth_observeposlocalstoragehealth",
+      "label": "observePosLocalStorageHealth()",
+      "norm_label": "observeposlocalstoragehealth()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageHealth.ts",
+      "source_location": "L91"
     },
     {
       "community": 221,
       "file_type": "code",
-      "id": "useexpenseregisterviewmodel_isexpenseproductcartitem",
-      "label": "isExpenseProductCartItem()",
-      "norm_label": "isexpenseproductcartitem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
-      "source_location": "L56"
+      "id": "poslocalstoragehealth_requestposlocalpersistentstorage",
+      "label": "requestPosLocalPersistentStorage()",
+      "norm_label": "requestposlocalpersistentstorage()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageHealth.ts",
+      "source_location": "L243"
     },
     {
       "community": 221,
       "file_type": "code",
-      "id": "useexpenseregisterviewmodel_ispendingoptimisticexpensecartitem",
-      "label": "isPendingOptimisticExpenseCartItem()",
-      "norm_label": "ispendingoptimisticexpensecartitem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
-      "source_location": "L126"
+      "id": "poslocalstoragehealth_safecapacity",
+      "label": "safeCapacity()",
+      "norm_label": "safecapacity()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageHealth.ts",
+      "source_location": "L229"
     },
     {
       "community": 221,
       "file_type": "code",
-      "id": "useexpenseregisterviewmodel_isscopedexpenselocalevent",
-      "label": "isScopedExpenseLocalEvent()",
-      "norm_label": "isscopedexpenselocalevent()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
-      "source_location": "L164"
+      "id": "poslocalstoragehealth_safeeventcount",
+      "label": "safeEventCount()",
+      "norm_label": "safeeventcount()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageHealth.ts",
+      "source_location": "L235"
     },
     {
       "community": 221,
       "file_type": "code",
-      "id": "useexpenseregisterviewmodel_localexpensesessionstostoresessions",
-      "label": "localExpenseSessionsToStoreSessions()",
-      "norm_label": "localexpensesessionstostoresessions()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
-      "source_location": "L102"
+      "id": "poslocalstoragehealth_safetimestamp",
+      "label": "safeTimestamp()",
+      "norm_label": "safetimestamp()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageHealth.ts",
+      "source_location": "L223"
     },
     {
       "community": 221,
       "file_type": "code",
-      "id": "useexpenseregisterviewmodel_localexpensesessiontostoresession",
-      "label": "localExpenseSessionToStoreSession()",
-      "norm_label": "localexpensesessiontostoresession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
-      "source_location": "L73"
+      "id": "poslocalstoragehealth_storagehealthfreshness",
+      "label": "storageHealthFreshness()",
+      "norm_label": "storagehealthfreshness()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageHealth.ts",
+      "source_location": "L202"
     },
     {
       "community": 221,
       "file_type": "code",
-      "id": "useexpenseregisterviewmodel_sessionitemrepresentscartitem",
-      "label": "sessionItemRepresentsCartItem()",
-      "norm_label": "sessionitemrepresentscartitem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
-      "source_location": "L130"
+      "id": "poslocalstoragehealth_tosafeposlocalstoragehealthdiagnostic",
+      "label": "toSafePosLocalStorageHealthDiagnostic()",
+      "norm_label": "tosafeposlocalstoragehealthdiagnostic()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageHealth.ts",
+      "source_location": "L134"
     },
     {
       "community": 221,
       "file_type": "code",
-      "id": "useexpenseregisterviewmodel_useexpenseregisterviewmodel",
-      "label": "useExpenseRegisterViewModel()",
-      "norm_label": "useexpenseregisterviewmodel()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
-      "source_location": "L193"
+      "id": "poslocalstoragehealth_unknownenginehealth",
+      "label": "unknownEngineHealth()",
+      "norm_label": "unknownenginehealth()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageHealth.ts",
+      "source_location": "L190"
     },
     {
       "community": 2210,
@@ -224685,110 +224745,110 @@
     {
       "community": 222,
       "file_type": "code",
-      "id": "guardrails_createsensitiveregionset",
-      "label": "createSensitiveRegionSet()",
-      "norm_label": "createsensitiveregionset()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/guardrails.ts",
-      "source_location": "L91"
-    },
-    {
-      "community": 222,
-      "file_type": "code",
-      "id": "guardrails_isfinitenumber",
-      "label": "isFiniteNumber()",
-      "norm_label": "isfinitenumber()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/guardrails.ts",
-      "source_location": "L254"
-    },
-    {
-      "community": 222,
-      "file_type": "code",
-      "id": "guardrails_ispointinsiderect",
-      "label": "isPointInsideRect()",
-      "norm_label": "ispointinsiderect()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/guardrails.ts",
-      "source_location": "L234"
-    },
-    {
-      "community": 222,
-      "file_type": "code",
-      "id": "guardrails_ispointinsideviewport",
-      "label": "isPointInsideViewport()",
-      "norm_label": "ispointinsideviewport()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/guardrails.ts",
-      "source_location": "L222"
-    },
-    {
-      "community": 222,
-      "file_type": "code",
-      "id": "guardrails_ispositivefinitenumber",
-      "label": "isPositiveFiniteNumber()",
-      "norm_label": "ispositivefinitenumber()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/guardrails.ts",
-      "source_location": "L258"
-    },
-    {
-      "community": 222,
-      "file_type": "code",
-      "id": "guardrails_isrecord",
-      "label": "isRecord()",
-      "norm_label": "isrecord()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/guardrails.ts",
-      "source_location": "L250"
-    },
-    {
-      "community": 222,
-      "file_type": "code",
-      "id": "guardrails_isvalidviewport",
-      "label": "isValidViewport()",
-      "norm_label": "isvalidviewport()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/guardrails.ts",
-      "source_location": "L243"
-    },
-    {
-      "community": 222,
-      "file_type": "code",
-      "id": "guardrails_masktextforremoteassist",
-      "label": "maskTextForRemoteAssist()",
-      "norm_label": "masktextforremoteassist()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/guardrails.ts",
-      "source_location": "L148"
-    },
-    {
-      "community": 222,
-      "file_type": "code",
-      "id": "guardrails_validatekeyevent",
-      "label": "validateKeyEvent()",
-      "norm_label": "validatekeyevent()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/guardrails.ts",
-      "source_location": "L198"
-    },
-    {
-      "community": 222,
-      "file_type": "code",
-      "id": "guardrails_validatepointerevent",
-      "label": "validatePointerEvent()",
-      "norm_label": "validatepointerevent()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/guardrails.ts",
-      "source_location": "L159"
-    },
-    {
-      "community": 222,
-      "file_type": "code",
-      "id": "guardrails_validateremoteassistcontrolevent",
-      "label": "validateRemoteAssistControlEvent()",
-      "norm_label": "validateremoteassistcontrolevent()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/guardrails.ts",
-      "source_location": "L124"
-    },
-    {
-      "community": 222,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_remote_assist_guardrails_ts",
-      "label": "guardrails.ts",
-      "norm_label": "guardrails.ts",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/guardrails.ts",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_ts",
+      "label": "useExpenseRegisterViewModel.ts",
+      "norm_label": "useexpenseregisterviewmodel.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 222,
+      "file_type": "code",
+      "id": "useexpenseregisterviewmodel_createlocalexpenseeventid",
+      "label": "createLocalExpenseEventId()",
+      "norm_label": "createlocalexpenseeventid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 222,
+      "file_type": "code",
+      "id": "useexpenseregisterviewmodel_expenseitemsourcekey",
+      "label": "expenseItemSourceKey()",
+      "norm_label": "expenseitemsourcekey()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
+      "source_location": "L108"
+    },
+    {
+      "community": 222,
+      "file_type": "code",
+      "id": "useexpenseregisterviewmodel_getcashierdisplayname",
+      "label": "getCashierDisplayName()",
+      "norm_label": "getcashierdisplayname()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
+      "source_location": "L44"
+    },
+    {
+      "community": 222,
+      "file_type": "code",
+      "id": "useexpenseregisterviewmodel_hasunrepresentedoptimisticexpensecartitem",
+      "label": "hasUnrepresentedOptimisticExpenseCartItem()",
+      "norm_label": "hasunrepresentedoptimisticexpensecartitem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
+      "source_location": "L146"
+    },
+    {
+      "community": 222,
+      "file_type": "code",
+      "id": "useexpenseregisterviewmodel_isexpenseproductcartitem",
+      "label": "isExpenseProductCartItem()",
+      "norm_label": "isexpenseproductcartitem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
+      "source_location": "L56"
+    },
+    {
+      "community": 222,
+      "file_type": "code",
+      "id": "useexpenseregisterviewmodel_ispendingoptimisticexpensecartitem",
+      "label": "isPendingOptimisticExpenseCartItem()",
+      "norm_label": "ispendingoptimisticexpensecartitem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
+      "source_location": "L126"
+    },
+    {
+      "community": 222,
+      "file_type": "code",
+      "id": "useexpenseregisterviewmodel_isscopedexpenselocalevent",
+      "label": "isScopedExpenseLocalEvent()",
+      "norm_label": "isscopedexpenselocalevent()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
+      "source_location": "L164"
+    },
+    {
+      "community": 222,
+      "file_type": "code",
+      "id": "useexpenseregisterviewmodel_localexpensesessionstostoresessions",
+      "label": "localExpenseSessionsToStoreSessions()",
+      "norm_label": "localexpensesessionstostoresessions()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
+      "source_location": "L102"
+    },
+    {
+      "community": 222,
+      "file_type": "code",
+      "id": "useexpenseregisterviewmodel_localexpensesessiontostoresession",
+      "label": "localExpenseSessionToStoreSession()",
+      "norm_label": "localexpensesessiontostoresession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 222,
+      "file_type": "code",
+      "id": "useexpenseregisterviewmodel_sessionitemrepresentscartitem",
+      "label": "sessionItemRepresentsCartItem()",
+      "norm_label": "sessionitemrepresentscartitem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
+      "source_location": "L130"
+    },
+    {
+      "community": 222,
+      "file_type": "code",
+      "id": "useexpenseregisterviewmodel_useexpenseregisterviewmodel",
+      "label": "useExpenseRegisterViewModel()",
+      "norm_label": "useexpenseregisterviewmodel()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts",
+      "source_location": "L193"
     },
     {
       "community": 2220,
@@ -224883,109 +224943,109 @@
     {
       "community": 223,
       "file_type": "code",
-      "id": "harness_mechanical_check_defaultreadpackagemanifest",
-      "label": "defaultReadPackageManifest()",
-      "norm_label": "defaultreadpackagemanifest()",
-      "source_file": "scripts/harness-mechanical-check.ts",
-      "source_location": "L180"
+      "id": "guardrails_createsensitiveregionset",
+      "label": "createSensitiveRegionSet()",
+      "norm_label": "createsensitiveregionset()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/guardrails.ts",
+      "source_location": "L91"
     },
     {
       "community": 223,
       "file_type": "code",
-      "id": "harness_mechanical_check_defaultrunpackagescript",
-      "label": "defaultRunPackageScript()",
-      "norm_label": "defaultrunpackagescript()",
-      "source_file": "scripts/harness-mechanical-check.ts",
-      "source_location": "L193"
+      "id": "guardrails_isfinitenumber",
+      "label": "isFiniteNumber()",
+      "norm_label": "isfinitenumber()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/guardrails.ts",
+      "source_location": "L254"
     },
     {
       "community": 223,
       "file_type": "code",
-      "id": "harness_mechanical_check_defaultrunrawcommand",
-      "label": "defaultRunRawCommand()",
-      "norm_label": "defaultrunrawcommand()",
-      "source_file": "scripts/harness-mechanical-check.ts",
-      "source_location": "L206"
+      "id": "guardrails_ispointinsiderect",
+      "label": "isPointInsideRect()",
+      "norm_label": "ispointinsiderect()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/guardrails.ts",
+      "source_location": "L234"
     },
     {
       "community": 223,
       "file_type": "code",
-      "id": "harness_mechanical_check_formatmechanicalcheckfailure",
-      "label": "formatMechanicalCheckFailure()",
-      "norm_label": "formatmechanicalcheckfailure()",
-      "source_file": "scripts/harness-mechanical-check.ts",
-      "source_location": "L293"
+      "id": "guardrails_ispointinsideviewport",
+      "label": "isPointInsideViewport()",
+      "norm_label": "ispointinsideviewport()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/guardrails.ts",
+      "source_location": "L222"
     },
     {
       "community": 223,
       "file_type": "code",
-      "id": "harness_mechanical_check_ismechanicalrawcommand",
-      "label": "isMechanicalRawCommand()",
-      "norm_label": "ismechanicalrawcommand()",
-      "source_file": "scripts/harness-mechanical-check.ts",
-      "source_location": "L40"
+      "id": "guardrails_ispositivefinitenumber",
+      "label": "isPositiveFiniteNumber()",
+      "norm_label": "ispositivefinitenumber()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/guardrails.ts",
+      "source_location": "L258"
     },
     {
       "community": 223,
       "file_type": "code",
-      "id": "harness_mechanical_check_ismechanicalscript",
-      "label": "isMechanicalScript()",
-      "norm_label": "ismechanicalscript()",
-      "source_file": "scripts/harness-mechanical-check.ts",
-      "source_location": "L95"
+      "id": "guardrails_isrecord",
+      "label": "isRecord()",
+      "norm_label": "isrecord()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/guardrails.ts",
+      "source_location": "L250"
     },
     {
       "community": 223,
       "file_type": "code",
-      "id": "harness_mechanical_check_main",
-      "label": "main()",
-      "norm_label": "main()",
-      "source_file": "scripts/harness-mechanical-check.ts",
-      "source_location": "L305"
+      "id": "guardrails_isvalidviewport",
+      "label": "isValidViewport()",
+      "norm_label": "isvalidviewport()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/guardrails.ts",
+      "source_location": "L243"
     },
     {
       "community": 223,
       "file_type": "code",
-      "id": "harness_mechanical_check_matchestouchedpath",
-      "label": "matchesTouchedPath()",
-      "norm_label": "matchestouchedpath()",
-      "source_file": "scripts/harness-mechanical-check.ts",
-      "source_location": "L99"
+      "id": "guardrails_masktextforremoteassist",
+      "label": "maskTextForRemoteAssist()",
+      "norm_label": "masktextforremoteassist()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/guardrails.ts",
+      "source_location": "L148"
     },
     {
       "community": 223,
       "file_type": "code",
-      "id": "harness_mechanical_check_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/harness-mechanical-check.ts",
-      "source_location": "L85"
+      "id": "guardrails_validatekeyevent",
+      "label": "validateKeyEvent()",
+      "norm_label": "validatekeyevent()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/guardrails.ts",
+      "source_location": "L198"
     },
     {
       "community": 223,
       "file_type": "code",
-      "id": "harness_mechanical_check_runharnessmechanicalcheck",
-      "label": "runHarnessMechanicalCheck()",
-      "norm_label": "runharnessmechanicalcheck()",
-      "source_file": "scripts/harness-mechanical-check.ts",
-      "source_location": "L217"
+      "id": "guardrails_validatepointerevent",
+      "label": "validatePointerEvent()",
+      "norm_label": "validatepointerevent()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/guardrails.ts",
+      "source_location": "L159"
     },
     {
       "community": 223,
       "file_type": "code",
-      "id": "harness_mechanical_check_selectmechanicalcommands",
-      "label": "selectMechanicalCommands()",
-      "norm_label": "selectmechanicalcommands()",
-      "source_file": "scripts/harness-mechanical-check.ts",
-      "source_location": "L121"
+      "id": "guardrails_validateremoteassistcontrolevent",
+      "label": "validateRemoteAssistControlEvent()",
+      "norm_label": "validateremoteassistcontrolevent()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/guardrails.ts",
+      "source_location": "L124"
     },
     {
       "community": 223,
       "file_type": "code",
-      "id": "scripts_harness_mechanical_check_ts",
-      "label": "harness-mechanical-check.ts",
-      "norm_label": "harness-mechanical-check.ts",
-      "source_file": "scripts/harness-mechanical-check.ts",
+      "id": "packages_athena_webapp_src_lib_remote_assist_guardrails_ts",
+      "label": "guardrails.ts",
+      "norm_label": "guardrails.ts",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/guardrails.ts",
       "source_location": "L1"
     },
     {
@@ -225081,101 +225141,110 @@
     {
       "community": 224,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_products_ts",
-      "label": "products.ts",
-      "norm_label": "products.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L1"
+      "id": "harness_mechanical_check_defaultreadpackagemanifest",
+      "label": "defaultReadPackageManifest()",
+      "norm_label": "defaultreadpackagemanifest()",
+      "source_file": "scripts/harness-mechanical-check.ts",
+      "source_location": "L180"
     },
     {
       "community": 224,
       "file_type": "code",
-      "id": "products_adjustskuavailabilityforactiveholds",
-      "label": "adjustSkuAvailabilityForActiveHolds()",
-      "norm_label": "adjustskuavailabilityforactiveholds()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L223"
+      "id": "harness_mechanical_check_defaultrunpackagescript",
+      "label": "defaultRunPackageScript()",
+      "norm_label": "defaultrunpackagescript()",
+      "source_file": "scripts/harness-mechanical-check.ts",
+      "source_location": "L193"
     },
     {
       "community": 224,
       "file_type": "code",
-      "id": "products_calculatetotalavailablecount",
-      "label": "calculateTotalAvailableCount()",
-      "norm_label": "calculatetotalavailablecount()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L218"
+      "id": "harness_mechanical_check_defaultrunrawcommand",
+      "label": "defaultRunRawCommand()",
+      "norm_label": "defaultrunrawcommand()",
+      "source_file": "scripts/harness-mechanical-check.ts",
+      "source_location": "L206"
     },
     {
       "community": 224,
       "file_type": "code",
-      "id": "products_calculatetotalinventorycount",
-      "label": "calculateTotalInventoryCount()",
-      "norm_label": "calculatetotalinventorycount()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L213"
+      "id": "harness_mechanical_check_formatmechanicalcheckfailure",
+      "label": "formatMechanicalCheckFailure()",
+      "norm_label": "formatmechanicalcheckfailure()",
+      "source_file": "scripts/harness-mechanical-check.ts",
+      "source_location": "L293"
     },
     {
       "community": 224,
       "file_type": "code",
-      "id": "products_generatebarcode",
-      "label": "generateBarcode()",
-      "norm_label": "generatebarcode()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L190"
+      "id": "harness_mechanical_check_ismechanicalrawcommand",
+      "label": "isMechanicalRawCommand()",
+      "norm_label": "ismechanicalrawcommand()",
+      "source_file": "scripts/harness-mechanical-check.ts",
+      "source_location": "L40"
     },
     {
       "community": 224,
       "file_type": "code",
-      "id": "products_generatesku",
-      "label": "generateSKU()",
-      "norm_label": "generatesku()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L166"
+      "id": "harness_mechanical_check_ismechanicalscript",
+      "label": "isMechanicalScript()",
+      "norm_label": "ismechanicalscript()",
+      "source_file": "scripts/harness-mechanical-check.ts",
+      "source_location": "L95"
     },
     {
       "community": 224,
       "file_type": "code",
-      "id": "products_hasactivefinalizedlegacyimportrowsforproductwithctx",
-      "label": "hasActiveFinalizedLegacyImportRowsForProductWithCtx()",
-      "norm_label": "hasactivefinalizedlegacyimportrowsforproductwithctx()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L139"
+      "id": "harness_mechanical_check_main",
+      "label": "main()",
+      "norm_label": "main()",
+      "source_file": "scripts/harness-mechanical-check.ts",
+      "source_location": "L305"
     },
     {
       "community": 224,
       "file_type": "code",
-      "id": "products_hasathenataxonomywithctx",
-      "label": "hasAthenaTaxonomyWithCtx()",
-      "norm_label": "hasathenataxonomywithctx()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L114"
+      "id": "harness_mechanical_check_matchestouchedpath",
+      "label": "matchesTouchedPath()",
+      "norm_label": "matchestouchedpath()",
+      "source_file": "scripts/harness-mechanical-check.ts",
+      "source_location": "L99"
     },
     {
       "community": 224,
       "file_type": "code",
-      "id": "products_haspendingcheckoutregistercatalogdependency",
-      "label": "hasPendingCheckoutRegisterCatalogDependency()",
-      "norm_label": "haspendingcheckoutregistercatalogdependency()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 224,
-      "file_type": "code",
-      "id": "products_producthaspendingcheckoutregistercatalogdependency",
-      "label": "productHasPendingCheckoutRegisterCatalogDependency()",
-      "norm_label": "producthaspendingcheckoutregistercatalogdependency()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "id": "harness_mechanical_check_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/harness-mechanical-check.ts",
       "source_location": "L85"
     },
     {
       "community": 224,
       "file_type": "code",
-      "id": "products_removeproductandrefreshcatalog",
-      "label": "removeProductAndRefreshCatalog()",
-      "norm_label": "removeproductandrefreshcatalog()",
-      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
-      "source_location": "L99"
+      "id": "harness_mechanical_check_runharnessmechanicalcheck",
+      "label": "runHarnessMechanicalCheck()",
+      "norm_label": "runharnessmechanicalcheck()",
+      "source_file": "scripts/harness-mechanical-check.ts",
+      "source_location": "L217"
+    },
+    {
+      "community": 224,
+      "file_type": "code",
+      "id": "harness_mechanical_check_selectmechanicalcommands",
+      "label": "selectMechanicalCommands()",
+      "norm_label": "selectmechanicalcommands()",
+      "source_file": "scripts/harness-mechanical-check.ts",
+      "source_location": "L121"
+    },
+    {
+      "community": 224,
+      "file_type": "code",
+      "id": "scripts_harness_mechanical_check_ts",
+      "label": "harness-mechanical-check.ts",
+      "norm_label": "harness-mechanical-check.ts",
+      "source_file": "scripts/harness-mechanical-check.ts",
+      "source_location": "L1"
     },
     {
       "community": 2240,
@@ -225270,101 +225339,101 @@
     {
       "community": 225,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_storeschedule_ts",
-      "label": "storeSchedule.ts",
-      "norm_label": "storeschedule.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.ts",
+      "id": "packages_athena_webapp_convex_inventory_products_ts",
+      "label": "products.ts",
+      "norm_label": "products.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
       "source_location": "L1"
     },
     {
       "community": 225,
       "file_type": "code",
-      "id": "storeschedule_activeschedulesoverlap",
-      "label": "activeSchedulesOverlap()",
-      "norm_label": "activeschedulesoverlap()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.ts",
-      "source_location": "L425"
+      "id": "products_adjustskuavailabilityforactiveholds",
+      "label": "adjustSkuAvailabilityForActiveHolds()",
+      "norm_label": "adjustskuavailabilityforactiveholds()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L223"
     },
     {
       "community": 225,
       "file_type": "code",
-      "id": "storeschedule_findactivescheduleforstoreat",
-      "label": "findActiveScheduleForStoreAt()",
-      "norm_label": "findactivescheduleforstoreat()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.ts",
-      "source_location": "L362"
+      "id": "products_calculatetotalavailablecount",
+      "label": "calculateTotalAvailableCount()",
+      "norm_label": "calculatetotalavailablecount()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L218"
     },
     {
       "community": 225,
       "file_type": "code",
-      "id": "storeschedule_getstoreschedulecontextforstoreatwithctx",
-      "label": "getStoreScheduleContextForStoreAtWithCtx()",
-      "norm_label": "getstoreschedulecontextforstoreatwithctx()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.ts",
-      "source_location": "L390"
+      "id": "products_calculatetotalinventorycount",
+      "label": "calculateTotalInventoryCount()",
+      "norm_label": "calculatetotalinventorycount()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L213"
     },
     {
       "community": 225,
       "file_type": "code",
-      "id": "storeschedule_listactiveschedulesforstore",
-      "label": "listActiveSchedulesForStore()",
-      "norm_label": "listactiveschedulesforstore()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.ts",
-      "source_location": "L350"
+      "id": "products_generatebarcode",
+      "label": "generateBarcode()",
+      "norm_label": "generatebarcode()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L190"
     },
     {
       "community": 225,
       "file_type": "code",
-      "id": "storeschedule_minutestotimeinput",
-      "label": "minutesToTimeInput()",
-      "norm_label": "minutestotimeinput()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.ts",
-      "source_location": "L261"
+      "id": "products_generatesku",
+      "label": "generateSKU()",
+      "norm_label": "generatesku()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L166"
     },
     {
       "community": 225,
       "file_type": "code",
-      "id": "storeschedule_resolvestoreoperatingrangefordatewithctx",
-      "label": "resolveStoreOperatingRangeForDateWithCtx()",
-      "norm_label": "resolvestoreoperatingrangefordatewithctx()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.ts",
-      "source_location": "L404"
+      "id": "products_hasactivefinalizedlegacyimportrowsforproductwithctx",
+      "label": "hasActiveFinalizedLegacyImportRowsForProductWithCtx()",
+      "norm_label": "hasactivefinalizedlegacyimportrowsforproductwithctx()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L139"
     },
     {
       "community": 225,
       "file_type": "code",
-      "id": "storeschedule_toadminresult",
-      "label": "toAdminResult()",
-      "norm_label": "toadminresult()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.ts",
-      "source_location": "L268"
+      "id": "products_hasathenataxonomywithctx",
+      "label": "hasAthenaTaxonomyWithCtx()",
+      "norm_label": "hasathenataxonomywithctx()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L114"
     },
     {
       "community": 225,
       "file_type": "code",
-      "id": "storeschedule_todraft",
-      "label": "toDraft()",
-      "norm_label": "todraft()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.ts",
-      "source_location": "L206"
+      "id": "products_haspendingcheckoutregistercatalogdependency",
+      "label": "hasPendingCheckoutRegisterCatalogDependency()",
+      "norm_label": "haspendingcheckoutregistercatalogdependency()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L57"
     },
     {
       "community": 225,
       "file_type": "code",
-      "id": "storeschedule_tosummary",
-      "label": "toSummary()",
-      "norm_label": "tosummary()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.ts",
-      "source_location": "L230"
+      "id": "products_producthaspendingcheckoutregistercatalogdependency",
+      "label": "productHasPendingCheckoutRegisterCatalogDependency()",
+      "norm_label": "producthaspendingcheckoutregistercatalogdependency()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L85"
     },
     {
       "community": 225,
       "file_type": "code",
-      "id": "storeschedule_upsertstoreschedulecommandwithctx",
-      "label": "upsertStoreScheduleCommandWithCtx()",
-      "norm_label": "upsertstoreschedulecommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.ts",
-      "source_location": "L436"
+      "id": "products_removeproductandrefreshcatalog",
+      "label": "removeProductAndRefreshCatalog()",
+      "norm_label": "removeproductandrefreshcatalog()",
+      "source_file": "packages/athena-webapp/convex/inventory/products.ts",
+      "source_location": "L99"
     },
     {
       "community": 2250,
@@ -225459,101 +225528,101 @@
     {
       "community": 226,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_notifications_subscriptions_test_ts",
-      "label": "subscriptions.test.ts",
-      "norm_label": "subscriptions.test.ts",
-      "source_file": "packages/athena-webapp/convex/notifications/subscriptions.test.ts",
+      "id": "packages_athena_webapp_convex_inventory_storeschedule_ts",
+      "label": "storeSchedule.ts",
+      "norm_label": "storeschedule.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.ts",
       "source_location": "L1"
     },
     {
       "community": 226,
       "file_type": "code",
-      "id": "subscriptions_test_asadmitted",
-      "label": "asAdmitted()",
-      "norm_label": "asadmitted()",
-      "source_file": "packages/athena-webapp/convex/notifications/subscriptions.test.ts",
-      "source_location": "L44"
+      "id": "storeschedule_activeschedulesoverlap",
+      "label": "activeSchedulesOverlap()",
+      "norm_label": "activeschedulesoverlap()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.ts",
+      "source_location": "L425"
     },
     {
       "community": 226,
       "file_type": "code",
-      "id": "subscriptions_test_calladd",
-      "label": "callAdd()",
-      "norm_label": "calladd()",
-      "source_file": "packages/athena-webapp/convex/notifications/subscriptions.test.ts",
-      "source_location": "L143"
+      "id": "storeschedule_findactivescheduleforstoreat",
+      "label": "findActiveScheduleForStoreAt()",
+      "norm_label": "findactivescheduleforstoreat()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.ts",
+      "source_location": "L362"
     },
     {
       "community": 226,
       "file_type": "code",
-      "id": "subscriptions_test_calllist",
-      "label": "callList()",
-      "norm_label": "calllist()",
-      "source_file": "packages/athena-webapp/convex/notifications/subscriptions.test.ts",
-      "source_location": "L120"
+      "id": "storeschedule_getstoreschedulecontextforstoreatwithctx",
+      "label": "getStoreScheduleContextForStoreAtWithCtx()",
+      "norm_label": "getstoreschedulecontextforstoreatwithctx()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.ts",
+      "source_location": "L390"
     },
     {
       "community": 226,
       "file_type": "code",
-      "id": "subscriptions_test_calllistmembercandidates",
-      "label": "callListMemberCandidates()",
-      "norm_label": "calllistmembercandidates()",
-      "source_file": "packages/athena-webapp/convex/notifications/subscriptions.test.ts",
-      "source_location": "L130"
+      "id": "storeschedule_listactiveschedulesforstore",
+      "label": "listActiveSchedulesForStore()",
+      "norm_label": "listactiveschedulesforstore()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.ts",
+      "source_location": "L350"
     },
     {
       "community": 226,
       "file_type": "code",
-      "id": "subscriptions_test_callremove",
-      "label": "callRemove()",
-      "norm_label": "callremove()",
-      "source_file": "packages/athena-webapp/convex/notifications/subscriptions.test.ts",
-      "source_location": "L163"
+      "id": "storeschedule_minutestotimeinput",
+      "label": "minutesToTimeInput()",
+      "norm_label": "minutestotimeinput()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.ts",
+      "source_location": "L261"
     },
     {
       "community": 226,
       "file_type": "code",
-      "id": "subscriptions_test_callsetenabled",
-      "label": "callSetEnabled()",
-      "norm_label": "callsetenabled()",
-      "source_file": "packages/athena-webapp/convex/notifications/subscriptions.test.ts",
-      "source_location": "L153"
+      "id": "storeschedule_resolvestoreoperatingrangefordatewithctx",
+      "label": "resolveStoreOperatingRangeForDateWithCtx()",
+      "norm_label": "resolvestoreoperatingrangefordatewithctx()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.ts",
+      "source_location": "L404"
     },
     {
       "community": 226,
       "file_type": "code",
-      "id": "subscriptions_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/notifications/subscriptions.test.ts",
-      "source_location": "L36"
+      "id": "storeschedule_toadminresult",
+      "label": "toAdminResult()",
+      "norm_label": "toadminresult()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.ts",
+      "source_location": "L268"
     },
     {
       "community": 226,
       "file_type": "code",
-      "id": "subscriptions_test_insertapprovalsintent",
-      "label": "insertApprovalsIntent()",
-      "norm_label": "insertapprovalsintent()",
-      "source_file": "packages/athena-webapp/convex/notifications/subscriptions.test.ts",
-      "source_location": "L195"
+      "id": "storeschedule_todraft",
+      "label": "toDraft()",
+      "norm_label": "todraft()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.ts",
+      "source_location": "L206"
     },
     {
       "community": 226,
       "file_type": "code",
-      "id": "subscriptions_test_insertsubscription",
-      "label": "insertSubscription()",
-      "norm_label": "insertsubscription()",
-      "source_file": "packages/athena-webapp/convex/notifications/subscriptions.test.ts",
-      "source_location": "L173"
+      "id": "storeschedule_tosummary",
+      "label": "toSummary()",
+      "norm_label": "tosummary()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.ts",
+      "source_location": "L230"
     },
     {
       "community": 226,
       "file_type": "code",
-      "id": "subscriptions_test_seedfixture",
-      "label": "seedFixture()",
-      "norm_label": "seedfixture()",
-      "source_file": "packages/athena-webapp/convex/notifications/subscriptions.test.ts",
-      "source_location": "L63"
+      "id": "storeschedule_upsertstoreschedulecommandwithctx",
+      "label": "upsertStoreScheduleCommandWithCtx()",
+      "norm_label": "upsertstoreschedulecommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.ts",
+      "source_location": "L436"
     },
     {
       "community": 2260,
@@ -225648,101 +225717,101 @@
     {
       "community": 227,
       "file_type": "code",
-      "id": "dailymanagerreportemail_test_ask",
-      "label": "ask()",
-      "norm_label": "ask()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L425"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "dailymanagerreportemail_test_askforday",
-      "label": "askForDay()",
-      "norm_label": "askforday()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L632"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "dailymanagerreportemail_test_insertcompletedclose",
-      "label": "insertCompletedClose()",
-      "norm_label": "insertcompletedclose()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L485"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "dailymanagerreportemail_test_insertlegacydelivery",
-      "label": "insertLegacyDelivery()",
-      "norm_label": "insertlegacydelivery()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L396"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "dailymanagerreportemail_test_insertreportday",
-      "label": "insertReportDay()",
-      "norm_label": "insertreportday()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L535"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "dailymanagerreportemail_test_insertskuday",
-      "label": "insertSkuDay()",
-      "norm_label": "insertskuday()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L569"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "dailymanagerreportemail_test_money",
-      "label": "money()",
-      "norm_label": "money()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "dailymanagerreportemail_test_seedstore",
-      "label": "seedStore()",
-      "norm_label": "seedstore()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L465"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "dailymanagerreportemail_test_seedstoreandrun",
-      "label": "seedStoreAndRun()",
-      "norm_label": "seedstoreandrun()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L358"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "dailymanagerreportemail_test_unitsmetric",
-      "label": "unitsMetric()",
-      "norm_label": "unitsmetric()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L623"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_dailymanagerreportemail_test_ts",
-      "label": "dailyManagerReportEmail.test.ts",
-      "norm_label": "dailymanagerreportemail.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
+      "id": "packages_athena_webapp_convex_notifications_subscriptions_test_ts",
+      "label": "subscriptions.test.ts",
+      "norm_label": "subscriptions.test.ts",
+      "source_file": "packages/athena-webapp/convex/notifications/subscriptions.test.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 227,
+      "file_type": "code",
+      "id": "subscriptions_test_asadmitted",
+      "label": "asAdmitted()",
+      "norm_label": "asadmitted()",
+      "source_file": "packages/athena-webapp/convex/notifications/subscriptions.test.ts",
+      "source_location": "L44"
+    },
+    {
+      "community": 227,
+      "file_type": "code",
+      "id": "subscriptions_test_calladd",
+      "label": "callAdd()",
+      "norm_label": "calladd()",
+      "source_file": "packages/athena-webapp/convex/notifications/subscriptions.test.ts",
+      "source_location": "L143"
+    },
+    {
+      "community": 227,
+      "file_type": "code",
+      "id": "subscriptions_test_calllist",
+      "label": "callList()",
+      "norm_label": "calllist()",
+      "source_file": "packages/athena-webapp/convex/notifications/subscriptions.test.ts",
+      "source_location": "L120"
+    },
+    {
+      "community": 227,
+      "file_type": "code",
+      "id": "subscriptions_test_calllistmembercandidates",
+      "label": "callListMemberCandidates()",
+      "norm_label": "calllistmembercandidates()",
+      "source_file": "packages/athena-webapp/convex/notifications/subscriptions.test.ts",
+      "source_location": "L130"
+    },
+    {
+      "community": 227,
+      "file_type": "code",
+      "id": "subscriptions_test_callremove",
+      "label": "callRemove()",
+      "norm_label": "callremove()",
+      "source_file": "packages/athena-webapp/convex/notifications/subscriptions.test.ts",
+      "source_location": "L163"
+    },
+    {
+      "community": 227,
+      "file_type": "code",
+      "id": "subscriptions_test_callsetenabled",
+      "label": "callSetEnabled()",
+      "norm_label": "callsetenabled()",
+      "source_file": "packages/athena-webapp/convex/notifications/subscriptions.test.ts",
+      "source_location": "L153"
+    },
+    {
+      "community": 227,
+      "file_type": "code",
+      "id": "subscriptions_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/notifications/subscriptions.test.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 227,
+      "file_type": "code",
+      "id": "subscriptions_test_insertapprovalsintent",
+      "label": "insertApprovalsIntent()",
+      "norm_label": "insertapprovalsintent()",
+      "source_file": "packages/athena-webapp/convex/notifications/subscriptions.test.ts",
+      "source_location": "L195"
+    },
+    {
+      "community": 227,
+      "file_type": "code",
+      "id": "subscriptions_test_insertsubscription",
+      "label": "insertSubscription()",
+      "norm_label": "insertsubscription()",
+      "source_file": "packages/athena-webapp/convex/notifications/subscriptions.test.ts",
+      "source_location": "L173"
+    },
+    {
+      "community": 227,
+      "file_type": "code",
+      "id": "subscriptions_test_seedfixture",
+      "label": "seedFixture()",
+      "norm_label": "seedfixture()",
+      "source_file": "packages/athena-webapp/convex/notifications/subscriptions.test.ts",
+      "source_location": "L63"
     },
     {
       "community": 2270,
@@ -230103,92 +230172,92 @@
     {
       "community": 247,
       "file_type": "code",
-      "id": "index_resolveverificationcoderecipient",
-      "label": "resolveVerificationCodeRecipient()",
-      "norm_label": "resolveverificationcoderecipient()",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "index_senddailymanagerreportemail",
-      "label": "sendDailyManagerReportEmail()",
-      "norm_label": "senddailymanagerreportemail()",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
-      "source_location": "L373"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "index_senddiscountcodeemail",
-      "label": "sendDiscountCodeEmail()",
-      "norm_label": "senddiscountcodeemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L255"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "index_senddiscountreminderemail",
-      "label": "sendDiscountReminderEmail()",
-      "norm_label": "senddiscountreminderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L334"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "index_sendfeedbackrequestemail",
-      "label": "sendFeedbackRequestEmail()",
-      "norm_label": "sendfeedbackrequestemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L167"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "index_sendneworderemail",
-      "label": "sendNewOrderEmail()",
-      "norm_label": "sendneworderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L117"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "index_sendorderemail",
-      "label": "sendOrderEmail()",
-      "norm_label": "sendorderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "index_sendverificationcode",
-      "label": "sendVerificationCode()",
-      "norm_label": "sendverificationcode()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "id": "packages_athena_webapp_convex_marketing_walkthroughconfig_ts",
+      "label": "walkthroughConfig.ts",
+      "norm_label": "walkthroughconfig.ts",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
       "source_location": "L1"
     },
     {
       "community": 247,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L1"
+      "id": "walkthroughconfig_landingfunnelhourlylimit",
+      "label": "landingFunnelHourlyLimit()",
+      "norm_label": "landingfunnelhourlylimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "walkthroughconfig_parseboundedpositiveinteger",
+      "label": "parseBoundedPositiveInteger()",
+      "norm_label": "parseboundedpositiveinteger()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "walkthroughconfig_resolvewalkthroughallowedorigins",
+      "label": "resolveWalkthroughAllowedOrigins()",
+      "norm_label": "resolvewalkthroughallowedorigins()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughallowedorigins",
+      "label": "walkthroughAllowedOrigins()",
+      "norm_label": "walkthroughallowedorigins()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughdailyperemaillimit",
+      "label": "walkthroughDailyPerEmailLimit()",
+      "norm_label": "walkthroughdailyperemaillimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughhourlygloballimit",
+      "label": "walkthroughHourlyGlobalLimit()",
+      "norm_label": "walkthroughhourlygloballimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughhourlynotificationlimit",
+      "label": "walkthroughHourlyNotificationLimit()",
+      "norm_label": "walkthroughhourlynotificationlimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughmaxbodybytes",
+      "label": "walkthroughMaxBodyBytes()",
+      "norm_label": "walkthroughmaxbodybytes()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughprivacycontact",
+      "label": "walkthroughPrivacyContact()",
+      "norm_label": "walkthroughprivacycontact()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L95"
     },
     {
       "community": 2470,
@@ -230283,92 +230352,92 @@
     {
       "community": 248,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_marketing_walkthroughconfig_ts",
-      "label": "walkthroughConfig.ts",
-      "norm_label": "walkthroughconfig.ts",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "id": "definitions_costoverlaystorewriteoperation",
+      "label": "costOverlayStoreWriteOperation()",
+      "norm_label": "costoverlaystorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L569"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "definitions_cyclecountdraftstorewriteoperation",
+      "label": "cycleCountDraftStoreWriteOperation()",
+      "norm_label": "cyclecountdraftstorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L383"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "definitions_defineoperation",
+      "label": "defineOperation()",
+      "norm_label": "defineoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "definitions_inventoryimportreviewpayloadwriteoperation",
+      "label": "inventoryImportReviewPayloadWriteOperation()",
+      "norm_label": "inventoryimportreviewpayloadwriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L544"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "definitions_notificationsubscriptionrowwriteoperation",
+      "label": "notificationSubscriptionRowWriteOperation()",
+      "norm_label": "notificationsubscriptionrowwriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L629"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "definitions_orderstorewriteoperation",
+      "label": "orderStoreWriteOperation()",
+      "norm_label": "orderstorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L155"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "definitions_storewriteoperation",
+      "label": "storeWriteOperation()",
+      "norm_label": "storewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L108"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "definitions_transactionstorewriteoperation",
+      "label": "transactionStoreWriteOperation()",
+      "norm_label": "transactionstorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "definitions_validateoperationdefinition",
+      "label": "validateOperationDefinition()",
+      "norm_label": "validateoperationdefinition()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L724"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operationadmission_definitions_ts",
+      "label": "definitions.ts",
+      "norm_label": "definitions.ts",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "walkthroughconfig_landingfunnelhourlylimit",
-      "label": "landingFunnelHourlyLimit()",
-      "norm_label": "landingfunnelhourlylimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "walkthroughconfig_parseboundedpositiveinteger",
-      "label": "parseBoundedPositiveInteger()",
-      "norm_label": "parseboundedpositiveinteger()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "walkthroughconfig_resolvewalkthroughallowedorigins",
-      "label": "resolveWalkthroughAllowedOrigins()",
-      "norm_label": "resolvewalkthroughallowedorigins()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughallowedorigins",
-      "label": "walkthroughAllowedOrigins()",
-      "norm_label": "walkthroughallowedorigins()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughdailyperemaillimit",
-      "label": "walkthroughDailyPerEmailLimit()",
-      "norm_label": "walkthroughdailyperemaillimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L55"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughhourlygloballimit",
-      "label": "walkthroughHourlyGlobalLimit()",
-      "norm_label": "walkthroughhourlygloballimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughhourlynotificationlimit",
-      "label": "walkthroughHourlyNotificationLimit()",
-      "norm_label": "walkthroughhourlynotificationlimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughmaxbodybytes",
-      "label": "walkthroughMaxBodyBytes()",
-      "norm_label": "walkthroughmaxbodybytes()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughprivacycontact",
-      "label": "walkthroughPrivacyContact()",
-      "norm_label": "walkthroughprivacycontact()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L95"
     },
     {
       "community": 2480,
@@ -230463,91 +230532,91 @@
     {
       "community": 249,
       "file_type": "code",
-      "id": "definitions_costoverlaystorewriteoperation",
-      "label": "costOverlayStoreWriteOperation()",
-      "norm_label": "costoverlaystorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L569"
+      "id": "adjustmentreports_adjustmentappliedat",
+      "label": "adjustmentAppliedAt()",
+      "norm_label": "adjustmentappliedat()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L101"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "definitions_cyclecountdraftstorewriteoperation",
-      "label": "cycleCountDraftStoreWriteOperation()",
-      "norm_label": "cyclecountdraftstorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L383"
+      "id": "adjustmentreports_adjustmentsalesdelta",
+      "label": "adjustmentSalesDelta()",
+      "norm_label": "adjustmentsalesdelta()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L116"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "definitions_defineoperation",
-      "label": "defineOperation()",
-      "norm_label": "defineoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L11"
+      "id": "adjustmentreports_adjustmentsettlementamount",
+      "label": "adjustmentSettlementAmount()",
+      "norm_label": "adjustmentsettlementamount()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L143"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "definitions_inventoryimportreviewpayloadwriteoperation",
-      "label": "inventoryImportReviewPayloadWriteOperation()",
-      "norm_label": "inventoryimportreviewpayloadwriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L544"
+      "id": "adjustmentreports_adjustmenttransactionid",
+      "label": "adjustmentTransactionId()",
+      "norm_label": "adjustmenttransactionid()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L110"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "definitions_notificationsubscriptionrowwriteoperation",
-      "label": "notificationSubscriptionRowWriteOperation()",
-      "norm_label": "notificationsubscriptionrowwriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L629"
+      "id": "adjustmentreports_buildadjustmentpaymenttotals",
+      "label": "buildAdjustmentPaymentTotals()",
+      "norm_label": "buildadjustmentpaymenttotals()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L242"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "definitions_orderstorewriteoperation",
-      "label": "orderStoreWriteOperation()",
-      "norm_label": "orderstorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L155"
+      "id": "adjustmentreports_buildadjustmentreporttotals",
+      "label": "buildAdjustmentReportTotals()",
+      "norm_label": "buildadjustmentreporttotals()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L275"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "definitions_storewriteoperation",
-      "label": "storeWriteOperation()",
-      "norm_label": "storewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L108"
+      "id": "adjustmentreports_listappliedtransactionadjustmentsforday",
+      "label": "listAppliedTransactionAdjustmentsForDay()",
+      "norm_label": "listappliedtransactionadjustmentsforday()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L229"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "definitions_transactionstorewriteoperation",
-      "label": "transactionStoreWriteOperation()",
-      "norm_label": "transactionstorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L128"
+      "id": "adjustmentreports_readappliedtransactionadjustmentsforday",
+      "label": "readAppliedTransactionAdjustmentsForDay()",
+      "norm_label": "readappliedtransactionadjustmentsforday()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L173"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "definitions_validateoperationdefinition",
-      "label": "validateOperationDefinition()",
-      "norm_label": "validateoperationdefinition()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L724"
+      "id": "adjustmentreports_sourcecompletenessentry",
+      "label": "sourceCompletenessEntry()",
+      "norm_label": "sourcecompletenessentry()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L76"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operationadmission_definitions_ts",
-      "label": "definitions.ts",
-      "norm_label": "definitions.ts",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "id": "packages_athena_webapp_convex_operations_dailyclose_adjustmentreports_ts",
+      "label": "adjustmentReports.ts",
+      "norm_label": "adjustmentreports.ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
       "source_location": "L1"
     },
     {
@@ -230994,91 +231063,91 @@
     {
       "community": 250,
       "file_type": "code",
-      "id": "adjustmentreports_adjustmentappliedat",
-      "label": "adjustmentAppliedAt()",
-      "norm_label": "adjustmentappliedat()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L101"
+      "id": "inventorymovements_assertnobusinesseventconflict",
+      "label": "assertNoBusinessEventConflict()",
+      "norm_label": "assertnobusinesseventconflict()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L178"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "adjustmentreports_adjustmentsalesdelta",
-      "label": "adjustmentSalesDelta()",
-      "norm_label": "adjustmentsalesdelta()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L116"
+      "id": "inventorymovements_buildinventorymovement",
+      "label": "buildInventoryMovement()",
+      "norm_label": "buildinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L124"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "adjustmentreports_adjustmentsettlementamount",
-      "label": "adjustmentSettlementAmount()",
-      "norm_label": "adjustmentsettlementamount()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L143"
+      "id": "inventorymovements_buildskuactivityforinventorymovement",
+      "label": "buildSkuActivityForInventoryMovement()",
+      "norm_label": "buildskuactivityforinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L66"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "adjustmentreports_adjustmenttransactionid",
-      "label": "adjustmentTransactionId()",
-      "norm_label": "adjustmenttransactionid()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L110"
+      "id": "inventorymovements_getskuactivitytypeformovement",
+      "label": "getSkuActivityTypeForMovement()",
+      "norm_label": "getskuactivitytypeformovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L49"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "adjustmentreports_buildadjustmentpaymenttotals",
-      "label": "buildAdjustmentPaymentTotals()",
-      "norm_label": "buildadjustmentpaymenttotals()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L242"
+      "id": "inventorymovements_matchesexistingmovement",
+      "label": "matchesExistingMovement()",
+      "norm_label": "matchesexistingmovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L150"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "adjustmentreports_buildadjustmentreporttotals",
-      "label": "buildAdjustmentReportTotals()",
-      "norm_label": "buildadjustmentreporttotals()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L275"
+      "id": "inventorymovements_recordinventorymovementwithctx",
+      "label": "recordInventoryMovementWithCtx()",
+      "norm_label": "recordinventorymovementwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L200"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "adjustmentreports_listappliedtransactionadjustmentsforday",
-      "label": "listAppliedTransactionAdjustmentsForDay()",
-      "norm_label": "listappliedtransactionadjustmentsforday()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L229"
+      "id": "inventorymovements_recordinventorymovementwithdispositionwithctx",
+      "label": "recordInventoryMovementWithDispositionWithCtx()",
+      "norm_label": "recordinventorymovementwithdispositionwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L245"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "adjustmentreports_readappliedtransactionadjustmentsforday",
-      "label": "readAppliedTransactionAdjustmentsForDay()",
-      "norm_label": "readappliedtransactionadjustmentsforday()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L173"
+      "id": "inventorymovements_recordskuactivityforinventorymovementwithctx",
+      "label": "recordSkuActivityForInventoryMovementWithCtx()",
+      "norm_label": "recordskuactivityforinventorymovementwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L111"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "adjustmentreports_sourcecompletenessentry",
-      "label": "sourceCompletenessEntry()",
-      "norm_label": "sourcecompletenessentry()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L76"
+      "id": "inventorymovements_summarizeinventorymovements",
+      "label": "summarizeInventoryMovements()",
+      "norm_label": "summarizeinventorymovements()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L135"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_dailyclose_adjustmentreports_ts",
-      "label": "adjustmentReports.ts",
-      "norm_label": "adjustmentreports.ts",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
+      "label": "inventoryMovements.ts",
+      "norm_label": "inventorymovements.ts",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
       "source_location": "L1"
     },
     {
@@ -231174,91 +231243,91 @@
     {
       "community": 251,
       "file_type": "code",
-      "id": "inventorymovements_assertnobusinesseventconflict",
-      "label": "assertNoBusinessEventConflict()",
-      "norm_label": "assertnobusinesseventconflict()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L178"
+      "id": "operationalevents_buildoperationalevent",
+      "label": "buildOperationalEvent()",
+      "norm_label": "buildoperationalevent()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L43"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "inventorymovements_buildinventorymovement",
-      "label": "buildInventoryMovement()",
-      "norm_label": "buildinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L124"
+      "id": "operationalevents_buildtracemetadata",
+      "label": "buildTraceMetadata()",
+      "norm_label": "buildtracemetadata()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L96"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "inventorymovements_buildskuactivityforinventorymovement",
-      "label": "buildSkuActivityForInventoryMovement()",
-      "norm_label": "buildskuactivityforinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L66"
+      "id": "operationalevents_isrecord",
+      "label": "isRecord()",
+      "norm_label": "isrecord()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L145"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "inventorymovements_getskuactivitytypeformovement",
-      "label": "getSkuActivityTypeForMovement()",
-      "norm_label": "getskuactivitytypeformovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L49"
+      "id": "operationalevents_listproductoperationaltimelinewithctx",
+      "label": "listProductOperationalTimelineWithCtx()",
+      "norm_label": "listproductoperationaltimelinewithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L246"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "inventorymovements_matchesexistingmovement",
-      "label": "matchesExistingMovement()",
-      "norm_label": "matchesexistingmovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L150"
+      "id": "operationalevents_matchesexistingevent",
+      "label": "matchesExistingEvent()",
+      "norm_label": "matchesexistingevent()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L149"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "inventorymovements_recordinventorymovementwithctx",
-      "label": "recordInventoryMovementWithCtx()",
-      "norm_label": "recordinventorymovementwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L200"
+      "id": "operationalevents_metadatadedupekeysmatch",
+      "label": "metadataDedupeKeysMatch()",
+      "norm_label": "metadatadedupekeysmatch()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L205"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "inventorymovements_recordinventorymovementwithdispositionwithctx",
-      "label": "recordInventoryMovementWithDispositionWithCtx()",
-      "norm_label": "recordinventorymovementwithdispositionwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L245"
+      "id": "operationalevents_normalizeoperationaleventtracefields",
+      "label": "normalizeOperationalEventTraceFields()",
+      "norm_label": "normalizeoperationaleventtracefields()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L60"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "inventorymovements_recordskuactivityforinventorymovementwithctx",
-      "label": "recordSkuActivityForInventoryMovementWithCtx()",
-      "norm_label": "recordskuactivityforinventorymovementwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L111"
+      "id": "operationalevents_recordoperationaleventwithctx",
+      "label": "recordOperationalEventWithCtx()",
+      "norm_label": "recordoperationaleventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L215"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "inventorymovements_summarizeinventorymovements",
-      "label": "summarizeInventoryMovements()",
-      "norm_label": "summarizeinventorymovements()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L135"
+      "id": "operationalevents_shouldnormalizepostrace",
+      "label": "shouldNormalizePosTrace()",
+      "norm_label": "shouldnormalizepostrace()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L118"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
-      "label": "inventoryMovements.ts",
-      "norm_label": "inventorymovements.ts",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
+      "label": "operationalEvents.ts",
+      "norm_label": "operationalevents.ts",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
       "source_location": "L1"
     },
     {
@@ -231354,91 +231423,91 @@
     {
       "community": 252,
       "file_type": "code",
-      "id": "operationalevents_buildoperationalevent",
-      "label": "buildOperationalEvent()",
-      "norm_label": "buildoperationalevent()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L43"
+      "id": "oversizedoperationalworkrepair_amendrepairwithctx",
+      "label": "amendRepairWithCtx()",
+      "norm_label": "amendrepairwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L430"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "operationalevents_buildtracemetadata",
-      "label": "buildTraceMetadata()",
-      "norm_label": "buildtracemetadata()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L96"
+      "id": "oversizedoperationalworkrepair_createrepairwithctx",
+      "label": "createRepairWithCtx()",
+      "norm_label": "createrepairwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L160"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "operationalevents_isrecord",
-      "label": "isRecord()",
-      "norm_label": "isrecord()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L145"
+      "id": "oversizedoperationalworkrepair_pauserepair",
+      "label": "pauseRepair()",
+      "norm_label": "pauserepair()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L231"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "operationalevents_listproductoperationaltimelinewithctx",
-      "label": "listProductOperationalTimelineWithCtx()",
-      "norm_label": "listproductoperationaltimelinewithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L246"
+      "id": "oversizedoperationalworkrepair_processrepairbatchwithctx",
+      "label": "processRepairBatchWithCtx()",
+      "norm_label": "processrepairbatchwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L249"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "operationalevents_matchesexistingevent",
-      "label": "matchesExistingEvent()",
-      "norm_label": "matchesexistingevent()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L149"
+      "id": "oversizedoperationalworkrepair_readcurrentgroup",
+      "label": "readCurrentGroup()",
+      "norm_label": "readcurrentgroup()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L49"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "operationalevents_metadatadedupekeysmatch",
-      "label": "metadataDedupeKeysMatch()",
-      "norm_label": "metadatadedupekeysmatch()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L205"
+      "id": "oversizedoperationalworkrepair_recordrepairauditevent",
+      "label": "recordRepairAuditEvent()",
+      "norm_label": "recordrepairauditevent()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L85"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "operationalevents_normalizeoperationaleventtracefields",
-      "label": "normalizeOperationalEventTraceFields()",
-      "norm_label": "normalizeoperationaleventtracefields()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L60"
+      "id": "oversizedoperationalworkrepair_requireevidence",
+      "label": "requireEvidence()",
+      "norm_label": "requireevidence()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L37"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "operationalevents_recordoperationaleventwithctx",
-      "label": "recordOperationalEventWithCtx()",
-      "norm_label": "recordoperationaleventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L215"
+      "id": "oversizedoperationalworkrepair_resumerepairwithctx",
+      "label": "resumeRepairWithCtx()",
+      "norm_label": "resumerepairwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L472"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "operationalevents_shouldnormalizepostrace",
-      "label": "shouldNormalizePosTrace()",
-      "norm_label": "shouldnormalizepostrace()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L118"
+      "id": "oversizedoperationalworkrepair_schedulenextbatch",
+      "label": "scheduleNextBatch()",
+      "norm_label": "schedulenextbatch()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L153"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
-      "label": "operationalEvents.ts",
-      "norm_label": "operationalevents.ts",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "id": "packages_athena_webapp_convex_operations_oversizedoperationalworkrepair_ts",
+      "label": "oversizedOperationalWorkRepair.ts",
+      "norm_label": "oversizedoperationalworkrepair.ts",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
       "source_location": "L1"
     },
     {
@@ -231534,92 +231603,92 @@
     {
       "community": 253,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_amendrepairwithctx",
-      "label": "amendRepairWithCtx()",
-      "norm_label": "amendrepairwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L430"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_createrepairwithctx",
-      "label": "createRepairWithCtx()",
-      "norm_label": "createrepairwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L160"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_pauserepair",
-      "label": "pauseRepair()",
-      "norm_label": "pauserepair()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L231"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_processrepairbatchwithctx",
-      "label": "processRepairBatchWithCtx()",
-      "norm_label": "processrepairbatchwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L249"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_readcurrentgroup",
-      "label": "readCurrentGroup()",
-      "norm_label": "readcurrentgroup()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_recordrepairauditevent",
-      "label": "recordRepairAuditEvent()",
-      "norm_label": "recordrepairauditevent()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_requireevidence",
-      "label": "requireEvidence()",
-      "norm_label": "requireevidence()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_resumerepairwithctx",
-      "label": "resumeRepairWithCtx()",
-      "norm_label": "resumerepairwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L472"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_schedulenextbatch",
-      "label": "scheduleNextBatch()",
-      "norm_label": "schedulenextbatch()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_oversizedoperationalworkrepair_ts",
-      "label": "oversizedOperationalWorkRepair.ts",
-      "norm_label": "oversizedoperationalworkrepair.ts",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "id": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
+      "label": "registerSessionTracing.ts",
+      "norm_label": "registersessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registersessiontracing_buildactorrefs",
+      "label": "buildActorRefs()",
+      "norm_label": "buildactorrefs()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registersessiontracing_buildtraceevent",
+      "label": "buildTraceEvent()",
+      "norm_label": "buildtraceevent()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L196"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registersessiontracing_buildtracerecord",
+      "label": "buildTraceRecord()",
+      "norm_label": "buildtracerecord()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L161"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registersessiontracing_displaytraceamount",
+      "label": "displayTraceAmount()",
+      "norm_label": "displaytraceamount()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L114"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registersessiontracing_formattransactionlabel",
+      "label": "formatTransactionLabel()",
+      "norm_label": "formattransactionlabel()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L132"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registersessiontracing_recordregistersessiontracebesteffort",
+      "label": "recordRegisterSessionTraceBestEffort()",
+      "norm_label": "recordregistersessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L407"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registersessiontracing_resolveoccurredat",
+      "label": "resolveOccurredAt()",
+      "norm_label": "resolveoccurredat()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registersessiontracing_resolvestorecurrency",
+      "label": "resolveStoreCurrency()",
+      "norm_label": "resolvestorecurrency()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L146"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registersessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L92"
     },
     {
       "community": 2530,
@@ -231714,92 +231783,92 @@
     {
       "community": 254,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
-      "label": "registerSessionTracing.ts",
-      "norm_label": "registersessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "id": "finalizedlineageremediation_classifyfinalizedlineagerepairconflicts",
+      "label": "classifyFinalizedLineageRepairConflicts()",
+      "norm_label": "classifyfinalizedlineagerepairconflicts()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L222"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_classifyrepaircandidate",
+      "label": "classifyRepairCandidate()",
+      "norm_label": "classifyrepaircandidate()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L164"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_countrepairablefinalizedlineagelines",
+      "label": "countRepairableFinalizedLineageLines()",
+      "norm_label": "countrepairablefinalizedlineagelines()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L284"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_getprovisionalimportsku",
+      "label": "getProvisionalImportSku()",
+      "norm_label": "getprovisionalimportsku()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L318"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_isclosedregisterrepairreplayconflict",
+      "label": "isClosedRegisterRepairReplayConflict()",
+      "norm_label": "isclosedregisterrepairreplayconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L273"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_isfinalizedlineagerepairconflict",
+      "label": "isFinalizedLineageRepairConflict()",
+      "norm_label": "isfinalizedlineagerepairconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L258"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_isprovisionalrowchangedconflict",
+      "label": "isProvisionalRowChangedConflict()",
+      "norm_label": "isprovisionalrowchangedconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L265"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_recordfinalizedlineagerepairevent",
+      "label": "recordFinalizedLineageRepairEvent()",
+      "norm_label": "recordfinalizedlineagerepairevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L358"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_skipped",
+      "label": "skipped()",
+      "norm_label": "skipped()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L346"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_sync_finalizedlineageremediation_ts",
+      "label": "finalizedLineageRemediation.ts",
+      "norm_label": "finalizedlineageremediation.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "registersessiontracing_buildactorrefs",
-      "label": "buildActorRefs()",
-      "norm_label": "buildactorrefs()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "registersessiontracing_buildtraceevent",
-      "label": "buildTraceEvent()",
-      "norm_label": "buildtraceevent()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L196"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "registersessiontracing_buildtracerecord",
-      "label": "buildTraceRecord()",
-      "norm_label": "buildtracerecord()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L161"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "registersessiontracing_displaytraceamount",
-      "label": "displayTraceAmount()",
-      "norm_label": "displaytraceamount()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L114"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "registersessiontracing_formattransactionlabel",
-      "label": "formatTransactionLabel()",
-      "norm_label": "formattransactionlabel()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L132"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "registersessiontracing_recordregistersessiontracebesteffort",
-      "label": "recordRegisterSessionTraceBestEffort()",
-      "norm_label": "recordregistersessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L407"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "registersessiontracing_resolveoccurredat",
-      "label": "resolveOccurredAt()",
-      "norm_label": "resolveoccurredat()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L76"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "registersessiontracing_resolvestorecurrency",
-      "label": "resolveStoreCurrency()",
-      "norm_label": "resolvestorecurrency()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L146"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "registersessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L92"
     },
     {
       "community": 2540,
@@ -231894,92 +231963,92 @@
     {
       "community": 255,
       "file_type": "code",
-      "id": "finalizedlineageremediation_classifyfinalizedlineagerepairconflicts",
-      "label": "classifyFinalizedLineageRepairConflicts()",
-      "norm_label": "classifyfinalizedlineagerepairconflicts()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_terminalrecoveryrepository_ts",
+      "label": "terminalRecoveryRepository.ts",
+      "norm_label": "terminalrecoveryrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_createterminalrecoverycommandreadrepository",
+      "label": "createTerminalRecoveryCommandReadRepository()",
+      "norm_label": "createterminalrecoverycommandreadrepository()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_createterminalrecoverycommandrepository",
+      "label": "createTerminalRecoveryCommandRepository()",
+      "norm_label": "createterminalrecoverycommandrepository()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L127"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_deduperecoverycommandsbyid",
+      "label": "dedupeRecoveryCommandsById()",
+      "norm_label": "deduperecoverycommandsbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L116"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_deduperecoveryconflictsbyid",
+      "label": "dedupeRecoveryConflictsById()",
+      "norm_label": "deduperecoveryconflictsbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L193"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_getterminalrecoverysourceevent",
+      "label": "getTerminalRecoverySourceEvent()",
+      "norm_label": "getterminalrecoverysourceevent()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
       "source_location": "L222"
     },
     {
       "community": 255,
       "file_type": "code",
-      "id": "finalizedlineageremediation_classifyrepaircandidate",
-      "label": "classifyRepairCandidate()",
-      "norm_label": "classifyrepaircandidate()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L164"
+      "id": "terminalrecoveryrepository_iscurrentterminalrecoveryconflict",
+      "label": "isCurrentTerminalRecoveryConflict()",
+      "norm_label": "iscurrentterminalrecoveryconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L206"
     },
     {
       "community": 255,
       "file_type": "code",
-      "id": "finalizedlineageremediation_countrepairablefinalizedlineagelines",
-      "label": "countRepairableFinalizedLineageLines()",
-      "norm_label": "countrepairablefinalizedlineagelines()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L284"
+      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsforrepair",
+      "label": "listTerminalRecoveryConflictsForRepair()",
+      "norm_label": "listterminalrecoveryconflictsforrepair()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L141"
     },
     {
       "community": 255,
       "file_type": "code",
-      "id": "finalizedlineageremediation_getprovisionalimportsku",
-      "label": "getProvisionalImportSku()",
-      "norm_label": "getprovisionalimportsku()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L318"
+      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsources",
+      "label": "listTerminalRecoveryConflictSources()",
+      "norm_label": "listterminalrecoveryconflictsources()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L162"
     },
     {
       "community": 255,
       "file_type": "code",
-      "id": "finalizedlineageremediation_isclosedregisterrepairreplayconflict",
-      "label": "isClosedRegisterRepairReplayConflict()",
-      "norm_label": "isclosedregisterrepairreplayconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L273"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_isfinalizedlineagerepairconflict",
-      "label": "isFinalizedLineageRepairConflict()",
-      "norm_label": "isfinalizedlineagerepairconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L258"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_isprovisionalrowchangedconflict",
-      "label": "isProvisionalRowChangedConflict()",
-      "norm_label": "isprovisionalrowchangedconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L265"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_recordfinalizedlineagerepairevent",
-      "label": "recordFinalizedLineageRepairEvent()",
-      "norm_label": "recordfinalizedlineagerepairevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L358"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_skipped",
-      "label": "skipped()",
-      "norm_label": "skipped()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L346"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sync_finalizedlineageremediation_ts",
-      "label": "finalizedLineageRemediation.ts",
-      "norm_label": "finalizedlineageremediation.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L1"
+      "id": "terminalrecoveryrepository_patchterminalrecoveryconflict",
+      "label": "patchTerminalRecoveryConflict()",
+      "norm_label": "patchterminalrecoveryconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L241"
     },
     {
       "community": 2550,
@@ -232074,92 +232143,92 @@
     {
       "community": 256,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_terminalrecoveryrepository_ts",
-      "label": "terminalRecoveryRepository.ts",
-      "norm_label": "terminalrecoveryrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "id": "contract_test_day",
+      "label": "day()",
+      "norm_label": "day()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L1308"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "contract_test_fieldsof",
+      "label": "fieldsOf()",
+      "norm_label": "fieldsof()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L86"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "contract_test_headerfor",
+      "label": "headerFor()",
+      "norm_label": "headerfor()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L972"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "contract_test_inclusivedays",
+      "label": "inclusiveDays()",
+      "norm_label": "inclusivedays()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L1216"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "contract_test_movementidentityargs",
+      "label": "movementIdentityArgs()",
+      "norm_label": "movementidentityargs()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L602"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "contract_test_probe",
+      "label": "probe()",
+      "norm_label": "probe()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L1312"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "contract_test_seedproductsku",
+      "label": "seedProductSku()",
+      "norm_label": "seedproductsku()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L561"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "contract_test_seedstore",
+      "label": "seedStore()",
+      "norm_label": "seedstore()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L542"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "contract_test_unionliterals",
+      "label": "unionLiterals()",
+      "norm_label": "unionliterals()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_reports_contract_test_ts",
+      "label": "contract.test.ts",
+      "norm_label": "contract.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_createterminalrecoverycommandreadrepository",
-      "label": "createTerminalRecoveryCommandReadRepository()",
-      "norm_label": "createterminalrecoverycommandreadrepository()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_createterminalrecoverycommandrepository",
-      "label": "createTerminalRecoveryCommandRepository()",
-      "norm_label": "createterminalrecoverycommandrepository()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L127"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_deduperecoverycommandsbyid",
-      "label": "dedupeRecoveryCommandsById()",
-      "norm_label": "deduperecoverycommandsbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_deduperecoveryconflictsbyid",
-      "label": "dedupeRecoveryConflictsById()",
-      "norm_label": "deduperecoveryconflictsbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L193"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_getterminalrecoverysourceevent",
-      "label": "getTerminalRecoverySourceEvent()",
-      "norm_label": "getterminalrecoverysourceevent()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L222"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_iscurrentterminalrecoveryconflict",
-      "label": "isCurrentTerminalRecoveryConflict()",
-      "norm_label": "iscurrentterminalrecoveryconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L206"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsforrepair",
-      "label": "listTerminalRecoveryConflictsForRepair()",
-      "norm_label": "listterminalrecoveryconflictsforrepair()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L141"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsources",
-      "label": "listTerminalRecoveryConflictSources()",
-      "norm_label": "listterminalrecoveryconflictsources()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L162"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_patchterminalrecoveryconflict",
-      "label": "patchTerminalRecoveryConflict()",
-      "norm_label": "patchterminalrecoveryconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L241"
     },
     {
       "community": 2560,
@@ -232254,91 +232323,91 @@
     {
       "community": 257,
       "file_type": "code",
-      "id": "contract_test_day",
-      "label": "day()",
-      "norm_label": "day()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L1308"
+      "id": "customrange_aggregateskudays",
+      "label": "aggregateSkuDays()",
+      "norm_label": "aggregateskudays()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L217"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "contract_test_fieldsof",
-      "label": "fieldsOf()",
-      "norm_label": "fieldsof()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L86"
+      "id": "customrange_computerange",
+      "label": "computeRange()",
+      "norm_label": "computerange()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L253"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "contract_test_headerfor",
-      "label": "headerFor()",
-      "norm_label": "headerfor()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L972"
+      "id": "customrange_computerequestkey",
+      "label": "computeRequestKey()",
+      "norm_label": "computerequestkey()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L84"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "contract_test_inclusivedays",
-      "label": "inclusiveDays()",
-      "norm_label": "inclusivedays()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L1216"
+      "id": "customrange_inclusivedayspan",
+      "label": "inclusiveDaySpan()",
+      "norm_label": "inclusivedayspan()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L52"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "contract_test_movementidentityargs",
-      "label": "movementIdentityArgs()",
-      "norm_label": "movementidentityargs()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L602"
+      "id": "customrange_isvalidoperatingdate",
+      "label": "isValidOperatingDate()",
+      "norm_label": "isvalidoperatingdate()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L35"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "contract_test_probe",
-      "label": "probe()",
-      "norm_label": "probe()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L1312"
+      "id": "customrange_requestrangecore",
+      "label": "requestRangeCore()",
+      "norm_label": "requestrangecore()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L112"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "contract_test_seedproductsku",
-      "label": "seedProductSku()",
-      "norm_label": "seedproductsku()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L561"
+      "id": "customrange_sumdays",
+      "label": "sumDays()",
+      "norm_label": "sumdays()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L189"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "contract_test_seedstore",
-      "label": "seedStore()",
-      "norm_label": "seedstore()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L542"
+      "id": "customrange_utcmillisforlabel",
+      "label": "utcMillisForLabel()",
+      "norm_label": "utcmillisforlabel()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L46"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "contract_test_unionliterals",
-      "label": "unionLiterals()",
-      "norm_label": "unionliterals()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L92"
+      "id": "customrange_validaterangeargs",
+      "label": "validateRangeArgs()",
+      "norm_label": "validaterangeargs()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L58"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_contract_test_ts",
-      "label": "contract.test.ts",
-      "norm_label": "contract.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "id": "packages_athena_webapp_convex_reports_customrange_ts",
+      "label": "customRange.ts",
+      "norm_label": "customrange.ts",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
       "source_location": "L1"
     },
     {
@@ -232434,92 +232503,92 @@
     {
       "community": 258,
       "file_type": "code",
-      "id": "customrange_aggregateskudays",
-      "label": "aggregateSkuDays()",
-      "norm_label": "aggregateskudays()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L217"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "customrange_computerange",
-      "label": "computeRange()",
-      "norm_label": "computerange()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L253"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "customrange_computerequestkey",
-      "label": "computeRequestKey()",
-      "norm_label": "computerequestkey()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L84"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "customrange_inclusivedayspan",
-      "label": "inclusiveDaySpan()",
-      "norm_label": "inclusivedayspan()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "customrange_isvalidoperatingdate",
-      "label": "isValidOperatingDate()",
-      "norm_label": "isvalidoperatingdate()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "customrange_requestrangecore",
-      "label": "requestRangeCore()",
-      "norm_label": "requestrangecore()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L112"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "customrange_sumdays",
-      "label": "sumDays()",
-      "norm_label": "sumdays()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L189"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "customrange_utcmillisforlabel",
-      "label": "utcMillisForLabel()",
-      "norm_label": "utcmillisforlabel()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "customrange_validaterangeargs",
-      "label": "validateRangeArgs()",
-      "norm_label": "validaterangeargs()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_customrange_ts",
-      "label": "customRange.ts",
-      "norm_label": "customrange.ts",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "id": "packages_athena_webapp_convex_reports_rangesnapshotlifecycle_test_ts",
+      "label": "rangeSnapshotLifecycle.test.ts",
+      "norm_label": "rangesnapshotlifecycle.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_allow",
+      "label": "allow()",
+      "norm_label": "allow()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_certifyday",
+      "label": "certifyDay()",
+      "norm_label": "certifyday()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L109"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_consume",
+      "label": "consume()",
+      "norm_label": "consume()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L296"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_drive",
+      "label": "drive()",
+      "norm_label": "drive()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L247"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_ensuresynthetic",
+      "label": "ensureSynthetic()",
+      "norm_label": "ensuresynthetic()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L208"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_headerbykey",
+      "label": "headerByKey()",
+      "norm_label": "headerbykey()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L230"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_insertkindedheader",
+      "label": "insertKindedHeader()",
+      "norm_label": "insertkindedheader()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L612"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_seedstore",
+      "label": "seedStore()",
+      "norm_label": "seedstore()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "rangesnapshotlifecycle_test_synthetickind",
+      "label": "syntheticKind()",
+      "norm_label": "synthetickind()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L150"
     },
     {
       "community": 2580,
@@ -232614,92 +232683,92 @@
     {
       "community": 259,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_rangesnapshotlifecycle_test_ts",
-      "label": "rangeSnapshotLifecycle.test.ts",
-      "norm_label": "rangesnapshotlifecycle.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "id": "packages_athena_webapp_convex_reports_verificationclassify_ts",
+      "label": "verificationClassify.ts",
+      "norm_label": "verificationclassify.ts",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
       "source_location": "L1"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_allow",
-      "label": "allow()",
-      "norm_label": "allow()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L53"
+      "id": "verificationclassify_buildclassification",
+      "label": "buildClassification()",
+      "norm_label": "buildclassification()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L448"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_certifyday",
-      "label": "certifyDay()",
-      "norm_label": "certifyday()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L109"
+      "id": "verificationclassify_classifydayresult",
+      "label": "classifyDayResult()",
+      "norm_label": "classifydayresult()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L481"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_consume",
-      "label": "consume()",
-      "norm_label": "consume()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L296"
+      "id": "verificationclassify_classifyweekresult",
+      "label": "classifyWeekResult()",
+      "norm_label": "classifyweekresult()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L562"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_drive",
-      "label": "drive()",
-      "norm_label": "drive()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L247"
+      "id": "verificationclassify_confirmsclean",
+      "label": "confirmsClean()",
+      "norm_label": "confirmsclean()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L681"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_ensuresynthetic",
-      "label": "ensureSynthetic()",
-      "norm_label": "ensuresynthetic()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L208"
+      "id": "verificationclassify_explainmetricdifference",
+      "label": "explainMetricDifference()",
+      "norm_label": "explainmetricdifference()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L378"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_headerbykey",
-      "label": "headerByKey()",
-      "norm_label": "headerbykey()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L230"
+      "id": "verificationclassify_fingerprintdifferences",
+      "label": "fingerprintDifferences()",
+      "norm_label": "fingerprintdifferences()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L354"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_insertkindedheader",
-      "label": "insertKindedHeader()",
-      "norm_label": "insertkindedheader()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L612"
+      "id": "verificationclassify_initialstreakstate",
+      "label": "initialStreakState()",
+      "norm_label": "initialstreakstate()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L658"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_seedstore",
-      "label": "seedStore()",
-      "norm_label": "seedstore()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L73"
+      "id": "verificationclassify_nextstreakstate",
+      "label": "nextStreakState()",
+      "norm_label": "nextstreakstate()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L707"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_synthetickind",
-      "label": "syntheticKind()",
-      "norm_label": "synthetickind()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L150"
+      "id": "verificationclassify_partitiondifferences",
+      "label": "partitionDifferences()",
+      "norm_label": "partitiondifferences()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L434"
     },
     {
       "community": 2590,
@@ -233136,92 +233205,92 @@
     {
       "community": 260,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_verificationclassify_ts",
-      "label": "verificationClassify.ts",
-      "norm_label": "verificationclassify.ts",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "id": "index_resolveverificationcoderecipient",
+      "label": "resolveVerificationCodeRecipient()",
+      "norm_label": "resolveverificationcoderecipient()",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "index_senddailymanagerreportemail",
+      "label": "sendDailyManagerReportEmail()",
+      "norm_label": "senddailymanagerreportemail()",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "source_location": "L373"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "index_senddiscountcodeemail",
+      "label": "sendDiscountCodeEmail()",
+      "norm_label": "senddiscountcodeemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L255"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "index_senddiscountreminderemail",
+      "label": "sendDiscountReminderEmail()",
+      "norm_label": "senddiscountreminderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L334"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "index_sendfeedbackrequestemail",
+      "label": "sendFeedbackRequestEmail()",
+      "norm_label": "sendfeedbackrequestemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "index_sendneworderemail",
+      "label": "sendNewOrderEmail()",
+      "norm_label": "sendneworderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L117"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "index_sendorderemail",
+      "label": "sendOrderEmail()",
+      "norm_label": "sendorderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "index_sendverificationcode",
+      "label": "sendVerificationCode()",
+      "norm_label": "sendverificationcode()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
       "source_location": "L1"
     },
     {
       "community": 260,
       "file_type": "code",
-      "id": "verificationclassify_buildclassification",
-      "label": "buildClassification()",
-      "norm_label": "buildclassification()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L448"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "verificationclassify_classifydayresult",
-      "label": "classifyDayResult()",
-      "norm_label": "classifydayresult()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L481"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "verificationclassify_classifyweekresult",
-      "label": "classifyWeekResult()",
-      "norm_label": "classifyweekresult()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L562"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "verificationclassify_confirmsclean",
-      "label": "confirmsClean()",
-      "norm_label": "confirmsclean()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L681"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "verificationclassify_explainmetricdifference",
-      "label": "explainMetricDifference()",
-      "norm_label": "explainmetricdifference()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L378"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "verificationclassify_fingerprintdifferences",
-      "label": "fingerprintDifferences()",
-      "norm_label": "fingerprintdifferences()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L354"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "verificationclassify_initialstreakstate",
-      "label": "initialStreakState()",
-      "norm_label": "initialstreakstate()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L658"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "verificationclassify_nextstreakstate",
-      "label": "nextStreakState()",
-      "norm_label": "nextstreakstate()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L707"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "verificationclassify_partitiondifferences",
-      "label": "partitionDifferences()",
-      "norm_label": "partitiondifferences()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L434"
+      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L1"
     },
     {
       "community": 2600,
@@ -234940,7 +235009,7 @@
       "label": "buildBlockers()",
       "norm_label": "buildblockers()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L903"
+      "source_location": "L912"
     },
     {
       "community": 27,
@@ -234949,7 +235018,7 @@
       "label": "buildCarryForwardItems()",
       "norm_label": "buildcarryforwarditems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L879"
+      "source_location": "L888"
     },
     {
       "community": 27,
@@ -234958,7 +235027,7 @@
       "label": "buildCashMetrics()",
       "norm_label": "buildcashmetrics()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1069"
+      "source_location": "L1078"
     },
     {
       "community": 27,
@@ -234967,7 +235036,7 @@
       "label": "buildDailyManagerReportPayload()",
       "norm_label": "builddailymanagerreportpayload()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L589"
+      "source_location": "L598"
     },
     {
       "community": 27,
@@ -234976,7 +235045,7 @@
       "label": "buildDailyTopMoversUrl()",
       "norm_label": "builddailytopmoversurl()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L574"
+      "source_location": "L583"
     },
     {
       "community": 27,
@@ -234985,7 +235054,7 @@
       "label": "buildOpenDailyManagerReportPayload()",
       "norm_label": "buildopendailymanagerreportpayload()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L666"
+      "source_location": "L675"
     },
     {
       "community": 27,
@@ -234994,7 +235063,7 @@
       "label": "buildPaymentTotals()",
       "norm_label": "buildpaymenttotals()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L947"
+      "source_location": "L956"
     },
     {
       "community": 27,
@@ -235003,7 +235072,7 @@
       "label": "buildPreparedBlockers()",
       "norm_label": "buildpreparedblockers()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L917"
+      "source_location": "L926"
     },
     {
       "community": 27,
@@ -235012,7 +235081,7 @@
       "label": "buildPreparedCarryForwardItems()",
       "norm_label": "buildpreparedcarryforwarditems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L892"
+      "source_location": "L901"
     },
     {
       "community": 27,
@@ -235021,7 +235090,7 @@
       "label": "buildPreparedDailyManagerReportPayload()",
       "norm_label": "buildprepareddailymanagerreportpayload()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L649"
+      "source_location": "L658"
     },
     {
       "community": 27,
@@ -235030,7 +235099,7 @@
       "label": "buildPreparedReviewItems()",
       "norm_label": "buildpreparedreviewitems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L868"
+      "source_location": "L877"
     },
     {
       "community": 27,
@@ -235039,7 +235108,7 @@
       "label": "buildRegisterCashPositionSummary()",
       "norm_label": "buildregistercashpositionsummary()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L705"
+      "source_location": "L714"
     },
     {
       "community": 27,
@@ -235048,7 +235117,7 @@
       "label": "buildReviewedItems()",
       "norm_label": "buildrevieweditems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L792"
+      "source_location": "L801"
     },
     {
       "community": 27,
@@ -235057,7 +235126,7 @@
       "label": "buildSummaryMetrics()",
       "norm_label": "buildsummarymetrics()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L987"
+      "source_location": "L996"
     },
     {
       "community": 27,
@@ -235066,7 +235135,7 @@
       "label": "buildTopItemsForDay()",
       "norm_label": "buildtopitemsforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L562"
+      "source_location": "L571"
     },
     {
       "community": 27,
@@ -235075,7 +235144,7 @@
       "label": "buildUnitsSoldSummary()",
       "norm_label": "buildunitssoldsummary()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L544"
+      "source_location": "L553"
     },
     {
       "community": 27,
@@ -235084,7 +235153,7 @@
       "label": "comparisonFromSummary()",
       "norm_label": "comparisonfromsummary()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1147"
+      "source_location": "L1156"
     },
     {
       "community": 27,
@@ -235093,7 +235162,7 @@
       "label": "countLabel()",
       "norm_label": "countlabel()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1183"
+      "source_location": "L1192"
     },
     {
       "community": 27,
@@ -235102,7 +235171,7 @@
       "label": "formatBlockerMessage()",
       "norm_label": "formatblockermessage()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L927"
+      "source_location": "L936"
     },
     {
       "community": 27,
@@ -235111,7 +235180,7 @@
       "label": "formatCompletedAt()",
       "norm_label": "formatcompletedat()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1227"
+      "source_location": "L1236"
     },
     {
       "community": 27,
@@ -235120,7 +235189,7 @@
       "label": "formatOperatingDate()",
       "norm_label": "formatoperatingdate()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1206"
+      "source_location": "L1215"
     },
     {
       "community": 27,
@@ -235129,7 +235198,7 @@
       "label": "formatPaymentMethod()",
       "norm_label": "formatpaymentmethod()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1193"
+      "source_location": "L1202"
     },
     {
       "community": 27,
@@ -235138,7 +235207,7 @@
       "label": "formatPriorDayComparison()",
       "norm_label": "formatpriordaycomparison()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1162"
+      "source_location": "L1171"
     },
     {
       "community": 27,
@@ -235147,7 +235216,7 @@
       "label": "formatUnitCount()",
       "norm_label": "formatunitcount()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1179"
+      "source_location": "L1188"
     },
     {
       "community": 27,
@@ -235156,7 +235225,7 @@
       "label": "isPaymentTotal()",
       "norm_label": "ispaymenttotal()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1114"
+      "source_location": "L1123"
     },
     {
       "community": 27,
@@ -235165,7 +235234,7 @@
       "label": "moneyFormatter()",
       "norm_label": "moneyformatter()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1127"
+      "source_location": "L1136"
     },
     {
       "community": 27,
@@ -235174,7 +235243,7 @@
       "label": "normalizeCurrency()",
       "norm_label": "normalizecurrency()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1187"
+      "source_location": "L1196"
     },
     {
       "community": 27,
@@ -235183,7 +235252,7 @@
       "label": "normalizePaymentMethod()",
       "norm_label": "normalizepaymentmethod()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1199"
+      "source_location": "L1208"
     },
     {
       "community": 27,
@@ -235192,7 +235261,7 @@
       "label": "numberFromSummary()",
       "norm_label": "numberfromsummary()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1133"
+      "source_location": "L1142"
     },
     {
       "community": 27,
@@ -235201,7 +235270,7 @@
       "label": "numberFromSummaryWithFallback()",
       "norm_label": "numberfromsummarywithfallback()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1138"
+      "source_location": "L1147"
     },
     {
       "community": 27,
@@ -235210,7 +235279,7 @@
       "label": "optionalMetadataLabel()",
       "norm_label": "optionalmetadatalabel()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L939"
+      "source_location": "L948"
     },
     {
       "community": 27,
@@ -235219,7 +235288,7 @@
       "label": "readUnitsSoldForDay()",
       "norm_label": "readunitssoldforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L526"
+      "source_location": "L535"
     },
     {
       "community": 27,
@@ -235228,7 +235297,7 @@
       "label": "resolveAppUrl()",
       "norm_label": "resolveappurl()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1235"
+      "source_location": "L1244"
     },
     {
       "community": 27,
@@ -235237,7 +235306,7 @@
       "label": "resolveStaffName()",
       "norm_label": "resolvestaffname()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L504"
+      "source_location": "L513"
     },
     {
       "community": 27,
@@ -235246,7 +235315,7 @@
       "label": "resolveStore()",
       "norm_label": "resolvestore()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L483"
+      "source_location": "L492"
     },
     {
       "community": 27,
@@ -235255,7 +235324,7 @@
       "label": "resolveStoreScheduleTimezoneForAt()",
       "norm_label": "resolvestorescheduletimezoneforat()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1219"
+      "source_location": "L1228"
     },
     {
       "community": 27,
@@ -235264,7 +235333,7 @@
       "label": "trimTrailingSlash()",
       "norm_label": "trimtrailingslash()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts",
-      "source_location": "L1248"
+      "source_location": "L1257"
     },
     {
       "community": 27,
@@ -242289,87 +242358,6 @@
     {
       "community": 318,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "productutils_getpreferredsku",
-      "label": "getPreferredSku()",
-      "norm_label": "getpreferredsku()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L82"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "productutils_sortskusbyavailabilitythenlength",
-      "label": "sortSkusByAvailabilityThenLength()",
-      "norm_label": "sortskusbyavailabilitythenlength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
       "id": "applyremoteassistcontrolintent_applyacceptedcontrolresult",
       "label": "applyAcceptedControlResult()",
       "norm_label": "applyacceptedcontrolresult()",
@@ -242377,7 +242365,7 @@
       "source_location": "L84"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_applykeyevent",
       "label": "applyKeyEvent()",
@@ -242386,7 +242374,7 @@
       "source_location": "L155"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_applypointerevent",
       "label": "applyPointerEvent()",
@@ -242395,7 +242383,7 @@
       "source_location": "L116"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_applyremoteassistcontrolintent",
       "label": "applyRemoteAssistControlIntent()",
@@ -242404,7 +242392,7 @@
       "source_location": "L17"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_getrecentcontrolresult",
       "label": "getRecentControlResult()",
@@ -242413,7 +242401,7 @@
       "source_location": "L95"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_getremoteassistcontroltarget",
       "label": "getRemoteAssistControlTarget()",
@@ -242422,7 +242410,7 @@
       "source_location": "L145"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_prepareremoteassistcontrolintent",
       "label": "prepareRemoteAssistControlIntent()",
@@ -242431,7 +242419,7 @@
       "source_location": "L27"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_remembercontrolresult",
       "label": "rememberControlResult()",
@@ -242440,13 +242428,94 @@
       "source_location": "L101"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_remote_assist_runtime_applyremoteassistcontrolintent_ts",
       "label": "applyRemoteAssistControlIntent.ts",
       "norm_label": "applyremoteassistcontrolintent.ts",
       "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_offline_posofflinereadiness_ts",
+      "label": "posOfflineReadiness.ts",
+      "norm_label": "posofflinereadiness.ts",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "posofflinereadiness_buildposofflinereadinesssummary",
+      "label": "buildPosOfflineReadinessSummary()",
+      "norm_label": "buildposofflinereadinesssummary()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L152"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "posofflinereadiness_buildsignal",
+      "label": "buildSignal()",
+      "norm_label": "buildsignal()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L178"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "posofflinereadiness_formatage",
+      "label": "formatAge()",
+      "norm_label": "formatage()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L290"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsignaldescription",
+      "label": "getSignalDescription()",
+      "norm_label": "getsignaldescription()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L221"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsignalstatus",
+      "label": "getSignalStatus()",
+      "norm_label": "getsignalstatus()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L201"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsummarydescription",
+      "label": "getSummaryDescription()",
+      "norm_label": "getsummarydescription()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L262"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsummarytitle",
+      "label": "getSummaryTitle()",
+      "norm_label": "getsummarytitle()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L256"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "posofflinereadiness_isreadylike",
+      "label": "isReadyLike()",
+      "norm_label": "isreadylike()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L286"
     },
     {
       "community": 32,
@@ -242775,87 +242844,6 @@
     {
       "community": 320,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_offline_posofflinereadiness_ts",
-      "label": "posOfflineReadiness.ts",
-      "norm_label": "posofflinereadiness.ts",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "posofflinereadiness_buildposofflinereadinesssummary",
-      "label": "buildPosOfflineReadinessSummary()",
-      "norm_label": "buildposofflinereadinesssummary()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L152"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "posofflinereadiness_buildsignal",
-      "label": "buildSignal()",
-      "norm_label": "buildsignal()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L178"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "posofflinereadiness_formatage",
-      "label": "formatAge()",
-      "norm_label": "formatage()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L290"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsignaldescription",
-      "label": "getSignalDescription()",
-      "norm_label": "getsignaldescription()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L221"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsignalstatus",
-      "label": "getSignalStatus()",
-      "norm_label": "getsignalstatus()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L201"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsummarydescription",
-      "label": "getSummaryDescription()",
-      "norm_label": "getsummarydescription()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L262"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsummarytitle",
-      "label": "getSummaryTitle()",
-      "norm_label": "getsummarytitle()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L256"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "posofflinereadiness_isreadylike",
-      "label": "isReadyLike()",
-      "norm_label": "isreadylike()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L286"
-    },
-    {
-      "community": 321,
-      "file_type": "code",
       "id": "foundations_content_colorrolecard",
       "label": "ColorRoleCard()",
       "norm_label": "colorrolecard()",
@@ -242863,7 +242851,7 @@
       "source_location": "L222"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "foundations_content_densitycard",
       "label": "DensityCard()",
@@ -242872,7 +242860,7 @@
       "source_location": "L283"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "foundations_content_detailviewrolecard",
       "label": "DetailViewRoleCard()",
@@ -242881,7 +242869,7 @@
       "source_location": "L363"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "foundations_content_hslvar",
       "label": "hslVar()",
@@ -242890,7 +242878,7 @@
       "source_location": "L214"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "foundations_content_motioncard",
       "label": "MotionCard()",
@@ -242899,7 +242887,7 @@
       "source_location": "L342"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "foundations_content_spacetokenrow",
       "label": "SpaceTokenRow()",
@@ -242908,7 +242896,7 @@
       "source_location": "L265"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "foundations_content_textvar",
       "label": "textVar()",
@@ -242917,7 +242905,7 @@
       "source_location": "L218"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "foundations_content_typespecimencard",
       "label": "TypeSpecimenCard()",
@@ -242926,7 +242914,7 @@
       "source_location": "L246"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_foundations_content_tsx",
       "label": "foundations-content.tsx",
@@ -242935,7 +242923,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -242944,7 +242932,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -242953,7 +242941,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "versionchecker_buildidfromscripts",
       "label": "buildIdFromScripts()",
@@ -242962,7 +242950,7 @@
       "source_location": "L192"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "versionchecker_createversionchecker",
       "label": "createVersionChecker()",
@@ -242971,7 +242959,7 @@
       "source_location": "L16"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "versionchecker_getinitialdeploybuildid",
       "label": "getInitialDeployBuildId()",
@@ -242980,7 +242968,7 @@
       "source_location": "L135"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "versionchecker_readdeploybuildid",
       "label": "readDeployBuildId()",
@@ -242989,7 +242977,7 @@
       "source_location": "L141"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "versionchecker_readdocumentscriptsources",
       "label": "readDocumentScriptSources()",
@@ -242998,7 +242986,7 @@
       "source_location": "L174"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "versionchecker_readentryhtmlscripts",
       "label": "readEntryHtmlScripts()",
@@ -243007,13 +242995,94 @@
       "source_location": "L151"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "versionchecker_readscriptsources",
       "label": "readScriptSources()",
       "norm_label": "readscriptsources()",
       "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
       "source_location": "L182"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
+      "id": "productutils_getpreferredsku",
+      "label": "getPreferredSku()",
+      "norm_label": "getpreferredsku()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L82"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
+      "id": "productutils_sortskusbyavailabilitythenlength",
+      "label": "sortSkusByAvailabilityThenLength()",
+      "norm_label": "sortskusbyavailabilitythenlength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L59"
     },
     {
       "community": 323,
@@ -255879,6 +255948,60 @@
     {
       "community": 450,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_notifications_registry_ts",
+      "label": "registry.ts",
+      "norm_label": "registry.ts",
+      "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "registry_findnotificationkind",
+      "label": "findNotificationKind()",
+      "norm_label": "findnotificationkind()",
+      "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
+      "source_location": "L420"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "registry_getnotificationkind",
+      "label": "getNotificationKind()",
+      "norm_label": "getnotificationkind()",
+      "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
+      "source_location": "L430"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "registry_isstaledailyclosepayload",
+      "label": "isStaleDailyClosePayload()",
+      "norm_label": "isstaledailyclosepayload()",
+      "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
+      "source_location": "L88"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "registry_listnotificationkinds",
+      "label": "listNotificationKinds()",
+      "norm_label": "listnotificationkinds()",
+      "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
+      "source_location": "L438"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "registry_requirestaledailyclosepayload",
+      "label": "requireStaleDailyClosePayload()",
+      "norm_label": "requirestaledailyclosepayload()",
+      "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
       "id": "actors_getoperationactorathenauserid",
       "label": "getOperationActorAthenaUserId()",
       "norm_label": "getoperationactorathenauserid()",
@@ -255886,7 +256009,7 @@
       "source_location": "L20"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "actors_isnormaluseroperationactor",
       "label": "isNormalUserOperationActor()",
@@ -255895,7 +256018,7 @@
       "source_location": "L8"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "actors_ispublicoperationactor",
       "label": "isPublicOperationActor()",
@@ -255904,7 +256027,7 @@
       "source_location": "L12"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "actors_isshareddemooperationactor",
       "label": "isSharedDemoOperationActor()",
@@ -255913,7 +256036,7 @@
       "source_location": "L4"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "actors_requireoperationactorathenauserid",
       "label": "requireOperationActorAthenaUserId()",
@@ -255922,7 +256045,7 @@
       "source_location": "L31"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_actors_ts",
       "label": "actors.ts",
@@ -255931,7 +256054,7 @@
       "source_location": "L1"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "approval_builddailycloseapprovalsubject",
       "label": "buildDailyCloseApprovalSubject()",
@@ -255940,7 +256063,7 @@
       "source_location": "L15"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "approval_builddailyclosecarryforwardapprovalrequirement",
       "label": "buildDailyCloseCarryForwardApprovalRequirement()",
@@ -255949,7 +256072,7 @@
       "source_location": "L101"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "approval_builddailyclosecarryforwardapprovalsubject",
       "label": "buildDailyCloseCarryForwardApprovalSubject()",
@@ -255958,7 +256081,7 @@
       "source_location": "L88"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "approval_builddailyclosecompletionapprovalrequirement",
       "label": "buildDailyCloseCompletionApprovalRequirement()",
@@ -255967,7 +256090,7 @@
       "source_location": "L26"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "approval_builddailyclosereopenapprovalrequirement",
       "label": "buildDailyCloseReopenApprovalRequirement()",
@@ -255976,7 +256099,7 @@
       "source_location": "L54"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_dailyclose_approval_ts",
       "label": "approval.ts",
@@ -255985,7 +256108,7 @@
       "source_location": "L1"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "eventbuilders_buildonlineorderoperationaleventmessage",
       "label": "buildOnlineOrderOperationalEventMessage()",
@@ -255994,7 +256117,7 @@
       "source_location": "L68"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "eventbuilders_buildoperationaleventmessage",
       "label": "buildOperationalEventMessage()",
@@ -256003,7 +256126,7 @@
       "source_location": "L1"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "eventbuilders_buildstockadjustmentoperationaleventmessage",
       "label": "buildStockAdjustmentOperationalEventMessage()",
@@ -256012,7 +256135,7 @@
       "source_location": "L93"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "eventbuilders_formatonlineorderlabel",
       "label": "formatOnlineOrderLabel()",
@@ -256021,7 +256144,7 @@
       "source_location": "L112"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "eventbuilders_formatstockadjustmentsubjectdetail",
       "label": "formatStockAdjustmentSubjectDetail()",
@@ -256030,7 +256153,7 @@
       "source_location": "L106"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_helpers_eventbuilders_ts",
       "label": "eventBuilders.ts",
@@ -256039,7 +256162,61 @@
       "source_location": "L1"
     },
     {
-      "community": 453,
+      "community": 454,
+      "file_type": "code",
+      "id": "oweddailyclosesweep_completedoperatingdatesforstore",
+      "label": "completedOperatingDatesForStore()",
+      "norm_label": "completedoperatingdatesforstore()",
+      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
+      "source_location": "L155"
+    },
+    {
+      "community": 454,
+      "file_type": "code",
+      "id": "oweddailyclosesweep_dailyclosesweepresultsettled",
+      "label": "dailyCloseSweepResultSettled()",
+      "norm_label": "dailyclosesweepresultsettled()",
+      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 454,
+      "file_type": "code",
+      "id": "oweddailyclosesweep_daysbetweenoperatingdates",
+      "label": "daysBetweenOperatingDates()",
+      "norm_label": "daysbetweenoperatingdates()",
+      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
+      "source_location": "L388"
+    },
+    {
+      "community": 454,
+      "file_type": "code",
+      "id": "oweddailyclosesweep_listenabledeodpolicies",
+      "label": "listEnabledEodPolicies()",
+      "norm_label": "listenabledeodpolicies()",
+      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
+      "source_location": "L141"
+    },
+    {
+      "community": 454,
+      "file_type": "code",
+      "id": "oweddailyclosesweep_selectoweddailyclosedates",
+      "label": "selectOwedDailyCloseDates()",
+      "norm_label": "selectoweddailyclosedates()",
+      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
+      "source_location": "L89"
+    },
+    {
+      "community": 454,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
+      "label": "owedDailyCloseSweep.ts",
+      "norm_label": "oweddailyclosesweep.ts",
+      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 455,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_serviceintake_test_ts",
       "label": "serviceIntake.test.ts",
@@ -256048,7 +256225,7 @@
       "source_location": "L1"
     },
     {
-      "community": 453,
+      "community": 455,
       "file_type": "code",
       "id": "serviceintake_test_buildcreateserviceintakeargs",
       "label": "buildCreateServiceIntakeArgs()",
@@ -256057,7 +256234,7 @@
       "source_location": "L38"
     },
     {
-      "community": 453,
+      "community": 455,
       "file_type": "code",
       "id": "serviceintake_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -256066,7 +256243,7 @@
       "source_location": "L52"
     },
     {
-      "community": 453,
+      "community": 455,
       "file_type": "code",
       "id": "serviceintake_test_createserviceintakebehaviorctx",
       "label": "createServiceIntakeBehaviorCtx()",
@@ -256075,7 +256252,7 @@
       "source_location": "L96"
     },
     {
-      "community": 453,
+      "community": 455,
       "file_type": "code",
       "id": "serviceintake_test_gethandler",
       "label": "getHandler()",
@@ -256084,7 +256261,7 @@
       "source_location": "L34"
     },
     {
-      "community": 453,
+      "community": 455,
       "file_type": "code",
       "id": "serviceintake_test_getsource",
       "label": "getSource()",
@@ -256093,7 +256270,7 @@
       "source_location": "L30"
     },
     {
-      "community": 454,
+      "community": 456,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_weeklymanagerreportemail_test_ts",
       "label": "weeklyManagerReportEmail.test.ts",
@@ -256102,7 +256279,7 @@
       "source_location": "L1"
     },
     {
-      "community": 454,
+      "community": 456,
       "file_type": "code",
       "id": "weeklymanagerreportemail_test_buildpayload",
       "label": "buildPayload()",
@@ -256111,7 +256288,7 @@
       "source_location": "L128"
     },
     {
-      "community": 454,
+      "community": 456,
       "file_type": "code",
       "id": "weeklymanagerreportemail_test_countedcashsection",
       "label": "countedCashSection()",
@@ -256120,7 +256297,7 @@
       "source_location": "L234"
     },
     {
-      "community": 454,
+      "community": 456,
       "file_type": "code",
       "id": "weeklymanagerreportemail_test_evidencecoverage",
       "label": "evidenceCoverage()",
@@ -256129,7 +256306,7 @@
       "source_location": "L61"
     },
     {
-      "community": 454,
+      "community": 456,
       "file_type": "code",
       "id": "weeklymanagerreportemail_test_lineageday",
       "label": "lineageDay()",
@@ -256138,7 +256315,7 @@
       "source_location": "L117"
     },
     {
-      "community": 454,
+      "community": 456,
       "file_type": "code",
       "id": "weeklymanagerreportemail_test_makecloseevidence",
       "label": "makeCloseEvidence()",
@@ -256147,7 +256324,7 @@
       "source_location": "L69"
     },
     {
-      "community": 455,
+      "community": 457,
       "file_type": "code",
       "id": "completetransaction_test_createvoidctx",
       "label": "createVoidCtx()",
@@ -256156,7 +256333,7 @@
       "source_location": "L219"
     },
     {
-      "community": 455,
+      "community": 457,
       "file_type": "code",
       "id": "completetransaction_test_expectnocompletionsideeffects",
       "label": "expectNoCompletionSideEffects()",
@@ -256165,7 +256342,7 @@
       "source_location": "L197"
     },
     {
-      "community": 455,
+      "community": 457,
       "file_type": "code",
       "id": "completetransaction_test_expectnovoidbusinesssideeffects",
       "label": "expectNoVoidBusinessSideEffects()",
@@ -256174,7 +256351,7 @@
       "source_location": "L211"
     },
     {
-      "community": 455,
+      "community": 457,
       "file_type": "code",
       "id": "completetransaction_test_seeddirect",
       "label": "seedDirect()",
@@ -256183,7 +256360,7 @@
       "source_location": "L4778"
     },
     {
-      "community": 455,
+      "community": 457,
       "file_type": "code",
       "id": "completetransaction_test_seeddirecthappypath",
       "label": "seedDirectHappyPath()",
@@ -256192,7 +256369,7 @@
       "source_location": "L4625"
     },
     {
-      "community": 455,
+      "community": 457,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_completetransaction_test_ts",
       "label": "completeTransaction.test.ts",
@@ -256201,7 +256378,7 @@
       "source_location": "L1"
     },
     {
-      "community": 456,
+      "community": 458,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_registerlifecycleauthority_test_ts",
       "label": "registerLifecycleAuthority.test.ts",
@@ -256210,7 +256387,7 @@
       "source_location": "L1"
     },
     {
-      "community": 456,
+      "community": 458,
       "file_type": "code",
       "id": "registerlifecycleauthority_test_createrepository",
       "label": "createRepository()",
@@ -256219,7 +256396,7 @@
       "source_location": "L675"
     },
     {
-      "community": 456,
+      "community": 458,
       "file_type": "code",
       "id": "registerlifecycleauthority_test_mapping",
       "label": "mapping()",
@@ -256228,7 +256405,7 @@
       "source_location": "L741"
     },
     {
-      "community": 456,
+      "community": 458,
       "file_type": "code",
       "id": "registerlifecycleauthority_test_mappingauthority",
       "label": "mappingAuthority()",
@@ -256237,7 +256414,7 @@
       "source_location": "L708"
     },
     {
-      "community": 456,
+      "community": 458,
       "file_type": "code",
       "id": "registerlifecycleauthority_test_registersession",
       "label": "registerSession()",
@@ -256246,7 +256423,7 @@
       "source_location": "L760"
     },
     {
-      "community": 456,
+      "community": 458,
       "file_type": "code",
       "id": "registerlifecycleauthority_test_terminal",
       "label": "terminal()",
@@ -256255,7 +256432,7 @@
       "source_location": "L726"
     },
     {
-      "community": 457,
+      "community": 459,
       "file_type": "code",
       "id": "localsyncrepository_areconflictdetailsequivalent",
       "label": "areConflictDetailsEquivalent()",
@@ -256264,7 +256441,7 @@
       "source_location": "L62"
     },
     {
-      "community": 457,
+      "community": 459,
       "file_type": "code",
       "id": "localsyncrepository_createconvexlocalsyncrepository",
       "label": "createConvexLocalSyncRepository()",
@@ -256273,7 +256450,7 @@
       "source_location": "L152"
     },
     {
-      "community": 457,
+      "community": 459,
       "file_type": "code",
       "id": "localsyncrepository_omitundefined",
       "label": "omitUndefined()",
@@ -256282,7 +256459,7 @@
       "source_location": "L56"
     },
     {
-      "community": 457,
+      "community": 459,
       "file_type": "code",
       "id": "localsyncrepository_reportfactsfromlocalsyncingressargs",
       "label": "reportFactsFromLocalSyncIngressArgs()",
@@ -256291,7 +256468,7 @@
       "source_location": "L107"
     },
     {
-      "community": 457,
+      "community": 459,
       "file_type": "code",
       "id": "localsyncrepository_trimoptional",
       "label": "trimOptional()",
@@ -256300,121 +256477,13 @@
       "source_location": "L92"
     },
     {
-      "community": 457,
+      "community": 459,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_localsyncrepository_ts",
       "label": "localSyncRepository.ts",
       "norm_label": "localsyncrepository.ts",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 458,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_public_sync_ts",
-      "label": "sync.ts",
-      "norm_label": "sync.ts",
-      "source_file": "packages/athena-webapp/convex/pos/public/sync.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 458,
-      "file_type": "code",
-      "id": "sync_isvariancereviewforcloseout",
-      "label": "isVarianceReviewForCloseout()",
-      "norm_label": "isvariancereviewforcloseout()",
-      "source_file": "packages/athena-webapp/convex/pos/public/sync.ts",
-      "source_location": "L455"
-    },
-    {
-      "community": 458,
-      "file_type": "code",
-      "id": "sync_readapprovalrequeststatuses",
-      "label": "readApprovalRequestStatuses()",
-      "norm_label": "readapprovalrequeststatuses()",
-      "source_file": "packages/athena-webapp/convex/pos/public/sync.ts",
-      "source_location": "L436"
-    },
-    {
-      "community": 458,
-      "file_type": "code",
-      "id": "sync_scheduleregistercloseoutnotifications",
-      "label": "scheduleRegisterCloseoutNotifications()",
-      "norm_label": "scheduleregistercloseoutnotifications()",
-      "source_file": "packages/athena-webapp/convex/pos/public/sync.ts",
-      "source_location": "L281"
-    },
-    {
-      "community": 458,
-      "file_type": "code",
-      "id": "sync_shareddemocapabilityforsyncevent",
-      "label": "sharedDemoCapabilityForSyncEvent()",
-      "norm_label": "shareddemocapabilityforsyncevent()",
-      "source_file": "packages/athena-webapp/convex/pos/public/sync.ts",
-      "source_location": "L112"
-    },
-    {
-      "community": 458,
-      "file_type": "code",
-      "id": "sync_wasvariancenotifiedbeforerail",
-      "label": "wasVarianceNotifiedBeforeRail()",
-      "norm_label": "wasvariancenotifiedbeforerail()",
-      "source_file": "packages/athena-webapp/convex/pos/public/sync.ts",
-      "source_location": "L471"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_public_telemetry_ts",
-      "label": "telemetry.ts",
-      "norm_label": "telemetry.ts",
-      "source_file": "packages/athena-webapp/convex/pos/public/telemetry.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "telemetry_cleaneventtext",
-      "label": "cleanEventText()",
-      "norm_label": "cleaneventtext()",
-      "source_file": "packages/athena-webapp/convex/pos/public/telemetry.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "telemetry_cleanoptionaleventtext",
-      "label": "cleanOptionalEventText()",
-      "norm_label": "cleanoptionaleventtext()",
-      "source_file": "packages/athena-webapp/convex/pos/public/telemetry.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "telemetry_requirepostelemetryaccess",
-      "label": "requirePosTelemetryAccess()",
-      "norm_label": "requirepostelemetryaccess()",
-      "source_file": "packages/athena-webapp/convex/pos/public/telemetry.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "telemetry_sanitizeclienteventmetadata",
-      "label": "sanitizeClientEventMetadata()",
-      "norm_label": "sanitizeclienteventmetadata()",
-      "source_file": "packages/athena-webapp/convex/pos/public/telemetry.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "telemetry_truncate",
-      "label": "truncate()",
-      "norm_label": "truncate()",
-      "source_file": "packages/athena-webapp/convex/pos/public/telemetry.ts",
-      "source_location": "L59"
     },
     {
       "community": 46,
@@ -256689,6 +256758,114 @@
     {
       "community": 460,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_public_sync_ts",
+      "label": "sync.ts",
+      "norm_label": "sync.ts",
+      "source_file": "packages/athena-webapp/convex/pos/public/sync.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "sync_isvariancereviewforcloseout",
+      "label": "isVarianceReviewForCloseout()",
+      "norm_label": "isvariancereviewforcloseout()",
+      "source_file": "packages/athena-webapp/convex/pos/public/sync.ts",
+      "source_location": "L455"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "sync_readapprovalrequeststatuses",
+      "label": "readApprovalRequestStatuses()",
+      "norm_label": "readapprovalrequeststatuses()",
+      "source_file": "packages/athena-webapp/convex/pos/public/sync.ts",
+      "source_location": "L436"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "sync_scheduleregistercloseoutnotifications",
+      "label": "scheduleRegisterCloseoutNotifications()",
+      "norm_label": "scheduleregistercloseoutnotifications()",
+      "source_file": "packages/athena-webapp/convex/pos/public/sync.ts",
+      "source_location": "L281"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "sync_shareddemocapabilityforsyncevent",
+      "label": "sharedDemoCapabilityForSyncEvent()",
+      "norm_label": "shareddemocapabilityforsyncevent()",
+      "source_file": "packages/athena-webapp/convex/pos/public/sync.ts",
+      "source_location": "L112"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "sync_wasvariancenotifiedbeforerail",
+      "label": "wasVarianceNotifiedBeforeRail()",
+      "norm_label": "wasvariancenotifiedbeforerail()",
+      "source_file": "packages/athena-webapp/convex/pos/public/sync.ts",
+      "source_location": "L471"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_public_telemetry_ts",
+      "label": "telemetry.ts",
+      "norm_label": "telemetry.ts",
+      "source_file": "packages/athena-webapp/convex/pos/public/telemetry.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
+      "id": "telemetry_cleaneventtext",
+      "label": "cleanEventText()",
+      "norm_label": "cleaneventtext()",
+      "source_file": "packages/athena-webapp/convex/pos/public/telemetry.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
+      "id": "telemetry_cleanoptionaleventtext",
+      "label": "cleanOptionalEventText()",
+      "norm_label": "cleanoptionaleventtext()",
+      "source_file": "packages/athena-webapp/convex/pos/public/telemetry.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
+      "id": "telemetry_requirepostelemetryaccess",
+      "label": "requirePosTelemetryAccess()",
+      "norm_label": "requirepostelemetryaccess()",
+      "source_file": "packages/athena-webapp/convex/pos/public/telemetry.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
+      "id": "telemetry_sanitizeclienteventmetadata",
+      "label": "sanitizeClientEventMetadata()",
+      "norm_label": "sanitizeclienteventmetadata()",
+      "source_file": "packages/athena-webapp/convex/pos/public/telemetry.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
+      "id": "telemetry_truncate",
+      "label": "truncate()",
+      "norm_label": "truncate()",
+      "source_file": "packages/athena-webapp/convex/pos/public/telemetry.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 462,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_transportinternal_test_ts",
       "label": "transportInternal.test.ts",
       "norm_label": "transportinternal.test.ts",
@@ -256696,7 +256873,7 @@
       "source_location": "L1"
     },
     {
-      "community": 460,
+      "community": 462,
       "file_type": "code",
       "id": "transportinternal_test_buildclient",
       "label": "buildClient()",
@@ -256705,7 +256882,7 @@
       "source_location": "L342"
     },
     {
-      "community": 460,
+      "community": 462,
       "file_type": "code",
       "id": "transportinternal_test_buildruntimectx",
       "label": "buildRuntimeCtx()",
@@ -256714,7 +256891,7 @@
       "source_location": "L318"
     },
     {
-      "community": 460,
+      "community": 462,
       "file_type": "code",
       "id": "transportinternal_test_buildsession",
       "label": "buildSession()",
@@ -256723,7 +256900,7 @@
       "source_location": "L352"
     },
     {
-      "community": 460,
+      "community": 462,
       "file_type": "code",
       "id": "transportinternal_test_buildterminal",
       "label": "buildTerminal()",
@@ -256732,7 +256909,7 @@
       "source_location": "L365"
     },
     {
-      "community": 460,
+      "community": 462,
       "file_type": "code",
       "id": "transportinternal_test_gethandler",
       "label": "getHandler()",
@@ -256741,7 +256918,7 @@
       "source_location": "L34"
     },
     {
-      "community": 461,
+      "community": 463,
       "file_type": "code",
       "id": "foldday_comparefacts",
       "label": "compareFacts()",
@@ -256750,7 +256927,7 @@
       "source_location": "L95"
     },
     {
-      "community": 461,
+      "community": 463,
       "file_type": "code",
       "id": "foldday_foldday",
       "label": "foldDay()",
@@ -256759,7 +256936,7 @@
       "source_location": "L126"
     },
     {
-      "community": 461,
+      "community": 463,
       "file_type": "code",
       "id": "foldday_revenuecontribution",
       "label": "revenueContribution()",
@@ -256768,7 +256945,7 @@
       "source_location": "L108"
     },
     {
-      "community": 461,
+      "community": 463,
       "file_type": "code",
       "id": "foldday_zerodaymetrics",
       "label": "zeroDayMetrics()",
@@ -256777,7 +256954,7 @@
       "source_location": "L51"
     },
     {
-      "community": 461,
+      "community": 463,
       "file_type": "code",
       "id": "foldday_zeroskuaccumulator",
       "label": "zeroSkuAccumulator()",
@@ -256786,7 +256963,7 @@
       "source_location": "L77"
     },
     {
-      "community": 461,
+      "community": 463,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_foldday_ts",
       "label": "foldDay.ts",
@@ -256795,7 +256972,7 @@
       "source_location": "L1"
     },
     {
-      "community": 462,
+      "community": 464,
       "file_type": "code",
       "id": "operatingday_configuredtimezone",
       "label": "configuredTimezone()",
@@ -256804,7 +256981,7 @@
       "source_location": "L52"
     },
     {
-      "community": 462,
+      "community": 464,
       "file_type": "code",
       "id": "operatingday_isvalidtimezone",
       "label": "isValidTimezone()",
@@ -256813,7 +256990,7 @@
       "source_location": "L27"
     },
     {
-      "community": 462,
+      "community": 464,
       "file_type": "code",
       "id": "operatingday_localdatelabel",
       "label": "localDateLabel()",
@@ -256822,7 +256999,7 @@
       "source_location": "L38"
     },
     {
-      "community": 462,
+      "community": 464,
       "file_type": "code",
       "id": "operatingday_resolveoperatingdate",
       "label": "resolveOperatingDate()",
@@ -256831,7 +257008,7 @@
       "source_location": "L98"
     },
     {
-      "community": 462,
+      "community": 464,
       "file_type": "code",
       "id": "operatingday_resolvestoretimezone",
       "label": "resolveStoreTimezone()",
@@ -256840,7 +257017,7 @@
       "source_location": "L68"
     },
     {
-      "community": 462,
+      "community": 464,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_operatingday_ts",
       "label": "operatingDay.ts",
@@ -256849,7 +257026,7 @@
       "source_location": "L1"
     },
     {
-      "community": 463,
+      "community": 465,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_reseed_test_ts",
       "label": "reseed.test.ts",
@@ -256858,7 +257035,7 @@
       "source_location": "L1"
     },
     {
-      "community": 463,
+      "community": 465,
       "file_type": "code",
       "id": "reseed_test_at",
       "label": "at()",
@@ -256867,7 +257044,7 @@
       "source_location": "L48"
     },
     {
-      "community": 463,
+      "community": 465,
       "file_type": "code",
       "id": "reseed_test_factsignature",
       "label": "factSignature()",
@@ -256876,7 +257053,7 @@
       "source_location": "L116"
     },
     {
-      "community": 463,
+      "community": 465,
       "file_type": "code",
       "id": "reseed_test_resumereseed",
       "label": "resumeReseed()",
@@ -256885,7 +257062,7 @@
       "source_location": "L99"
     },
     {
-      "community": 463,
+      "community": 465,
       "file_type": "code",
       "id": "reseed_test_runreseed",
       "label": "runReseed()",
@@ -256894,7 +257071,7 @@
       "source_location": "L75"
     },
     {
-      "community": 463,
+      "community": 465,
       "file_type": "code",
       "id": "reseed_test_seedfullday",
       "label": "seedFullDay()",
@@ -256903,7 +257080,7 @@
       "source_location": "L140"
     },
     {
-      "community": 464,
+      "community": 466,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_weeklyinventory_ts",
       "label": "weeklyInventory.ts",
@@ -256912,7 +257089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 464,
+      "community": 466,
       "file_type": "code",
       "id": "weeklyinventory_classifyweeklyinventorygroup",
       "label": "classifyWeeklyInventoryGroup()",
@@ -256921,7 +257098,7 @@
       "source_location": "L56"
     },
     {
-      "community": 464,
+      "community": 466,
       "file_type": "code",
       "id": "weeklyinventory_issyncedsaleinventoryreviewgroup",
       "label": "isSyncedSaleInventoryReviewGroup()",
@@ -256930,7 +257107,7 @@
       "source_location": "L101"
     },
     {
-      "community": 464,
+      "community": 466,
       "file_type": "code",
       "id": "weeklyinventory_projectfrozenweeklyinventoryattention",
       "label": "projectFrozenWeeklyInventoryAttention()",
@@ -256939,7 +257116,7 @@
       "source_location": "L144"
     },
     {
-      "community": 464,
+      "community": 466,
       "file_type": "code",
       "id": "weeklyinventory_projectliveweeklyinventoryattention",
       "label": "projectLiveWeeklyInventoryAttention()",
@@ -256948,7 +257125,7 @@
       "source_location": "L110"
     },
     {
-      "community": 464,
+      "community": 466,
       "file_type": "code",
       "id": "weeklyinventory_summarizeweeklyinventoryattention",
       "label": "summarizeWeeklyInventoryAttention()",
@@ -256957,7 +257134,7 @@
       "source_location": "L82"
     },
     {
-      "community": 465,
+      "community": 467,
       "file_type": "code",
       "id": "orderemailservice_buildorderstatusmessage",
       "label": "buildOrderStatusMessage()",
@@ -256966,7 +257143,7 @@
       "source_location": "L49"
     },
     {
-      "community": 465,
+      "community": 467,
       "file_type": "code",
       "id": "orderemailservice_buildpickupdetails",
       "label": "buildPickupDetails()",
@@ -256975,7 +257152,7 @@
       "source_location": "L77"
     },
     {
-      "community": 465,
+      "community": 467,
       "file_type": "code",
       "id": "orderemailservice_sendpaymentverificationemails",
       "label": "sendPaymentVerificationEmails()",
@@ -256984,7 +257161,7 @@
       "source_location": "L217"
     },
     {
-      "community": 465,
+      "community": 467,
       "file_type": "code",
       "id": "orderemailservice_sendpodorderemails",
       "label": "sendPODOrderEmails()",
@@ -256993,7 +257170,7 @@
       "source_location": "L96"
     },
     {
-      "community": 465,
+      "community": 467,
       "file_type": "code",
       "id": "orderemailservice_shouldsendtoadmins",
       "label": "shouldSendToAdmins()",
@@ -257002,7 +257179,7 @@
       "source_location": "L42"
     },
     {
-      "community": 465,
+      "community": 467,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
       "label": "orderEmailService.ts",
@@ -257011,7 +257188,7 @@
       "source_location": "L1"
     },
     {
-      "community": 466,
+      "community": 468,
       "file_type": "code",
       "id": "actor_getshareddemoactorwithctx",
       "label": "getSharedDemoActorWithCtx()",
@@ -257020,7 +257197,7 @@
       "source_location": "L14"
     },
     {
-      "community": 466,
+      "community": 468,
       "file_type": "code",
       "id": "actor_requirereadyshareddemostorecapabilityifapplicable",
       "label": "requireReadySharedDemoStoreCapabilityIfApplicable()",
@@ -257029,7 +257206,7 @@
       "source_location": "L92"
     },
     {
-      "community": 466,
+      "community": 468,
       "file_type": "code",
       "id": "actor_requireshareddemoactorwithctx",
       "label": "requireSharedDemoActorWithCtx()",
@@ -257038,7 +257215,7 @@
       "source_location": "L57"
     },
     {
-      "community": 466,
+      "community": 468,
       "file_type": "code",
       "id": "actor_requireshareddemocapabilityifapplicable",
       "label": "requireSharedDemoCapabilityIfApplicable()",
@@ -257047,7 +257224,7 @@
       "source_location": "L66"
     },
     {
-      "community": 466,
+      "community": 468,
       "file_type": "code",
       "id": "actor_requireshareddemostorecapabilityifapplicable",
       "label": "requireSharedDemoStoreCapabilityIfApplicable()",
@@ -257056,7 +257233,7 @@
       "source_location": "L78"
     },
     {
-      "community": 466,
+      "community": 468,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_actor_ts",
       "label": "actor.ts",
@@ -257065,7 +257242,7 @@
       "source_location": "L1"
     },
     {
-      "community": 467,
+      "community": 469,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_scheduledrestore_ts",
       "label": "scheduledRestore.ts",
@@ -257074,7 +257251,7 @@
       "source_location": "L1"
     },
     {
-      "community": 467,
+      "community": 469,
       "file_type": "code",
       "id": "scheduledrestore_continuerestorewithctx",
       "label": "continueRestoreWithCtx()",
@@ -257083,7 +257260,7 @@
       "source_location": "L20"
     },
     {
-      "community": 467,
+      "community": 469,
       "file_type": "code",
       "id": "scheduledrestore_provisionforscheduledworkwithctx",
       "label": "provisionForScheduledWorkWithCtx()",
@@ -257092,7 +257269,7 @@
       "source_location": "L76"
     },
     {
-      "community": 467,
+      "community": 469,
       "file_type": "code",
       "id": "scheduledrestore_rundailyrestorewithctx",
       "label": "runDailyRestoreWithCtx()",
@@ -257101,7 +257278,7 @@
       "source_location": "L117"
     },
     {
-      "community": 467,
+      "community": 469,
       "file_type": "code",
       "id": "scheduledrestore_runhourlyprovisionhealwithctx",
       "label": "runHourlyProvisionHealWithCtx()",
@@ -257110,121 +257287,13 @@
       "source_location": "L108"
     },
     {
-      "community": 467,
+      "community": 469,
       "file_type": "code",
       "id": "scheduledrestore_shareddemorestoreenabled",
       "label": "sharedDemoRestoreEnabled()",
       "norm_label": "shareddemorestoreenabled()",
       "source_file": "packages/athena-webapp/convex/sharedDemo/scheduledRestore.ts",
       "source_location": "L7"
-    },
-    {
-      "community": 468,
-      "file_type": "code",
-      "id": "adjustments_test_createapprovaldecisionmutationctx",
-      "label": "createApprovalDecisionMutationCtx()",
-      "norm_label": "createapprovaldecisionmutationctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L305"
-    },
-    {
-      "community": 468,
-      "file_type": "code",
-      "id": "adjustments_test_createinventorysnapshotqueryctx",
-      "label": "createInventorySnapshotQueryCtx()",
-      "norm_label": "createinventorysnapshotqueryctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 468,
-      "file_type": "code",
-      "id": "adjustments_test_createsubmissionmutationctx",
-      "label": "createSubmissionMutationCtx()",
-      "norm_label": "createsubmissionmutationctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L506"
-    },
-    {
-      "community": 468,
-      "file_type": "code",
-      "id": "adjustments_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L53"
-    },
-    {
-      "community": 468,
-      "file_type": "code",
-      "id": "adjustments_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 468,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
-      "label": "adjustments.test.ts",
-      "norm_label": "adjustments.test.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_vendors_ts",
-      "label": "vendors.ts",
-      "norm_label": "vendors.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "vendors_createvendorcommandwithctx",
-      "label": "createVendorCommandWithCtx()",
-      "norm_label": "createvendorcommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
-      "source_location": "L124"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "vendors_createvendorwithctx",
-      "label": "createVendorWithCtx()",
-      "norm_label": "createvendorwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "vendors_mapcreatevendorerror",
-      "label": "mapCreateVendorError()",
-      "norm_label": "mapcreatevendorerror()",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "vendors_normalizevendorlookupkey",
-      "label": "normalizeVendorLookupKey()",
-      "norm_label": "normalizevendorlookupkey()",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "vendors_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
-      "source_location": "L33"
     },
     {
       "community": 47,
@@ -257499,6 +257568,114 @@
     {
       "community": 470,
       "file_type": "code",
+      "id": "adjustments_test_createapprovaldecisionmutationctx",
+      "label": "createApprovalDecisionMutationCtx()",
+      "norm_label": "createapprovaldecisionmutationctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
+      "source_location": "L305"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "adjustments_test_createinventorysnapshotqueryctx",
+      "label": "createInventorySnapshotQueryCtx()",
+      "norm_label": "createinventorysnapshotqueryctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "adjustments_test_createsubmissionmutationctx",
+      "label": "createSubmissionMutationCtx()",
+      "norm_label": "createsubmissionmutationctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
+      "source_location": "L506"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "adjustments_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "adjustments_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
+      "label": "adjustments.test.ts",
+      "norm_label": "adjustments.test.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/adjustments.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_vendors_ts",
+      "label": "vendors.ts",
+      "norm_label": "vendors.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
+      "id": "vendors_createvendorcommandwithctx",
+      "label": "createVendorCommandWithCtx()",
+      "norm_label": "createvendorcommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "source_location": "L124"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
+      "id": "vendors_createvendorwithctx",
+      "label": "createVendorWithCtx()",
+      "norm_label": "createvendorwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
+      "id": "vendors_mapcreatevendorerror",
+      "label": "mapCreateVendorError()",
+      "norm_label": "mapcreatevendorerror()",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
+      "id": "vendors_normalizevendorlookupkey",
+      "label": "normalizeVendorLookupKey()",
+      "norm_label": "normalizevendorlookupkey()",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
+      "id": "vendors_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 472,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_returnexchangeoperations_ts",
       "label": "returnExchangeOperations.ts",
       "norm_label": "returnexchangeoperations.ts",
@@ -257506,7 +257683,7 @@
       "source_location": "L1"
     },
     {
-      "community": 470,
+      "community": 472,
       "file_type": "code",
       "id": "returnexchangeoperations_buildonlineorderreportedreturns",
       "label": "buildOnlineOrderReportedReturns()",
@@ -257515,7 +257692,7 @@
       "source_location": "L73"
     },
     {
-      "community": 470,
+      "community": 472,
       "file_type": "code",
       "id": "returnexchangeoperations_buildonlineorderreturnexchangeplan",
       "label": "buildOnlineOrderReturnExchangePlan()",
@@ -257524,7 +257701,7 @@
       "source_location": "L137"
     },
     {
-      "community": 470,
+      "community": 472,
       "file_type": "code",
       "id": "returnexchangeoperations_getapprovalreason",
       "label": "getApprovalReason()",
@@ -257533,7 +257710,7 @@
       "source_location": "L112"
     },
     {
-      "community": 470,
+      "community": 472,
       "file_type": "code",
       "id": "returnexchangeoperations_getkind",
       "label": "getKind()",
@@ -257542,7 +257719,7 @@
       "source_location": "L96"
     },
     {
-      "community": 470,
+      "community": 472,
       "file_type": "code",
       "id": "returnexchangeoperations_getlinerefundamount",
       "label": "getLineRefundAmount()",
@@ -257551,7 +257728,7 @@
       "source_location": "L92"
     },
     {
-      "community": 471,
+      "community": 473,
       "file_type": "code",
       "id": "onlineorder_test_createunauthorizednormalorderctx",
       "label": "createUnauthorizedNormalOrderCtx()",
@@ -257560,7 +257737,7 @@
       "source_location": "L164"
     },
     {
-      "community": 471,
+      "community": 473,
       "file_type": "code",
       "id": "onlineorder_test_gethandler",
       "label": "getHandler()",
@@ -257569,7 +257746,7 @@
       "source_location": "L160"
     },
     {
-      "community": 471,
+      "community": 473,
       "file_type": "code",
       "id": "onlineorder_test_getsource",
       "label": "getSource()",
@@ -257578,7 +257755,7 @@
       "source_location": "L156"
     },
     {
-      "community": 471,
+      "community": 473,
       "file_type": "code",
       "id": "onlineorder_test_readstorefrontfacts",
       "label": "readStorefrontFacts()",
@@ -257587,7 +257764,7 @@
       "source_location": "L150"
     },
     {
-      "community": 471,
+      "community": 473,
       "file_type": "code",
       "id": "onlineorder_test_seedfulfillableorder",
       "label": "seedFulfillableOrder()",
@@ -257596,7 +257773,7 @@
       "source_location": "L29"
     },
     {
-      "community": 471,
+      "community": 473,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorder_test_ts",
       "label": "onlineOrder.test.ts",
@@ -257605,7 +257782,7 @@
       "source_location": "L1"
     },
     {
-      "community": 472,
+      "community": 474,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storetime_storetimeauthority_ts",
       "label": "storeTimeAuthority.ts",
@@ -257614,7 +257791,7 @@
       "source_location": "L1"
     },
     {
-      "community": 472,
+      "community": 474,
       "file_type": "code",
       "id": "storetimeauthority_assertstoretimezoneversioncanbeinserted",
       "label": "assertStoreTimezoneVersionCanBeInserted()",
@@ -257623,7 +257800,7 @@
       "source_location": "L50"
     },
     {
-      "community": 472,
+      "community": 474,
       "file_type": "code",
       "id": "storetimeauthority_includesoccurrence",
       "label": "includesOccurrence()",
@@ -257632,7 +257809,7 @@
       "source_location": "L18"
     },
     {
-      "community": 472,
+      "community": 474,
       "file_type": "code",
       "id": "storetimeauthority_intervalsoverlap",
       "label": "intervalsOverlap()",
@@ -257641,7 +257818,7 @@
       "source_location": "L41"
     },
     {
-      "community": 472,
+      "community": 474,
       "file_type": "code",
       "id": "storetimeauthority_localdate",
       "label": "localDate()",
@@ -257650,7 +257827,7 @@
       "source_location": "L28"
     },
     {
-      "community": 472,
+      "community": 474,
       "file_type": "code",
       "id": "storetimeauthority_resolvestoretimeauthority",
       "label": "resolveStoreTimeAuthority()",
@@ -257659,7 +257836,7 @@
       "source_location": "L84"
     },
     {
-      "community": 473,
+      "community": 475,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_purchaseorder_ts",
       "label": "purchaseOrder.ts",
@@ -257668,7 +257845,7 @@
       "source_location": "L1"
     },
     {
-      "community": 473,
+      "community": 475,
       "file_type": "code",
       "id": "purchaseorder_buildpurchaseorderreceivinglookup",
       "label": "buildPurchaseOrderReceivingLookup()",
@@ -257677,7 +257854,7 @@
       "source_location": "L162"
     },
     {
-      "community": 473,
+      "community": 475,
       "file_type": "code",
       "id": "purchaseorder_buildpurchaseordertraceseed",
       "label": "buildPurchaseOrderTraceSeed()",
@@ -257686,7 +257863,7 @@
       "source_location": "L82"
     },
     {
-      "community": 473,
+      "community": 475,
       "file_type": "code",
       "id": "purchaseorder_compactdetails",
       "label": "compactDetails()",
@@ -257695,7 +257872,7 @@
       "source_location": "L74"
     },
     {
-      "community": 473,
+      "community": 475,
       "file_type": "code",
       "id": "purchaseorder_formatpurchaseorderlabel",
       "label": "formatPurchaseOrderLabel()",
@@ -257704,7 +257881,7 @@
       "source_location": "L45"
     },
     {
-      "community": 473,
+      "community": 475,
       "file_type": "code",
       "id": "purchaseorder_normalizelookup",
       "label": "normalizeLookup()",
@@ -257713,7 +257890,7 @@
       "source_location": "L53"
     },
     {
-      "community": 474,
+      "community": 476,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_find_block_end",
       "label": "find_block_end()",
@@ -257722,7 +257899,7 @@
       "source_location": "L123"
     },
     {
-      "community": 474,
+      "community": 476,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_list_convex_files",
       "label": "list_convex_files()",
@@ -257731,7 +257908,7 @@
       "source_location": "L187"
     },
     {
-      "community": 474,
+      "community": 476,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_main",
       "label": "main()",
@@ -257740,7 +257917,7 @@
       "source_location": "L207"
     },
     {
-      "community": 474,
+      "community": 476,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_scan_file",
       "label": "scan_file()",
@@ -257749,7 +257926,7 @@
       "source_location": "L137"
     },
     {
-      "community": 474,
+      "community": 476,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_strip_code",
       "label": "strip_code()",
@@ -257758,7 +257935,7 @@
       "source_location": "L9"
     },
     {
-      "community": 474,
+      "community": 476,
       "file_type": "code",
       "id": "packages_athena_webapp_scripts_convexpaginationantipatterncheck_py",
       "label": "convexPaginationAntiPatternCheck.py",
@@ -257767,7 +257944,7 @@
       "source_location": "L1"
     },
     {
-      "community": 475,
+      "community": 477,
       "file_type": "code",
       "id": "commandresult_approvalrequired",
       "label": "approvalRequired()",
@@ -257776,7 +257953,7 @@
       "source_location": "L62"
     },
     {
-      "community": 475,
+      "community": 477,
       "file_type": "code",
       "id": "commandresult_isapprovalrequiredresult",
       "label": "isApprovalRequiredResult()",
@@ -257785,7 +257962,7 @@
       "source_location": "L77"
     },
     {
-      "community": 475,
+      "community": 477,
       "file_type": "code",
       "id": "commandresult_isusererrorresult",
       "label": "isUserErrorResult()",
@@ -257794,7 +257971,7 @@
       "source_location": "L71"
     },
     {
-      "community": 475,
+      "community": 477,
       "file_type": "code",
       "id": "commandresult_ok",
       "label": "ok()",
@@ -257803,7 +257980,7 @@
       "source_location": "L48"
     },
     {
-      "community": 475,
+      "community": 477,
       "file_type": "code",
       "id": "commandresult_usererror",
       "label": "userError()",
@@ -257812,7 +257989,7 @@
       "source_location": "L55"
     },
     {
-      "community": 475,
+      "community": 477,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_commandresult_ts",
       "label": "commandResult.ts",
@@ -257821,7 +257998,7 @@
       "source_location": "L1"
     },
     {
-      "community": 476,
+      "community": 478,
       "file_type": "code",
       "id": "homepageranking_comparehomepagerankeditems",
       "label": "compareHomepageRankedItems()",
@@ -257830,7 +258007,7 @@
       "source_location": "L22"
     },
     {
-      "community": 476,
+      "community": 478,
       "file_type": "code",
       "id": "homepageranking_gethomepagesortrank",
       "label": "getHomepageSortRank()",
@@ -257839,7 +258016,7 @@
       "source_location": "L9"
     },
     {
-      "community": 476,
+      "community": 478,
       "file_type": "code",
       "id": "homepageranking_getnexthomepagerank",
       "label": "getNextHomepageRank()",
@@ -257848,7 +258025,7 @@
       "source_location": "L40"
     },
     {
-      "community": 476,
+      "community": 478,
       "file_type": "code",
       "id": "homepageranking_getpresentedhomepagerank",
       "label": "getPresentedHomepageRank()",
@@ -257857,7 +258034,7 @@
       "source_location": "L15"
     },
     {
-      "community": 476,
+      "community": 478,
       "file_type": "code",
       "id": "homepageranking_sorthomepagerankeditems",
       "label": "sortHomepageRankedItems()",
@@ -257866,7 +258043,7 @@
       "source_location": "L36"
     },
     {
-      "community": 476,
+      "community": 478,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_homepageranking_ts",
       "label": "homepageRanking.ts",
@@ -257875,7 +258052,7 @@
       "source_location": "L1"
     },
     {
-      "community": 477,
+      "community": 479,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_poslocalsynccontract_ts",
       "label": "posLocalSyncContract.ts",
@@ -257884,7 +258061,7 @@
       "source_location": "L1"
     },
     {
-      "community": 477,
+      "community": 479,
       "file_type": "code",
       "id": "poslocalsynccontract_canuploadposlocalsynclocaleventtype",
       "label": "canUploadPosLocalSyncLocalEventType()",
@@ -257893,7 +258070,7 @@
       "source_location": "L143"
     },
     {
-      "community": 477,
+      "community": 479,
       "file_type": "code",
       "id": "poslocalsynccontract_eventtypesfromcontract",
       "label": "eventTypesFromContract()",
@@ -257902,7 +258079,7 @@
       "source_location": "L60"
     },
     {
-      "community": 477,
+      "community": 479,
       "file_type": "code",
       "id": "poslocalsynccontract_getposlocalsynceventcontractforlocaleventtype",
       "label": "getPosLocalSyncEventContractForLocalEventType()",
@@ -257911,7 +258088,7 @@
       "source_location": "L123"
     },
     {
-      "community": 477,
+      "community": 479,
       "file_type": "code",
       "id": "poslocalsynccontract_getposlocalsynceventtypeforlocaleventtype",
       "label": "getPosLocalSyncEventTypeForLocalEventType()",
@@ -257920,121 +258097,13 @@
       "source_location": "L136"
     },
     {
-      "community": 477,
+      "community": 479,
       "file_type": "code",
       "id": "poslocalsynccontract_isposlocalsynceventtype",
       "label": "isPosLocalSyncEventType()",
       "norm_label": "isposlocalsynceventtype()",
       "source_file": "packages/athena-webapp/shared/posLocalSyncContract.ts",
       "source_location": "L117"
-    },
-    {
-      "community": 478,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_registersessionstatus_ts",
-      "label": "registerSessionStatus.ts",
-      "norm_label": "registersessionstatus.ts",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 478,
-      "file_type": "code",
-      "id": "registersessionstatus_includesregistersessionstatus",
-      "label": "includesRegisterSessionStatus()",
-      "norm_label": "includesregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 478,
-      "file_type": "code",
-      "id": "registersessionstatus_iscashcontrolvisibleregistersessionstatus",
-      "label": "isCashControlVisibleRegisterSessionStatus()",
-      "norm_label": "iscashcontrolvisibleregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 478,
-      "file_type": "code",
-      "id": "registersessionstatus_isposusableregistersessionstatus",
-      "label": "isPosUsableRegisterSessionStatus()",
-      "norm_label": "isposusableregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 478,
-      "file_type": "code",
-      "id": "registersessionstatus_isregistersessionconflictblockingstatus",
-      "label": "isRegisterSessionConflictBlockingStatus()",
-      "norm_label": "isregistersessionconflictblockingstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L55"
-    },
-    {
-      "community": 478,
-      "file_type": "code",
-      "id": "registersessionstatus_isregistersessionstatus",
-      "label": "isRegisterSessionStatus()",
-      "norm_label": "isregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_workflowtrace_ts",
-      "label": "workflowTrace.ts",
-      "norm_label": "workflowtrace.ts",
-      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "workflowtrace_assertobjectkeysareminimized",
-      "label": "assertObjectKeysAreMinimized()",
-      "norm_label": "assertobjectkeysareminimized()",
-      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
-      "source_location": "L44"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "workflowtrace_assertworkflowtracedetailsareminimized",
-      "label": "assertWorkflowTraceDetailsAreMinimized()",
-      "norm_label": "assertworkflowtracedetailsareminimized()",
-      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "workflowtrace_createworkflowtraceid",
-      "label": "createWorkflowTraceId()",
-      "norm_label": "createworkflowtraceid()",
-      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
-      "source_location": "L93"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "workflowtrace_normalizeworkflowtraceeventkey",
-      "label": "normalizeWorkflowTraceEventKey()",
-      "norm_label": "normalizeworkflowtraceeventkey()",
-      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
-      "source_location": "L83"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "workflowtrace_normalizeworkflowtracelookupvalue",
-      "label": "normalizeWorkflowTraceLookupValue()",
-      "norm_label": "normalizeworkflowtracelookupvalue()",
-      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
-      "source_location": "L73"
     },
     {
       "community": 48,
@@ -258300,6 +258369,114 @@
     {
       "community": 480,
       "file_type": "code",
+      "id": "packages_athena_webapp_shared_registersessionstatus_ts",
+      "label": "registerSessionStatus.ts",
+      "norm_label": "registersessionstatus.ts",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "registersessionstatus_includesregistersessionstatus",
+      "label": "includesRegisterSessionStatus()",
+      "norm_label": "includesregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "registersessionstatus_iscashcontrolvisibleregistersessionstatus",
+      "label": "isCashControlVisibleRegisterSessionStatus()",
+      "norm_label": "iscashcontrolvisibleregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "registersessionstatus_isposusableregistersessionstatus",
+      "label": "isPosUsableRegisterSessionStatus()",
+      "norm_label": "isposusableregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "registersessionstatus_isregistersessionconflictblockingstatus",
+      "label": "isRegisterSessionConflictBlockingStatus()",
+      "norm_label": "isregistersessionconflictblockingstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "registersessionstatus_isregistersessionstatus",
+      "label": "isRegisterSessionStatus()",
+      "norm_label": "isregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
+      "id": "packages_athena_webapp_shared_workflowtrace_ts",
+      "label": "workflowTrace.ts",
+      "norm_label": "workflowtrace.ts",
+      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
+      "id": "workflowtrace_assertobjectkeysareminimized",
+      "label": "assertObjectKeysAreMinimized()",
+      "norm_label": "assertobjectkeysareminimized()",
+      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
+      "source_location": "L44"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
+      "id": "workflowtrace_assertworkflowtracedetailsareminimized",
+      "label": "assertWorkflowTraceDetailsAreMinimized()",
+      "norm_label": "assertworkflowtracedetailsareminimized()",
+      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
+      "id": "workflowtrace_createworkflowtraceid",
+      "label": "createWorkflowTraceId()",
+      "norm_label": "createworkflowtraceid()",
+      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
+      "source_location": "L93"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
+      "id": "workflowtrace_normalizeworkflowtraceeventkey",
+      "label": "normalizeWorkflowTraceEventKey()",
+      "norm_label": "normalizeworkflowtraceeventkey()",
+      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
+      "id": "workflowtrace_normalizeworkflowtracelookupvalue",
+      "label": "normalizeWorkflowTraceLookupValue()",
+      "norm_label": "normalizeworkflowtracelookupvalue()",
+      "source_file": "packages/athena-webapp/shared/workflowTrace.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 482,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productcategorization_tsx",
       "label": "ProductCategorization.tsx",
       "norm_label": "productcategorization.tsx",
@@ -258307,7 +258484,7 @@
       "source_location": "L1"
     },
     {
-      "community": 480,
+      "community": 482,
       "file_type": "code",
       "id": "productcategorization_getproductname",
       "label": "getProductName()",
@@ -258316,7 +258493,7 @@
       "source_location": "L327"
     },
     {
-      "community": 480,
+      "community": 482,
       "file_type": "code",
       "id": "productcategorization_handleclose",
       "label": "handleClose()",
@@ -258325,7 +258502,7 @@
       "source_location": "L234"
     },
     {
-      "community": 480,
+      "community": 482,
       "file_type": "code",
       "id": "productcategorization_handleproductposvisibility",
       "label": "handleProductPosVisibility()",
@@ -258334,7 +258511,7 @@
       "source_location": "L284"
     },
     {
-      "community": 480,
+      "community": 482,
       "file_type": "code",
       "id": "productcategorization_handleproductvisibility",
       "label": "handleProductVisibility()",
@@ -258343,7 +258520,7 @@
       "source_location": "L274"
     },
     {
-      "community": 480,
+      "community": 482,
       "file_type": "code",
       "id": "productcategorization_setinitialselectedoption",
       "label": "setInitialSelectedOption()",
@@ -258352,7 +258529,7 @@
       "source_location": "L261"
     },
     {
-      "community": 481,
+      "community": 483,
       "file_type": "code",
       "id": "data_table_toolbar_datatabletoolbar",
       "label": "DataTableToolbar()",
@@ -258361,7 +258538,7 @@
       "source_location": "L23"
     },
     {
-      "community": 481,
+      "community": 483,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -258370,7 +258547,7 @@
       "source_location": "L1"
     },
     {
-      "community": 481,
+      "community": 483,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -258379,7 +258556,7 @@
       "source_location": "L1"
     },
     {
-      "community": 481,
+      "community": 483,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -258388,7 +258565,7 @@
       "source_location": "L1"
     },
     {
-      "community": 481,
+      "community": 483,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -258397,7 +258574,7 @@
       "source_location": "L1"
     },
     {
-      "community": 481,
+      "community": 483,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -258406,7 +258583,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 484,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
       "label": "selectable-data-provider.tsx",
@@ -258415,7 +258592,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 484,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
       "label": "selectable-data-provider.tsx",
@@ -258424,7 +258601,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 484,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
       "label": "selectable-data-provider.tsx",
@@ -258433,7 +258610,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 484,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
       "label": "selectable-data-provider.tsx",
@@ -258442,7 +258619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 484,
       "file_type": "code",
       "id": "selectable_data_provider_selectedproductsprovider",
       "label": "SelectedProductsProvider()",
@@ -258451,7 +258628,7 @@
       "source_location": "L16"
     },
     {
-      "community": 482,
+      "community": 484,
       "file_type": "code",
       "id": "selectable_data_provider_useselectedproducts",
       "label": "useSelectedProducts()",
@@ -258460,7 +258637,7 @@
       "source_location": "L37"
     },
     {
-      "community": 483,
+      "community": 485,
       "file_type": "code",
       "id": "flipnumber_defaultformatvalue",
       "label": "defaultFormatValue()",
@@ -258469,7 +258646,7 @@
       "source_location": "L20"
     },
     {
-      "community": 483,
+      "community": 485,
       "file_type": "code",
       "id": "flipnumber_flipnumber",
       "label": "FlipNumber()",
@@ -258478,7 +258655,7 @@
       "source_location": "L202"
     },
     {
-      "community": 483,
+      "community": 485,
       "file_type": "code",
       "id": "flipnumber_fliptext",
       "label": "FlipText()",
@@ -258487,7 +258664,7 @@
       "source_location": "L47"
     },
     {
-      "community": 483,
+      "community": 485,
       "file_type": "code",
       "id": "flipnumber_renderflipglyphs",
       "label": "renderFlipGlyphs()",
@@ -258496,7 +258673,7 @@
       "source_location": "L24"
     },
     {
-      "community": 483,
+      "community": 485,
       "file_type": "code",
       "id": "flipnumber_renderfliptext",
       "label": "renderFlipText()",
@@ -258505,7 +258682,7 @@
       "source_location": "L37"
     },
     {
-      "community": 483,
+      "community": 485,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_flipnumber_tsx",
       "label": "FlipNumber.tsx",
@@ -258514,7 +258691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 484,
+      "community": 486,
       "file_type": "code",
       "id": "bannermessageeditor_getcountdownstatus",
       "label": "getCountdownStatus()",
@@ -258523,7 +258700,7 @@
       "source_location": "L130"
     },
     {
-      "community": 484,
+      "community": 486,
       "file_type": "code",
       "id": "bannermessageeditor_handleactivetoggle",
       "label": "handleActiveToggle()",
@@ -258532,7 +258709,7 @@
       "source_location": "L90"
     },
     {
-      "community": 484,
+      "community": 486,
       "file_type": "code",
       "id": "bannermessageeditor_handleclear",
       "label": "handleClear()",
@@ -258541,7 +258718,7 @@
       "source_location": "L65"
     },
     {
-      "community": 484,
+      "community": 486,
       "file_type": "code",
       "id": "bannermessageeditor_handlecountdownchange",
       "label": "handleCountdownChange()",
@@ -258550,7 +258727,7 @@
       "source_location": "L120"
     },
     {
-      "community": 484,
+      "community": 486,
       "file_type": "code",
       "id": "bannermessageeditor_handlesave",
       "label": "handleSave()",
@@ -258559,7 +258736,7 @@
       "source_location": "L45"
     },
     {
-      "community": 484,
+      "community": 486,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bannermessageeditor_tsx",
       "label": "BannerMessageEditor.tsx",
@@ -258568,7 +258745,7 @@
       "source_location": "L1"
     },
     {
-      "community": 485,
+      "community": 487,
       "file_type": "code",
       "id": "bestsellers_bestsellers",
       "label": "bestSellers()",
@@ -258577,7 +258754,7 @@
       "source_location": "L157"
     },
     {
-      "community": 485,
+      "community": 487,
       "file_type": "code",
       "id": "bestsellers_handleremovebestseller",
       "label": "handleRemoveBestSeller()",
@@ -258586,7 +258763,7 @@
       "source_location": "L66"
     },
     {
-      "community": 485,
+      "community": 487,
       "file_type": "code",
       "id": "bestsellers_movebestseller",
       "label": "moveBestSeller()",
@@ -258595,7 +258772,7 @@
       "source_location": "L126"
     },
     {
-      "community": 485,
+      "community": 487,
       "file_type": "code",
       "id": "bestsellers_ondragend",
       "label": "onDragEnd()",
@@ -258604,7 +258781,7 @@
       "source_location": "L76"
     },
     {
-      "community": 485,
+      "community": 487,
       "file_type": "code",
       "id": "bestsellers_saveorder",
       "label": "saveOrder()",
@@ -258613,7 +258790,7 @@
       "source_location": "L104"
     },
     {
-      "community": 485,
+      "community": 487,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
       "label": "BestSellers.tsx",
@@ -258622,7 +258799,7 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 488,
       "file_type": "code",
       "id": "featuredsection_formatstoredcurrencyamount",
       "label": "formatStoredCurrencyAmount()",
@@ -258631,7 +258808,7 @@
       "source_location": "L215"
     },
     {
-      "community": 486,
+      "community": 488,
       "file_type": "code",
       "id": "featuredsection_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -258640,7 +258817,7 @@
       "source_location": "L66"
     },
     {
-      "community": 486,
+      "community": 488,
       "file_type": "code",
       "id": "featuredsection_movefeatureditem",
       "label": "moveFeaturedItem()",
@@ -258649,7 +258826,7 @@
       "source_location": "L128"
     },
     {
-      "community": 486,
+      "community": 488,
       "file_type": "code",
       "id": "featuredsection_ondragend",
       "label": "onDragEnd()",
@@ -258658,7 +258835,7 @@
       "source_location": "L78"
     },
     {
-      "community": 486,
+      "community": 488,
       "file_type": "code",
       "id": "featuredsection_saveorder",
       "label": "saveOrder()",
@@ -258667,7 +258844,7 @@
       "source_location": "L106"
     },
     {
-      "community": 486,
+      "community": 488,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
       "label": "FeaturedSection.tsx",
@@ -258676,7 +258853,7 @@
       "source_location": "L1"
     },
     {
-      "community": 487,
+      "community": 489,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_landing_story_scenechrome_tsx",
       "label": "SceneChrome.tsx",
@@ -258685,7 +258862,7 @@
       "source_location": "L1"
     },
     {
-      "community": 487,
+      "community": 489,
       "file_type": "code",
       "id": "scenechrome_appshellexhibit",
       "label": "AppShellExhibit()",
@@ -258694,7 +258871,7 @@
       "source_location": "L131"
     },
     {
-      "community": 487,
+      "community": 489,
       "file_type": "code",
       "id": "scenechrome_automationbeat",
       "label": "AutomationBeat()",
@@ -258703,7 +258880,7 @@
       "source_location": "L272"
     },
     {
-      "community": 487,
+      "community": 489,
       "file_type": "code",
       "id": "scenechrome_possyncbadge",
       "label": "PosSyncBadge()",
@@ -258712,7 +258889,7 @@
       "source_location": "L248"
     },
     {
-      "community": 487,
+      "community": 489,
       "file_type": "code",
       "id": "scenechrome_workspaceexhibit",
       "label": "WorkspaceExhibit()",
@@ -258721,121 +258898,13 @@
       "source_location": "L80"
     },
     {
-      "community": 487,
+      "community": 489,
       "file_type": "code",
       "id": "scenechrome_workspaceframe",
       "label": "WorkspaceFrame()",
       "norm_label": "workspaceframe()",
       "source_file": "packages/athena-webapp/src/components/landing/story/SceneChrome.tsx",
       "source_location": "L39"
-    },
-    {
-      "community": 488,
-      "file_type": "code",
-      "id": "dailyclosehistoryview_test_historyrecord",
-      "label": "historyRecord()",
-      "norm_label": "historyrecord()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.test.tsx",
-      "source_location": "L190"
-    },
-    {
-      "community": 488,
-      "file_type": "code",
-      "id": "dailyclosehistoryview_test_mockprotectedstate",
-      "label": "mockProtectedState()",
-      "norm_label": "mockprotectedstate()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.test.tsx",
-      "source_location": "L241"
-    },
-    {
-      "community": 488,
-      "file_type": "code",
-      "id": "dailyclosehistoryview_test_mockqueries",
-      "label": "mockQueries()",
-      "norm_label": "mockqueries()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.test.tsx",
-      "source_location": "L255"
-    },
-    {
-      "community": 488,
-      "file_type": "code",
-      "id": "dailyclosehistoryview_test_snapshot",
-      "label": "snapshot()",
-      "norm_label": "snapshot()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.test.tsx",
-      "source_location": "L104"
-    },
-    {
-      "community": 488,
-      "file_type": "code",
-      "id": "dailyclosehistoryview_test_storedreportsnapshot",
-      "label": "storedReportSnapshot()",
-      "norm_label": "storedreportsnapshot()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.test.tsx",
-      "source_location": "L171"
-    },
-    {
-      "community": 488,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_dailyclosehistoryview_test_tsx",
-      "label": "DailyCloseHistoryView.test.tsx",
-      "norm_label": "dailyclosehistoryview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "dailyopeningview_test_async",
-      "label": "async()",
-      "norm_label": "async()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx",
-      "source_location": "L124"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "dailyopeningview_test_disconnect",
-      "label": "disconnect()",
-      "norm_label": "disconnect()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx",
-      "source_location": "L359"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "dailyopeningview_test_formatexpectedtimestamp",
-      "label": "formatExpectedTimestamp()",
-      "norm_label": "formatexpectedtimestamp()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx",
-      "source_location": "L258"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "dailyopeningview_test_observe",
-      "label": "observe()",
-      "norm_label": "observe()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx",
-      "source_location": "L360"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "dailyopeningview_test_unobserve",
-      "label": "unobserve()",
-      "norm_label": "unobserve()",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx",
-      "source_location": "L361"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_dailyopeningview_test_tsx",
-      "label": "DailyOpeningView.test.tsx",
-      "norm_label": "dailyopeningview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx",
-      "source_location": "L1"
     },
     {
       "community": 49,
@@ -259101,6 +259170,114 @@
     {
       "community": 490,
       "file_type": "code",
+      "id": "dailyclosehistoryview_test_historyrecord",
+      "label": "historyRecord()",
+      "norm_label": "historyrecord()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.test.tsx",
+      "source_location": "L190"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "dailyclosehistoryview_test_mockprotectedstate",
+      "label": "mockProtectedState()",
+      "norm_label": "mockprotectedstate()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.test.tsx",
+      "source_location": "L241"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "dailyclosehistoryview_test_mockqueries",
+      "label": "mockQueries()",
+      "norm_label": "mockqueries()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.test.tsx",
+      "source_location": "L255"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "dailyclosehistoryview_test_snapshot",
+      "label": "snapshot()",
+      "norm_label": "snapshot()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.test.tsx",
+      "source_location": "L104"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "dailyclosehistoryview_test_storedreportsnapshot",
+      "label": "storedReportSnapshot()",
+      "norm_label": "storedreportsnapshot()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.test.tsx",
+      "source_location": "L171"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_operations_dailyclosehistoryview_test_tsx",
+      "label": "DailyCloseHistoryView.test.tsx",
+      "norm_label": "dailyclosehistoryview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyCloseHistoryView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
+      "id": "dailyopeningview_test_async",
+      "label": "async()",
+      "norm_label": "async()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx",
+      "source_location": "L124"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
+      "id": "dailyopeningview_test_disconnect",
+      "label": "disconnect()",
+      "norm_label": "disconnect()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx",
+      "source_location": "L359"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
+      "id": "dailyopeningview_test_formatexpectedtimestamp",
+      "label": "formatExpectedTimestamp()",
+      "norm_label": "formatexpectedtimestamp()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx",
+      "source_location": "L258"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
+      "id": "dailyopeningview_test_observe",
+      "label": "observe()",
+      "norm_label": "observe()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx",
+      "source_location": "L360"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
+      "id": "dailyopeningview_test_unobserve",
+      "label": "unobserve()",
+      "norm_label": "unobserve()",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx",
+      "source_location": "L361"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_operations_dailyopeningview_test_tsx",
+      "label": "DailyOpeningView.test.tsx",
+      "norm_label": "dailyopeningview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 492,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_skuactivityuntrustedsales_tsx",
       "label": "SkuActivityUntrustedSales.tsx",
       "norm_label": "skuactivityuntrustedsales.tsx",
@@ -259108,7 +259285,7 @@
       "source_location": "L1"
     },
     {
-      "community": 490,
+      "community": 492,
       "file_type": "code",
       "id": "skuactivityuntrustedsales_cn",
       "label": "cn()",
@@ -259117,7 +259294,7 @@
       "source_location": "L207"
     },
     {
-      "community": 490,
+      "community": 492,
       "file_type": "code",
       "id": "skuactivityuntrustedsales_formatcountlabel",
       "label": "formatCountLabel()",
@@ -259126,7 +259303,7 @@
       "source_location": "L139"
     },
     {
-      "community": 490,
+      "community": 492,
       "file_type": "code",
       "id": "skuactivityuntrustedsales_handlesourcepagechange",
       "label": "handleSourcePageChange()",
@@ -259135,7 +259312,7 @@
       "source_location": "L932"
     },
     {
-      "community": 490,
+      "community": 492,
       "file_type": "code",
       "id": "skuactivityuntrustedsales_sourcematchesevidencequery",
       "label": "sourceMatchesEvidenceQuery()",
@@ -259144,7 +259321,7 @@
       "source_location": "L147"
     },
     {
-      "community": 490,
+      "community": 492,
       "file_type": "code",
       "id": "skuactivityuntrustedsales_usedetailstickyposition",
       "label": "useDetailStickyPosition()",
@@ -259153,7 +259330,7 @@
       "source_location": "L83"
     },
     {
-      "community": 491,
+      "community": 493,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_useapprovedcommand_tsx",
       "label": "useApprovedCommand.tsx",
@@ -259162,7 +259339,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 493,
       "file_type": "code",
       "id": "useapprovedcommand_buildapprovalretryargs",
       "label": "buildApprovalRetryArgs()",
@@ -259171,7 +259348,7 @@
       "source_location": "L90"
     },
     {
-      "community": 491,
+      "community": 493,
       "file_type": "code",
       "id": "useapprovedcommand_getasyncapprovalrequestid",
       "label": "getAsyncApprovalRequestId()",
@@ -259180,7 +259357,7 @@
       "source_location": "L78"
     },
     {
-      "community": 491,
+      "community": 493,
       "file_type": "code",
       "id": "useapprovedcommand_hasasyncapprovalrequest",
       "label": "hasAsyncApprovalRequest()",
@@ -259189,7 +259366,7 @@
       "source_location": "L72"
     },
     {
-      "community": 491,
+      "community": 493,
       "file_type": "code",
       "id": "useapprovedcommand_hasinlinemanagerproof",
       "label": "hasInlineManagerProof()",
@@ -259198,7 +259375,7 @@
       "source_location": "L66"
     },
     {
-      "community": 491,
+      "community": 493,
       "file_type": "code",
       "id": "useapprovedcommand_useapprovedcommand",
       "label": "useApprovedCommand()",
@@ -259207,7 +259384,7 @@
       "source_location": "L102"
     },
     {
-      "community": 492,
+      "community": 494,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_test_tsx",
       "label": "PaymentsAddedList.test.tsx",
@@ -259216,7 +259393,7 @@
       "source_location": "L1"
     },
     {
-      "community": 492,
+      "community": 494,
       "file_type": "code",
       "id": "paymentsaddedlist_test_deferred",
       "label": "deferred()",
@@ -259225,7 +259402,7 @@
       "source_location": "L46"
     },
     {
-      "community": 492,
+      "community": 494,
       "file_type": "code",
       "id": "paymentsaddedlist_test_getsummaryamount",
       "label": "getSummaryAmount()",
@@ -259234,7 +259411,7 @@
       "source_location": "L28"
     },
     {
-      "community": 492,
+      "community": 494,
       "file_type": "code",
       "id": "paymentsaddedlist_test_getsummarylabel",
       "label": "getSummaryLabel()",
@@ -259243,7 +259420,7 @@
       "source_location": "L19"
     },
     {
-      "community": 492,
+      "community": 494,
       "file_type": "code",
       "id": "paymentsaddedlist_test_getsummarypanel",
       "label": "getSummaryPanel()",
@@ -259252,7 +259429,7 @@
       "source_location": "L41"
     },
     {
-      "community": 492,
+      "community": 494,
       "file_type": "code",
       "id": "paymentsaddedlist_test_stripwhitespace",
       "label": "stripWhitespace()",
@@ -259261,7 +259438,7 @@
       "source_location": "L15"
     },
     {
-      "community": 493,
+      "community": 495,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
       "label": "PointOfSaleView.tsx",
@@ -259270,7 +259447,7 @@
       "source_location": "L1"
     },
     {
-      "community": 493,
+      "community": 495,
       "file_type": "code",
       "id": "pointofsaleview_formatnextopeninglabel",
       "label": "formatNextOpeningLabel()",
@@ -259279,7 +259456,7 @@
       "source_location": "L132"
     },
     {
-      "community": 493,
+      "community": 495,
       "file_type": "code",
       "id": "pointofsaleview_formatstorehourstimelabel",
       "label": "formatStoreHoursTimeLabel()",
@@ -259288,7 +259465,7 @@
       "source_location": "L101"
     },
     {
-      "community": 493,
+      "community": 495,
       "file_type": "code",
       "id": "pointofsaleview_formatstorelocaldatelabel",
       "label": "formatStoreLocalDateLabel()",
@@ -259297,7 +259474,7 @@
       "source_location": "L117"
     },
     {
-      "community": 493,
+      "community": 495,
       "file_type": "code",
       "id": "pointofsaleview_formatstorelocaldatetime",
       "label": "formatStoreLocalDateTime()",
@@ -259306,7 +259483,7 @@
       "source_location": "L80"
     },
     {
-      "community": 493,
+      "community": 495,
       "file_type": "code",
       "id": "pointofsaleview_useminutenow",
       "label": "useMinuteNow()",
@@ -259315,7 +259492,7 @@
       "source_location": "L145"
     },
     {
-      "community": 494,
+      "community": 496,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_posregisteropeningguard_tsx",
       "label": "POSRegisterOpeningGuard.tsx",
@@ -259324,7 +259501,7 @@
       "source_location": "L1"
     },
     {
-      "community": 494,
+      "community": 496,
       "file_type": "code",
       "id": "posregisteropeningguard_getlocaloperatingdate",
       "label": "getLocalOperatingDate()",
@@ -259333,7 +259510,7 @@
       "source_location": "L65"
     },
     {
-      "community": 494,
+      "community": 496,
       "file_type": "code",
       "id": "posregisteropeningguard_getlocaloperatingdaterange",
       "label": "getLocalOperatingDateRange()",
@@ -259342,7 +259519,7 @@
       "source_location": "L73"
     },
     {
-      "community": 494,
+      "community": 496,
       "file_type": "code",
       "id": "posregisteropeningguard_if",
       "label": "if()",
@@ -259351,7 +259528,7 @@
       "source_location": "L689"
     },
     {
-      "community": 494,
+      "community": 496,
       "file_type": "code",
       "id": "posregisteropeningguard_isbrowseroffline",
       "label": "isBrowserOffline()",
@@ -259360,7 +259537,7 @@
       "source_location": "L92"
     },
     {
-      "community": 494,
+      "community": 496,
       "file_type": "code",
       "id": "posregisteropeningguard_posregisteropeningguard",
       "label": "POSRegisterOpeningGuard()",
@@ -259369,7 +259546,7 @@
       "source_location": "L96"
     },
     {
-      "community": 495,
+      "community": 497,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
       "label": "TransactionView.test.tsx",
@@ -259378,7 +259555,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 497,
       "file_type": "code",
       "id": "transactionview_test_async",
       "label": "async()",
@@ -259387,7 +259564,7 @@
       "source_location": "L199"
     },
     {
-      "community": 495,
+      "community": 497,
       "file_type": "code",
       "id": "transactionview_test_deferred",
       "label": "deferred()",
@@ -259396,7 +259573,7 @@
       "source_location": "L15"
     },
     {
-      "community": 495,
+      "community": 497,
       "file_type": "code",
       "id": "transactionview_test_mocktransactionmutations",
       "label": "mockTransactionMutations()",
@@ -259405,7 +259582,7 @@
       "source_location": "L554"
     },
     {
-      "community": 495,
+      "community": 497,
       "file_type": "code",
       "id": "transactionview_test_paymentapprovalrequirement",
       "label": "paymentApprovalRequirement()",
@@ -259414,7 +259591,7 @@
       "source_location": "L473"
     },
     {
-      "community": 495,
+      "community": 497,
       "file_type": "code",
       "id": "transactionview_test_voidapprovalrequirement",
       "label": "voidApprovalRequirement()",
@@ -259423,7 +259600,7 @@
       "source_location": "L506"
     },
     {
-      "community": 496,
+      "community": 498,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_test_tsx",
       "label": "ProcurementView.test.tsx",
@@ -259432,7 +259609,7 @@
       "source_location": "L1"
     },
     {
-      "community": 496,
+      "community": 498,
       "file_type": "code",
       "id": "procurementview_test_choosedraftvendor",
       "label": "chooseDraftVendor()",
@@ -259441,7 +259618,7 @@
       "source_location": "L367"
     },
     {
-      "community": 496,
+      "community": 498,
       "file_type": "code",
       "id": "procurementview_test_chooseprocurementmode",
       "label": "chooseProcurementMode()",
@@ -259450,7 +259627,7 @@
       "source_location": "L357"
     },
     {
-      "community": 496,
+      "community": 498,
       "file_type": "code",
       "id": "procurementview_test_installmutationmocks",
       "label": "installMutationMocks()",
@@ -259459,7 +259636,7 @@
       "source_location": "L323"
     },
     {
-      "community": 496,
+      "community": 498,
       "file_type": "code",
       "id": "procurementview_test_makeproductskusearchresult",
       "label": "makeProductSkuSearchResult()",
@@ -259468,7 +259645,7 @@
       "source_location": "L294"
     },
     {
-      "community": 496,
+      "community": 498,
       "file_type": "code",
       "id": "procurementview_test_makerecommendation",
       "label": "makeRecommendation()",
@@ -259477,7 +259654,7 @@
       "source_location": "L285"
     },
     {
-      "community": 497,
+      "community": 499,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_weeklyreportpresentation_ts",
       "label": "weeklyReportPresentation.ts",
@@ -259486,7 +259663,7 @@
       "source_location": "L1"
     },
     {
-      "community": 497,
+      "community": 499,
       "file_type": "code",
       "id": "weeklyreportpresentation_weeklyamendmentlabel",
       "label": "weeklyAmendmentLabel()",
@@ -259495,7 +259672,7 @@
       "source_location": "L74"
     },
     {
-      "community": 497,
+      "community": 499,
       "file_type": "code",
       "id": "weeklyreportpresentation_weeklylifecyclelabel",
       "label": "weeklyLifecycleLabel()",
@@ -259504,7 +259681,7 @@
       "source_location": "L16"
     },
     {
-      "community": 497,
+      "community": 499,
       "file_type": "code",
       "id": "weeklyreportpresentation_weeklytotalswithheld",
       "label": "weeklyTotalsWithheld()",
@@ -259513,7 +259690,7 @@
       "source_location": "L50"
     },
     {
-      "community": 497,
+      "community": 499,
       "file_type": "code",
       "id": "weeklyreportpresentation_weeklyupdatedat",
       "label": "weeklyUpdatedAt()",
@@ -259522,121 +259699,13 @@
       "source_location": "L3"
     },
     {
-      "community": 497,
+      "community": 499,
       "file_type": "code",
       "id": "weeklyreportpresentation_weeklyvaluelabelprefix",
       "label": "weeklyValueLabelPrefix()",
       "norm_label": "weeklyvaluelabelprefix()",
       "source_file": "packages/athena-webapp/src/components/reports/weeklyReportPresentation.ts",
       "source_location": "L63"
-    },
-    {
-      "community": 498,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reviews_reviewsview_tsx",
-      "label": "ReviewsView.tsx",
-      "norm_label": "reviewsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 498,
-      "file_type": "code",
-      "id": "reviewsview_handleapprove",
-      "label": "handleApprove()",
-      "norm_label": "handleapprove()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L44"
-    },
-    {
-      "community": 498,
-      "file_type": "code",
-      "id": "reviewsview_handlepublish",
-      "label": "handlePublish()",
-      "norm_label": "handlepublish()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L80"
-    },
-    {
-      "community": 498,
-      "file_type": "code",
-      "id": "reviewsview_handlereject",
-      "label": "handleReject()",
-      "norm_label": "handlereject()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L62"
-    },
-    {
-      "community": 498,
-      "file_type": "code",
-      "id": "reviewsview_handleunpublish",
-      "label": "handleUnpublish()",
-      "norm_label": "handleunpublish()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L98"
-    },
-    {
-      "community": 498,
-      "file_type": "code",
-      "id": "reviewsview_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_servicecatalogform_ts",
-      "label": "serviceCatalogForm.ts",
-      "norm_label": "servicecatalogform.ts",
-      "source_file": "packages/athena-webapp/src/components/services/serviceCatalogForm.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "servicecatalogform_formatservicecatalogname",
-      "label": "formatServiceCatalogName()",
-      "norm_label": "formatservicecatalogname()",
-      "source_file": "packages/athena-webapp/src/components/services/serviceCatalogForm.ts",
-      "source_location": "L92"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "servicecatalogform_itemtoservicecatalogformstate",
-      "label": "itemToServiceCatalogFormState()",
-      "norm_label": "itemtoservicecatalogformstate()",
-      "source_file": "packages/athena-webapp/src/components/services/serviceCatalogForm.ts",
-      "source_location": "L154"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "servicecatalogform_parseservicecatalogcreateform",
-      "label": "parseServiceCatalogCreateForm()",
-      "norm_label": "parseservicecatalogcreateform()",
-      "source_file": "packages/athena-webapp/src/components/services/serviceCatalogForm.ts",
-      "source_location": "L178"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "servicecatalogform_parseservicecatalogupdateform",
-      "label": "parseServiceCatalogUpdateForm()",
-      "norm_label": "parseservicecatalogupdateform()",
-      "source_file": "packages/athena-webapp/src/components/services/serviceCatalogForm.ts",
-      "source_location": "L203"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "servicecatalogform_validateservicecatalogform",
-      "label": "validateServiceCatalogForm()",
-      "norm_label": "validateservicecatalogform()",
-      "source_file": "packages/athena-webapp/src/components/services/serviceCatalogForm.ts",
-      "source_location": "L102"
     },
     {
       "community": 5,
@@ -260586,6 +260655,114 @@
     {
       "community": 500,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_reviews_reviewsview_tsx",
+      "label": "ReviewsView.tsx",
+      "norm_label": "reviewsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "reviewsview_handleapprove",
+      "label": "handleApprove()",
+      "norm_label": "handleapprove()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L44"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "reviewsview_handlepublish",
+      "label": "handlePublish()",
+      "norm_label": "handlepublish()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L80"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "reviewsview_handlereject",
+      "label": "handleReject()",
+      "norm_label": "handlereject()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L62"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "reviewsview_handleunpublish",
+      "label": "handleUnpublish()",
+      "norm_label": "handleunpublish()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L98"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "reviewsview_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_servicecatalogform_ts",
+      "label": "serviceCatalogForm.ts",
+      "norm_label": "servicecatalogform.ts",
+      "source_file": "packages/athena-webapp/src/components/services/serviceCatalogForm.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
+      "id": "servicecatalogform_formatservicecatalogname",
+      "label": "formatServiceCatalogName()",
+      "norm_label": "formatservicecatalogname()",
+      "source_file": "packages/athena-webapp/src/components/services/serviceCatalogForm.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
+      "id": "servicecatalogform_itemtoservicecatalogformstate",
+      "label": "itemToServiceCatalogFormState()",
+      "norm_label": "itemtoservicecatalogformstate()",
+      "source_file": "packages/athena-webapp/src/components/services/serviceCatalogForm.ts",
+      "source_location": "L154"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
+      "id": "servicecatalogform_parseservicecatalogcreateform",
+      "label": "parseServiceCatalogCreateForm()",
+      "norm_label": "parseservicecatalogcreateform()",
+      "source_file": "packages/athena-webapp/src/components/services/serviceCatalogForm.ts",
+      "source_location": "L178"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
+      "id": "servicecatalogform_parseservicecatalogupdateform",
+      "label": "parseServiceCatalogUpdateForm()",
+      "norm_label": "parseservicecatalogupdateform()",
+      "source_file": "packages/athena-webapp/src/components/services/serviceCatalogForm.ts",
+      "source_location": "L203"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
+      "id": "servicecatalogform_validateservicecatalogform",
+      "label": "validateServiceCatalogForm()",
+      "norm_label": "validateservicecatalogform()",
+      "source_file": "packages/athena-webapp/src/components/services/serviceCatalogForm.ts",
+      "source_location": "L102"
+    },
+    {
+      "community": 502,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemolivereportsday_test_ts",
       "label": "sharedDemoLiveReportsDay.test.ts",
       "norm_label": "shareddemolivereportsday.test.ts",
@@ -260593,7 +260770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 500,
+      "community": 502,
       "file_type": "code",
       "id": "shareddemolivereportsday_test_identity",
       "label": "identity()",
@@ -260602,7 +260779,7 @@
       "source_location": "L21"
     },
     {
-      "community": 500,
+      "community": 502,
       "file_type": "code",
       "id": "shareddemolivereportsday_test_liveresult",
       "label": "liveResult()",
@@ -260611,7 +260788,7 @@
       "source_location": "L77"
     },
     {
-      "community": 500,
+      "community": 502,
       "file_type": "code",
       "id": "shareddemolivereportsday_test_metrics",
       "label": "metrics()",
@@ -260620,7 +260797,7 @@
       "source_location": "L48"
     },
     {
-      "community": 500,
+      "community": 502,
       "file_type": "code",
       "id": "shareddemolivereportsday_test_quickaddidentity",
       "label": "quickAddIdentity()",
@@ -260629,7 +260806,7 @@
       "source_location": "L36"
     },
     {
-      "community": 500,
+      "community": 502,
       "file_type": "code",
       "id": "shareddemolivereportsday_test_skumetrics",
       "label": "skuMetrics()",
@@ -260638,7 +260815,7 @@
       "source_location": "L64"
     },
     {
-      "community": 501,
+      "community": 503,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemolivereportsday_ts",
       "label": "sharedDemoLiveReportsDay.ts",
@@ -260647,7 +260824,7 @@
       "source_location": "L1"
     },
     {
-      "community": 501,
+      "community": 503,
       "file_type": "code",
       "id": "shareddemolivereportsday_addskumetrics",
       "label": "addSkuMetrics()",
@@ -260656,7 +260833,7 @@
       "source_location": "L142"
     },
     {
-      "community": 501,
+      "community": 503,
       "file_type": "code",
       "id": "shareddemolivereportsday_shareddemofixtureskuid",
       "label": "sharedDemoFixtureSkuId()",
@@ -260665,7 +260842,7 @@
       "source_location": "L117"
     },
     {
-      "community": 501,
+      "community": 503,
       "file_type": "code",
       "id": "shareddemolivereportsday_toshareddemolivereportsday",
       "label": "toSharedDemoLiveReportsDay()",
@@ -260674,7 +260851,7 @@
       "source_location": "L169"
     },
     {
-      "community": 501,
+      "community": 503,
       "file_type": "code",
       "id": "shareddemolivereportsday_toshareddemoliveskustock",
       "label": "toSharedDemoLiveSkuStock()",
@@ -260683,7 +260860,7 @@
       "source_location": "L240"
     },
     {
-      "community": 501,
+      "community": 503,
       "file_type": "code",
       "id": "shareddemolivereportsday_zerodaymetrics",
       "label": "zeroDayMetrics()",
@@ -260692,7 +260869,7 @@
       "source_location": "L127"
     },
     {
-      "community": 502,
+      "community": 504,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemosurfacecatalog_ts",
       "label": "sharedDemoSurfaceCatalog.ts",
@@ -260701,7 +260878,7 @@
       "source_location": "L1"
     },
     {
-      "community": 502,
+      "community": 504,
       "file_type": "code",
       "id": "shareddemosurfacecatalog_classifyathenaviewsurface",
       "label": "classifyAthenaViewSurface()",
@@ -260710,7 +260887,7 @@
       "source_location": "L395"
     },
     {
-      "community": 502,
+      "community": 504,
       "file_type": "code",
       "id": "shareddemosurfacecatalog_isshareddemosurfacevisible",
       "label": "isSharedDemoSurfaceVisible()",
@@ -260719,7 +260896,7 @@
       "source_location": "L401"
     },
     {
-      "community": 502,
+      "community": 504,
       "file_type": "code",
       "id": "shareddemosurfacecatalog_normalizepathname",
       "label": "normalizePathname()",
@@ -260728,7 +260905,7 @@
       "source_location": "L332"
     },
     {
-      "community": 502,
+      "community": 504,
       "file_type": "code",
       "id": "shareddemosurfacecatalog_resolveathenaviewroute",
       "label": "resolveAthenaViewRoute()",
@@ -260737,7 +260914,7 @@
       "source_location": "L364"
     },
     {
-      "community": 502,
+      "community": 504,
       "file_type": "code",
       "id": "shareddemosurfacecatalog_routetemplatematches",
       "label": "routeTemplateMatches()",
@@ -260746,7 +260923,7 @@
       "source_location": "L340"
     },
     {
-      "community": 503,
+      "community": 505,
       "file_type": "code",
       "id": "feesview_formatdeliveryfeeinput",
       "label": "formatDeliveryFeeInput()",
@@ -260755,7 +260932,7 @@
       "source_location": "L31"
     },
     {
-      "community": 503,
+      "community": 505,
       "file_type": "code",
       "id": "feesview_handletoggleallfees",
       "label": "handleToggleAllFees()",
@@ -260764,7 +260941,7 @@
       "source_location": "L162"
     },
     {
-      "community": 503,
+      "community": 505,
       "file_type": "code",
       "id": "feesview_handleupdatefees",
       "label": "handleUpdateFees()",
@@ -260773,7 +260950,7 @@
       "source_location": "L88"
     },
     {
-      "community": 503,
+      "community": 505,
       "file_type": "code",
       "id": "feesview_parsedeliveryfeeinputs",
       "label": "parseDeliveryFeeInputs()",
@@ -260782,7 +260959,7 @@
       "source_location": "L45"
     },
     {
-      "community": 503,
+      "community": 505,
       "file_type": "code",
       "id": "feesview_parseoptionaldeliveryfeeinput",
       "label": "parseOptionalDeliveryFeeInput()",
@@ -260791,7 +260968,7 @@
       "source_location": "L35"
     },
     {
-      "community": 503,
+      "community": 505,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_tsx",
       "label": "FeesView.tsx",
@@ -260800,7 +260977,7 @@
       "source_location": "L1"
     },
     {
-      "community": 504,
+      "community": 506,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usenotificationsubscriptions_ts",
       "label": "useNotificationSubscriptions.ts",
@@ -260809,7 +260986,7 @@
       "source_location": "L1"
     },
     {
-      "community": 504,
+      "community": 506,
       "file_type": "code",
       "id": "usenotificationsubscriptions_derivecategorystate",
       "label": "deriveCategoryState()",
@@ -260818,7 +260995,7 @@
       "source_location": "L113"
     },
     {
-      "community": 504,
+      "community": 506,
       "file_type": "code",
       "id": "usenotificationsubscriptions_isvalidrecipientemail",
       "label": "isValidRecipientEmail()",
@@ -260827,7 +261004,7 @@
       "source_location": "L104"
     },
     {
-      "community": 504,
+      "community": 506,
       "file_type": "code",
       "id": "usenotificationsubscriptions_normalizerecipientemailinput",
       "label": "normalizeRecipientEmailInput()",
@@ -260836,7 +261013,7 @@
       "source_location": "L100"
     },
     {
-      "community": 504,
+      "community": 506,
       "file_type": "code",
       "id": "usenotificationsubscriptions_sortrecipientcandidates",
       "label": "sortRecipientCandidates()",
@@ -260845,7 +261022,7 @@
       "source_location": "L127"
     },
     {
-      "community": 504,
+      "community": 506,
       "file_type": "code",
       "id": "usenotificationsubscriptions_usenotificationsubscriptions",
       "label": "useNotificationSubscriptions()",
@@ -260854,7 +261031,7 @@
       "source_location": "L138"
     },
     {
-      "community": 505,
+      "community": 507,
       "file_type": "code",
       "id": "config_derivestorefrontfromadminhost",
       "label": "deriveStoreFrontFromAdminHost()",
@@ -260863,7 +261040,7 @@
       "source_location": "L29"
     },
     {
-      "community": 505,
+      "community": 507,
       "file_type": "code",
       "id": "config_getruntimeorigin",
       "label": "getRuntimeOrigin()",
@@ -260872,7 +261049,7 @@
       "source_location": "L12"
     },
     {
-      "community": 505,
+      "community": 507,
       "file_type": "code",
       "id": "config_islocalhost",
       "label": "isLocalHost()",
@@ -260881,7 +261058,7 @@
       "source_location": "L20"
     },
     {
-      "community": 505,
+      "community": 507,
       "file_type": "code",
       "id": "config_resolvestorefronturl",
       "label": "resolveStoreFrontUrl()",
@@ -260890,7 +261067,7 @@
       "source_location": "L51"
     },
     {
-      "community": 505,
+      "community": 507,
       "file_type": "code",
       "id": "config_trimtrailingslash",
       "label": "trimTrailingSlash()",
@@ -260899,7 +261076,7 @@
       "source_location": "L8"
     },
     {
-      "community": 505,
+      "community": 507,
       "file_type": "code",
       "id": "packages_athena_webapp_src_config_ts",
       "label": "config.ts",
@@ -260908,7 +261085,7 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 508,
       "file_type": "code",
       "id": "managerelevationcontext_getstaffdisplayname",
       "label": "getStaffDisplayName()",
@@ -260917,7 +261094,7 @@
       "source_location": "L64"
     },
     {
-      "community": 506,
+      "community": 508,
       "file_type": "code",
       "id": "managerelevationcontext_managerelevationprovider",
       "label": "ManagerElevationProvider()",
@@ -260926,7 +261103,7 @@
       "source_location": "L87"
     },
     {
-      "community": 506,
+      "community": 508,
       "file_type": "code",
       "id": "managerelevationcontext_tostaffauthenticationresult",
       "label": "toStaffAuthenticationResult()",
@@ -260935,7 +261112,7 @@
       "source_location": "L74"
     },
     {
-      "community": 506,
+      "community": 508,
       "file_type": "code",
       "id": "managerelevationcontext_usemanagerelevation",
       "label": "useManagerElevation()",
@@ -260944,7 +261121,7 @@
       "source_location": "L242"
     },
     {
-      "community": 506,
+      "community": 508,
       "file_type": "code",
       "id": "managerelevationcontext_useoptionalmanagerelevation",
       "label": "useOptionalManagerElevation()",
@@ -260953,7 +261130,7 @@
       "source_location": "L251"
     },
     {
-      "community": 506,
+      "community": 508,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_managerelevationcontext_tsx",
       "label": "ManagerElevationContext.tsx",
@@ -260962,7 +261139,7 @@
       "source_location": "L1"
     },
     {
-      "community": 507,
+      "community": 509,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
       "label": "useExpenseSessions.ts",
@@ -260971,7 +261148,7 @@
       "source_location": "L1"
     },
     {
-      "community": 507,
+      "community": 509,
       "file_type": "code",
       "id": "useexpensesessions_useexpenseactivesession",
       "label": "useExpenseActiveSession()",
@@ -260980,7 +261157,7 @@
       "source_location": "L42"
     },
     {
-      "community": 507,
+      "community": 509,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesession",
       "label": "useExpenseSession()",
@@ -260989,7 +261166,7 @@
       "source_location": "L32"
     },
     {
-      "community": 507,
+      "community": 509,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessioncreate",
       "label": "useExpenseSessionCreate()",
@@ -260998,7 +261175,7 @@
       "source_location": "L62"
     },
     {
-      "community": 507,
+      "community": 509,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessionupdate",
       "label": "useExpenseSessionUpdate()",
@@ -261007,121 +261184,13 @@
       "source_location": "L101"
     },
     {
-      "community": 507,
+      "community": 509,
       "file_type": "code",
       "id": "useexpensesessions_useexpensestoresessions",
       "label": "useExpenseStoreSessions()",
       "norm_label": "useexpensestoresessions()",
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L10"
-    },
-    {
-      "community": 508,
-      "file_type": "code",
-      "id": "capabilities_canaccesscashcontrolssurface",
-      "label": "canAccessCashControlsSurface()",
-      "norm_label": "canaccesscashcontrolssurface()",
-      "source_file": "packages/athena-webapp/src/lib/access/capabilities.ts",
-      "source_location": "L54"
-    },
-    {
-      "community": 508,
-      "file_type": "code",
-      "id": "capabilities_canaccessfulladminsurface",
-      "label": "canAccessFullAdminSurface()",
-      "norm_label": "canaccessfulladminsurface()",
-      "source_file": "packages/athena-webapp/src/lib/access/capabilities.ts",
-      "source_location": "L41"
-    },
-    {
-      "community": 508,
-      "file_type": "code",
-      "id": "capabilities_canaccessstoredaysurface",
-      "label": "canAccessStoreDaySurface()",
-      "norm_label": "canaccessstoredaysurface()",
-      "source_file": "packages/athena-webapp/src/lib/access/capabilities.ts",
-      "source_location": "L47"
-    },
-    {
-      "community": 508,
-      "file_type": "code",
-      "id": "capabilities_canviewfinancialdetails",
-      "label": "canViewFinancialDetails()",
-      "norm_label": "canviewfinancialdetails()",
-      "source_file": "packages/athena-webapp/src/lib/access/capabilities.ts",
-      "source_location": "L61"
-    },
-    {
-      "community": 508,
-      "file_type": "code",
-      "id": "capabilities_getsurfaceaccess",
-      "label": "getSurfaceAccess()",
-      "norm_label": "getsurfaceaccess()",
-      "source_file": "packages/athena-webapp/src/lib/access/capabilities.ts",
-      "source_location": "L68"
-    },
-    {
-      "community": 508,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_access_capabilities_ts",
-      "label": "capabilities.ts",
-      "norm_label": "capabilities.ts",
-      "source_file": "packages/athena-webapp/src/lib/access/capabilities.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "behaviorutils_calculateengagementmetrics",
-      "label": "calculateEngagementMetrics()",
-      "norm_label": "calculateengagementmetrics()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L173"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "behaviorutils_calculateriskindicators",
-      "label": "calculateRiskIndicators()",
-      "norm_label": "calculateriskindicators()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "behaviorutils_getactivitypriority",
-      "label": "getActivityPriority()",
-      "norm_label": "getactivitypriority()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L251"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "behaviorutils_getcustomerjourneystage",
-      "label": "getCustomerJourneyStage()",
-      "norm_label": "getcustomerjourneystage()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "behaviorutils_getjourneystageinfo",
-      "label": "getJourneyStageInfo()",
-      "norm_label": "getjourneystageinfo()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L277"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
-      "label": "behaviorUtils.ts",
-      "norm_label": "behaviorutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L1"
     },
     {
       "community": 51,
@@ -261387,6 +261456,114 @@
     {
       "community": 510,
       "file_type": "code",
+      "id": "capabilities_canaccesscashcontrolssurface",
+      "label": "canAccessCashControlsSurface()",
+      "norm_label": "canaccesscashcontrolssurface()",
+      "source_file": "packages/athena-webapp/src/lib/access/capabilities.ts",
+      "source_location": "L54"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "capabilities_canaccessfulladminsurface",
+      "label": "canAccessFullAdminSurface()",
+      "norm_label": "canaccessfulladminsurface()",
+      "source_file": "packages/athena-webapp/src/lib/access/capabilities.ts",
+      "source_location": "L41"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "capabilities_canaccessstoredaysurface",
+      "label": "canAccessStoreDaySurface()",
+      "norm_label": "canaccessstoredaysurface()",
+      "source_file": "packages/athena-webapp/src/lib/access/capabilities.ts",
+      "source_location": "L47"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "capabilities_canviewfinancialdetails",
+      "label": "canViewFinancialDetails()",
+      "norm_label": "canviewfinancialdetails()",
+      "source_file": "packages/athena-webapp/src/lib/access/capabilities.ts",
+      "source_location": "L61"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "capabilities_getsurfaceaccess",
+      "label": "getSurfaceAccess()",
+      "norm_label": "getsurfaceaccess()",
+      "source_file": "packages/athena-webapp/src/lib/access/capabilities.ts",
+      "source_location": "L68"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_access_capabilities_ts",
+      "label": "capabilities.ts",
+      "norm_label": "capabilities.ts",
+      "source_file": "packages/athena-webapp/src/lib/access/capabilities.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
+      "id": "behaviorutils_calculateengagementmetrics",
+      "label": "calculateEngagementMetrics()",
+      "norm_label": "calculateengagementmetrics()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L173"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
+      "id": "behaviorutils_calculateriskindicators",
+      "label": "calculateRiskIndicators()",
+      "norm_label": "calculateriskindicators()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
+      "id": "behaviorutils_getactivitypriority",
+      "label": "getActivityPriority()",
+      "norm_label": "getactivitypriority()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L251"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
+      "id": "behaviorutils_getcustomerjourneystage",
+      "label": "getCustomerJourneyStage()",
+      "norm_label": "getcustomerjourneystage()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
+      "id": "behaviorutils_getjourneystageinfo",
+      "label": "getJourneyStageInfo()",
+      "norm_label": "getjourneystageinfo()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L277"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
+      "label": "behaviorUtils.ts",
+      "norm_label": "behaviorutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 512,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
       "label": "results.ts",
       "norm_label": "results.ts",
@@ -261394,7 +261571,7 @@
       "source_location": "L1"
     },
     {
-      "community": 510,
+      "community": 512,
       "file_type": "code",
       "id": "results_isposusecasesuccess",
       "label": "isPosUseCaseSuccess()",
@@ -261403,7 +261580,7 @@
       "source_location": "L134"
     },
     {
-      "community": 510,
+      "community": 512,
       "file_type": "code",
       "id": "results_mapcommandoutcome",
       "label": "mapCommandOutcome()",
@@ -261412,7 +261589,7 @@
       "source_location": "L69"
     },
     {
-      "community": 510,
+      "community": 512,
       "file_type": "code",
       "id": "results_mapcommandresult",
       "label": "mapCommandResult()",
@@ -261421,7 +261598,7 @@
       "source_location": "L86"
     },
     {
-      "community": 510,
+      "community": 512,
       "file_type": "code",
       "id": "results_maplegacymutationresult",
       "label": "mapLegacyMutationResult()",
@@ -261430,7 +261607,7 @@
       "source_location": "L52"
     },
     {
-      "community": 510,
+      "community": 512,
       "file_type": "code",
       "id": "results_mapthrownerror",
       "label": "mapThrownError()",
@@ -261439,7 +261616,7 @@
       "source_location": "L103"
     },
     {
-      "community": 511,
+      "community": 513,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registerlifecycleauthoritycandidates_ts",
       "label": "registerLifecycleAuthorityCandidates.ts",
@@ -261448,7 +261625,7 @@
       "source_location": "L1"
     },
     {
-      "community": 511,
+      "community": 513,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_deriveregisterlifecycleauthoritycandidates",
       "label": "deriveRegisterLifecycleAuthorityCandidates()",
@@ -261457,7 +261634,7 @@
       "source_location": "L45"
     },
     {
-      "community": 511,
+      "community": 513,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_isboundedidentifier",
       "label": "isBoundedIdentifier()",
@@ -261466,7 +261643,7 @@
       "source_location": "L220"
     },
     {
-      "community": 511,
+      "community": 513,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_iseligibleregistermapping",
       "label": "isEligibleRegisterMapping()",
@@ -261475,7 +261652,7 @@
       "source_location": "L167"
     },
     {
-      "community": 511,
+      "community": 513,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_legacymappingmatchesactivesession",
       "label": "legacyMappingMatchesActiveSession()",
@@ -261484,7 +261661,7 @@
       "source_location": "L182"
     },
     {
-      "community": 511,
+      "community": 513,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_mappingcandidate",
       "label": "mappingCandidate()",
@@ -261493,7 +261670,7 @@
       "source_location": "L194"
     },
     {
-      "community": 512,
+      "community": 514,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_useposlocalsyncruntime_test_ts",
       "label": "usePosLocalSyncRuntime.test.ts",
@@ -261502,7 +261679,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 514,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_buildlocalevent",
       "label": "buildLocalEvent()",
@@ -261511,7 +261688,7 @@
       "source_location": "L7449"
     },
     {
-      "community": 512,
+      "community": 514,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_buildrecoverycommand",
       "label": "buildRecoveryCommand()",
@@ -261520,7 +261697,7 @@
       "source_location": "L7472"
     },
     {
-      "community": 512,
+      "community": 514,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_buildrecoverycommandstore",
       "label": "buildRecoveryCommandStore()",
@@ -261529,7 +261706,7 @@
       "source_location": "L7491"
     },
     {
-      "community": 512,
+      "community": 514,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_deferred",
       "label": "deferred()",
@@ -261538,7 +261715,7 @@
       "source_location": "L108"
     },
     {
-      "community": 512,
+      "community": 514,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_storefactory",
       "label": "storeFactory()",
@@ -261547,7 +261724,7 @@
       "source_location": "L352"
     },
     {
-      "community": 513,
+      "community": 515,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
       "label": "selectors.ts",
@@ -261556,7 +261733,7 @@
       "source_location": "L1"
     },
     {
-      "community": 513,
+      "community": 515,
       "file_type": "code",
       "id": "selectors_buildregisterheaderstate",
       "label": "buildRegisterHeaderState()",
@@ -261565,7 +261742,7 @@
       "source_location": "L28"
     },
     {
-      "community": 513,
+      "community": 515,
       "file_type": "code",
       "id": "selectors_buildregisterinfostate",
       "label": "buildRegisterInfoState()",
@@ -261574,7 +261751,7 @@
       "source_location": "L37"
     },
     {
-      "community": 513,
+      "community": 515,
       "file_type": "code",
       "id": "selectors_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -261583,7 +261760,7 @@
       "source_location": "L12"
     },
     {
-      "community": 513,
+      "community": 515,
       "file_type": "code",
       "id": "selectors_getregistercustomerinfo",
       "label": "getRegisterCustomerInfo()",
@@ -261592,7 +261769,7 @@
       "source_location": "L6"
     },
     {
-      "community": 513,
+      "community": 515,
       "file_type": "code",
       "id": "selectors_isregistersessionactive",
       "label": "isRegisterSessionActive()",
@@ -261601,7 +261778,7 @@
       "source_location": "L49"
     },
     {
-      "community": 514,
+      "community": 516,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
       "label": "toastService.ts",
@@ -261610,7 +261787,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 516,
       "file_type": "code",
       "id": "toastservice_handleposoperation",
       "label": "handlePOSOperation()",
@@ -261619,7 +261796,7 @@
       "source_location": "L171"
     },
     {
-      "community": 514,
+      "community": 516,
       "file_type": "code",
       "id": "toastservice_showinventoryerror",
       "label": "showInventoryError()",
@@ -261628,7 +261805,7 @@
       "source_location": "L302"
     },
     {
-      "community": 514,
+      "community": 516,
       "file_type": "code",
       "id": "toastservice_shownoactivesessionerror",
       "label": "showNoActiveSessionError()",
@@ -261637,7 +261814,7 @@
       "source_location": "L319"
     },
     {
-      "community": 514,
+      "community": 516,
       "file_type": "code",
       "id": "toastservice_showsessionexpirederror",
       "label": "showSessionExpiredError()",
@@ -261646,7 +261823,7 @@
       "source_location": "L312"
     },
     {
-      "community": 514,
+      "community": 516,
       "file_type": "code",
       "id": "toastservice_showvalidationerror",
       "label": "showValidationError()",
@@ -261655,7 +261832,7 @@
       "source_location": "L293"
     },
     {
-      "community": 515,
+      "community": 517,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_sheetreturn_ts",
       "label": "sheetReturn.ts",
@@ -261664,7 +261841,7 @@
       "source_location": "L1"
     },
     {
-      "community": 515,
+      "community": 517,
       "file_type": "code",
       "id": "sheetreturn_decodesheetreturn",
       "label": "decodeSheetReturn()",
@@ -261673,7 +261850,7 @@
       "source_location": "L85"
     },
     {
-      "community": 515,
+      "community": 517,
       "file_type": "code",
       "id": "sheetreturn_encodefocuskey",
       "label": "encodeFocusKey()",
@@ -261682,7 +261859,7 @@
       "source_location": "L74"
     },
     {
-      "community": 515,
+      "community": 517,
       "file_type": "code",
       "id": "sheetreturn_encodesheetreturn",
       "label": "encodeSheetReturn()",
@@ -261691,7 +261868,7 @@
       "source_location": "L55"
     },
     {
-      "community": 515,
+      "community": 517,
       "file_type": "code",
       "id": "sheetreturn_sheetreturnfocusselector",
       "label": "sheetReturnFocusSelector()",
@@ -261700,7 +261877,7 @@
       "source_location": "L126"
     },
     {
-      "community": 515,
+      "community": 517,
       "file_type": "code",
       "id": "sheetreturn_sheetreturntargetprops",
       "label": "sheetReturnTargetProps()",
@@ -261709,7 +261886,7 @@
       "source_location": "L131"
     },
     {
-      "community": 516,
+      "community": 518,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_skusearch_productskusearchadapters_ts",
       "label": "productSkuSearchAdapters.ts",
@@ -261718,7 +261895,7 @@
       "source_location": "L1"
     },
     {
-      "community": 516,
+      "community": 518,
       "file_type": "code",
       "id": "productskusearchadapters_buildadminskusearchoption",
       "label": "buildAdminSkuSearchOption()",
@@ -261727,7 +261904,7 @@
       "source_location": "L80"
     },
     {
-      "community": 516,
+      "community": 518,
       "file_type": "code",
       "id": "productskusearchadapters_buildadminskusearchoptions",
       "label": "buildAdminSkuSearchOptions()",
@@ -261736,7 +261913,7 @@
       "source_location": "L132"
     },
     {
-      "community": 516,
+      "community": 518,
       "file_type": "code",
       "id": "productskusearchadapters_compactjoin",
       "label": "compactJoin()",
@@ -261745,7 +261922,7 @@
       "source_location": "L73"
     },
     {
-      "community": 516,
+      "community": 518,
       "file_type": "code",
       "id": "productskusearchadapters_groupadminskusearchoptionsbyproduct",
       "label": "groupAdminSkuSearchOptionsByProduct()",
@@ -261754,7 +261931,7 @@
       "source_location": "L138"
     },
     {
-      "community": 516,
+      "community": 518,
       "file_type": "code",
       "id": "productskusearchadapters_presentationtext",
       "label": "presentationText()",
@@ -261763,7 +261940,7 @@
       "source_location": "L66"
     },
     {
-      "community": 517,
+      "community": 519,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_stockops_skusearch_ts",
       "label": "skuSearch.ts",
@@ -261772,7 +261949,7 @@
       "source_location": "L1"
     },
     {
-      "community": 517,
+      "community": 519,
       "file_type": "code",
       "id": "skusearch_isbarcodeshapedsearchquery",
       "label": "isBarcodeShapedSearchQuery()",
@@ -261781,7 +261958,7 @@
       "source_location": "L49"
     },
     {
-      "community": 517,
+      "community": 519,
       "file_type": "code",
       "id": "skusearch_matchesskusearchterms",
       "label": "matchesSkuSearchTerms()",
@@ -261790,7 +261967,7 @@
       "source_location": "L11"
     },
     {
-      "community": 517,
+      "community": 519,
       "file_type": "code",
       "id": "skusearch_normalizeidentifier",
       "label": "normalizeIdentifier()",
@@ -261799,7 +261976,7 @@
       "source_location": "L53"
     },
     {
-      "community": 517,
+      "community": 519,
       "file_type": "code",
       "id": "skusearch_normalizeskusearchquery",
       "label": "normalizeSkuSearchQuery()",
@@ -261808,121 +261985,13 @@
       "source_location": "L7"
     },
     {
-      "community": 517,
+      "community": 519,
       "file_type": "code",
       "id": "skusearch_scoreskusearchterms",
       "label": "scoreSkuSearchTerms()",
       "norm_label": "scoreskusearchterms()",
       "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
       "source_location": "L18"
-    },
-    {
-      "community": 518,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_offline_posappshellroutes_ts",
-      "label": "posAppShellRoutes.ts",
-      "norm_label": "posappshellroutes.ts",
-      "source_file": "packages/athena-webapp/src/offline/posAppShellRoutes.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 518,
-      "file_type": "code",
-      "id": "posappshellroutes_isexcludedfromposappshellcache",
-      "label": "isExcludedFromPosAppShellCache()",
-      "norm_label": "isexcludedfromposappshellcache()",
-      "source_file": "packages/athena-webapp/src/offline/posAppShellRoutes.ts",
-      "source_location": "L53"
-    },
-    {
-      "community": 518,
-      "file_type": "code",
-      "id": "posappshellroutes_isposappshellnavigationrequest",
-      "label": "isPosAppShellNavigationRequest()",
-      "norm_label": "isposappshellnavigationrequest()",
-      "source_file": "packages/athena-webapp/src/offline/posAppShellRoutes.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 518,
-      "file_type": "code",
-      "id": "posappshellroutes_isposappshellroutepath",
-      "label": "isPosAppShellRoutePath()",
-      "norm_label": "isposappshellroutepath()",
-      "source_file": "packages/athena-webapp/src/offline/posAppShellRoutes.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 518,
-      "file_type": "code",
-      "id": "posappshellroutes_isposappshellstaticassetrequest",
-      "label": "isPosAppShellStaticAssetRequest()",
-      "norm_label": "isposappshellstaticassetrequest()",
-      "source_file": "packages/athena-webapp/src/offline/posAppShellRoutes.ts",
-      "source_location": "L88"
-    },
-    {
-      "community": 518,
-      "file_type": "code",
-      "id": "posappshellroutes_readheader",
-      "label": "readHeader()",
-      "norm_label": "readheader()",
-      "source_file": "packages/athena-webapp/src/offline/posAppShellRoutes.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_offline_posappshellserviceworkerstaging_test_ts",
-      "label": "posAppShellServiceWorkerStaging.test.ts",
-      "norm_label": "posappshellserviceworkerstaging.test.ts",
-      "source_file": "packages/athena-webapp/src/offline/posAppShellServiceWorkerStaging.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "posappshellserviceworkerstaging_test_createserviceworkerfixture",
-      "label": "createServiceWorkerFixture()",
-      "norm_label": "createserviceworkerfixture()",
-      "source_file": "packages/athena-webapp/src/offline/posAppShellServiceWorkerStaging.test.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "posappshellserviceworkerstaging_test_memorycache",
-      "label": "MemoryCache",
-      "norm_label": "memorycache",
-      "source_file": "packages/athena-webapp/src/offline/posAppShellServiceWorkerStaging.test.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "posappshellserviceworkerstaging_test_memorycache_keys",
-      "label": ".keys()",
-      "norm_label": ".keys()",
-      "source_file": "packages/athena-webapp/src/offline/posAppShellServiceWorkerStaging.test.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "posappshellserviceworkerstaging_test_memorycache_match",
-      "label": ".match()",
-      "norm_label": ".match()",
-      "source_file": "packages/athena-webapp/src/offline/posAppShellServiceWorkerStaging.test.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "posappshellserviceworkerstaging_test_memorycache_put",
-      "label": ".put()",
-      "norm_label": ".put()",
-      "source_file": "packages/athena-webapp/src/offline/posAppShellServiceWorkerStaging.test.ts",
-      "source_location": "L22"
     },
     {
       "community": 52,
@@ -262188,6 +262257,114 @@
     {
       "community": 520,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_offline_posappshellroutes_ts",
+      "label": "posAppShellRoutes.ts",
+      "norm_label": "posappshellroutes.ts",
+      "source_file": "packages/athena-webapp/src/offline/posAppShellRoutes.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "posappshellroutes_isexcludedfromposappshellcache",
+      "label": "isExcludedFromPosAppShellCache()",
+      "norm_label": "isexcludedfromposappshellcache()",
+      "source_file": "packages/athena-webapp/src/offline/posAppShellRoutes.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "posappshellroutes_isposappshellnavigationrequest",
+      "label": "isPosAppShellNavigationRequest()",
+      "norm_label": "isposappshellnavigationrequest()",
+      "source_file": "packages/athena-webapp/src/offline/posAppShellRoutes.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "posappshellroutes_isposappshellroutepath",
+      "label": "isPosAppShellRoutePath()",
+      "norm_label": "isposappshellroutepath()",
+      "source_file": "packages/athena-webapp/src/offline/posAppShellRoutes.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "posappshellroutes_isposappshellstaticassetrequest",
+      "label": "isPosAppShellStaticAssetRequest()",
+      "norm_label": "isposappshellstaticassetrequest()",
+      "source_file": "packages/athena-webapp/src/offline/posAppShellRoutes.ts",
+      "source_location": "L88"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "posappshellroutes_readheader",
+      "label": "readHeader()",
+      "norm_label": "readheader()",
+      "source_file": "packages/athena-webapp/src/offline/posAppShellRoutes.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_offline_posappshellserviceworkerstaging_test_ts",
+      "label": "posAppShellServiceWorkerStaging.test.ts",
+      "norm_label": "posappshellserviceworkerstaging.test.ts",
+      "source_file": "packages/athena-webapp/src/offline/posAppShellServiceWorkerStaging.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
+      "id": "posappshellserviceworkerstaging_test_createserviceworkerfixture",
+      "label": "createServiceWorkerFixture()",
+      "norm_label": "createserviceworkerfixture()",
+      "source_file": "packages/athena-webapp/src/offline/posAppShellServiceWorkerStaging.test.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
+      "id": "posappshellserviceworkerstaging_test_memorycache",
+      "label": "MemoryCache",
+      "norm_label": "memorycache",
+      "source_file": "packages/athena-webapp/src/offline/posAppShellServiceWorkerStaging.test.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
+      "id": "posappshellserviceworkerstaging_test_memorycache_keys",
+      "label": ".keys()",
+      "norm_label": ".keys()",
+      "source_file": "packages/athena-webapp/src/offline/posAppShellServiceWorkerStaging.test.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
+      "id": "posappshellserviceworkerstaging_test_memorycache_match",
+      "label": ".match()",
+      "norm_label": ".match()",
+      "source_file": "packages/athena-webapp/src/offline/posAppShellServiceWorkerStaging.test.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
+      "id": "posappshellserviceworkerstaging_test_memorycache_put",
+      "label": ".put()",
+      "norm_label": ".put()",
+      "source_file": "packages/athena-webapp/src/offline/posAppShellServiceWorkerStaging.test.ts",
+      "source_location": "L22"
+    },
+    {
+      "community": 522,
+      "file_type": "code",
       "id": "docs_shared_companionsection",
       "label": "CompanionSection()",
       "norm_label": "companionsection()",
@@ -262195,7 +262372,7 @@
       "source_location": "L81"
     },
     {
-      "community": 520,
+      "community": 522,
       "file_type": "code",
       "id": "docs_shared_formatcategorylabel",
       "label": "formatCategoryLabel()",
@@ -262204,7 +262381,7 @@
       "source_location": "L7"
     },
     {
-      "community": 520,
+      "community": 522,
       "file_type": "code",
       "id": "docs_shared_formatdocdate",
       "label": "formatDocDate()",
@@ -262213,7 +262390,7 @@
       "source_location": "L11"
     },
     {
-      "community": 520,
+      "community": 522,
       "file_type": "code",
       "id": "docs_shared_severityindicator",
       "label": "SeverityIndicator()",
@@ -262222,7 +262399,7 @@
       "source_location": "L32"
     },
     {
-      "community": 520,
+      "community": 522,
       "file_type": "code",
       "id": "docs_shared_solutiondoccard",
       "label": "SolutionDocCard()",
@@ -262231,7 +262408,7 @@
       "source_location": "L48"
     },
     {
-      "community": 520,
+      "community": 522,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_docs_shared_tsx",
       "label": "-docs-shared.tsx",
@@ -262240,7 +262417,7 @@
       "source_location": "L1"
     },
     {
-      "community": 521,
+      "community": 523,
       "file_type": "code",
       "id": "index_route_view_democtabutton",
       "label": "DemoCtaButton()",
@@ -262249,7 +262426,7 @@
       "source_location": "L192"
     },
     {
-      "community": 521,
+      "community": 523,
       "file_type": "code",
       "id": "index_route_view_herogrid",
       "label": "HeroGrid()",
@@ -262258,7 +262435,7 @@
       "source_location": "L178"
     },
     {
-      "community": 521,
+      "community": 523,
       "file_type": "code",
       "id": "index_route_view_rest",
       "label": "rest()",
@@ -262267,7 +262444,7 @@
       "source_location": "L246"
     },
     {
-      "community": 521,
+      "community": 523,
       "file_type": "code",
       "id": "index_route_view_useheroshotrevealref",
       "label": "useHeroShotRevealRef()",
@@ -262276,7 +262453,7 @@
       "source_location": "L54"
     },
     {
-      "community": 521,
+      "community": 523,
       "file_type": "code",
       "id": "index_route_view_useheroshottiltref",
       "label": "useHeroShotTiltRef()",
@@ -262285,7 +262462,7 @@
       "source_location": "L107"
     },
     {
-      "community": 521,
+      "community": 523,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_route_view_tsx",
       "label": "-index-route-view.tsx",
@@ -262294,7 +262471,7 @@
       "source_location": "L1"
     },
     {
-      "community": 522,
+      "community": 524,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
       "label": "procurement.index.tsx",
@@ -262303,7 +262480,7 @@
       "source_location": "L1"
     },
     {
-      "community": 522,
+      "community": 524,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementmodesearch",
       "label": "getNextProcurementModeSearch()",
@@ -262312,7 +262489,7 @@
       "source_location": "L19"
     },
     {
-      "community": 522,
+      "community": 524,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementpagesearch",
       "label": "getNextProcurementPageSearch()",
@@ -262321,7 +262498,7 @@
       "source_location": "L37"
     },
     {
-      "community": 522,
+      "community": 524,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementquerysearch",
       "label": "getNextProcurementQuerySearch()",
@@ -262330,7 +262507,7 @@
       "source_location": "L47"
     },
     {
-      "community": 522,
+      "community": 524,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementselectedskusearch",
       "label": "getNextProcurementSelectedSkuSearch()",
@@ -262339,7 +262516,7 @@
       "source_location": "L62"
     },
     {
-      "community": 522,
+      "community": 524,
       "file_type": "code",
       "id": "procurement_index_procurementroute",
       "label": "ProcurementRoute()",
@@ -262348,7 +262525,7 @@
       "source_location": "L88"
     },
     {
-      "community": 523,
+      "community": 525,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_weekly_lifecycle_test_tsx",
       "label": "weekly.lifecycle.test.tsx",
@@ -262357,7 +262534,7 @@
       "source_location": "L1"
     },
     {
-      "community": 523,
+      "community": 525,
       "file_type": "code",
       "id": "weekly_lifecycle_test_installcompletedmovement",
       "label": "installCompletedMovement()",
@@ -262366,7 +262543,7 @@
       "source_location": "L283"
     },
     {
-      "community": 523,
+      "community": 525,
       "file_type": "code",
       "id": "weekly_lifecycle_test_isshareddemostandingread",
       "label": "isSharedDemoStandingRead()",
@@ -262375,7 +262552,7 @@
       "source_location": "L102"
     },
     {
-      "community": 523,
+      "community": 525,
       "file_type": "code",
       "id": "weekly_lifecycle_test_movementrow",
       "label": "movementRow()",
@@ -262384,7 +262561,7 @@
       "source_location": "L268"
     },
     {
-      "community": 523,
+      "community": 525,
       "file_type": "code",
       "id": "weekly_lifecycle_test_params",
       "label": "params()",
@@ -262393,7 +262570,7 @@
       "source_location": "L40"
     },
     {
-      "community": 523,
+      "community": 525,
       "file_type": "code",
       "id": "weekly_lifecycle_test_stubensuremutation",
       "label": "stubEnsureMutation()",
@@ -262402,7 +262579,7 @@
       "source_location": "L81"
     },
     {
-      "community": 524,
+      "community": 526,
       "file_type": "code",
       "id": "login_layout_completependingauthsync",
       "label": "completePendingAuthSync()",
@@ -262411,7 +262588,7 @@
       "source_location": "L145"
     },
     {
-      "community": 524,
+      "community": 526,
       "file_type": "code",
       "id": "login_layout_handlependingauthsync",
       "label": "handlePendingAuthSync()",
@@ -262420,7 +262597,7 @@
       "source_location": "L95"
     },
     {
-      "community": 524,
+      "community": 526,
       "file_type": "code",
       "id": "login_layout_navigationtargetforredirect",
       "label": "navigationTargetForRedirect()",
@@ -262429,7 +262606,7 @@
       "source_location": "L33"
     },
     {
-      "community": 524,
+      "community": 526,
       "file_type": "code",
       "id": "login_layout_sleep",
       "label": "sleep()",
@@ -262438,7 +262615,7 @@
       "source_location": "L29"
     },
     {
-      "community": 524,
+      "community": 526,
       "file_type": "code",
       "id": "login_layout_usedocumentscrolllock",
       "label": "useDocumentScrollLock()",
@@ -262447,7 +262624,7 @@
       "source_location": "L45"
     },
     {
-      "community": 524,
+      "community": 526,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_login_layout_tsx",
       "label": "-login-layout.tsx",
@@ -262456,7 +262633,7 @@
       "source_location": "L1"
     },
     {
-      "community": 525,
+      "community": 527,
       "file_type": "code",
       "id": "organizationsettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -262465,7 +262642,7 @@
       "source_location": "L155"
     },
     {
-      "community": 525,
+      "community": 527,
       "file_type": "code",
       "id": "organizationsettingsview_navigation",
       "label": "Navigation()",
@@ -262474,7 +262651,7 @@
       "source_location": "L197"
     },
     {
-      "community": 525,
+      "community": 527,
       "file_type": "code",
       "id": "organizationsettingsview_onsubmit",
       "label": "onSubmit()",
@@ -262483,7 +262660,7 @@
       "source_location": "L104"
     },
     {
-      "community": 525,
+      "community": 527,
       "file_type": "code",
       "id": "organizationsettingsview_organizationsettings",
       "label": "OrganizationSettings()",
@@ -262492,7 +262669,7 @@
       "source_location": "L25"
     },
     {
-      "community": 525,
+      "community": 527,
       "file_type": "code",
       "id": "organizationsettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -262501,7 +262678,7 @@
       "source_location": "L72"
     },
     {
-      "community": 525,
+      "community": 527,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
       "label": "OrganizationSettingsView.tsx",
@@ -262510,7 +262687,7 @@
       "source_location": "L1"
     },
     {
-      "community": 526,
+      "community": 528,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
       "label": "StoreSettingsView.tsx",
@@ -262519,7 +262696,7 @@
       "source_location": "L1"
     },
     {
-      "community": 526,
+      "community": 528,
       "file_type": "code",
       "id": "storesettingsview_handledeleteallproductsinstore",
       "label": "handleDeleteAllProductsInStore()",
@@ -262528,7 +262705,7 @@
       "source_location": "L231"
     },
     {
-      "community": 526,
+      "community": 528,
       "file_type": "code",
       "id": "storesettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -262537,7 +262714,7 @@
       "source_location": "L167"
     },
     {
-      "community": 526,
+      "community": 528,
       "file_type": "code",
       "id": "storesettingsview_onsubmit",
       "label": "onSubmit()",
@@ -262546,7 +262723,7 @@
       "source_location": "L116"
     },
     {
-      "community": 526,
+      "community": 528,
       "file_type": "code",
       "id": "storesettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -262555,7 +262732,7 @@
       "source_location": "L83"
     },
     {
-      "community": 526,
+      "community": 528,
       "file_type": "code",
       "id": "storesettingsview_storesettings",
       "label": "StoreSettings()",
@@ -262564,7 +262741,7 @@
       "source_location": "L29"
     },
     {
-      "community": 527,
+      "community": 529,
       "file_type": "code",
       "id": "devfixtureactivation_usedailyclosefixture",
       "label": "useDailyCloseFixture()",
@@ -262573,7 +262750,7 @@
       "source_location": "L102"
     },
     {
-      "community": 527,
+      "community": 529,
       "file_type": "code",
       "id": "devfixtureactivation_usedailyopeningfixture",
       "label": "useDailyOpeningFixture()",
@@ -262582,7 +262759,7 @@
       "source_location": "L96"
     },
     {
-      "community": 527,
+      "community": 529,
       "file_type": "code",
       "id": "devfixtureactivation_usedailyoperationsfixture",
       "label": "useDailyOperationsFixture()",
@@ -262591,7 +262768,7 @@
       "source_location": "L90"
     },
     {
-      "community": 527,
+      "community": 529,
       "file_type": "code",
       "id": "devfixtureactivation_useposhubfixture",
       "label": "usePosHubFixture()",
@@ -262600,7 +262777,7 @@
       "source_location": "L108"
     },
     {
-      "community": 527,
+      "community": 529,
       "file_type": "code",
       "id": "devfixtureactivation_useworkspacefixture",
       "label": "useWorkspaceFixture()",
@@ -262609,121 +262786,13 @@
       "source_location": "L46"
     },
     {
-      "community": 527,
+      "community": 529,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_operations_devfixtureactivation_ts",
       "label": "devFixtureActivation.ts",
       "norm_label": "devfixtureactivation.ts",
       "source_file": "packages/athena-webapp/src/stories/operations/devFixtureActivation.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 528,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
-      "label": "storybook-shell.tsx",
-      "norm_label": "storybook-shell.tsx",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 528,
-      "file_type": "code",
-      "id": "storybook_shell_storybookcallout",
-      "label": "StorybookCallout()",
-      "norm_label": "storybookcallout()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L76"
-    },
-    {
-      "community": 528,
-      "file_type": "code",
-      "id": "storybook_shell_storybooklist",
-      "label": "StorybookList()",
-      "norm_label": "storybooklist()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L55"
-    },
-    {
-      "community": 528,
-      "file_type": "code",
-      "id": "storybook_shell_storybookpillrow",
-      "label": "StorybookPillRow()",
-      "norm_label": "storybookpillrow()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L88"
-    },
-    {
-      "community": 528,
-      "file_type": "code",
-      "id": "storybook_shell_storybooksection",
-      "label": "StorybookSection()",
-      "norm_label": "storybooksection()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L34"
-    },
-    {
-      "community": 528,
-      "file_type": "code",
-      "id": "storybook_shell_storybookshell",
-      "label": "StorybookShell()",
-      "norm_label": "storybookshell()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_postransaction_ts",
-      "label": "posTransaction.ts",
-      "norm_label": "postransaction.ts",
-      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "postransaction_fetchpostransaction",
-      "label": "fetchPosTransaction()",
-      "norm_label": "fetchpostransaction()",
-      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
-      "source_location": "L69"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "postransaction_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "postransaction_getpostransactionbyreceipttoken",
-      "label": "getPosTransactionByReceiptToken()",
-      "norm_label": "getpostransactionbyreceipttoken()",
-      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "postransaction_postransactionreceipterror",
-      "label": "PosTransactionReceiptError",
-      "norm_label": "postransactionreceipterror",
-      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "postransaction_postransactionreceipterror_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
-      "source_location": "L62"
     },
     {
       "community": 53,
@@ -262989,6 +263058,114 @@
     {
       "community": 530,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
+      "label": "storybook-shell.tsx",
+      "norm_label": "storybook-shell.tsx",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "storybook_shell_storybookcallout",
+      "label": "StorybookCallout()",
+      "norm_label": "storybookcallout()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L76"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "storybook_shell_storybooklist",
+      "label": "StorybookList()",
+      "norm_label": "storybooklist()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L55"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "storybook_shell_storybookpillrow",
+      "label": "StorybookPillRow()",
+      "norm_label": "storybookpillrow()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L88"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "storybook_shell_storybooksection",
+      "label": "StorybookSection()",
+      "norm_label": "storybooksection()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L34"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "storybook_shell_storybookshell",
+      "label": "StorybookShell()",
+      "norm_label": "storybookshell()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_postransaction_ts",
+      "label": "posTransaction.ts",
+      "norm_label": "postransaction.ts",
+      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
+      "id": "postransaction_fetchpostransaction",
+      "label": "fetchPosTransaction()",
+      "norm_label": "fetchpostransaction()",
+      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
+      "source_location": "L69"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
+      "id": "postransaction_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
+      "id": "postransaction_getpostransactionbyreceipttoken",
+      "label": "getPosTransactionByReceiptToken()",
+      "norm_label": "getpostransactionbyreceipttoken()",
+      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
+      "id": "postransaction_postransactionreceipterror",
+      "label": "PosTransactionReceiptError",
+      "norm_label": "postransactionreceipterror",
+      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
+      "id": "postransaction_postransactionreceipterror_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 532,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_promocodes_ts",
       "label": "promoCodes.ts",
       "norm_label": "promocodes.ts",
@@ -262996,7 +263173,7 @@
       "source_location": "L1"
     },
     {
-      "community": 530,
+      "community": 532,
       "file_type": "code",
       "id": "promocodes_getbaseurl",
       "label": "getBaseUrl()",
@@ -263005,7 +263182,7 @@
       "source_location": "L4"
     },
     {
-      "community": 530,
+      "community": 532,
       "file_type": "code",
       "id": "promocodes_getpromocodeitems",
       "label": "getPromoCodeItems()",
@@ -263014,7 +263191,7 @@
       "source_location": "L49"
     },
     {
-      "community": 530,
+      "community": 532,
       "file_type": "code",
       "id": "promocodes_getpromocodes",
       "label": "getPromoCodes()",
@@ -263023,7 +263200,7 @@
       "source_location": "L34"
     },
     {
-      "community": 530,
+      "community": 532,
       "file_type": "code",
       "id": "promocodes_getredeemedpromocodes",
       "label": "getRedeemedPromoCodes()",
@@ -263032,7 +263209,7 @@
       "source_location": "L74"
     },
     {
-      "community": 530,
+      "community": 532,
       "file_type": "code",
       "id": "promocodes_redeempromocode",
       "label": "redeemPromoCode()",
@@ -263041,7 +263218,7 @@
       "source_location": "L6"
     },
     {
-      "community": 531,
+      "community": 533,
       "file_type": "code",
       "id": "billingdetails_clearform",
       "label": "clearForm()",
@@ -263050,7 +263227,7 @@
       "source_location": "L173"
     },
     {
-      "community": 531,
+      "community": 533,
       "file_type": "code",
       "id": "billingdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -263059,7 +263236,7 @@
       "source_location": "L102"
     },
     {
-      "community": 531,
+      "community": 533,
       "file_type": "code",
       "id": "billingdetails_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -263068,7 +263245,7 @@
       "source_location": "L201"
     },
     {
-      "community": 531,
+      "community": 533,
       "file_type": "code",
       "id": "billingdetails_onsubmit",
       "label": "onSubmit()",
@@ -263077,7 +263254,7 @@
       "source_location": "L150"
     },
     {
-      "community": 531,
+      "community": 533,
       "file_type": "code",
       "id": "billingdetails_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -263086,7 +263263,7 @@
       "source_location": "L155"
     },
     {
-      "community": 531,
+      "community": 533,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
       "label": "BillingDetails.tsx",
@@ -263095,7 +263272,7 @@
       "source_location": "L1"
     },
     {
-      "community": 532,
+      "community": 534,
       "file_type": "code",
       "id": "homehero_test_attachmedia",
       "label": "attachMedia()",
@@ -263104,7 +263281,7 @@
       "source_location": "L22"
     },
     {
-      "community": 532,
+      "community": 534,
       "file_type": "code",
       "id": "homehero_test_destroy",
       "label": "destroy()",
@@ -263113,7 +263290,7 @@
       "source_location": "L24"
     },
     {
-      "community": 532,
+      "community": 534,
       "file_type": "code",
       "id": "homehero_test_issupported",
       "label": "isSupported()",
@@ -263122,7 +263299,7 @@
       "source_location": "L18"
     },
     {
-      "community": 532,
+      "community": 534,
       "file_type": "code",
       "id": "homehero_test_loadsource",
       "label": "loadSource()",
@@ -263131,7 +263308,7 @@
       "source_location": "L21"
     },
     {
-      "community": 532,
+      "community": 534,
       "file_type": "code",
       "id": "homehero_test_on",
       "label": "on()",
@@ -263140,7 +263317,7 @@
       "source_location": "L23"
     },
     {
-      "community": 532,
+      "community": 534,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homehero_test_tsx",
       "label": "HomeHero.test.tsx",
@@ -263149,7 +263326,7 @@
       "source_location": "L1"
     },
     {
-      "community": 533,
+      "community": 535,
       "file_type": "code",
       "id": "mobileproductactions_collapseonpageclick",
       "label": "collapseOnPageClick()",
@@ -263158,7 +263335,7 @@
       "source_location": "L76"
     },
     {
-      "community": 533,
+      "community": 535,
       "file_type": "code",
       "id": "mobileproductactions_handleconfirm",
       "label": "handleConfirm()",
@@ -263167,7 +263344,7 @@
       "source_location": "L120"
     },
     {
-      "community": 533,
+      "community": 535,
       "file_type": "code",
       "id": "mobileproductactions_handleprimaryaction",
       "label": "handlePrimaryAction()",
@@ -263176,7 +263353,7 @@
       "source_location": "L129"
     },
     {
-      "community": 533,
+      "community": 535,
       "file_type": "code",
       "id": "mobileproductactions_handlesecondaryaction",
       "label": "handleSecondaryAction()",
@@ -263185,7 +263362,7 @@
       "source_location": "L133"
     },
     {
-      "community": 533,
+      "community": 535,
       "file_type": "code",
       "id": "mobileproductactions_updateposition",
       "label": "updatePosition()",
@@ -263194,7 +263371,7 @@
       "source_location": "L44"
     },
     {
-      "community": 533,
+      "community": 535,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
       "label": "MobileProductActions.tsx",
@@ -263203,7 +263380,7 @@
       "source_location": "L1"
     },
     {
-      "community": 534,
+      "community": 536,
       "file_type": "code",
       "id": "checkoutexpired_checkoutexpired",
       "label": "CheckoutExpired()",
@@ -263212,7 +263389,7 @@
       "source_location": "L9"
     },
     {
-      "community": 534,
+      "community": 536,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessiongeneric",
       "label": "CheckoutSessionGeneric()",
@@ -263221,7 +263398,7 @@
       "source_location": "L73"
     },
     {
-      "community": 534,
+      "community": 536,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessionnotfound",
       "label": "CheckoutSessionNotFound()",
@@ -263230,7 +263407,7 @@
       "source_location": "L54"
     },
     {
-      "community": 534,
+      "community": 536,
       "file_type": "code",
       "id": "checkoutexpired_handlesendemail",
       "label": "handleSendEmail()",
@@ -263239,7 +263416,7 @@
       "source_location": "L98"
     },
     {
-      "community": 534,
+      "community": 536,
       "file_type": "code",
       "id": "checkoutexpired_nocheckoutsession",
       "label": "NoCheckoutSession()",
@@ -263248,7 +263425,7 @@
       "source_location": "L33"
     },
     {
-      "community": 534,
+      "community": 536,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
       "label": "CheckoutExpired.tsx",
@@ -263257,7 +263434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 535,
+      "community": 537,
       "file_type": "code",
       "id": "image_uploader_ondragend",
       "label": "onDragEnd()",
@@ -263266,7 +263443,7 @@
       "source_location": "L101"
     },
     {
-      "community": 535,
+      "community": 537,
       "file_type": "code",
       "id": "image_uploader_ondrop",
       "label": "onDrop()",
@@ -263275,7 +263452,7 @@
       "source_location": "L20"
     },
     {
-      "community": 535,
+      "community": 537,
       "file_type": "code",
       "id": "image_uploader_removeimage",
       "label": "removeImage()",
@@ -263284,7 +263461,7 @@
       "source_location": "L31"
     },
     {
-      "community": 535,
+      "community": 537,
       "file_type": "code",
       "id": "image_uploader_unmarkfordeletion",
       "label": "unmarkForDeletion()",
@@ -263293,7 +263470,7 @@
       "source_location": "L46"
     },
     {
-      "community": 535,
+      "community": 537,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
       "label": "image-uploader.tsx",
@@ -263302,7 +263479,7 @@
       "source_location": "L1"
     },
     {
-      "community": 535,
+      "community": 537,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
       "label": "image-uploader.tsx",
@@ -263311,7 +263488,7 @@
       "source_location": "L1"
     },
     {
-      "community": 536,
+      "community": 538,
       "file_type": "code",
       "id": "feeutils_getremainingforfreedelivery",
       "label": "getRemainingForFreeDelivery()",
@@ -263320,7 +263497,7 @@
       "source_location": "L138"
     },
     {
-      "community": 536,
+      "community": 538,
       "file_type": "code",
       "id": "feeutils_haswaiverconfigured",
       "label": "hasWaiverConfigured()",
@@ -263329,7 +263506,7 @@
       "source_location": "L100"
     },
     {
-      "community": 536,
+      "community": 538,
       "file_type": "code",
       "id": "feeutils_isanyfeewaived",
       "label": "isAnyFeeWaived()",
@@ -263338,7 +263515,7 @@
       "source_location": "L74"
     },
     {
-      "community": 536,
+      "community": 538,
       "file_type": "code",
       "id": "feeutils_isfeewaived",
       "label": "isFeeWaived()",
@@ -263347,7 +263524,7 @@
       "source_location": "L34"
     },
     {
-      "community": 536,
+      "community": 538,
       "file_type": "code",
       "id": "feeutils_meetsthreshold",
       "label": "meetsThreshold()",
@@ -263356,7 +263533,7 @@
       "source_location": "L17"
     },
     {
-      "community": 536,
+      "community": 538,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_feeutils_ts",
       "label": "feeUtils.ts",
@@ -263365,7 +263542,7 @@
       "source_location": "L1"
     },
     {
-      "community": 537,
+      "community": 539,
       "file_type": "code",
       "id": "auth_verify_formattime",
       "label": "formatTime()",
@@ -263374,7 +263551,7 @@
       "source_location": "L149"
     },
     {
-      "community": 537,
+      "community": 539,
       "file_type": "code",
       "id": "auth_verify_handlecodechange",
       "label": "handleCodeChange()",
@@ -263383,7 +263560,7 @@
       "source_location": "L156"
     },
     {
-      "community": 537,
+      "community": 539,
       "file_type": "code",
       "id": "auth_verify_onsubmit",
       "label": "onSubmit()",
@@ -263392,7 +263569,7 @@
       "source_location": "L201"
     },
     {
-      "community": 537,
+      "community": 539,
       "file_type": "code",
       "id": "auth_verify_reportauthfailure",
       "label": "reportAuthFailure()",
@@ -263401,7 +263578,7 @@
       "source_location": "L93"
     },
     {
-      "community": 537,
+      "community": 539,
       "file_type": "code",
       "id": "auth_verify_resendverificationcode",
       "label": "resendVerificationCode()",
@@ -263410,120 +263587,12 @@
       "source_location": "L282"
     },
     {
-      "community": 537,
+      "community": 539,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_auth_verify_tsx",
       "label": "auth.verify.tsx",
       "norm_label": "auth.verify.tsx",
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 538,
-      "file_type": "code",
-      "id": "coverage_summary_test_coveragesummary",
-      "label": "coverageSummary()",
-      "norm_label": "coveragesummary()",
-      "source_file": "scripts/coverage-summary.test.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 538,
-      "file_type": "code",
-      "id": "coverage_summary_test_createfixtureroot",
-      "label": "createFixtureRoot()",
-      "norm_label": "createfixtureroot()",
-      "source_file": "scripts/coverage-summary.test.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 538,
-      "file_type": "code",
-      "id": "coverage_summary_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/coverage-summary.test.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 538,
-      "file_type": "code",
-      "id": "coverage_summary_test_writepackagesummaries",
-      "label": "writePackageSummaries()",
-      "norm_label": "writepackagesummaries()",
-      "source_file": "scripts/coverage-summary.test.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 538,
-      "file_type": "code",
-      "id": "coverage_summary_test_writerealbaselinesummaries",
-      "label": "writeRealBaselineSummaries()",
-      "norm_label": "writerealbaselinesummaries()",
-      "source_file": "scripts/coverage-summary.test.ts",
-      "source_location": "L54"
-    },
-    {
-      "community": 538,
-      "file_type": "code",
-      "id": "scripts_coverage_summary_test_ts",
-      "label": "coverage-summary.test.ts",
-      "norm_label": "coverage-summary.test.ts",
-      "source_file": "scripts/coverage-summary.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "docs_solution_link_check_assertdocslinks",
-      "label": "assertDocsLinks()",
-      "norm_label": "assertdocslinks()",
-      "source_file": "scripts/docs-solution-link-check.ts",
-      "source_location": "L148"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "docs_solution_link_check_classifylink",
-      "label": "classifyLink()",
-      "norm_label": "classifylink()",
-      "source_file": "scripts/docs-solution-link-check.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "docs_solution_link_check_collectdocslinkfindings",
-      "label": "collectDocsLinkFindings()",
-      "norm_label": "collectdocslinkfindings()",
-      "source_file": "scripts/docs-solution-link-check.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "docs_solution_link_check_collectsolutionslugs",
-      "label": "collectSolutionSlugs()",
-      "norm_label": "collectsolutionslugs()",
-      "source_file": "scripts/docs-solution-link-check.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "docs_solution_link_check_solutionsroot",
-      "label": "solutionsRoot()",
-      "norm_label": "solutionsroot()",
-      "source_file": "scripts/docs-solution-link-check.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "scripts_docs_solution_link_check_ts",
-      "label": "docs-solution-link-check.ts",
-      "norm_label": "docs-solution-link-check.ts",
-      "source_file": "scripts/docs-solution-link-check.ts",
       "source_location": "L1"
     },
     {
@@ -263781,6 +263850,114 @@
     {
       "community": 540,
       "file_type": "code",
+      "id": "coverage_summary_test_coveragesummary",
+      "label": "coverageSummary()",
+      "norm_label": "coveragesummary()",
+      "source_file": "scripts/coverage-summary.test.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "coverage_summary_test_createfixtureroot",
+      "label": "createFixtureRoot()",
+      "norm_label": "createfixtureroot()",
+      "source_file": "scripts/coverage-summary.test.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "coverage_summary_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/coverage-summary.test.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "coverage_summary_test_writepackagesummaries",
+      "label": "writePackageSummaries()",
+      "norm_label": "writepackagesummaries()",
+      "source_file": "scripts/coverage-summary.test.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "coverage_summary_test_writerealbaselinesummaries",
+      "label": "writeRealBaselineSummaries()",
+      "norm_label": "writerealbaselinesummaries()",
+      "source_file": "scripts/coverage-summary.test.ts",
+      "source_location": "L54"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "scripts_coverage_summary_test_ts",
+      "label": "coverage-summary.test.ts",
+      "norm_label": "coverage-summary.test.ts",
+      "source_file": "scripts/coverage-summary.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
+      "id": "docs_solution_link_check_assertdocslinks",
+      "label": "assertDocsLinks()",
+      "norm_label": "assertdocslinks()",
+      "source_file": "scripts/docs-solution-link-check.ts",
+      "source_location": "L148"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
+      "id": "docs_solution_link_check_classifylink",
+      "label": "classifyLink()",
+      "norm_label": "classifylink()",
+      "source_file": "scripts/docs-solution-link-check.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
+      "id": "docs_solution_link_check_collectdocslinkfindings",
+      "label": "collectDocsLinkFindings()",
+      "norm_label": "collectdocslinkfindings()",
+      "source_file": "scripts/docs-solution-link-check.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
+      "id": "docs_solution_link_check_collectsolutionslugs",
+      "label": "collectSolutionSlugs()",
+      "norm_label": "collectsolutionslugs()",
+      "source_file": "scripts/docs-solution-link-check.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
+      "id": "docs_solution_link_check_solutionsroot",
+      "label": "solutionsRoot()",
+      "norm_label": "solutionsroot()",
+      "source_file": "scripts/docs-solution-link-check.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
+      "id": "scripts_docs_solution_link_check_ts",
+      "label": "docs-solution-link-check.ts",
+      "norm_label": "docs-solution-link-check.ts",
+      "source_file": "scripts/docs-solution-link-check.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 542,
+      "file_type": "code",
       "id": "graphify_check_collectrepocodefiles",
       "label": "collectRepoCodeFiles()",
       "norm_label": "collectrepocodefiles()",
@@ -263788,7 +263965,7 @@
       "source_location": "L73"
     },
     {
-      "community": 540,
+      "community": 542,
       "file_type": "code",
       "id": "graphify_check_collectstalegraphifyartifacts",
       "label": "collectStaleGraphifyArtifacts()",
@@ -263797,7 +263974,7 @@
       "source_location": "L125"
     },
     {
-      "community": 540,
+      "community": 542,
       "file_type": "code",
       "id": "graphify_check_copygraphifycheckinputs",
       "label": "copyGraphifyCheckInputs()",
@@ -263806,7 +263983,7 @@
       "source_location": "L107"
     },
     {
-      "community": 540,
+      "community": 542,
       "file_type": "code",
       "id": "graphify_check_fileexists",
       "label": "fileExists()",
@@ -263815,7 +263992,7 @@
       "source_location": "L64"
     },
     {
-      "community": 540,
+      "community": 542,
       "file_type": "code",
       "id": "graphify_check_rungraphifycheck",
       "label": "runGraphifyCheck()",
@@ -263824,7 +264001,7 @@
       "source_location": "L152"
     },
     {
-      "community": 540,
+      "community": 542,
       "file_type": "code",
       "id": "scripts_graphify_check_ts",
       "label": "graphify-check.ts",
@@ -263833,7 +264010,7 @@
       "source_location": "L1"
     },
     {
-      "community": 541,
+      "community": 543,
       "file_type": "code",
       "id": "harness_inferential_review_test_commitfixturerepo",
       "label": "commitFixtureRepo()",
@@ -263842,7 +264019,7 @@
       "source_location": "L169"
     },
     {
-      "community": 541,
+      "community": 543,
       "file_type": "code",
       "id": "harness_inferential_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -263851,7 +264028,7 @@
       "source_location": "L66"
     },
     {
-      "community": 541,
+      "community": 543,
       "file_type": "code",
       "id": "harness_inferential_review_test_gitfixtureenv",
       "label": "gitFixtureEnv()",
@@ -263860,7 +264037,7 @@
       "source_location": "L60"
     },
     {
-      "community": 541,
+      "community": 543,
       "file_type": "code",
       "id": "harness_inferential_review_test_runfixturecommand",
       "label": "runFixtureCommand()",
@@ -263869,7 +264046,7 @@
       "source_location": "L22"
     },
     {
-      "community": 541,
+      "community": 543,
       "file_type": "code",
       "id": "harness_inferential_review_test_write",
       "label": "write()",
@@ -263878,7 +264055,7 @@
       "source_location": "L16"
     },
     {
-      "community": 541,
+      "community": 543,
       "file_type": "code",
       "id": "scripts_harness_inferential_review_test_ts",
       "label": "harness-inferential-review.test.ts",
@@ -263887,7 +264064,7 @@
       "source_location": "L1"
     },
     {
-      "community": 542,
+      "community": 544,
       "file_type": "code",
       "id": "harness_repo_validation_collectharnessrepovalidationcapabilities",
       "label": "collectHarnessRepoValidationCapabilities()",
@@ -263896,7 +264073,7 @@
       "source_location": "L73"
     },
     {
-      "community": 542,
+      "community": 544,
       "file_type": "code",
       "id": "harness_repo_validation_collectharnessrepovalidationselection",
       "label": "collectHarnessRepoValidationSelection()",
@@ -263905,7 +264082,7 @@
       "source_location": "L50"
     },
     {
-      "community": 542,
+      "community": 544,
       "file_type": "code",
       "id": "harness_repo_validation_matchesharnessrepovalidationpath",
       "label": "matchesHarnessRepoValidationPath()",
@@ -263914,7 +264091,7 @@
       "source_location": "L42"
     },
     {
-      "community": 542,
+      "community": 544,
       "file_type": "code",
       "id": "harness_repo_validation_normalizerepopath",
       "label": "normalizeRepoPath()",
@@ -263923,7 +264100,7 @@
       "source_location": "L32"
     },
     {
-      "community": 542,
+      "community": 544,
       "file_type": "code",
       "id": "harness_repo_validation_sortuniquepaths",
       "label": "sortUniquePaths()",
@@ -263932,7 +264109,7 @@
       "source_location": "L36"
     },
     {
-      "community": 542,
+      "community": 544,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_ts",
       "label": "harness-repo-validation.ts",
@@ -263941,7 +264118,7 @@
       "source_location": "L1"
     },
     {
-      "community": 543,
+      "community": 545,
       "file_type": "code",
       "id": "pre_push_validation_proof_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -263950,7 +264127,7 @@
       "source_location": "L21"
     },
     {
-      "community": 543,
+      "community": 545,
       "file_type": "code",
       "id": "pre_push_validation_proof_test_createspawn",
       "label": "createSpawn()",
@@ -263959,7 +264136,7 @@
       "source_location": "L64"
     },
     {
-      "community": 543,
+      "community": 545,
       "file_type": "code",
       "id": "pre_push_validation_proof_test_log",
       "label": "log()",
@@ -263968,7 +264145,7 @@
       "source_location": "L185"
     },
     {
-      "community": 543,
+      "community": 545,
       "file_type": "code",
       "id": "pre_push_validation_proof_test_warn",
       "label": "warn()",
@@ -263977,7 +264154,7 @@
       "source_location": "L323"
     },
     {
-      "community": 543,
+      "community": 545,
       "file_type": "code",
       "id": "pre_push_validation_proof_test_write",
       "label": "write()",
@@ -263986,7 +264163,7 @@
       "source_location": "L15"
     },
     {
-      "community": 543,
+      "community": 545,
       "file_type": "code",
       "id": "scripts_pre_push_validation_proof_test_ts",
       "label": "pre-push-validation-proof.test.ts",
@@ -263995,7 +264172,7 @@
       "source_location": "L1"
     },
     {
-      "community": 544,
+      "community": 546,
       "file_type": "code",
       "id": "scripts_validate_plan_html_ts",
       "label": "validate-plan-html.ts",
@@ -264004,7 +264181,7 @@
       "source_location": "L1"
     },
     {
-      "community": 544,
+      "community": 546,
       "file_type": "code",
       "id": "validate_plan_html_collectdefaultplanhtmlfiles",
       "label": "collectDefaultPlanHtmlFiles()",
@@ -264013,7 +264190,7 @@
       "source_location": "L16"
     },
     {
-      "community": 544,
+      "community": 546,
       "file_type": "code",
       "id": "validate_plan_html_collectplanhtmlfindings",
       "label": "collectPlanHtmlFindings()",
@@ -264022,7 +264199,7 @@
       "source_location": "L31"
     },
     {
-      "community": 544,
+      "community": 546,
       "file_type": "code",
       "id": "validate_plan_html_hasremotereference",
       "label": "hasRemoteReference()",
@@ -264031,7 +264208,7 @@
       "source_location": "L27"
     },
     {
-      "community": 544,
+      "community": 546,
       "file_type": "code",
       "id": "validate_plan_html_normalizerepopath",
       "label": "normalizeRepoPath()",
@@ -264040,7 +264217,7 @@
       "source_location": "L12"
     },
     {
-      "community": 544,
+      "community": 546,
       "file_type": "code",
       "id": "validate_plan_html_runplanhtmlvalidation",
       "label": "runPlanHtmlValidation()",
@@ -264049,7 +264226,7 @@
       "source_location": "L119"
     },
     {
-      "community": 545,
+      "community": 547,
       "file_type": "code",
       "id": "closeouts_test_createcloseoutmappingholdctx",
       "label": "createCloseoutMappingHoldCtx()",
@@ -264058,7 +264235,7 @@
       "source_location": "L32"
     },
     {
-      "community": 545,
+      "community": 547,
       "file_type": "code",
       "id": "closeouts_test_creatependingitemadjustmentapprovalctx",
       "label": "createPendingItemAdjustmentApprovalCtx()",
@@ -264067,7 +264244,7 @@
       "source_location": "L184"
     },
     {
-      "community": 545,
+      "community": 547,
       "file_type": "code",
       "id": "closeouts_test_gethandler",
       "label": "getHandler()",
@@ -264076,7 +264253,7 @@
       "source_location": "L28"
     },
     {
-      "community": 545,
+      "community": 547,
       "file_type": "code",
       "id": "closeouts_test_getsource",
       "label": "getSource()",
@@ -264085,7 +264262,7 @@
       "source_location": "L24"
     },
     {
-      "community": 545,
+      "community": 547,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_closeouts_test_ts",
       "label": "closeouts.test.ts",
@@ -264094,7 +264271,7 @@
       "source_location": "L1"
     },
     {
-      "community": 546,
+      "community": 548,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
       "label": "paymentAllocationAttribution.ts",
@@ -264103,7 +264280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 546,
+      "community": 548,
       "file_type": "code",
       "id": "paymentallocationattribution_buildinstorepaymentallocations",
       "label": "buildInStorePaymentAllocations()",
@@ -264112,7 +264289,7 @@
       "source_location": "L46"
     },
     {
-      "community": 546,
+      "community": 548,
       "file_type": "code",
       "id": "paymentallocationattribution_normalizeinstorepayments",
       "label": "normalizeInStorePayments()",
@@ -264121,7 +264298,7 @@
       "source_location": "L22"
     },
     {
-      "community": 546,
+      "community": 548,
       "file_type": "code",
       "id": "paymentallocationattribution_resolveregistersessionforinstorecollectionwithctx",
       "label": "resolveRegisterSessionForInStoreCollectionWithCtx()",
@@ -264130,7 +264307,7 @@
       "source_location": "L124"
     },
     {
-      "community": 546,
+      "community": 548,
       "file_type": "code",
       "id": "paymentallocationattribution_selectregistersessionforattribution",
       "label": "selectRegisterSessionForAttribution()",
@@ -264139,7 +264316,7 @@
       "source_location": "L87"
     },
     {
-      "community": 547,
+      "community": 549,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_registersessionactivity_test_ts",
       "label": "registerSessionActivity.test.ts",
@@ -264148,7 +264325,7 @@
       "source_location": "L1"
     },
     {
-      "community": 547,
+      "community": 549,
       "file_type": "code",
       "id": "registersessionactivity_test_admissionawareauthimplementation",
       "label": "admissionAwareAuthImplementation()",
@@ -264157,7 +264334,7 @@
       "source_location": "L218"
     },
     {
-      "community": 547,
+      "community": 549,
       "file_type": "code",
       "id": "registersessionactivity_test_baseevent",
       "label": "baseEvent()",
@@ -264166,7 +264343,7 @@
       "source_location": "L27"
     },
     {
-      "community": 547,
+      "community": 549,
       "file_type": "code",
       "id": "registersessionactivity_test_basemapping",
       "label": "baseMapping()",
@@ -264175,103 +264352,13 @@
       "source_location": "L58"
     },
     {
-      "community": 547,
+      "community": 549,
       "file_type": "code",
       "id": "registersessionactivity_test_gethandler",
       "label": "getHandler()",
       "norm_label": "gethandler()",
       "source_file": "packages/athena-webapp/convex/cashControls/registerSessionActivity.test.ts",
       "source_location": "L22"
-    },
-    {
-      "community": 548,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cashcontrols_registersessiontracelifecycle_test_ts",
-      "label": "registerSessionTraceLifecycle.test.ts",
-      "norm_label": "registersessiontracelifecycle.test.ts",
-      "source_file": "packages/athena-webapp/convex/cashControls/registerSessionTraceLifecycle.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 548,
-      "file_type": "code",
-      "id": "registersessiontracelifecycle_test_buildapprovalproof",
-      "label": "buildApprovalProof()",
-      "norm_label": "buildapprovalproof()",
-      "source_file": "packages/athena-webapp/convex/cashControls/registerSessionTraceLifecycle.test.ts",
-      "source_location": "L382"
-    },
-    {
-      "community": 548,
-      "file_type": "code",
-      "id": "registersessiontracelifecycle_test_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/cashControls/registerSessionTraceLifecycle.test.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 548,
-      "file_type": "code",
-      "id": "registersessiontracelifecycle_test_createmutationctx",
-      "label": "createMutationCtx()",
-      "norm_label": "createmutationctx()",
-      "source_file": "packages/athena-webapp/convex/cashControls/registerSessionTraceLifecycle.test.ts",
-      "source_location": "L122"
-    },
-    {
-      "community": 548,
-      "file_type": "code",
-      "id": "registersessiontracelifecycle_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/cashControls/registerSessionTraceLifecycle.test.ts",
-      "source_location": "L401"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "homepagesnapshot_isdisplayablemarker",
-      "label": "isDisplayableMarker()",
-      "norm_label": "isdisplayablemarker()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/homepageSnapshot.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "homepagesnapshot_presentsnapshotatrequesttime",
-      "label": "presentSnapshotAtRequestTime()",
-      "norm_label": "presentsnapshotatrequesttime()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/homepageSnapshot.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "homepagesnapshot_resolvehomepagesnapshotbootstrap",
-      "label": "resolveHomepageSnapshotBootstrap()",
-      "norm_label": "resolvehomepagesnapshotbootstrap()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/homepageSnapshot.ts",
-      "source_location": "L53"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "homepagesnapshot_setbootstrapcookie",
-      "label": "setBootstrapCookie()",
-      "norm_label": "setbootstrapcookie()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/homepageSnapshot.ts",
-      "source_location": "L124"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_homepagesnapshot_ts",
-      "label": "homepageSnapshot.ts",
-      "norm_label": "homepagesnapshot.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/homepageSnapshot.ts",
-      "source_location": "L1"
     },
     {
       "community": 55,
@@ -264519,6 +264606,96 @@
     {
       "community": 550,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_cashcontrols_registersessiontracelifecycle_test_ts",
+      "label": "registerSessionTraceLifecycle.test.ts",
+      "norm_label": "registersessiontracelifecycle.test.ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/registerSessionTraceLifecycle.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 550,
+      "file_type": "code",
+      "id": "registersessiontracelifecycle_test_buildapprovalproof",
+      "label": "buildApprovalProof()",
+      "norm_label": "buildapprovalproof()",
+      "source_file": "packages/athena-webapp/convex/cashControls/registerSessionTraceLifecycle.test.ts",
+      "source_location": "L382"
+    },
+    {
+      "community": 550,
+      "file_type": "code",
+      "id": "registersessiontracelifecycle_test_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/cashControls/registerSessionTraceLifecycle.test.ts",
+      "source_location": "L106"
+    },
+    {
+      "community": 550,
+      "file_type": "code",
+      "id": "registersessiontracelifecycle_test_createmutationctx",
+      "label": "createMutationCtx()",
+      "norm_label": "createmutationctx()",
+      "source_file": "packages/athena-webapp/convex/cashControls/registerSessionTraceLifecycle.test.ts",
+      "source_location": "L122"
+    },
+    {
+      "community": 550,
+      "file_type": "code",
+      "id": "registersessiontracelifecycle_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/cashControls/registerSessionTraceLifecycle.test.ts",
+      "source_location": "L401"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
+      "id": "homepagesnapshot_isdisplayablemarker",
+      "label": "isDisplayableMarker()",
+      "norm_label": "isdisplayablemarker()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/homepageSnapshot.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
+      "id": "homepagesnapshot_presentsnapshotatrequesttime",
+      "label": "presentSnapshotAtRequestTime()",
+      "norm_label": "presentsnapshotatrequesttime()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/homepageSnapshot.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
+      "id": "homepagesnapshot_resolvehomepagesnapshotbootstrap",
+      "label": "resolveHomepageSnapshotBootstrap()",
+      "norm_label": "resolvehomepagesnapshotbootstrap()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/homepageSnapshot.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
+      "id": "homepagesnapshot_setbootstrapcookie",
+      "label": "setBootstrapCookie()",
+      "norm_label": "setbootstrapcookie()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/homepageSnapshot.ts",
+      "source_location": "L124"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_homepagesnapshot_ts",
+      "label": "homepageSnapshot.ts",
+      "norm_label": "homepagesnapshot.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/homepageSnapshot.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 552,
+      "file_type": "code",
       "id": "lifecycle_assertartifacttransition",
       "label": "assertArtifactTransition()",
       "norm_label": "assertartifacttransition()",
@@ -264526,7 +264703,7 @@
       "source_location": "L59"
     },
     {
-      "community": 550,
+      "community": 552,
       "file_type": "code",
       "id": "lifecycle_assertruntransition",
       "label": "assertRunTransition()",
@@ -264535,7 +264712,7 @@
       "source_location": "L43"
     },
     {
-      "community": 550,
+      "community": 552,
       "file_type": "code",
       "id": "lifecycle_cantransitionartifact",
       "label": "canTransitionArtifact()",
@@ -264544,7 +264721,7 @@
       "source_location": "L52"
     },
     {
-      "community": 550,
+      "community": 552,
       "file_type": "code",
       "id": "lifecycle_cantransitionrun",
       "label": "canTransitionRun()",
@@ -264553,7 +264730,7 @@
       "source_location": "L36"
     },
     {
-      "community": 550,
+      "community": 552,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_intelligence_lifecycle_ts",
       "label": "lifecycle.ts",
@@ -264562,7 +264739,7 @@
       "source_location": "L1"
     },
     {
-      "community": 551,
+      "community": 553,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_intelligence_providers_tanstack_ts",
       "label": "tanstack.ts",
@@ -264571,7 +264748,7 @@
       "source_location": "L1"
     },
     {
-      "community": 551,
+      "community": 553,
       "file_type": "code",
       "id": "tanstack_createtanstackstructuredtextprovider",
       "label": "createTanStackStructuredTextProvider()",
@@ -264580,7 +264757,7 @@
       "source_location": "L41"
     },
     {
-      "community": 551,
+      "community": 553,
       "file_type": "code",
       "id": "tanstack_extractstructuredoutput",
       "label": "extractStructuredOutput()",
@@ -264589,7 +264766,7 @@
       "source_location": "L134"
     },
     {
-      "community": 551,
+      "community": 553,
       "file_type": "code",
       "id": "tanstack_loadopenaiadapter",
       "label": "loadOpenAiAdapter()",
@@ -264598,7 +264775,7 @@
       "source_location": "L147"
     },
     {
-      "community": 551,
+      "community": 553,
       "file_type": "code",
       "id": "tanstack_loadtanstackai",
       "label": "loadTanStackAi()",
@@ -264607,7 +264784,7 @@
       "source_location": "L143"
     },
     {
-      "community": 552,
+      "community": 554,
       "file_type": "code",
       "id": "featureditem_countfeaturedtargets",
       "label": "countFeaturedTargets()",
@@ -264616,7 +264793,7 @@
       "source_location": "L43"
     },
     {
-      "community": 552,
+      "community": 554,
       "file_type": "code",
       "id": "featureditem_getnextfeatureditemrank",
       "label": "getNextFeaturedItemRank()",
@@ -264625,7 +264802,7 @@
       "source_location": "L103"
     },
     {
-      "community": 552,
+      "community": 554,
       "file_type": "code",
       "id": "featureditem_requirehomepagestoreadmin",
       "label": "requireHomepageStoreAdmin()",
@@ -264634,7 +264811,7 @@
       "source_location": "L23"
     },
     {
-      "community": 552,
+      "community": 554,
       "file_type": "code",
       "id": "featureditem_validatefeaturedplacement",
       "label": "validateFeaturedPlacement()",
@@ -264643,7 +264820,7 @@
       "source_location": "L52"
     },
     {
-      "community": 552,
+      "community": 554,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -264652,7 +264829,7 @@
       "source_location": "L1"
     },
     {
-      "community": 553,
+      "community": 555,
       "file_type": "code",
       "id": "expensesessionvalidation_validateexpenseitembelongstosession",
       "label": "validateExpenseItemBelongsToSession()",
@@ -264661,7 +264838,7 @@
       "source_location": "L114"
     },
     {
-      "community": 553,
+      "community": 555,
       "file_type": "code",
       "id": "expensesessionvalidation_validateexpensesessionactive",
       "label": "validateExpenseSessionActive()",
@@ -264670,7 +264847,7 @@
       "source_location": "L39"
     },
     {
-      "community": 553,
+      "community": 555,
       "file_type": "code",
       "id": "expensesessionvalidation_validateexpensesessionexists",
       "label": "validateExpenseSessionExists()",
@@ -264679,7 +264856,7 @@
       "source_location": "L19"
     },
     {
-      "community": 553,
+      "community": 555,
       "file_type": "code",
       "id": "expensesessionvalidation_validateexpensesessionmodifiable",
       "label": "validateExpenseSessionModifiable()",
@@ -264688,7 +264865,7 @@
       "source_location": "L81"
     },
     {
-      "community": 553,
+      "community": 555,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionvalidation_ts",
       "label": "expenseSessionValidation.ts",
@@ -264697,7 +264874,7 @@
       "source_location": "L1"
     },
     {
-      "community": 554,
+      "community": 556,
       "file_type": "code",
       "id": "commerceeffects_applycommerceinventoryeffectwithctx",
       "label": "applyCommerceInventoryEffectWithCtx()",
@@ -264706,7 +264883,7 @@
       "source_location": "L152"
     },
     {
-      "community": 554,
+      "community": 556,
       "file_type": "code",
       "id": "commerceeffects_outboundbasisfromeffect",
       "label": "outboundBasisFromEffect()",
@@ -264715,7 +264892,7 @@
       "source_location": "L79"
     },
     {
-      "community": 554,
+      "community": 556,
       "file_type": "code",
       "id": "commerceeffects_reportinglinecostfromeffect",
       "label": "reportingLineCostFromEffect()",
@@ -264724,7 +264901,7 @@
       "source_location": "L116"
     },
     {
-      "community": 554,
+      "community": 556,
       "file_type": "code",
       "id": "commerceeffects_uncostedoutboundbasis",
       "label": "uncostedOutboundBasis()",
@@ -264733,7 +264910,7 @@
       "source_location": "L64"
     },
     {
-      "community": 554,
+      "community": 556,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventoryledger_commerceeffects_ts",
       "label": "commerceEffects.ts",
@@ -264742,7 +264919,7 @@
       "source_location": "L1"
     },
     {
-      "community": 555,
+      "community": 557,
       "file_type": "code",
       "id": "deficitresolutionwork_allocatedeferreddeficitcost",
       "label": "allocateDeferredDeficitCost()",
@@ -264751,7 +264928,7 @@
       "source_location": "L25"
     },
     {
-      "community": 555,
+      "community": 557,
       "file_type": "code",
       "id": "deficitresolutionwork_enqueuedeficitresolutionworkwithctx",
       "label": "enqueueDeficitResolutionWorkWithCtx()",
@@ -264760,7 +264937,7 @@
       "source_location": "L46"
     },
     {
-      "community": 555,
+      "community": 557,
       "file_type": "code",
       "id": "deficitresolutionwork_historicalcostlane",
       "label": "historicalCostLane()",
@@ -264769,7 +264946,7 @@
       "source_location": "L19"
     },
     {
-      "community": 555,
+      "community": 557,
       "file_type": "code",
       "id": "deficitresolutionwork_materializedeferredadjustmentwithctx",
       "label": "materializeDeferredAdjustmentWithCtx()",
@@ -264778,7 +264955,7 @@
       "source_location": "L107"
     },
     {
-      "community": 555,
+      "community": 557,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventoryledger_deficitresolutionwork_ts",
       "label": "deficitResolutionWork.ts",
@@ -264787,7 +264964,7 @@
       "source_location": "L1"
     },
     {
-      "community": 556,
+      "community": 558,
       "file_type": "code",
       "id": "currency_formatstoredamount",
       "label": "formatStoredAmount()",
@@ -264796,7 +264973,7 @@
       "source_location": "L9"
     },
     {
-      "community": 556,
+      "community": 558,
       "file_type": "code",
       "id": "currency_todisplayamount",
       "label": "toDisplayAmount()",
@@ -264805,7 +264982,7 @@
       "source_location": "L5"
     },
     {
-      "community": 556,
+      "community": 558,
       "file_type": "code",
       "id": "currency_topesewas",
       "label": "toPesewas()",
@@ -264814,7 +264991,7 @@
       "source_location": "L1"
     },
     {
-      "community": 556,
+      "community": 558,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_ts",
       "label": "currency.ts",
@@ -264823,7 +265000,7 @@
       "source_location": "L1"
     },
     {
-      "community": 556,
+      "community": 558,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_currency_ts",
       "label": "currency.ts",
@@ -264832,7 +265009,7 @@
       "source_location": "L1"
     },
     {
-      "community": 557,
+      "community": 559,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_marketing_walkthroughrequestnotifications_ts",
       "label": "walkthroughRequestNotifications.ts",
@@ -264841,7 +265018,7 @@
       "source_location": "L1"
     },
     {
-      "community": 557,
+      "community": 559,
       "file_type": "code",
       "id": "walkthroughrequestnotifications_boundedauditvalue",
       "label": "boundedAuditValue()",
@@ -264850,7 +265027,7 @@
       "source_location": "L27"
     },
     {
-      "community": 557,
+      "community": 559,
       "file_type": "code",
       "id": "walkthroughrequestnotifications_classifydeliveryresult",
       "label": "classifyDeliveryResult()",
@@ -264859,7 +265036,7 @@
       "source_location": "L13"
     },
     {
-      "community": 557,
+      "community": 559,
       "file_type": "code",
       "id": "walkthroughrequestnotifications_isdeliberateretryeligible",
       "label": "isDeliberateRetryEligible()",
@@ -264868,103 +265045,13 @@
       "source_location": "L20"
     },
     {
-      "community": 557,
+      "community": 559,
       "file_type": "code",
       "id": "walkthroughrequestnotifications_nextbackoffms",
       "label": "nextBackoffMs()",
       "norm_label": "nextbackoffms()",
       "source_file": "packages/athena-webapp/convex/marketing/walkthroughRequestNotifications.ts",
       "source_location": "L12"
-    },
-    {
-      "community": 558,
-      "file_type": "code",
-      "id": "backfillreportingcyclestart_test_createctx",
-      "label": "createCtx()",
-      "norm_label": "createctx()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillReportingCycleStart.test.ts",
-      "source_location": "L80"
-    },
-    {
-      "community": 558,
-      "file_type": "code",
-      "id": "backfillreportingcyclestart_test_createstoreverificationctx",
-      "label": "createStoreVerificationCtx()",
-      "norm_label": "createstoreverificationctx()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillReportingCycleStart.test.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 558,
-      "file_type": "code",
-      "id": "backfillreportingcyclestart_test_finishbackfill",
-      "label": "finishBackfill()",
-      "norm_label": "finishbackfill()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillReportingCycleStart.test.ts",
-      "source_location": "L118"
-    },
-    {
-      "community": 558,
-      "file_type": "code",
-      "id": "backfillreportingcyclestart_test_finishverification",
-      "label": "finishVerification()",
-      "norm_label": "finishverification()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillReportingCycleStart.test.ts",
-      "source_location": "L139"
-    },
-    {
-      "community": 558,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_migrations_backfillreportingcyclestart_test_ts",
-      "label": "backfillReportingCycleStart.test.ts",
-      "norm_label": "backfillreportingcyclestart.test.ts",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillReportingCycleStart.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "backfillstoretimezoneauthority_backfillstoretimezoneauthoritywithctx",
-      "label": "backfillStoreTimezoneAuthorityWithCtx()",
-      "norm_label": "backfillstoretimezoneauthoritywithctx()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreTimezoneAuthority.ts",
-      "source_location": "L127"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "backfillstoretimezoneauthority_buildrow",
-      "label": "buildRow()",
-      "norm_label": "buildrow()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreTimezoneAuthority.ts",
-      "source_location": "L47"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "backfillstoretimezoneauthority_listschedulesforstore",
-      "label": "listSchedulesForStore()",
-      "norm_label": "listschedulesforstore()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreTimezoneAuthority.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "backfillstoretimezoneauthority_normalizelimit",
-      "label": "normalizeLimit()",
-      "norm_label": "normalizelimit()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreTimezoneAuthority.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_migrations_backfillstoretimezoneauthority_ts",
-      "label": "backfillStoreTimezoneAuthority.ts",
-      "norm_label": "backfillstoretimezoneauthority.ts",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreTimezoneAuthority.ts",
-      "source_location": "L1"
     },
     {
       "community": 56,
@@ -265212,6 +265299,96 @@
     {
       "community": 560,
       "file_type": "code",
+      "id": "backfillreportingcyclestart_test_createctx",
+      "label": "createCtx()",
+      "norm_label": "createctx()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillReportingCycleStart.test.ts",
+      "source_location": "L80"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "backfillreportingcyclestart_test_createstoreverificationctx",
+      "label": "createStoreVerificationCtx()",
+      "norm_label": "createstoreverificationctx()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillReportingCycleStart.test.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "backfillreportingcyclestart_test_finishbackfill",
+      "label": "finishBackfill()",
+      "norm_label": "finishbackfill()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillReportingCycleStart.test.ts",
+      "source_location": "L118"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "backfillreportingcyclestart_test_finishverification",
+      "label": "finishVerification()",
+      "norm_label": "finishverification()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillReportingCycleStart.test.ts",
+      "source_location": "L139"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_migrations_backfillreportingcyclestart_test_ts",
+      "label": "backfillReportingCycleStart.test.ts",
+      "norm_label": "backfillreportingcyclestart.test.ts",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillReportingCycleStart.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
+      "id": "backfillstoretimezoneauthority_backfillstoretimezoneauthoritywithctx",
+      "label": "backfillStoreTimezoneAuthorityWithCtx()",
+      "norm_label": "backfillstoretimezoneauthoritywithctx()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreTimezoneAuthority.ts",
+      "source_location": "L127"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
+      "id": "backfillstoretimezoneauthority_buildrow",
+      "label": "buildRow()",
+      "norm_label": "buildrow()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreTimezoneAuthority.ts",
+      "source_location": "L47"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
+      "id": "backfillstoretimezoneauthority_listschedulesforstore",
+      "label": "listSchedulesForStore()",
+      "norm_label": "listschedulesforstore()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreTimezoneAuthority.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
+      "id": "backfillstoretimezoneauthority_normalizelimit",
+      "label": "normalizeLimit()",
+      "norm_label": "normalizelimit()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreTimezoneAuthority.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_migrations_backfillstoretimezoneauthority_ts",
+      "label": "backfillStoreTimezoneAuthority.ts",
+      "norm_label": "backfillstoretimezoneauthority.ts",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreTimezoneAuthority.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 562,
+      "file_type": "code",
       "id": "dispatch_recordnotificationfailureeventwithctx",
       "label": "recordNotificationFailureEventWithCtx()",
       "norm_label": "recordnotificationfailureeventwithctx()",
@@ -265219,7 +265396,7 @@
       "source_location": "L400"
     },
     {
-      "community": 560,
+      "community": 562,
       "file_type": "code",
       "id": "dispatch_recordterminaldeliveryfailureevent",
       "label": "recordTerminalDeliveryFailureEvent()",
@@ -265228,7 +265405,7 @@
       "source_location": "L427"
     },
     {
-      "community": 560,
+      "community": 562,
       "file_type": "code",
       "id": "dispatch_resolverecipients",
       "label": "resolveRecipients()",
@@ -265237,7 +265414,7 @@
       "source_location": "L53"
     },
     {
-      "community": 560,
+      "community": 562,
       "file_type": "code",
       "id": "dispatch_suppressintentwithctx",
       "label": "suppressIntentWithCtx()",
@@ -265246,7 +265423,7 @@
       "source_location": "L85"
     },
     {
-      "community": 560,
+      "community": 562,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_notifications_dispatch_ts",
       "label": "dispatch.ts",
@@ -265255,7 +265432,7 @@
       "source_location": "L1"
     },
     {
-      "community": 561,
+      "community": 563,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_notifications_registry_test_ts",
       "label": "registry.test.ts",
@@ -265264,7 +265441,7 @@
       "source_location": "L1"
     },
     {
-      "community": 561,
+      "community": 563,
       "file_type": "code",
       "id": "registry_test_dedupekey",
       "label": "dedupeKey()",
@@ -265273,7 +265450,7 @@
       "source_location": "L609"
     },
     {
-      "community": 561,
+      "community": 563,
       "file_type": "code",
       "id": "registry_test_keyfor",
       "label": "keyFor()",
@@ -265282,7 +265459,7 @@
       "source_location": "L794"
     },
     {
-      "community": 561,
+      "community": 563,
       "file_type": "code",
       "id": "registry_test_prepare",
       "label": "prepare()",
@@ -265291,7 +265468,7 @@
       "source_location": "L48"
     },
     {
-      "community": 561,
+      "community": 563,
       "file_type": "code",
       "id": "registry_test_stubctx",
       "label": "stubCtx()",
@@ -265300,7 +265477,7 @@
       "source_location": "L29"
     },
     {
-      "community": 562,
+      "community": 564,
       "file_type": "code",
       "id": "adapters_createnormaluseroperationadapter",
       "label": "createNormalUserOperationAdapter()",
@@ -265309,7 +265486,7 @@
       "source_location": "L13"
     },
     {
-      "community": 562,
+      "community": 564,
       "file_type": "code",
       "id": "adapters_createpublicoperationadapter",
       "label": "createPublicOperationAdapter()",
@@ -265318,7 +265495,7 @@
       "source_location": "L41"
     },
     {
-      "community": 562,
+      "community": 564,
       "file_type": "code",
       "id": "adapters_isadmitted",
       "label": "isAdmitted()",
@@ -265327,7 +265504,7 @@
       "source_location": "L115"
     },
     {
-      "community": 562,
+      "community": 564,
       "file_type": "code",
       "id": "adapters_resolveoperationadmission",
       "label": "resolveOperationAdmission()",
@@ -265336,7 +265513,7 @@
       "source_location": "L59"
     },
     {
-      "community": 562,
+      "community": 564,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_adapters_ts",
       "label": "adapters.ts",
@@ -265345,7 +265522,7 @@
       "source_location": "L1"
     },
     {
-      "community": 563,
+      "community": 565,
       "file_type": "code",
       "id": "approvalrequesterchallenges_consumeapprovalrequesterchallengewithctx",
       "label": "consumeApprovalRequesterChallengeWithCtx()",
@@ -265354,7 +265531,7 @@
       "source_location": "L97"
     },
     {
-      "community": 563,
+      "community": 565,
       "file_type": "code",
       "id": "approvalrequesterchallenges_createapprovalrequesterchallengewithctx",
       "label": "createApprovalRequesterChallengeWithCtx()",
@@ -265363,7 +265540,7 @@
       "source_location": "L55"
     },
     {
-      "community": 563,
+      "community": 565,
       "file_type": "code",
       "id": "approvalrequesterchallenges_invalidapprovalrequesterchallengeresult",
       "label": "invalidApprovalRequesterChallengeResult()",
@@ -265372,7 +265549,7 @@
       "source_location": "L37"
     },
     {
-      "community": 563,
+      "community": 565,
       "file_type": "code",
       "id": "approvalrequesterchallenges_torequesterbinding",
       "label": "toRequesterBinding()",
@@ -265381,7 +265558,7 @@
       "source_location": "L44"
     },
     {
-      "community": 563,
+      "community": 565,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequesterchallenges_ts",
       "label": "approvalRequesterChallenges.ts",
@@ -265390,7 +265567,7 @@
       "source_location": "L1"
     },
     {
-      "community": 564,
+      "community": 566,
       "file_type": "code",
       "id": "customerprofiles_compactrecord",
       "label": "compactRecord()",
@@ -265399,7 +265576,7 @@
       "source_location": "L24"
     },
     {
-      "community": 564,
+      "community": 566,
       "file_type": "code",
       "id": "customerprofiles_ensurecustomerprofilefromsourceswithctx",
       "label": "ensureCustomerProfileFromSourcesWithCtx()",
@@ -265408,7 +265585,7 @@
       "source_location": "L207"
     },
     {
-      "community": 564,
+      "community": 566,
       "file_type": "code",
       "id": "customerprofiles_findexistingprofile",
       "label": "findExistingProfile()",
@@ -265417,7 +265594,7 @@
       "source_location": "L45"
     },
     {
-      "community": 564,
+      "community": 566,
       "file_type": "code",
       "id": "customerprofiles_loadcustomersources",
       "label": "loadCustomerSources()",
@@ -265426,7 +265603,7 @@
       "source_location": "L30"
     },
     {
-      "community": 564,
+      "community": 566,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_customerprofiles_ts",
       "label": "customerProfiles.ts",
@@ -265435,7 +265612,7 @@
       "source_location": "L1"
     },
     {
-      "community": 565,
+      "community": 567,
       "file_type": "code",
       "id": "operationalworkitems_test_approvalrequest",
       "label": "approvalRequest()",
@@ -265444,7 +265621,7 @@
       "source_location": "L46"
     },
     {
-      "community": 565,
+      "community": 567,
       "file_type": "code",
       "id": "operationalworkitems_test_createqueuecontext",
       "label": "createQueueContext()",
@@ -265453,7 +265630,7 @@
       "source_location": "L59"
     },
     {
-      "community": 565,
+      "community": 567,
       "file_type": "code",
       "id": "operationalworkitems_test_gethandler",
       "label": "getHandler()",
@@ -265462,7 +265639,7 @@
       "source_location": "L25"
     },
     {
-      "community": 565,
+      "community": 567,
       "file_type": "code",
       "id": "operationalworkitems_test_workitem",
       "label": "workItem()",
@@ -265471,7 +265648,7 @@
       "source_location": "L31"
     },
     {
-      "community": 565,
+      "community": 567,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalworkitems_test_ts",
       "label": "operationalWorkItems.test.ts",
@@ -265480,52 +265657,7 @@
       "source_location": "L1"
     },
     {
-      "community": 566,
-      "file_type": "code",
-      "id": "oweddailyclosesweep_completedoperatingdatesforstore",
-      "label": "completedOperatingDatesForStore()",
-      "norm_label": "completedoperatingdatesforstore()",
-      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L151"
-    },
-    {
-      "community": 566,
-      "file_type": "code",
-      "id": "oweddailyclosesweep_daysbetweenoperatingdates",
-      "label": "daysBetweenOperatingDates()",
-      "norm_label": "daysbetweenoperatingdates()",
-      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L369"
-    },
-    {
-      "community": 566,
-      "file_type": "code",
-      "id": "oweddailyclosesweep_listenabledeodpolicies",
-      "label": "listEnabledEodPolicies()",
-      "norm_label": "listenabledeodpolicies()",
-      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L137"
-    },
-    {
-      "community": 566,
-      "file_type": "code",
-      "id": "oweddailyclosesweep_selectoweddailyclosedates",
-      "label": "selectOwedDailyCloseDates()",
-      "norm_label": "selectoweddailyclosedates()",
-      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 566,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
-      "label": "owedDailyCloseSweep.ts",
-      "norm_label": "oweddailyclosesweep.ts",
-      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_paymenttotals_ts",
       "label": "paymentTotals.ts",
@@ -265534,7 +265666,7 @@
       "source_location": "L1"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "paymenttotals_buildpaymenttotals",
       "label": "buildPaymentTotals()",
@@ -265543,7 +265675,7 @@
       "source_location": "L50"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "paymenttotals_listtransactionpayments",
       "label": "listTransactionPayments()",
@@ -265552,7 +265684,7 @@
       "source_location": "L11"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "paymenttotals_transactioncashdelta",
       "label": "transactionCashDelta()",
@@ -265561,7 +265693,7 @@
       "source_location": "L81"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "paymenttotals_transactionpaymenttotals",
       "label": "transactionPaymentTotals()",
@@ -265570,7 +265702,7 @@
       "source_location": "L25"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffcredentials_test_ts",
       "label": "staffCredentials.test.ts",
@@ -265579,7 +265711,7 @@
       "source_location": "L1"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "staffcredentials_test_admissionawareauth",
       "label": "admissionAwareAuth()",
@@ -265588,7 +265720,7 @@
       "source_location": "L256"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "staffcredentials_test_createrestoredproofvalidationctx",
       "label": "createRestoredProofValidationCtx()",
@@ -265597,7 +265729,7 @@
       "source_location": "L271"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "staffcredentials_test_createstaffcredentialsmutationctx",
       "label": "createStaffCredentialsMutationCtx()",
@@ -265606,58 +265738,13 @@
       "source_location": "L81"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "staffcredentials_test_gethandler",
       "label": "getHandler()",
       "norm_label": "gethandler()",
       "source_file": "packages/athena-webapp/convex/operations/staffCredentials.test.ts",
       "source_location": "L267"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "assigncustomer_test_customerprofile",
-      "label": "customerProfile()",
-      "norm_label": "customerprofile()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.test.ts",
-      "source_location": "L319"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "assigncustomer_test_guest",
-      "label": "guest()",
-      "norm_label": "guest()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.test.ts",
-      "source_location": "L346"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "assigncustomer_test_poscustomer",
-      "label": "posCustomer()",
-      "norm_label": "poscustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.test.ts",
-      "source_location": "L303"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "assigncustomer_test_storefrontuser",
-      "label": "storeFrontUser()",
-      "norm_label": "storefrontuser()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.test.ts",
-      "source_location": "L333"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_test_ts",
-      "label": "assignCustomer.test.ts",
-      "norm_label": "assigncustomer.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.test.ts",
-      "source_location": "L1"
     },
     {
       "community": 57,
@@ -265905,6 +265992,51 @@
     {
       "community": 570,
       "file_type": "code",
+      "id": "assigncustomer_test_customerprofile",
+      "label": "customerProfile()",
+      "norm_label": "customerprofile()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.test.ts",
+      "source_location": "L319"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "assigncustomer_test_guest",
+      "label": "guest()",
+      "norm_label": "guest()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.test.ts",
+      "source_location": "L346"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "assigncustomer_test_poscustomer",
+      "label": "posCustomer()",
+      "norm_label": "poscustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.test.ts",
+      "source_location": "L303"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "assigncustomer_test_storefrontuser",
+      "label": "storeFrontUser()",
+      "norm_label": "storefrontuser()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.test.ts",
+      "source_location": "L333"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_test_ts",
+      "label": "assignCustomer.test.ts",
+      "norm_label": "assigncustomer.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_registerlifecycleauthority_ts",
       "label": "registerLifecycleAuthority.ts",
       "norm_label": "registerlifecycleauthority.ts",
@@ -265912,7 +266044,7 @@
       "source_location": "L1"
     },
     {
-      "community": 570,
+      "community": 571,
       "file_type": "code",
       "id": "registerlifecycleauthority_acknowledgeregisterlifecycleauthority",
       "label": "acknowledgeRegisterLifecycleAuthority()",
@@ -265921,7 +266053,7 @@
       "source_location": "L46"
     },
     {
-      "community": 570,
+      "community": 571,
       "file_type": "code",
       "id": "registerlifecycleauthority_equivalentacknowledgement",
       "label": "equivalentAcknowledgement()",
@@ -265930,7 +266062,7 @@
       "source_location": "L124"
     },
     {
-      "community": 570,
+      "community": 571,
       "file_type": "code",
       "id": "registerlifecycleauthority_isrevision",
       "label": "isRevision()",
@@ -265939,7 +266071,7 @@
       "source_location": "L153"
     },
     {
-      "community": 570,
+      "community": 571,
       "file_type": "code",
       "id": "registerlifecycleauthority_normalizesafemetadata",
       "label": "normalizeSafeMetadata()",
@@ -265948,7 +266080,7 @@
       "source_location": "L145"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "correctionpolicy_builddecision",
       "label": "buildDecision()",
@@ -265957,7 +266089,7 @@
       "source_location": "L107"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "correctionpolicy_classifycorrectionintent",
       "label": "classifyCorrectionIntent()",
@@ -265966,7 +266098,7 @@
       "source_location": "L117"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "correctionpolicy_issupportedcorrectionintent",
       "label": "isSupportedCorrectionIntent()",
@@ -265975,7 +266107,7 @@
       "source_location": "L91"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "correctionpolicy_isunsupportedhighriskcorrectionintent",
       "label": "isUnsupportedHighRiskCorrectionIntent()",
@@ -265984,7 +266116,7 @@
       "source_location": "L99"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_corrections_correctionpolicy_ts",
       "label": "correctionPolicy.ts",
@@ -265993,7 +266125,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_reconcilesequencegaps_ts",
       "label": "reconcileSequenceGaps.ts",
@@ -266002,7 +266134,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "reconcilesequencegaps_collectterminalevidence",
       "label": "collectTerminalEvidence()",
@@ -266011,7 +266143,7 @@
       "source_location": "L185"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "reconcilesequencegaps_issuegapprobe",
       "label": "issueGapProbe()",
@@ -266020,7 +266152,7 @@
       "source_location": "L249"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "reconcilesequencegaps_listheldeventsforcursor",
       "label": "listHeldEventsForCursor()",
@@ -266029,7 +266161,7 @@
       "source_location": "L156"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "reconcilesequencegaps_skipsequencegap",
       "label": "skipSequenceGap()",
@@ -266038,7 +266170,7 @@
       "source_location": "L295"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminaloperationalstate_policy_test_ts",
       "label": "policy.test.ts",
@@ -266047,7 +266179,7 @@
       "source_location": "L1"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "policy_test_baseinput",
       "label": "baseInput()",
@@ -266056,7 +266188,7 @@
       "source_location": "L1225"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "policy_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -266065,7 +266197,7 @@
       "source_location": "L1329"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "policy_test_buildruntimestatus",
       "label": "buildRuntimeStatus()",
@@ -266074,7 +266206,7 @@
       "source_location": "L1287"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "policy_test_emptysyncevidence",
       "label": "emptySyncEvidence()",
@@ -266083,7 +266215,7 @@
       "source_location": "L1267"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_terminalrecoveryrepository_test_ts",
       "label": "terminalRecoveryRepository.test.ts",
@@ -266092,7 +266224,7 @@
       "source_location": "L1"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "terminalrecoveryrepository_test_buildctx",
       "label": "buildCtx()",
@@ -266101,7 +266233,7 @@
       "source_location": "L381"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "terminalrecoveryrepository_test_buildqueryctx",
       "label": "buildQueryCtx()",
@@ -266110,7 +266242,7 @@
       "source_location": "L469"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "terminalrecoveryrepository_test_filterrows",
       "label": "filterRows()",
@@ -266119,7 +266251,7 @@
       "source_location": "L483"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "terminalrecoveryrepository_test_orderedrows",
       "label": "orderedRows()",
@@ -266128,7 +266260,7 @@
       "source_location": "L492"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "customers_requireposcustomeraccessbyid",
       "label": "requirePosCustomerAccessById()",
@@ -266137,7 +266269,7 @@
       "source_location": "L76"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "customers_requireposcustomerreadaccessbyid",
       "label": "requirePosCustomerReadAccessById()",
@@ -266146,7 +266278,7 @@
       "source_location": "L123"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "customers_requireposcustomerstoreaccess",
       "label": "requirePosCustomerStoreAccess()",
@@ -266155,7 +266287,7 @@
       "source_location": "L53"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "customers_requireposcustomerstorereadaccess",
       "label": "requirePosCustomerStoreReadAccess()",
@@ -266164,7 +266296,7 @@
       "source_location": "L99"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_customers_ts",
       "label": "customers.ts",
@@ -266173,7 +266305,7 @@
       "source_location": "L1"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_posrecoverycodes_test_ts",
       "label": "posRecoveryCodes.test.ts",
@@ -266182,7 +266314,7 @@
       "source_location": "L1"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "posrecoverycodes_test_buildctx",
       "label": "buildCtx()",
@@ -266191,7 +266323,7 @@
       "source_location": "L565"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "posrecoverycodes_test_createfilter",
       "label": "createFilter()",
@@ -266200,7 +266332,7 @@
       "source_location": "L669"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "posrecoverycodes_test_createquery",
       "label": "createQuery()",
@@ -266209,7 +266341,7 @@
       "source_location": "L642"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "posrecoverycodes_test_gethandler",
       "label": "getHandler()",
@@ -266218,7 +266350,7 @@
       "source_location": "L25"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_telemetry_test_ts",
       "label": "telemetry.test.ts",
@@ -266227,7 +266359,7 @@
       "source_location": "L1"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "telemetry_test_baseevent",
       "label": "baseEvent()",
@@ -266236,7 +266368,7 @@
       "source_location": "L106"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "telemetry_test_createctx",
       "label": "createCtx()",
@@ -266245,7 +266377,7 @@
       "source_location": "L34"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "telemetry_test_gethandler",
       "label": "getHandler()",
@@ -266254,7 +266386,7 @@
       "source_location": "L24"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "telemetry_test_storedevent",
       "label": "storedEvent()",
@@ -266263,7 +266395,7 @@
       "source_location": "L371"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_ts",
       "label": "transactions.ts",
@@ -266272,7 +266404,7 @@
       "source_location": "L1"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "transactions_mapcorrectionerror",
       "label": "mapCorrectionError()",
@@ -266281,7 +266413,7 @@
       "source_location": "L339"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "transactions_redactpospulsesummary",
       "label": "redactPosPulseSummary()",
@@ -266290,7 +266422,7 @@
       "source_location": "L307"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "transactions_requirepostransactionaccess",
       "label": "requirePosTransactionAccess()",
@@ -266299,58 +266431,13 @@
       "source_location": "L93"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "transactions_requirepostransactionstoreaccess",
       "label": "requirePosTransactionStoreAccess()",
       "norm_label": "requirepostransactionstoreaccess()",
       "source_file": "packages/athena-webapp/convex/pos/public/transactions.ts",
       "source_location": "L64"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_remoteassist_application_policy_ts",
-      "label": "policy.ts",
-      "norm_label": "policy.ts",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/application/policy.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "policy_denied",
-      "label": "denied()",
-      "norm_label": "denied()",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/application/policy.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "policy_evaluateremoteassistpolicy",
-      "label": "evaluateRemoteAssistPolicy()",
-      "norm_label": "evaluateremoteassistpolicy()",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/application/policy.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "policy_isclientfresh",
-      "label": "isClientFresh()",
-      "norm_label": "isclientfresh()",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/application/policy.ts",
-      "source_location": "L88"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "policy_policydecisiontocommandresult",
-      "label": "policyDecisionToCommandResult()",
-      "norm_label": "policydecisiontocommandresult()",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/application/policy.ts",
-      "source_location": "L76"
     },
     {
       "community": 58,
@@ -266598,6 +266685,51 @@
     {
       "community": 580,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_remoteassist_application_policy_ts",
+      "label": "policy.ts",
+      "norm_label": "policy.ts",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/application/policy.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "policy_denied",
+      "label": "denied()",
+      "norm_label": "denied()",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/application/policy.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "policy_evaluateremoteassistpolicy",
+      "label": "evaluateRemoteAssistPolicy()",
+      "norm_label": "evaluateremoteassistpolicy()",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/application/policy.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "policy_isclientfresh",
+      "label": "isClientFresh()",
+      "norm_label": "isclientfresh()",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/application/policy.ts",
+      "source_location": "L88"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "policy_policydecisiontocommandresult",
+      "label": "policyDecisionToCommandResult()",
+      "norm_label": "policydecisiontocommandresult()",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/application/policy.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_infrastructure_remoteassistreadrepository_ts",
       "label": "remoteAssistReadRepository.ts",
       "norm_label": "remoteassistreadrepository.ts",
@@ -266605,7 +266737,7 @@
       "source_location": "L1"
     },
     {
-      "community": 580,
+      "community": 581,
       "file_type": "code",
       "id": "remoteassistreadrepository_compareremoteassistsessionforsupportview",
       "label": "compareRemoteAssistSessionForSupportView()",
@@ -266614,7 +266746,7 @@
       "source_location": "L88"
     },
     {
-      "community": 580,
+      "community": 581,
       "file_type": "code",
       "id": "remoteassistreadrepository_createremoteassistreadrepository",
       "label": "createRemoteAssistReadRepository()",
@@ -266623,7 +266755,7 @@
       "source_location": "L10"
     },
     {
-      "community": 580,
+      "community": 581,
       "file_type": "code",
       "id": "remoteassistreadrepository_toremoteassistclient",
       "label": "toRemoteAssistClient()",
@@ -266632,7 +266764,7 @@
       "source_location": "L108"
     },
     {
-      "community": 580,
+      "community": 581,
       "file_type": "code",
       "id": "remoteassistreadrepository_toremoteassistsession",
       "label": "toRemoteAssistSession()",
@@ -266641,7 +266773,7 @@
       "source_location": "L121"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "fingerprint_factfingerprint",
       "label": "factFingerprint()",
@@ -266650,7 +266782,7 @@
       "source_location": "L86"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "fingerprint_fingerprintpayload",
       "label": "fingerprintPayload()",
@@ -266659,7 +266791,7 @@
       "source_location": "L33"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "fingerprint_matchesstoredfingerprint",
       "label": "matchesStoredFingerprint()",
@@ -266668,7 +266800,7 @@
       "source_location": "L103"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "fingerprint_stablestringhash",
       "label": "stableStringHash()",
@@ -266677,7 +266809,7 @@
       "source_location": "L72"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_fingerprint_ts",
       "label": "fingerprint.ts",
@@ -266686,7 +266818,7 @@
       "source_location": "L1"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "foldday_test_fact",
       "label": "fact()",
@@ -266695,7 +266827,7 @@
       "source_location": "L78"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "foldday_test_receipt",
       "label": "receipt()",
@@ -266704,7 +266836,7 @@
       "source_location": "L757"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "foldday_test_sale",
       "label": "sale()",
@@ -266713,7 +266845,7 @@
       "source_location": "L97"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "foldday_test_shuffle",
       "label": "shuffle()",
@@ -266722,7 +266854,7 @@
       "source_location": "L108"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_foldday_test_ts",
       "label": "foldDay.test.ts",
@@ -266731,7 +266863,7 @@
       "source_location": "L1"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_servicecases_test_ts",
       "label": "serviceCases.test.ts",
@@ -266740,7 +266872,7 @@
       "source_location": "L1"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "servicecases_test_createinventoryusagectx",
       "label": "createInventoryUsageCtx()",
@@ -266749,7 +266881,7 @@
       "source_location": "L77"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "servicecases_test_expectindex",
       "label": "expectIndex()",
@@ -266758,7 +266890,7 @@
       "source_location": "L66"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "servicecases_test_gethandler",
       "label": "getHandler()",
@@ -266767,7 +266899,7 @@
       "source_location": "L73"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "servicecases_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -266776,7 +266908,7 @@
       "source_location": "L59"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_services_paystackservice_ts",
       "label": "paystackService.ts",
@@ -266785,7 +266917,7 @@
       "source_location": "L1"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "paystackservice_getpaystackheaders",
       "label": "getPaystackHeaders()",
@@ -266794,7 +266926,7 @@
       "source_location": "L11"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "paystackservice_initializetransaction",
       "label": "initializeTransaction()",
@@ -266803,7 +266935,7 @@
       "source_location": "L21"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "paystackservice_initiaterefund",
       "label": "initiateRefund()",
@@ -266812,7 +266944,7 @@
       "source_location": "L87"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "paystackservice_verifytransaction",
       "label": "verifyTransaction()",
@@ -266821,7 +266953,7 @@
       "source_location": "L65"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "admission_test_admissioncontext",
       "label": "admissionContext()",
@@ -266830,7 +266962,7 @@
       "source_location": "L17"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "admission_test_configureadmissionenvironment",
       "label": "configureAdmissionEnvironment()",
@@ -266839,7 +266971,7 @@
       "source_location": "L60"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "admission_test_contextwith",
       "label": "contextWith()",
@@ -266848,7 +266980,7 @@
       "source_location": "L120"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "admission_test_invoke",
       "label": "invoke()",
@@ -266857,7 +266989,7 @@
       "source_location": "L14"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_admission_test_ts",
       "label": "admission.test.ts",
@@ -266866,7 +266998,7 @@
       "source_location": "L1"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "config_calculateshareddemoexpectedcash",
       "label": "calculateSharedDemoExpectedCash()",
@@ -266875,7 +267007,7 @@
       "source_location": "L23"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "config_isshareddemoenabled",
       "label": "isSharedDemoEnabled()",
@@ -266884,7 +267016,7 @@
       "source_location": "L33"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "config_readruntimeshareddemoconfig",
       "label": "readRuntimeSharedDemoConfig()",
@@ -266893,7 +267025,7 @@
       "source_location": "L59"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "config_readshareddemoconfig",
       "label": "readSharedDemoConfig()",
@@ -266902,7 +267034,7 @@
       "source_location": "L40"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_config_ts",
       "label": "config.ts",
@@ -266911,7 +267043,7 @@
       "source_location": "L1"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "openingbaseline_buildshareddemoopeningbaseline",
       "label": "buildSharedDemoOpeningBaseline()",
@@ -266920,7 +267052,7 @@
       "source_location": "L63"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "openingbaseline_buildshareddemostoredayevent",
       "label": "buildSharedDemoStoreDayEvent()",
@@ -266929,7 +267061,7 @@
       "source_location": "L105"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "openingbaseline_rollshareddemoopeningbaselinewithctx",
       "label": "rollSharedDemoOpeningBaselineWithCtx()",
@@ -266938,7 +267070,7 @@
       "source_location": "L132"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "openingbaseline_shareddemooperatingdaterange",
       "label": "sharedDemoOperatingDateRange()",
@@ -266947,7 +267079,7 @@
       "source_location": "L21"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_openingbaseline_ts",
       "label": "openingBaseline.ts",
@@ -266956,7 +267088,7 @@
       "source_location": "L1"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "operationadapter_createshareddemooperationadapter",
       "label": "createSharedDemoOperationAdapter()",
@@ -266965,7 +267097,7 @@
       "source_location": "L18"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "operationadapter_isrecognizedshareddemoactorerror",
       "label": "isRecognizedSharedDemoActorError()",
@@ -266974,7 +267106,7 @@
       "source_location": "L100"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "operationadapter_shareddemodenialerror",
       "label": "sharedDemoDenialError()",
@@ -266983,7 +267115,7 @@
       "source_location": "L124"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "operationadapter_shareddemodenied",
       "label": "sharedDemoDenied()",
@@ -266992,58 +267124,13 @@
       "source_location": "L108"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_operationadapter_ts",
       "label": "operationAdapter.ts",
       "norm_label": "operationadapter.ts",
       "source_file": "packages/athena-webapp/convex/sharedDemo/operationAdapter.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_ts",
-      "label": "storefrontObservabilityReport.ts",
-      "norm_label": "storefrontobservabilityreport.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "storefrontobservabilityreport_buildstorefrontobservabilityreport",
-      "label": "buildStorefrontObservabilityReport()",
-      "norm_label": "buildstorefrontobservabilityreport()",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
-      "source_location": "L124"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "storefrontobservabilityreport_getnonemptystring",
-      "label": "getNonEmptyString()",
-      "norm_label": "getnonemptystring()",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "storefrontobservabilityreport_gettrafficsource",
-      "label": "getTrafficSource()",
-      "norm_label": "gettrafficsource()",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "storefrontobservabilityreport_normalizestorefrontobservabilityevent",
-      "label": "normalizeStorefrontObservabilityEvent()",
-      "norm_label": "normalizestorefrontobservabilityevent()",
-      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
-      "source_location": "L73"
     },
     {
       "community": 59,
@@ -267282,6 +267369,51 @@
     {
       "community": 590,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_ts",
+      "label": "storefrontObservabilityReport.ts",
+      "norm_label": "storefrontobservabilityreport.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "storefrontobservabilityreport_buildstorefrontobservabilityreport",
+      "label": "buildStorefrontObservabilityReport()",
+      "norm_label": "buildstorefrontobservabilityreport()",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
+      "source_location": "L124"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "storefrontobservabilityreport_getnonemptystring",
+      "label": "getNonEmptyString()",
+      "norm_label": "getnonemptystring()",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "storefrontobservabilityreport_gettrafficsource",
+      "label": "getTrafficSource()",
+      "norm_label": "gettrafficsource()",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
+      "source_location": "L106"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "storefrontobservabilityreport_normalizestorefrontobservabilityevent",
+      "label": "normalizeStorefrontObservabilityEvent()",
+      "norm_label": "normalizestorefrontobservabilityevent()",
+      "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
       "id": "onlineorder_buildlookup",
       "label": "buildLookup()",
       "norm_label": "buildlookup()",
@@ -267289,7 +267421,7 @@
       "source_location": "L65"
     },
     {
-      "community": 590,
+      "community": 591,
       "file_type": "code",
       "id": "onlineorder_buildonlineordertraceseed",
       "label": "buildOnlineOrderTraceSeed()",
@@ -267298,7 +267430,7 @@
       "source_location": "L85"
     },
     {
-      "community": 590,
+      "community": 591,
       "file_type": "code",
       "id": "onlineorder_buildsafeexternalreferenceref",
       "label": "buildSafeExternalReferenceRef()",
@@ -267307,7 +267439,7 @@
       "source_location": "L53"
     },
     {
-      "community": 590,
+      "community": 591,
       "file_type": "code",
       "id": "onlineorder_stablefingerprint",
       "label": "stableFingerprint()",
@@ -267316,7 +267448,7 @@
       "source_location": "L43"
     },
     {
-      "community": 590,
+      "community": 591,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -267325,7 +267457,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_queryusage_test_ts",
       "label": "queryUsage.test.ts",
@@ -267334,7 +267466,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "queryusage_test_comparebyfields",
       "label": "compareByFields()",
@@ -267343,7 +267475,7 @@
       "source_location": "L102"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "queryusage_test_createadmintracereadctx",
       "label": "createAdminTraceReadCtx()",
@@ -267352,7 +267484,7 @@
       "source_location": "L220"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "queryusage_test_createtestctx",
       "label": "createTestCtx()",
@@ -267361,7 +267493,7 @@
       "source_location": "L118"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "queryusage_test_deniedauthorizer",
       "label": "deniedAuthorizer()",
@@ -267370,7 +267502,7 @@
       "source_location": "L1071"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "appsettingsview_appearancelabel",
       "label": "appearanceLabel()",
@@ -267379,7 +267511,7 @@
       "source_location": "L38"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "appsettingsview_cn",
       "label": "cn()",
@@ -267388,7 +267520,7 @@
       "source_location": "L154"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "appsettingsview_selectthememode",
       "label": "selectThemeMode()",
@@ -267397,7 +267529,7 @@
       "source_location": "L85"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "appsettingsview_transitiontimelabel",
       "label": "transitionTimeLabel()",
@@ -267406,7 +267538,7 @@
       "source_location": "L42"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_settings_appsettingsview_tsx",
       "label": "AppSettingsView.tsx",
@@ -267415,7 +267547,7 @@
       "source_location": "L1"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "dashboard_getperiodrange",
       "label": "getPeriodRange()",
@@ -267424,7 +267556,7 @@
       "source_location": "L19"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "dashboard_loadingsection",
       "label": "LoadingSection()",
@@ -267433,7 +267565,7 @@
       "source_location": "L49"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "dashboard_renderproductssection",
       "label": "renderProductsSection()",
@@ -267442,7 +267574,7 @@
       "source_location": "L341"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "dashboard_rendersalessection",
       "label": "renderSalesSection()",
@@ -267451,7 +267583,7 @@
       "source_location": "L321"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
       "label": "Dashboard.tsx",
@@ -267460,7 +267592,7 @@
       "source_location": "L1"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "docsscrolltotop_cancel",
       "label": "cancel()",
@@ -267469,7 +267601,7 @@
       "source_location": "L87"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "docsscrolltotop_handleclick",
       "label": "handleClick()",
@@ -267478,7 +267610,7 @@
       "source_location": "L103"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "docsscrolltotop_read",
       "label": "read()",
@@ -267487,7 +267619,7 @@
       "source_location": "L37"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "docsscrolltotop_schedule",
       "label": "schedule()",
@@ -267496,7 +267628,7 @@
       "source_location": "L59"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_docs_docsscrolltotop_tsx",
       "label": "DocsScrollToTop.tsx",
@@ -267505,7 +267637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "herosectiontabs_handledisplaytypechange",
       "label": "handleDisplayTypeChange()",
@@ -267514,7 +267646,7 @@
       "source_location": "L61"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "herosectiontabs_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -267523,7 +267655,7 @@
       "source_location": "L57"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "herosectiontabs_handleoverlaytoggle",
       "label": "handleOverlayToggle()",
@@ -267532,7 +267664,7 @@
       "source_location": "L98"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "herosectiontabs_handletexttoggle",
       "label": "handleTextToggle()",
@@ -267541,7 +267673,7 @@
       "source_location": "L134"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
       "label": "HeroSectionTabs.tsx",
@@ -267550,7 +267682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
       "label": "ReelUploader.tsx",
@@ -267559,7 +267691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "reeluploader_formatfilesize",
       "label": "formatFileSize()",
@@ -267568,7 +267700,7 @@
       "source_location": "L38"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "reeluploader_handlefileselect",
       "label": "handleFileSelect()",
@@ -267577,7 +267709,7 @@
       "source_location": "L64"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "reeluploader_handleupload",
       "label": "handleUpload()",
@@ -267586,7 +267718,7 @@
       "source_location": "L135"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "reeluploader_validatefile",
       "label": "validateFile()",
@@ -267595,7 +267727,7 @@
       "source_location": "L43"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "activityview_iscreatedaction",
       "label": "isCreatedAction()",
@@ -267604,7 +267736,7 @@
       "source_location": "L90"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "activityview_isfeedbackrequestaction",
       "label": "isFeedbackRequestAction()",
@@ -267613,7 +267745,7 @@
       "source_location": "L95"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "activityview_isrefundaction",
       "label": "isRefundAction()",
@@ -267622,7 +267754,7 @@
       "source_location": "L82"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "activityview_istransitionaction",
       "label": "isTransitionAction()",
@@ -267631,7 +267763,7 @@
       "source_location": "L85"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
       "label": "ActivityView.tsx",
@@ -267640,7 +267772,7 @@
       "source_location": "L1"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "orderitemsview_handlerequestfeedback",
       "label": "handleRequestFeedback()",
@@ -267649,7 +267781,7 @@
       "source_location": "L113"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "orderitemsview_handlerestockall",
       "label": "handleRestockAll()",
@@ -267658,7 +267790,7 @@
       "source_location": "L349"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "orderitemsview_handlereturnitemtostock",
       "label": "handleReturnItemToStock()",
@@ -267667,7 +267799,7 @@
       "source_location": "L86"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "orderitemsview_handleupdateorderitem",
       "label": "handleUpdateOrderItem()",
@@ -267676,57 +267808,12 @@
       "source_location": "L62"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
       "label": "OrderItemsView.tsx",
       "norm_label": "orderitemsview.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "cashierauthdialog_test_buildlocalauthorityrecord",
-      "label": "buildLocalAuthorityRecord()",
-      "norm_label": "buildlocalauthorityrecord()",
-      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx",
-      "source_location": "L121"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "cashierauthdialog_test_renderdialog",
-      "label": "renderDialog()",
-      "norm_label": "renderdialog()",
-      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx",
-      "source_location": "L152"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "cashierauthdialog_test_submitcredentials",
-      "label": "submitCredentials()",
-      "norm_label": "submitcredentials()",
-      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx",
-      "source_location": "L216"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "cashierauthdialog_test_submitlockedcashierpin",
-      "label": "submitLockedCashierPin()",
-      "norm_label": "submitlockedcashierpin()",
-      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx",
-      "source_location": "L208"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_test_tsx",
-      "label": "CashierAuthDialog.test.tsx",
-      "norm_label": "cashierauthdialog.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx",
       "source_location": "L1"
     },
     {
@@ -268614,6 +268701,51 @@
     {
       "community": 600,
       "file_type": "code",
+      "id": "cashierauthdialog_test_buildlocalauthorityrecord",
+      "label": "buildLocalAuthorityRecord()",
+      "norm_label": "buildlocalauthorityrecord()",
+      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx",
+      "source_location": "L121"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "cashierauthdialog_test_renderdialog",
+      "label": "renderDialog()",
+      "norm_label": "renderdialog()",
+      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx",
+      "source_location": "L152"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "cashierauthdialog_test_submitcredentials",
+      "label": "submitCredentials()",
+      "norm_label": "submitcredentials()",
+      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx",
+      "source_location": "L216"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "cashierauthdialog_test_submitlockedcashierpin",
+      "label": "submitLockedCashierPin()",
+      "norm_label": "submitlockedcashierpin()",
+      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx",
+      "source_location": "L208"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_test_tsx",
+      "label": "CashierAuthDialog.test.tsx",
+      "norm_label": "cashierauthdialog.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
       "id": "ordersummary_test_getbalancedueamount",
       "label": "getBalanceDueAmount()",
       "norm_label": "getbalancedueamount()",
@@ -268621,7 +268753,7 @@
       "source_location": "L49"
     },
     {
-      "community": 600,
+      "community": 601,
       "file_type": "code",
       "id": "ordersummary_test_getbalanceduelabel",
       "label": "getBalanceDueLabel()",
@@ -268630,7 +268762,7 @@
       "source_location": "L66"
     },
     {
-      "community": 600,
+      "community": 601,
       "file_type": "code",
       "id": "ordersummary_test_getbalanceduepanel",
       "label": "getBalanceDuePanel()",
@@ -268639,7 +268771,7 @@
       "source_location": "L75"
     },
     {
-      "community": 600,
+      "community": 601,
       "file_type": "code",
       "id": "ordersummary_test_stripwhitespace",
       "label": "stripWhitespace()",
@@ -268648,7 +268780,7 @@
       "source_location": "L45"
     },
     {
-      "community": 600,
+      "community": 601,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_ordersummary_test_tsx",
       "label": "OrderSummary.test.tsx",
@@ -268657,7 +268789,7 @@
       "source_location": "L1"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_test_tsx",
       "label": "POSSettingsView.test.tsx",
@@ -268666,7 +268798,7 @@
       "source_location": "L1"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "possettingsview_test_findtrigger",
       "label": "findTrigger()",
@@ -268675,7 +268807,7 @@
       "source_location": "L185"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "possettingsview_test_selectcontent",
       "label": "SelectContent()",
@@ -268684,7 +268816,7 @@
       "source_location": "L160"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "possettingsview_test_selectitem",
       "label": "SelectItem()",
@@ -268693,7 +268825,7 @@
       "source_location": "L163"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "possettingsview_test_selecttrigger",
       "label": "SelectTrigger()",
@@ -268702,7 +268834,7 @@
       "source_location": "L165"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productslistview_tsx",
       "label": "ProductsListView.tsx",
@@ -268711,7 +268843,7 @@
       "source_location": "L1"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "productslistview_handlecategorypageindexchange",
       "label": "handleCategoryPageIndexChange()",
@@ -268720,7 +268852,7 @@
       "source_location": "L220"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "productslistview_handleclearcache",
       "label": "handleClearCache()",
@@ -268729,7 +268861,7 @@
       "source_location": "L108"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "productslistview_handlestorefrontvisibilitychange",
       "label": "handleStorefrontVisibilityChange()",
@@ -268738,7 +268870,7 @@
       "source_location": "L87"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "productslistview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -268747,7 +268879,7 @@
       "source_location": "L33"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeview_tsx",
       "label": "PromoCodeView.tsx",
@@ -268756,7 +268888,7 @@
       "source_location": "L1"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "promocodeview_handleaddpromocode",
       "label": "handleAddPromoCode()",
@@ -268765,7 +268897,7 @@
       "source_location": "L158"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "promocodeview_handleupdatepromocode",
       "label": "handleUpdatePromoCode()",
@@ -268774,7 +268906,7 @@
       "source_location": "L231"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "promocodeview_updatehomepagediscountcode",
       "label": "updateHomepageDiscountCode()",
@@ -268783,7 +268915,7 @@
       "source_location": "L324"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "promocodeview_updateleaveareviewdiscountcode",
       "label": "updateLeaveAReviewDiscountCode()",
@@ -268792,7 +268924,7 @@
       "source_location": "L379"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportsoverviewview_test_tsx",
       "label": "ReportsOverviewView.test.tsx",
@@ -268801,7 +268933,7 @@
       "source_location": "L1"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "reportsoverviewview_test_expectanimatedmetrics",
       "label": "expectAnimatedMetrics()",
@@ -268810,7 +268942,7 @@
       "source_location": "L450"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "reportsoverviewview_test_harness",
       "label": "Harness()",
@@ -268819,7 +268951,7 @@
       "source_location": "L173"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "reportsoverviewview_test_linkedrange",
       "label": "linkedRange()",
@@ -268828,7 +268960,7 @@
       "source_location": "L584"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "reportsoverviewview_test_snapshot",
       "label": "snapshot()",
@@ -268837,7 +268969,7 @@
       "source_location": "L87"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportroutesearch_ts",
       "label": "reportRouteSearch.ts",
@@ -268846,7 +268978,7 @@
       "source_location": "L1"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "reportroutesearch_overviewsearchfromweeklyreturn",
       "label": "overviewSearchFromWeeklyReturn()",
@@ -268855,7 +268987,7 @@
       "source_location": "L148"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "reportroutesearch_parseunitssheetfocussearch",
       "label": "parseUnitsSheetFocusSearch()",
@@ -268864,7 +268996,7 @@
       "source_location": "L81"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "reportroutesearch_unitssheetfocussearchvalue",
       "label": "unitsSheetFocusSearchValue()",
@@ -268873,7 +269005,7 @@
       "source_location": "L72"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "reportroutesearch_weeklyreturnsearchfromoverview",
       "label": "weeklyReturnSearchFromOverview()",
@@ -268882,7 +269014,7 @@
       "source_location": "L125"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_pulse_storepulsesummaryview_tsx",
       "label": "StorePulseSummaryView.tsx",
@@ -268891,7 +269023,7 @@
       "source_location": "L1"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "storepulsesummaryview_formatcomparisonhelper",
       "label": "formatComparisonHelper()",
@@ -268900,7 +269032,7 @@
       "source_location": "L165"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "storepulsesummaryview_formatxaxistick",
       "label": "formatXAxisTick()",
@@ -268909,7 +269041,7 @@
       "source_location": "L379"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "storepulsesummaryview_gettrendvalue",
       "label": "getTrendValue()",
@@ -268918,7 +269050,7 @@
       "source_location": "L312"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "storepulsesummaryview_helper",
       "label": "helper()",
@@ -268927,7 +269059,7 @@
       "source_location": "L202"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "date_time_picker_handleclear",
       "label": "handleClear()",
@@ -268936,7 +269068,7 @@
       "source_location": "L101"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "date_time_picker_handledateselect",
       "label": "handleDateSelect()",
@@ -268945,7 +269077,7 @@
       "source_location": "L55"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "date_time_picker_handletimeblur",
       "label": "handleTimeBlur()",
@@ -268954,7 +269086,7 @@
       "source_location": "L77"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "date_time_picker_handletimechange",
       "label": "handleTimeChange()",
@@ -268963,7 +269095,7 @@
       "source_location": "L65"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
       "label": "date-time-picker.tsx",
@@ -268972,7 +269104,7 @@
       "source_location": "L1"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "custom_modal_example_basicmodalexample",
       "label": "BasicModalExample()",
@@ -268981,7 +269113,7 @@
       "source_location": "L7"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "custom_modal_example_customclosebuttonexample",
       "label": "CustomCloseButtonExample()",
@@ -268990,7 +269122,7 @@
       "source_location": "L69"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "custom_modal_example_custompositionmodalexample",
       "label": "CustomPositionModalExample()",
@@ -268999,7 +269131,7 @@
       "source_location": "L44"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "custom_modal_example_fullscreenmodalexample",
       "label": "FullScreenModalExample()",
@@ -269008,58 +269140,13 @@
       "source_location": "L103"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_example_tsx",
       "label": "custom-modal-example.tsx",
       "norm_label": "custom-modal-example.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useexpenselocalruntime_ts",
-      "label": "useExpenseLocalRuntime.ts",
-      "norm_label": "useexpenselocalruntime.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseLocalRuntime.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "useexpenselocalruntime_createlocalid",
-      "label": "createLocalId()",
-      "norm_label": "createlocalid()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseLocalRuntime.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "useexpenselocalruntime_getexpenselocalstore",
-      "label": "getExpenseLocalStore()",
-      "norm_label": "getexpenselocalstore()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseLocalRuntime.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "useexpenselocalruntime_notifyexpenselocaleventappended",
-      "label": "notifyExpenseLocalEventAppended()",
-      "norm_label": "notifyexpenselocaleventappended()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseLocalRuntime.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "useexpenselocalruntime_useexpenselocalruntime",
-      "label": "useExpenseLocalRuntime()",
-      "norm_label": "useexpenselocalruntime()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseLocalRuntime.ts",
-      "source_location": "L31"
     },
     {
       "community": 61,
@@ -269289,6 +269376,51 @@
     {
       "community": 610,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useexpenselocalruntime_ts",
+      "label": "useExpenseLocalRuntime.ts",
+      "norm_label": "useexpenselocalruntime.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseLocalRuntime.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "useexpenselocalruntime_createlocalid",
+      "label": "createLocalId()",
+      "norm_label": "createlocalid()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseLocalRuntime.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "useexpenselocalruntime_getexpenselocalstore",
+      "label": "getExpenseLocalStore()",
+      "norm_label": "getexpenselocalstore()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseLocalRuntime.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "useexpenselocalruntime_notifyexpenselocaleventappended",
+      "label": "notifyExpenseLocalEventAppended()",
+      "norm_label": "notifyexpenselocaleventappended()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseLocalRuntime.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "useexpenselocalruntime_useexpenselocalruntime",
+      "label": "useExpenseLocalRuntime()",
+      "norm_label": "useexpenselocalruntime()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseLocalRuntime.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
       "id": "appmessagesprovider_appmessagesprovider",
       "label": "AppMessagesProvider()",
       "norm_label": "appmessagesprovider()",
@@ -269296,7 +269428,7 @@
       "source_location": "L28"
     },
     {
-      "community": 610,
+      "community": 611,
       "file_type": "code",
       "id": "appmessagesprovider_areblockersequal",
       "label": "areBlockersEqual()",
@@ -269305,7 +269437,7 @@
       "source_location": "L215"
     },
     {
-      "community": 610,
+      "community": 611,
       "file_type": "code",
       "id": "appmessagesprovider_aremessagesequal",
       "label": "areMessagesEqual()",
@@ -269314,7 +269446,7 @@
       "source_location": "L185"
     },
     {
-      "community": 610,
+      "community": 611,
       "file_type": "code",
       "id": "appmessagesprovider_getpreferredvariant",
       "label": "getPreferredVariant()",
@@ -269323,7 +269455,7 @@
       "source_location": "L203"
     },
     {
-      "community": 610,
+      "community": 611,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_messages_appmessagesprovider_tsx",
       "label": "AppMessagesProvider.tsx",
@@ -269332,7 +269464,7 @@
       "source_location": "L1"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "appactionblockers_compareappactionblockers",
       "label": "compareAppActionBlockers()",
@@ -269341,7 +269473,7 @@
       "source_location": "L41"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "appactionblockers_getselectedappactionblocker",
       "label": "getSelectedAppActionBlocker()",
@@ -269350,7 +269482,7 @@
       "source_location": "L26"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "appactionblockers_isvalidappactionblockerinput",
       "label": "isValidAppActionBlockerInput()",
@@ -269359,7 +269491,7 @@
       "source_location": "L30"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "appactionblockers_sortappactionblockers",
       "label": "sortAppActionBlockers()",
@@ -269368,7 +269500,7 @@
       "source_location": "L22"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_messages_appactionblockers_ts",
       "label": "appActionBlockers.ts",
@@ -269377,7 +269509,7 @@
       "source_location": "L1"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "appmessages_compareappmessages",
       "label": "compareAppMessages()",
@@ -269386,7 +269518,7 @@
       "source_location": "L39"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "appmessages_getselectedappmessage",
       "label": "getSelectedAppMessage()",
@@ -269395,7 +269527,7 @@
       "source_location": "L27"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "appmessages_isvalidappmessageinput",
       "label": "isValidAppMessageInput()",
@@ -269404,7 +269536,7 @@
       "source_location": "L31"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "appmessages_sortappmessages",
       "label": "sortAppMessages()",
@@ -269413,7 +269545,7 @@
       "source_location": "L23"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_messages_appmessages_ts",
       "label": "appMessages.ts",
@@ -269422,7 +269554,7 @@
       "source_location": "L1"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "appupdatereload_cleartrackedbeforeunloadhandlers",
       "label": "clearTrackedBeforeUnloadHandlers()",
@@ -269431,7 +269563,7 @@
       "source_location": "L85"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "appupdatereload_getcapture",
       "label": "getCapture()",
@@ -269440,7 +269572,7 @@
       "source_location": "L102"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "appupdatereload_installappupdateunloadpromptbypass",
       "label": "installAppUpdateUnloadPromptBypass()",
@@ -269449,7 +269581,7 @@
       "source_location": "L13"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "appupdatereload_reloadbrowserforappupdate",
       "label": "reloadBrowserForAppUpdate()",
@@ -269458,7 +269590,7 @@
       "source_location": "L74"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_update_appupdatereload_ts",
       "label": "appUpdateReload.ts",
@@ -269467,7 +269599,7 @@
       "source_location": "L1"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "browserfingerprint_buffertohex",
       "label": "bufferToHex()",
@@ -269476,7 +269608,7 @@
       "source_location": "L18"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "browserfingerprint_collectbrowserinfo",
       "label": "collectBrowserInfo()",
@@ -269485,7 +269617,7 @@
       "source_location": "L23"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "browserfingerprint_generatebrowserfingerprint",
       "label": "generateBrowserFingerprint()",
@@ -269494,7 +269626,7 @@
       "source_location": "L65"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "browserfingerprint_hashfingerprintsource",
       "label": "hashFingerprintSource()",
@@ -269503,7 +269635,7 @@
       "source_location": "L45"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_browserfingerprint_ts",
       "label": "browserFingerprint.ts",
@@ -269512,7 +269644,7 @@
       "source_location": "L1"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_ts",
       "label": "runCommand.ts",
@@ -269521,7 +269653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "runcommand_extracttraceid",
       "label": "extractTraceId()",
@@ -269530,7 +269662,7 @@
       "source_location": "L40"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "runcommand_getshareddemodenial",
       "label": "getSharedDemoDenial()",
@@ -269539,7 +269671,7 @@
       "source_location": "L48"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "runcommand_isapprovalrequiredresult",
       "label": "isApprovalRequiredResult()",
@@ -269548,7 +269680,7 @@
       "source_location": "L34"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "runcommand_runcommand",
       "label": "runCommand()",
@@ -269557,7 +269689,7 @@
       "source_location": "L68"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "imageutils_test_arraybuffer",
       "label": "arrayBuffer()",
@@ -269566,7 +269698,7 @@
       "source_location": "L78"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "imageutils_test_constructor",
       "label": "constructor()",
@@ -269575,7 +269707,7 @@
       "source_location": "L74"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "imageutils_test_mockimage",
       "label": "MockImage",
@@ -269584,7 +269716,7 @@
       "source_location": "L103"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "imageutils_test_mockimage_src",
       "label": ".src()",
@@ -269593,7 +269725,7 @@
       "source_location": "L109"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_test_ts",
       "label": "imageUtils.test.ts",
@@ -269602,7 +269734,7 @@
       "source_location": "L1"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "imageutils_convertimagestojpg",
       "label": "convertImagesToJpg()",
@@ -269611,7 +269743,7 @@
       "source_location": "L75"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "imageutils_convertimagestowebp",
       "label": "convertImagesToWebp()",
@@ -269620,7 +269752,7 @@
       "source_location": "L26"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "imageutils_converttojpg",
       "label": "convertToJpg()",
@@ -269629,7 +269761,7 @@
       "source_location": "L38"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "imageutils_getuploadimagesdata",
       "label": "getUploadImagesData()",
@@ -269638,7 +269770,7 @@
       "source_location": "L4"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_ts",
       "label": "imageUtils.ts",
@@ -269647,7 +269779,7 @@
       "source_location": "L1"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_ts",
       "label": "registerGateway.ts",
@@ -269656,7 +269788,7 @@
       "source_location": "L1"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "registergateway_mapregisterstatedto",
       "label": "mapRegisterStateDto()",
@@ -269665,7 +269797,7 @@
       "source_location": "L13"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "registergateway_mapterminaldto",
       "label": "mapTerminalDto()",
@@ -269674,7 +269806,7 @@
       "source_location": "L31"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "registergateway_useconvexregisterstate",
       "label": "useConvexRegisterState()",
@@ -269683,58 +269815,13 @@
       "source_location": "L37"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "registergateway_useconvexterminalbyfingerprint",
       "label": "useConvexTerminalByFingerprint()",
       "norm_label": "useconvexterminalbyfingerprint()",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts",
       "source_location": "L59"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "expenselocalcommandgateway_createexpenselocalcommandgateway",
-      "label": "createExpenseLocalCommandGateway()",
-      "norm_label": "createexpenselocalcommandgateway()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/expenseLocalCommandGateway.ts",
-      "source_location": "L55"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "expenselocalcommandgateway_itempayload",
-      "label": "itemPayload()",
-      "norm_label": "itempayload()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/expenseLocalCommandGateway.ts",
-      "source_location": "L282"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "expenselocalcommandgateway_reasonpayload",
-      "label": "reasonPayload()",
-      "norm_label": "reasonpayload()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/expenseLocalCommandGateway.ts",
-      "source_location": "L303"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "expenselocalcommandgateway_resolvestaffprooftoken",
-      "label": "resolveStaffProofToken()",
-      "norm_label": "resolvestaffprooftoken()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/expenseLocalCommandGateway.ts",
-      "source_location": "L310"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_expenselocalcommandgateway_ts",
-      "label": "expenseLocalCommandGateway.ts",
-      "norm_label": "expenselocalcommandgateway.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/expenseLocalCommandGateway.ts",
-      "source_location": "L1"
     },
     {
       "community": 62,
@@ -269964,6 +270051,51 @@
     {
       "community": 620,
       "file_type": "code",
+      "id": "expenselocalcommandgateway_createexpenselocalcommandgateway",
+      "label": "createExpenseLocalCommandGateway()",
+      "norm_label": "createexpenselocalcommandgateway()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/expenseLocalCommandGateway.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 620,
+      "file_type": "code",
+      "id": "expenselocalcommandgateway_itempayload",
+      "label": "itemPayload()",
+      "norm_label": "itempayload()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/expenseLocalCommandGateway.ts",
+      "source_location": "L282"
+    },
+    {
+      "community": 620,
+      "file_type": "code",
+      "id": "expenselocalcommandgateway_reasonpayload",
+      "label": "reasonPayload()",
+      "norm_label": "reasonpayload()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/expenseLocalCommandGateway.ts",
+      "source_location": "L303"
+    },
+    {
+      "community": 620,
+      "file_type": "code",
+      "id": "expenselocalcommandgateway_resolvestaffprooftoken",
+      "label": "resolveStaffProofToken()",
+      "norm_label": "resolvestaffprooftoken()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/expenseLocalCommandGateway.ts",
+      "source_location": "L310"
+    },
+    {
+      "community": 620,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_expenselocalcommandgateway_ts",
+      "label": "expenseLocalCommandGateway.ts",
+      "norm_label": "expenselocalcommandgateway.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/expenseLocalCommandGateway.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
       "id": "localcommandgateway_test_appendopendrawer",
       "label": "appendOpenDrawer()",
       "norm_label": "appendopendrawer()",
@@ -269971,7 +270103,7 @@
       "source_location": "L22"
     },
     {
-      "community": 620,
+      "community": 621,
       "file_type": "code",
       "id": "localcommandgateway_test_blockdrawerauthority",
       "label": "blockDrawerAuthority()",
@@ -269980,7 +270112,7 @@
       "source_location": "L34"
     },
     {
-      "community": 620,
+      "community": 621,
       "file_type": "code",
       "id": "localcommandgateway_test_createblockedsalegateway",
       "label": "createBlockedSaleGateway()",
@@ -269989,7 +270121,7 @@
       "source_location": "L48"
     },
     {
-      "community": 620,
+      "community": 621,
       "file_type": "code",
       "id": "localcommandgateway_test_salecommandinput",
       "label": "saleCommandInput()",
@@ -269998,7 +270130,7 @@
       "source_location": "L11"
     },
     {
-      "community": 620,
+      "community": 621,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localcommandgateway_test_ts",
       "label": "localCommandGateway.test.ts",
@@ -270007,7 +270139,7 @@
       "source_location": "L1"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "localregisterreader_readlatestdrawerauthoritystate",
       "label": "readLatestDrawerAuthorityState()",
@@ -270016,7 +270148,7 @@
       "source_location": "L325"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "localregisterreader_readprojectedlocalregistermodel",
       "label": "readProjectedLocalRegisterModel()",
@@ -270025,7 +270157,7 @@
       "source_location": "L129"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "localregisterreader_readscopedpagesorfallback",
       "label": "readScopedPagesOrFallback()",
@@ -270034,7 +270166,7 @@
       "source_location": "L266"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "localregisterreader_readscopedposlocalevents",
       "label": "readScopedPosLocalEvents()",
@@ -270043,7 +270175,7 @@
       "source_location": "L86"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localregisterreader_ts",
       "label": "localRegisterReader.ts",
@@ -270052,7 +270184,7 @@
       "source_location": "L1"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registerreadmodel_test_ts",
       "label": "registerReadModel.test.ts",
@@ -270061,7 +270193,7 @@
       "source_location": "L1"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "registerreadmodel_test_errorcodes",
       "label": "errorCodes()",
@@ -270070,7 +270202,7 @@
       "source_location": "L1565"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "registerreadmodel_test_event",
       "label": "event()",
@@ -270079,7 +270211,7 @@
       "source_location": "L1569"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "registerreadmodel_test_servicedraftevent",
       "label": "serviceDraftEvent()",
@@ -270088,7 +270220,7 @@
       "source_location": "L1611"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "registerreadmodel_test_servicedraftprelude",
       "label": "serviceDraftPrelude()",
@@ -270097,7 +270229,7 @@
       "source_location": "L1593"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_runtimereadiness_ts",
       "label": "runtimeReadiness.ts",
@@ -270106,7 +270238,7 @@
       "source_location": "L1"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "runtimereadiness_emptyposterminalruntimereadiness",
       "label": "emptyPosTerminalRuntimeReadiness()",
@@ -270115,7 +270247,7 @@
       "source_location": "L39"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "runtimereadiness_getruntimevisibleactiveregistersession",
       "label": "getRuntimeVisibleActiveRegisterSession()",
@@ -270124,7 +270256,7 @@
       "source_location": "L165"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "runtimereadiness_refreshterminalruntimereadiness",
       "label": "refreshTerminalRuntimeReadiness()",
@@ -270133,7 +270265,7 @@
       "source_location": "L51"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "runtimereadiness_toruntimeactiveregistersession",
       "label": "toRuntimeActiveRegisterSession()",
@@ -270142,7 +270274,7 @@
       "source_location": "L179"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_useregisterlifecycleauthorityruntime_ts",
       "label": "useRegisterLifecycleAuthorityRuntime.ts",
@@ -270151,7 +270283,7 @@
       "source_location": "L1"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_applysnapshot",
       "label": "applySnapshot()",
@@ -270160,7 +270292,7 @@
       "source_location": "L389"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_isregisterlifecyclerepairclassification",
       "label": "isRegisterLifecycleRepairClassification()",
@@ -270169,7 +270301,7 @@
       "source_location": "L554"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_toobservation",
       "label": "toObservation()",
@@ -270178,7 +270310,7 @@
       "source_location": "L523"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_useregisterlifecycleauthorityruntime",
       "label": "useRegisterLifecycleAuthorityRuntime()",
@@ -270187,7 +270319,7 @@
       "source_location": "L53"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_transactionutils_ts",
       "label": "transactionUtils.ts",
@@ -270196,7 +270328,7 @@
       "source_location": "L1"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "transactionutils_calculatechange",
       "label": "calculateChange()",
@@ -270205,7 +270337,7 @@
       "source_location": "L42"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "transactionutils_formatcurrency",
       "label": "formatCurrency()",
@@ -270214,7 +270346,7 @@
       "source_location": "L29"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "transactionutils_formattimestamp",
       "label": "formatTimestamp()",
@@ -270223,7 +270355,7 @@
       "source_location": "L49"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "transactionutils_generatetransactionnumber",
       "label": "generateTransactionNumber()",
@@ -270232,7 +270364,7 @@
       "source_location": "L14"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_runtimebuildmetadata_ts",
       "label": "runtimeBuildMetadata.ts",
@@ -270241,7 +270373,7 @@
       "source_location": "L1"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "runtimebuildmetadata_getinitialruntimebuildmetadata",
       "label": "getInitialRuntimeBuildMetadata()",
@@ -270250,7 +270382,7 @@
       "source_location": "L16"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "runtimebuildmetadata_normalizedeploymetadata",
       "label": "normalizeDeployMetadata()",
@@ -270259,7 +270391,7 @@
       "source_location": "L49"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "runtimebuildmetadata_normalizemetadatavalue",
       "label": "normalizeMetadataValue()",
@@ -270268,7 +270400,7 @@
       "source_location": "L63"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "runtimebuildmetadata_readruntimebuildmetadata",
       "label": "readRuntimeBuildMetadata()",
@@ -270277,7 +270409,7 @@
       "source_location": "L32"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_timelineutils_ts",
       "label": "timelineUtils.ts",
@@ -270286,7 +270418,7 @@
       "source_location": "L1"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevent",
       "label": "enrichTimelineEvent()",
@@ -270295,7 +270427,7 @@
       "source_location": "L184"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevents",
       "label": "enrichTimelineEvents()",
@@ -270304,7 +270436,7 @@
       "source_location": "L200"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "timelineutils_gettimerangelabel",
       "label": "getTimeRangeLabel()",
@@ -270313,7 +270445,7 @@
       "source_location": "L244"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "timelineutils_groupeventsbytimeframe",
       "label": "groupEventsByTimeframe()",
@@ -270322,7 +270454,7 @@
       "source_location": "L206"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "packages_athena_webapp_src_offline_registerposappshellserviceworker_ts",
       "label": "registerPosAppShellServiceWorker.ts",
@@ -270331,7 +270463,7 @@
       "source_location": "L1"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "registerposappshellserviceworker_isposappshellserviceworkerregistration",
       "label": "isPosAppShellServiceWorkerRegistration()",
@@ -270340,7 +270472,7 @@
       "source_location": "L52"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "registerposappshellserviceworker_registerposappshellserviceworker",
       "label": "registerPosAppShellServiceWorker()",
@@ -270349,7 +270481,7 @@
       "source_location": "L6"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "registerposappshellserviceworker_resetposappshellserviceworkerregistrationfortest",
       "label": "resetPosAppShellServiceWorkerRegistrationForTest()",
@@ -270358,58 +270490,13 @@
       "source_location": "L20"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "registerposappshellserviceworker_unregisterposappshellserviceworkerfordev",
       "label": "unregisterPosAppShellServiceWorkerForDev()",
       "norm_label": "unregisterposappshellserviceworkerfordev()",
       "source_file": "packages/athena-webapp/src/offline/registerPosAppShellServiceWorker.ts",
       "source_location": "L24"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_root_tsx",
-      "label": "__root.tsx",
-      "norm_label": "__root.tsx",
-      "source_file": "packages/athena-webapp/src/routes/__root.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "root_getathenadocumenttitle",
-      "label": "getAthenaDocumentTitle()",
-      "norm_label": "getathenadocumenttitle()",
-      "source_file": "packages/athena-webapp/src/routes/__root.tsx",
-      "source_location": "L89"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "root_rootcomponent",
-      "label": "RootComponent()",
-      "norm_label": "rootcomponent()",
-      "source_file": "packages/athena-webapp/src/routes/__root.tsx",
-      "source_location": "L62"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "root_rootdocument",
-      "label": "RootDocument()",
-      "norm_label": "rootdocument()",
-      "source_file": "packages/athena-webapp/src/routes/__root.tsx",
-      "source_location": "L72"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "root_rootnotfound",
-      "label": "RootNotFound()",
-      "norm_label": "rootnotfound()",
-      "source_file": "packages/athena-webapp/src/routes/__root.tsx",
-      "source_location": "L48"
     },
     {
       "community": 63,
@@ -270639,6 +270726,51 @@
     {
       "community": 630,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_root_tsx",
+      "label": "__root.tsx",
+      "norm_label": "__root.tsx",
+      "source_file": "packages/athena-webapp/src/routes/__root.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 630,
+      "file_type": "code",
+      "id": "root_getathenadocumenttitle",
+      "label": "getAthenaDocumentTitle()",
+      "norm_label": "getathenadocumenttitle()",
+      "source_file": "packages/athena-webapp/src/routes/__root.tsx",
+      "source_location": "L89"
+    },
+    {
+      "community": 630,
+      "file_type": "code",
+      "id": "root_rootcomponent",
+      "label": "RootComponent()",
+      "norm_label": "rootcomponent()",
+      "source_file": "packages/athena-webapp/src/routes/__root.tsx",
+      "source_location": "L62"
+    },
+    {
+      "community": 630,
+      "file_type": "code",
+      "id": "root_rootdocument",
+      "label": "RootDocument()",
+      "norm_label": "rootdocument()",
+      "source_file": "packages/athena-webapp/src/routes/__root.tsx",
+      "source_location": "L72"
+    },
+    {
+      "community": 630,
+      "file_type": "code",
+      "id": "root_rootnotfound",
+      "label": "RootNotFound()",
+      "norm_label": "rootnotfound()",
+      "source_file": "packages/athena-webapp/src/routes/__root.tsx",
+      "source_location": "L48"
+    },
+    {
+      "community": 631,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
       "label": "$traceId.tsx",
       "norm_label": "$traceid.tsx",
@@ -270646,7 +270778,7 @@
       "source_location": "L1"
     },
     {
-      "community": 630,
+      "community": 631,
       "file_type": "code",
       "id": "traceid_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -270655,7 +270787,7 @@
       "source_location": "L10"
     },
     {
-      "community": 630,
+      "community": 631,
       "file_type": "code",
       "id": "traceid_workflowtraceroute",
       "label": "WorkflowTraceRoute()",
@@ -270664,7 +270796,7 @@
       "source_location": "L85"
     },
     {
-      "community": 630,
+      "community": 631,
       "file_type": "code",
       "id": "traceid_workflowtraceroutecontent",
       "label": "WorkflowTraceRouteContent()",
@@ -270673,7 +270805,7 @@
       "source_location": "L19"
     },
     {
-      "community": 630,
+      "community": 631,
       "file_type": "code",
       "id": "traceid_workflowtracerouteshell",
       "label": "WorkflowTraceRouteShell()",
@@ -270682,7 +270814,7 @@
       "source_location": "L50"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "expensestore_expensecartitemsourcekey",
       "label": "expenseCartItemSourceKey()",
@@ -270691,7 +270823,7 @@
       "source_location": "L179"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "expensestore_ispendingoptimisticexpensecartitem",
       "label": "isPendingOptimisticExpenseCartItem()",
@@ -270700,7 +270832,7 @@
       "source_location": "L197"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "expensestore_mapexpensesessioncartitemtocartitem",
       "label": "mapExpenseSessionCartItemToCartItem()",
@@ -270709,7 +270841,7 @@
       "source_location": "L213"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "expensestore_sessionitemrepresentscartitem",
       "label": "sessionItemRepresentsCartItem()",
@@ -270718,7 +270850,7 @@
       "source_location": "L201"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stores_expensestore_ts",
       "label": "expenseStore.ts",
@@ -270727,7 +270859,7 @@
       "source_location": "L1"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "analytics_getproductviewcount",
       "label": "getProductViewCount()",
@@ -270736,7 +270868,7 @@
       "source_location": "L93"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "analytics_logout",
       "label": "logout()",
@@ -270745,7 +270877,7 @@
       "source_location": "L75"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "analytics_postanalytics",
       "label": "postAnalytics()",
@@ -270754,7 +270886,7 @@
       "source_location": "L4"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "analytics_updateanalyticsowner",
       "label": "updateAnalyticsOwner()",
@@ -270763,7 +270895,7 @@
       "source_location": "L47"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_ts",
       "label": "analytics.ts",
@@ -270772,7 +270904,7 @@
       "source_location": "L1"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "category_getallcategories",
       "label": "getAllCategories()",
@@ -270781,7 +270913,7 @@
       "source_location": "L11"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "category_getallcategorieswithsubcategories",
       "label": "getAllCategoriesWithSubcategories()",
@@ -270790,7 +270922,7 @@
       "source_location": "L25"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "category_getbaseurl",
       "label": "getBaseUrl()",
@@ -270799,7 +270931,7 @@
       "source_location": "L9"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "category_getcategory",
       "label": "getCategory()",
@@ -270808,7 +270940,7 @@
       "source_location": "L39"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_category_ts",
       "label": "category.ts",
@@ -270817,7 +270949,7 @@
       "source_location": "L1"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "onlineorder_getbaseurl",
       "label": "getBaseUrl()",
@@ -270826,7 +270958,7 @@
       "source_location": "L4"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "onlineorder_getorder",
       "label": "getOrder()",
@@ -270835,7 +270967,7 @@
       "source_location": "L24"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "onlineorder_getorders",
       "label": "getOrders()",
@@ -270844,7 +270976,7 @@
       "source_location": "L6"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "onlineorder_updateordersowner",
       "label": "updateOrdersOwner()",
@@ -270853,7 +270985,7 @@
       "source_location": "L42"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -270862,7 +270994,7 @@
       "source_location": "L1"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefrontuser_ts",
       "label": "storeFrontUser.ts",
@@ -270871,7 +271003,7 @@
       "source_location": "L1"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "storefrontuser_getactiveuser",
       "label": "getActiveUser()",
@@ -270880,7 +271012,7 @@
       "source_location": "L28"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "storefrontuser_getbaseurl",
       "label": "getBaseUrl()",
@@ -270889,7 +271021,7 @@
       "source_location": "L5"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "storefrontuser_getguest",
       "label": "getGuest()",
@@ -270898,7 +271030,7 @@
       "source_location": "L7"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "storefrontuser_updateuser",
       "label": "updateUser()",
@@ -270907,7 +271039,7 @@
       "source_location": "L46"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "homepage_enableprompts",
       "label": "enablePrompts()",
@@ -270916,7 +271048,7 @@
       "source_location": "L137"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "homepage_handleclickonleavereviewbutton",
       "label": "handleClickOnLeaveReviewButton()",
@@ -270925,7 +271057,7 @@
       "source_location": "L176"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "homepage_handlescroll",
       "label": "handleScroll()",
@@ -270934,7 +271066,7 @@
       "source_location": "L105"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "homepage_homepagereadyshell",
       "label": "HomePageReadyShell()",
@@ -270943,7 +271075,7 @@
       "source_location": "L31"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_tsx",
       "label": "HomePage.tsx",
@@ -270952,7 +271084,7 @@
       "source_location": "L1"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "homepagecontent_resolvehomepagecontent",
       "label": "resolveHomepageContent()",
@@ -270961,7 +271093,7 @@
       "source_location": "L102"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "homepagecontent_todisplayproduct",
       "label": "toDisplayProduct()",
@@ -270970,7 +271102,7 @@
       "source_location": "L70"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "homepagecontent_todisplaysku",
       "label": "toDisplaySku()",
@@ -270979,7 +271111,7 @@
       "source_location": "L54"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "homepagecontent_tofeatureditem",
       "label": "toFeaturedItem()",
@@ -270988,7 +271120,7 @@
       "source_location": "L78"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
       "label": "homePageContent.ts",
@@ -270997,7 +271129,7 @@
       "source_location": "L1"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "inventorylevelbadge_lowstockbadge",
       "label": "LowStockBadge()",
@@ -271006,7 +271138,7 @@
       "source_location": "L14"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastbadge",
       "label": "SellingFastBadge()",
@@ -271015,7 +271147,7 @@
       "source_location": "L22"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastsignal",
       "label": "SellingFastSignal()",
@@ -271024,7 +271156,7 @@
       "source_location": "L30"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "inventorylevelbadge_soldoutbadge",
       "label": "SoldOutBadge()",
@@ -271033,58 +271165,13 @@
       "source_location": "L3"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_inventorylevelbadge_tsx",
       "label": "InventoryLevelBadge.tsx",
       "norm_label": "inventorylevelbadge.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_ts",
-      "label": "storefrontFailureObservability.ts",
-      "norm_label": "storefrontfailureobservability.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "storefrontfailureobservability_createstorefrontfailureevent",
-      "label": "createStorefrontFailureEvent()",
-      "norm_label": "createstorefrontfailureevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
-      "source_location": "L136"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "storefrontfailureobservability_emitstorefrontfailure",
-      "label": "emitStorefrontFailure()",
-      "norm_label": "emitstorefrontfailure()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
-      "source_location": "L154"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "storefrontfailureobservability_inferstorefrontjourneyfromroute",
-      "label": "inferStorefrontJourneyFromRoute()",
-      "norm_label": "inferstorefrontjourneyfromroute()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "storefrontfailureobservability_normalizestorefronterror",
-      "label": "normalizeStorefrontError()",
-      "norm_label": "normalizestorefronterror()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
-      "source_location": "L47"
     },
     {
       "community": 64,
@@ -271314,6 +271401,51 @@
     {
       "community": 640,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_ts",
+      "label": "storefrontFailureObservability.ts",
+      "norm_label": "storefrontfailureobservability.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 640,
+      "file_type": "code",
+      "id": "storefrontfailureobservability_createstorefrontfailureevent",
+      "label": "createStorefrontFailureEvent()",
+      "norm_label": "createstorefrontfailureevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
+      "source_location": "L136"
+    },
+    {
+      "community": 640,
+      "file_type": "code",
+      "id": "storefrontfailureobservability_emitstorefrontfailure",
+      "label": "emitStorefrontFailure()",
+      "norm_label": "emitstorefrontfailure()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
+      "source_location": "L154"
+    },
+    {
+      "community": 640,
+      "file_type": "code",
+      "id": "storefrontfailureobservability_inferstorefrontjourneyfromroute",
+      "label": "inferStorefrontJourneyFromRoute()",
+      "norm_label": "inferstorefrontjourneyfromroute()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 640,
+      "file_type": "code",
+      "id": "storefrontfailureobservability_normalizestorefronterror",
+      "label": "normalizeStorefrontError()",
+      "norm_label": "normalizestorefronterror()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
+      "source_location": "L47"
+    },
+    {
+      "community": 641,
+      "file_type": "code",
       "id": "check_register_session_authority_writers_checkregistersessionauthoritywriters",
       "label": "checkRegisterSessionAuthorityWriters()",
       "norm_label": "checkregistersessionauthoritywriters()",
@@ -271321,7 +271453,7 @@
       "source_location": "L127"
     },
     {
-      "community": 640,
+      "community": 641,
       "file_type": "code",
       "id": "check_register_session_authority_writers_collectregistersessionauthoritywriterfindings",
       "label": "collectRegisterSessionAuthorityWriterFindings()",
@@ -271330,7 +271462,7 @@
       "source_location": "L37"
     },
     {
-      "community": 640,
+      "community": 641,
       "file_type": "code",
       "id": "check_register_session_authority_writers_listtypescriptfiles",
       "label": "listTypeScriptFiles()",
@@ -271339,7 +271471,7 @@
       "source_location": "L111"
     },
     {
-      "community": 640,
+      "community": 641,
       "file_type": "code",
       "id": "check_register_session_authority_writers_normalizepath",
       "label": "normalizePath()",
@@ -271348,7 +271480,7 @@
       "source_location": "L33"
     },
     {
-      "community": 640,
+      "community": 641,
       "file_type": "code",
       "id": "scripts_check_register_session_authority_writers_ts",
       "label": "check-register-session-authority-writers.ts",
@@ -271357,7 +271489,7 @@
       "source_location": "L1"
     },
     {
-      "community": 641,
+      "community": 642,
       "file_type": "code",
       "id": "convex_node_env_test_resolveesbuildwithenv",
       "label": "resolveEsbuildWithEnv()",
@@ -271366,7 +271498,7 @@
       "source_location": "L48"
     },
     {
-      "community": 641,
+      "community": 642,
       "file_type": "code",
       "id": "convex_node_env_test_resolvewithenv",
       "label": "resolveWithEnv()",
@@ -271375,7 +271507,7 @@
       "source_location": "L26"
     },
     {
-      "community": 641,
+      "community": 642,
       "file_type": "code",
       "id": "convex_node_env_test_withtempdir",
       "label": "withTempDir()",
@@ -271384,7 +271516,7 @@
       "source_location": "L6"
     },
     {
-      "community": 641,
+      "community": 642,
       "file_type": "code",
       "id": "convex_node_env_test_writenodeshim",
       "label": "writeNodeShim()",
@@ -271393,7 +271525,7 @@
       "source_location": "L16"
     },
     {
-      "community": 641,
+      "community": 642,
       "file_type": "code",
       "id": "scripts_convex_node_env_test_ts",
       "label": "convex-node-env.test.ts",
@@ -271402,7 +271534,7 @@
       "source_location": "L1"
     },
     {
-      "community": 642,
+      "community": 643,
       "file_type": "code",
       "id": "harness_contract_preflight_test_createrealauditfixturedrift",
       "label": "createRealAuditFixtureDrift()",
@@ -271411,7 +271543,7 @@
       "source_location": "L63"
     },
     {
-      "community": 642,
+      "community": 643,
       "file_type": "code",
       "id": "harness_contract_preflight_test_createsiblingpolicyfixture",
       "label": "createSiblingPolicyFixture()",
@@ -271420,7 +271552,7 @@
       "source_location": "L37"
     },
     {
-      "community": 642,
+      "community": 643,
       "file_type": "code",
       "id": "harness_contract_preflight_test_runcomposedpreflight",
       "label": "runComposedPreflight()",
@@ -271429,7 +271561,7 @@
       "source_location": "L239"
     },
     {
-      "community": 642,
+      "community": 643,
       "file_type": "code",
       "id": "harness_contract_preflight_test_rungit",
       "label": "runGit()",
@@ -271438,7 +271570,7 @@
       "source_location": "L23"
     },
     {
-      "community": 642,
+      "community": 643,
       "file_type": "code",
       "id": "scripts_harness_contract_preflight_test_ts",
       "label": "harness-contract-preflight.test.ts",
@@ -271447,7 +271579,7 @@
       "source_location": "L1"
     },
     {
-      "community": 643,
+      "community": 644,
       "file_type": "code",
       "id": "harness_contract_preflight_errormessage",
       "label": "errorMessage()",
@@ -271456,7 +271588,7 @@
       "source_location": "L48"
     },
     {
-      "community": 643,
+      "community": 644,
       "file_type": "code",
       "id": "harness_contract_preflight_formathumanreport",
       "label": "formatHumanReport()",
@@ -271465,7 +271597,7 @@
       "source_location": "L84"
     },
     {
-      "community": 643,
+      "community": 644,
       "file_type": "code",
       "id": "harness_contract_preflight_runfocusedcontracttests",
       "label": "runFocusedContractTests()",
@@ -271474,7 +271606,7 @@
       "source_location": "L52"
     },
     {
-      "community": 643,
+      "community": 644,
       "file_type": "code",
       "id": "harness_contract_preflight_runharnesscontractpreflight",
       "label": "runHarnessContractPreflight()",
@@ -271483,7 +271615,7 @@
       "source_location": "L111"
     },
     {
-      "community": 643,
+      "community": 644,
       "file_type": "code",
       "id": "scripts_harness_contract_preflight_ts",
       "label": "harness-contract-preflight.ts",
@@ -271492,7 +271624,7 @@
       "source_location": "L1"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "harness_gate_obligations_test_evidence",
       "label": "evidence()",
@@ -271501,7 +271633,7 @@
       "source_location": "L25"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "harness_gate_obligations_test_input",
       "label": "input()",
@@ -271510,7 +271642,7 @@
       "source_location": "L45"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "harness_gate_obligations_test_resolution",
       "label": "resolution()",
@@ -271519,7 +271651,7 @@
       "source_location": "L77"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "harness_gate_obligations_test_waiverfor",
       "label": "waiverFor()",
@@ -271528,7 +271660,7 @@
       "source_location": "L527"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "scripts_harness_gate_obligations_test_ts",
       "label": "harness-gate-obligations.test.ts",
@@ -271537,7 +271669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "operational_work_repair_buildoperationalworkrepairinvocation",
       "label": "buildOperationalWorkRepairInvocation()",
@@ -271546,7 +271678,7 @@
       "source_location": "L57"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "operational_work_repair_main",
       "label": "main()",
@@ -271555,7 +271687,7 @@
       "source_location": "L73"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "operational_work_repair_parseoperationalworkrepairargs",
       "label": "parseOperationalWorkRepairArgs()",
@@ -271564,7 +271696,7 @@
       "source_location": "L14"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "operational_work_repair_requirevalue",
       "label": "requireValue()",
@@ -271573,7 +271705,7 @@
       "source_location": "L8"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "scripts_operational_work_repair_ts",
       "label": "operational-work-repair.ts",
@@ -271582,7 +271714,7 @@
       "source_location": "L1"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_log",
       "label": "log()",
@@ -271591,7 +271723,7 @@
       "source_location": "L81"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_spawn",
       "label": "spawn()",
@@ -271600,7 +271732,7 @@
       "source_location": "L73"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_withtemprepo",
       "label": "withTempRepo()",
@@ -271609,7 +271741,7 @@
       "source_location": "L14"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_writeconvexapifixture",
       "label": "writeConvexApiFixture()",
@@ -271618,7 +271750,7 @@
       "source_location": "L24"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "scripts_pre_commit_generated_artifacts_test_ts",
       "label": "pre-commit-generated-artifacts.test.ts",
@@ -271627,7 +271759,7 @@
       "source_location": "L1"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "pre_push_hook_test_createhookfixture",
       "label": "createHookFixture()",
@@ -271636,7 +271768,7 @@
       "source_location": "L20"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "pre_push_hook_test_isprocessalive",
       "label": "isProcessAlive()",
@@ -271645,7 +271777,7 @@
       "source_location": "L93"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "pre_push_hook_test_retainedlogpath",
       "label": "retainedLogPath()",
@@ -271654,7 +271786,7 @@
       "source_location": "L85"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "pre_push_hook_test_waitforfile",
       "label": "waitForFile()",
@@ -271663,7 +271795,7 @@
       "source_location": "L72"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "scripts_pre_push_hook_test_ts",
       "label": "pre-push-hook.test.ts",
@@ -271672,7 +271804,7 @@
       "source_location": "L1"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "pre_push_review_test_createblockedpublicgatefixture",
       "label": "createBlockedPublicGateFixture()",
@@ -271681,7 +271813,7 @@
       "source_location": "L36"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "pre_push_review_test_error",
       "label": "error()",
@@ -271690,7 +271822,7 @@
       "source_location": "L209"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "pre_push_review_test_log",
       "label": "log()",
@@ -271699,7 +271831,7 @@
       "source_location": "L207"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "pre_push_review_test_warn",
       "label": "warn()",
@@ -271708,57 +271840,12 @@
       "source_location": "L208"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "scripts_pre_push_review_test_ts",
       "label": "pre-push-review.test.ts",
       "norm_label": "pre-push-review.test.ts",
       "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "report_presentation_check_test_messages",
-      "label": "messages()",
-      "norm_label": "messages()",
-      "source_file": "scripts/report-presentation-check.test.ts",
-      "source_location": "L68"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "report_presentation_check_test_newreportmessages",
-      "label": "newReportMessages()",
-      "norm_label": "newreportmessages()",
-      "source_file": "scripts/report-presentation-check.test.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "report_presentation_check_test_quizquestion",
-      "label": "quizQuestion()",
-      "norm_label": "quizquestion()",
-      "source_file": "scripts/report-presentation-check.test.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "report_presentation_check_test_validreport",
-      "label": "validReport()",
-      "norm_label": "validreport()",
-      "source_file": "scripts/report-presentation-check.test.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "scripts_report_presentation_check_test_ts",
-      "label": "report-presentation-check.test.ts",
-      "norm_label": "report-presentation-check.test.ts",
-      "source_file": "scripts/report-presentation-check.test.ts",
       "source_location": "L1"
     },
     {
@@ -271989,6 +272076,51 @@
     {
       "community": 650,
       "file_type": "code",
+      "id": "report_presentation_check_test_messages",
+      "label": "messages()",
+      "norm_label": "messages()",
+      "source_file": "scripts/report-presentation-check.test.ts",
+      "source_location": "L68"
+    },
+    {
+      "community": 650,
+      "file_type": "code",
+      "id": "report_presentation_check_test_newreportmessages",
+      "label": "newReportMessages()",
+      "norm_label": "newreportmessages()",
+      "source_file": "scripts/report-presentation-check.test.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 650,
+      "file_type": "code",
+      "id": "report_presentation_check_test_quizquestion",
+      "label": "quizQuestion()",
+      "norm_label": "quizquestion()",
+      "source_file": "scripts/report-presentation-check.test.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 650,
+      "file_type": "code",
+      "id": "report_presentation_check_test_validreport",
+      "label": "validReport()",
+      "norm_label": "validreport()",
+      "source_file": "scripts/report-presentation-check.test.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 650,
+      "file_type": "code",
+      "id": "scripts_report_presentation_check_test_ts",
+      "label": "report-presentation-check.test.ts",
+      "norm_label": "report-presentation-check.test.ts",
+      "source_file": "scripts/report-presentation-check.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 651,
+      "file_type": "code",
       "id": "scripts_worktree_manager_test_ts",
       "label": "worktree-manager.test.ts",
       "norm_label": "worktree-manager.test.ts",
@@ -271996,7 +272128,7 @@
       "source_location": "L1"
     },
     {
-      "community": 650,
+      "community": 651,
       "file_type": "code",
       "id": "worktree_manager_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -272005,7 +272137,7 @@
       "source_location": "L17"
     },
     {
-      "community": 650,
+      "community": 651,
       "file_type": "code",
       "id": "worktree_manager_test_fixtureenv",
       "label": "fixtureEnv()",
@@ -272014,7 +272146,7 @@
       "source_location": "L73"
     },
     {
-      "community": 650,
+      "community": 651,
       "file_type": "code",
       "id": "worktree_manager_test_rungit",
       "label": "runGit()",
@@ -272023,7 +272155,7 @@
       "source_location": "L45"
     },
     {
-      "community": 650,
+      "community": 651,
       "file_type": "code",
       "id": "worktree_manager_test_runworktreemanager",
       "label": "runWorktreeManager()",
@@ -272032,7 +272164,7 @@
       "source_location": "L60"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "actionregistry_automationactionkey",
       "label": "automationActionKey()",
@@ -272041,7 +272173,7 @@
       "source_location": "L22"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "actionregistry_defineautomationaction",
       "label": "defineAutomationAction()",
@@ -272050,7 +272182,7 @@
       "source_location": "L29"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "actionregistry_registerautomationactions",
       "label": "registerAutomationActions()",
@@ -272059,7 +272191,7 @@
       "source_location": "L47"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_automation_actionregistry_ts",
       "label": "actionRegistry.ts",
@@ -272068,7 +272200,7 @@
       "source_location": "L1"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "automationfoundation_evaluateautomationactionwithctx",
       "label": "evaluateAutomationActionWithCtx()",
@@ -272077,7 +272209,7 @@
       "source_location": "L77"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "automationfoundation_isvalidoperatingdate",
       "label": "isValidOperatingDate()",
@@ -272086,7 +272218,7 @@
       "source_location": "L43"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "automationfoundation_validateadapterdecision",
       "label": "validateAdapterDecision()",
@@ -272095,7 +272227,7 @@
       "source_location": "L56"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_automation_automationfoundation_ts",
       "label": "automationFoundation.ts",
@@ -272104,7 +272236,7 @@
       "source_location": "L1"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "contextevents_test_buildcontexteventctx",
       "label": "buildContextEventCtx()",
@@ -272113,7 +272245,7 @@
       "source_location": "L247"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "contextevents_test_buildcontexteventquery",
       "label": "buildContextEventQuery()",
@@ -272122,7 +272254,7 @@
       "source_location": "L272"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "contextevents_test_gethandler",
       "label": "getHandler()",
@@ -272131,7 +272263,7 @@
       "source_location": "L12"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_contexttracking_contextevents_test_ts",
       "label": "contextEvents.test.ts",
@@ -272140,7 +272272,7 @@
       "source_location": "L1"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_test_createtemproot",
       "label": "createTempRoot()",
@@ -272149,7 +272281,7 @@
       "source_location": "L12"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_test_runpaginationcheck",
       "label": "runPaginationCheck()",
@@ -272158,7 +272290,7 @@
       "source_location": "L26"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_test_writeconvexfile",
       "label": "writeConvexFile()",
@@ -272167,7 +272299,7 @@
       "source_location": "L20"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convexpaginationantipatterncheck_test_ts",
       "label": "convexPaginationAntiPatternCheck.test.ts",
@@ -272176,7 +272308,7 @@
       "source_location": "L1"
     },
     {
-      "community": 655,
+      "community": 656,
       "file_type": "code",
       "id": "domain_maskreceiptphone",
       "label": "maskReceiptPhone()",
@@ -272185,7 +272317,7 @@
       "source_location": "L67"
     },
     {
-      "community": 655,
+      "community": 656,
       "file_type": "code",
       "id": "domain_normalizereceiptphone",
       "label": "normalizeReceiptPhone()",
@@ -272194,7 +272326,7 @@
       "source_location": "L52"
     },
     {
-      "community": 655,
+      "community": 656,
       "file_type": "code",
       "id": "domain_statusisretryable",
       "label": "statusIsRetryable()",
@@ -272203,7 +272335,7 @@
       "source_location": "L79"
     },
     {
-      "community": 655,
+      "community": 656,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_domain_ts",
       "label": "domain.ts",
@@ -272212,7 +272344,7 @@
       "source_location": "L1"
     },
     {
-      "community": 656,
+      "community": 657,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_token_ts",
       "label": "token.ts",
@@ -272221,7 +272353,7 @@
       "source_location": "L1"
     },
     {
-      "community": 656,
+      "community": 657,
       "file_type": "code",
       "id": "token_createreceiptsharetoken",
       "label": "createReceiptShareToken()",
@@ -272230,7 +272362,7 @@
       "source_location": "L9"
     },
     {
-      "community": 656,
+      "community": 657,
       "file_type": "code",
       "id": "token_hashreceiptsharetoken",
       "label": "hashReceiptShareToken()",
@@ -272239,7 +272371,7 @@
       "source_location": "L15"
     },
     {
-      "community": 656,
+      "community": 657,
       "file_type": "code",
       "id": "token_tohex",
       "label": "toHex()",
@@ -272248,7 +272380,7 @@
       "source_location": "L3"
     },
     {
-      "community": 657,
+      "community": 658,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_webhooksecurity_ts",
       "label": "webhookSecurity.ts",
@@ -272257,7 +272389,7 @@
       "source_location": "L1"
     },
     {
-      "community": 657,
+      "community": 658,
       "file_type": "code",
       "id": "webhooksecurity_timingsafeequal",
       "label": "timingSafeEqual()",
@@ -272266,7 +272398,7 @@
       "source_location": "L9"
     },
     {
-      "community": 657,
+      "community": 658,
       "file_type": "code",
       "id": "webhooksecurity_tohex",
       "label": "toHex()",
@@ -272275,7 +272407,7 @@
       "source_location": "L3"
     },
     {
-      "community": 657,
+      "community": 658,
       "file_type": "code",
       "id": "webhooksecurity_verifymetawebhooksignature",
       "label": "verifyMetaWebhookSignature()",
@@ -272284,7 +272416,7 @@
       "source_location": "L22"
     },
     {
-      "community": 658,
+      "community": 659,
       "file_type": "code",
       "id": "categories_removestorefronthiddencategories",
       "label": "removeStorefrontHiddenCategories()",
@@ -272293,7 +272425,7 @@
       "source_location": "L23"
     },
     {
-      "community": 658,
+      "community": 659,
       "file_type": "code",
       "id": "categories_removestorefronthiddensubcategories",
       "label": "removeStorefrontHiddenSubcategories()",
@@ -272302,7 +272434,7 @@
       "source_location": "L31"
     },
     {
-      "community": 658,
+      "community": 659,
       "file_type": "code",
       "id": "categories_shouldshowcategoryonstorefront",
       "label": "shouldShowCategoryOnStorefront()",
@@ -272311,48 +272443,12 @@
       "source_location": "L12"
     },
     {
-      "community": 658,
+      "community": 659,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_categories_ts",
       "label": "categories.ts",
       "norm_label": "categories.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/core/routes/categories.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "checkout_hasallvisibilesessionitems",
-      "label": "hasAllVisibileSessionItems()",
-      "norm_label": "hasallvisibilesessionitems()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/checkout.ts",
-      "source_location": "L109"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "checkout_hasvalidcanonicalbagitem",
-      "label": "hasValidCanonicalBagItem()",
-      "norm_label": "hasvalidcanonicalbagitem()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/checkout.ts",
-      "source_location": "L84"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "checkout_hasvalidsessionitems",
-      "label": "hasValidSessionItems()",
-      "norm_label": "hasvalidsessionitems()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/checkout.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_checkout_ts",
-      "label": "checkout.ts",
-      "norm_label": "checkout.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/checkout.ts",
       "source_location": "L1"
     },
     {
@@ -272583,6 +272679,42 @@
     {
       "community": 660,
       "file_type": "code",
+      "id": "checkout_hasallvisibilesessionitems",
+      "label": "hasAllVisibileSessionItems()",
+      "norm_label": "hasallvisibilesessionitems()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/checkout.ts",
+      "source_location": "L109"
+    },
+    {
+      "community": 660,
+      "file_type": "code",
+      "id": "checkout_hasvalidcanonicalbagitem",
+      "label": "hasValidCanonicalBagItem()",
+      "norm_label": "hasvalidcanonicalbagitem()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/checkout.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 660,
+      "file_type": "code",
+      "id": "checkout_hasvalidsessionitems",
+      "label": "hasValidSessionItems()",
+      "norm_label": "hasvalidsessionitems()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/checkout.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 660,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_checkout_ts",
+      "label": "checkout.ts",
+      "norm_label": "checkout.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/checkout.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 661,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_utils_ts",
       "label": "utils.ts",
       "norm_label": "utils.ts",
@@ -272590,7 +272722,7 @@
       "source_location": "L1"
     },
     {
-      "community": 660,
+      "community": 661,
       "file_type": "code",
       "id": "utils_getstoredatafromrequest",
       "label": "getStoreDataFromRequest()",
@@ -272599,7 +272731,7 @@
       "source_location": "L5"
     },
     {
-      "community": 660,
+      "community": 661,
       "file_type": "code",
       "id": "utils_getstorefrontactorfromrequest",
       "label": "getStorefrontActorFromRequest()",
@@ -272608,7 +272740,7 @@
       "source_location": "L19"
     },
     {
-      "community": 660,
+      "community": 661,
       "file_type": "code",
       "id": "utils_getstorefrontuserfromrequest",
       "label": "getStorefrontUserFromRequest()",
@@ -272617,7 +272749,7 @@
       "source_location": "L12"
     },
     {
-      "community": 661,
+      "community": 662,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_intelligence_runs_test_ts",
       "label": "runs.test.ts",
@@ -272626,7 +272758,7 @@
       "source_location": "L1"
     },
     {
-      "community": 661,
+      "community": 662,
       "file_type": "code",
       "id": "runs_test_baseensurerunargs",
       "label": "baseEnsureRunArgs()",
@@ -272635,7 +272767,7 @@
       "source_location": "L600"
     },
     {
-      "community": 661,
+      "community": 662,
       "file_type": "code",
       "id": "runs_test_createdebugqueryrecorder",
       "label": "createDebugQueryRecorder()",
@@ -272644,7 +272776,7 @@
       "source_location": "L616"
     },
     {
-      "community": 661,
+      "community": 662,
       "file_type": "code",
       "id": "runs_test_gethandler",
       "label": "getHandler()",
@@ -272653,7 +272785,7 @@
       "source_location": "L596"
     },
     {
-      "community": 662,
+      "community": 663,
       "file_type": "code",
       "id": "bannermessage_normalizedisplaytext",
       "label": "normalizeDisplayText()",
@@ -272662,7 +272794,7 @@
       "source_location": "L63"
     },
     {
-      "community": 662,
+      "community": 663,
       "file_type": "code",
       "id": "bannermessage_presentpublicbannermessage",
       "label": "presentPublicBannerMessage()",
@@ -272671,7 +272803,7 @@
       "source_location": "L68"
     },
     {
-      "community": 662,
+      "community": 663,
       "file_type": "code",
       "id": "bannermessage_requirehomepagestoreadmin",
       "label": "requireHomepageStoreAdmin()",
@@ -272680,7 +272812,7 @@
       "source_location": "L34"
     },
     {
-      "community": 662,
+      "community": 663,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -272689,7 +272821,7 @@
       "source_location": "L1"
     },
     {
-      "community": 663,
+      "community": 664,
       "file_type": "code",
       "id": "bestseller_getnextbestsellerrank",
       "label": "getNextBestSellerRank()",
@@ -272698,7 +272830,7 @@
       "source_location": "L66"
     },
     {
-      "community": 663,
+      "community": 664,
       "file_type": "code",
       "id": "bestseller_requirehomepagestoreadmin",
       "label": "requireHomepageStoreAdmin()",
@@ -272707,7 +272839,7 @@
       "source_location": "L20"
     },
     {
-      "community": 663,
+      "community": 664,
       "file_type": "code",
       "id": "bestseller_validatebestsellerplacement",
       "label": "validateBestSellerPlacement()",
@@ -272716,7 +272848,7 @@
       "source_location": "L40"
     },
     {
-      "community": 663,
+      "community": 664,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -272725,7 +272857,7 @@
       "source_location": "L1"
     },
     {
-      "community": 664,
+      "community": 665,
       "file_type": "code",
       "id": "catalogsummary_computecatalogsummary",
       "label": "computeCatalogSummary()",
@@ -272734,7 +272866,7 @@
       "source_location": "L23"
     },
     {
-      "community": 664,
+      "community": 665,
       "file_type": "code",
       "id": "catalogsummary_markcatalogsummaryneedsrefresh",
       "label": "markCatalogSummaryNeedsRefresh()",
@@ -272743,7 +272875,7 @@
       "source_location": "L101"
     },
     {
-      "community": 664,
+      "community": 665,
       "file_type": "code",
       "id": "catalogsummary_refreshcatalogsummarywithctx",
       "label": "refreshCatalogSummaryWithCtx()",
@@ -272752,7 +272884,7 @@
       "source_location": "L77"
     },
     {
-      "community": 664,
+      "community": 665,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_catalogsummary_ts",
       "label": "catalogSummary.ts",
@@ -272761,7 +272893,7 @@
       "source_location": "L1"
     },
     {
-      "community": 665,
+      "community": 666,
       "file_type": "code",
       "id": "expensesessions_test_buildsession",
       "label": "buildSession()",
@@ -272770,7 +272902,7 @@
       "source_location": "L280"
     },
     {
-      "community": 665,
+      "community": 666,
       "file_type": "code",
       "id": "expensesessions_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -272779,7 +272911,7 @@
       "source_location": "L98"
     },
     {
-      "community": 665,
+      "community": 666,
       "file_type": "code",
       "id": "expensesessions_test_gethandler",
       "label": "getHandler()",
@@ -272788,7 +272920,7 @@
       "source_location": "L295"
     },
     {
-      "community": 665,
+      "community": 666,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessions_test_ts",
       "label": "expenseSessions.test.ts",
@@ -272797,7 +272929,7 @@
       "source_location": "L1"
     },
     {
-      "community": 666,
+      "community": 667,
       "file_type": "code",
       "id": "expensesessionexpiration_calculateexpensesessionexpiration",
       "label": "calculateExpenseSessionExpiration()",
@@ -272806,7 +272938,7 @@
       "source_location": "L21"
     },
     {
-      "community": 666,
+      "community": 667,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpiryduration",
       "label": "getExpenseSessionExpiryDuration()",
@@ -272815,7 +272947,7 @@
       "source_location": "L35"
     },
     {
-      "community": 666,
+      "community": 667,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpirydurationminutes",
       "label": "getExpenseSessionExpiryDurationMinutes()",
@@ -272824,7 +272956,7 @@
       "source_location": "L45"
     },
     {
-      "community": 666,
+      "community": 667,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionexpiration_ts",
       "label": "expenseSessionExpiration.ts",
@@ -272833,7 +272965,7 @@
       "source_location": "L1"
     },
     {
-      "community": 667,
+      "community": 668,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_sessionexpiration_ts",
       "label": "sessionExpiration.ts",
@@ -272842,7 +272974,7 @@
       "source_location": "L1"
     },
     {
-      "community": 667,
+      "community": 668,
       "file_type": "code",
       "id": "sessionexpiration_calculatesessionexpiration",
       "label": "calculateSessionExpiration()",
@@ -272851,7 +272983,7 @@
       "source_location": "L21"
     },
     {
-      "community": 667,
+      "community": 668,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpiryduration",
       "label": "getSessionExpiryDuration()",
@@ -272860,7 +272992,7 @@
       "source_location": "L35"
     },
     {
-      "community": 667,
+      "community": 668,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpirydurationminutes",
       "label": "getSessionExpiryDurationMinutes()",
@@ -272869,7 +273001,7 @@
       "source_location": "L45"
     },
     {
-      "community": 668,
+      "community": 669,
       "file_type": "code",
       "id": "inventoryimportcostoverlay_test_createpublicmutationharness",
       "label": "createPublicMutationHarness()",
@@ -272878,7 +273010,7 @@
       "source_location": "L96"
     },
     {
-      "community": 668,
+      "community": 669,
       "file_type": "code",
       "id": "inventoryimportcostoverlay_test_gethandler",
       "label": "getHandler()",
@@ -272887,7 +273019,7 @@
       "source_location": "L58"
     },
     {
-      "community": 668,
+      "community": 669,
       "file_type": "code",
       "id": "inventoryimportcostoverlay_test_overlayrun",
       "label": "overlayRun()",
@@ -272896,48 +273028,12 @@
       "source_location": "L203"
     },
     {
-      "community": 668,
+      "community": 669,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_inventoryimportcostoverlay_test_ts",
       "label": "inventoryImportCostOverlay.test.ts",
       "norm_label": "inventoryimportcostoverlay.test.ts",
       "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlay.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlaylineage_canonicalizecostoverlaylineages",
-      "label": "canonicalizeCostOverlayLineages()",
-      "norm_label": "canonicalizecostoverlaylineages()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayLineage.ts",
-      "source_location": "L22"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlaylineage_frozencostoverlaylineagesmatch",
-      "label": "frozenCostOverlayLineagesMatch()",
-      "norm_label": "frozencostoverlaylineagesmatch()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayLineage.ts",
-      "source_location": "L39"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlaylineage_readcostoverlayskulineageswithctx",
-      "label": "readCostOverlaySkuLineagesWithCtx()",
-      "norm_label": "readcostoverlayskulineageswithctx()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayLineage.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_inventoryimportcostoverlaylineage_ts",
-      "label": "inventoryImportCostOverlayLineage.ts",
-      "norm_label": "inventoryimportcostoverlaylineage.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayLineage.ts",
       "source_location": "L1"
     },
     {
@@ -273168,6 +273264,42 @@
     {
       "community": 670,
       "file_type": "code",
+      "id": "inventoryimportcostoverlaylineage_canonicalizecostoverlaylineages",
+      "label": "canonicalizeCostOverlayLineages()",
+      "norm_label": "canonicalizecostoverlaylineages()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayLineage.ts",
+      "source_location": "L22"
+    },
+    {
+      "community": 670,
+      "file_type": "code",
+      "id": "inventoryimportcostoverlaylineage_frozencostoverlaylineagesmatch",
+      "label": "frozenCostOverlayLineagesMatch()",
+      "norm_label": "frozencostoverlaylineagesmatch()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayLineage.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 670,
+      "file_type": "code",
+      "id": "inventoryimportcostoverlaylineage_readcostoverlayskulineageswithctx",
+      "label": "readCostOverlaySkuLineagesWithCtx()",
+      "norm_label": "readcostoverlayskulineageswithctx()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayLineage.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 670,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_inventoryimportcostoverlaylineage_ts",
+      "label": "inventoryImportCostOverlayLineage.ts",
+      "norm_label": "inventoryimportcostoverlaylineage.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayLineage.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 671,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessionitems_ts",
       "label": "posSessionItems.ts",
       "norm_label": "possessionitems.ts",
@@ -273175,7 +273307,7 @@
       "source_location": "L1"
     },
     {
-      "community": 670,
+      "community": 671,
       "file_type": "code",
       "id": "possessionitems_requiresessionitemreadaccess",
       "label": "requireSessionItemReadAccess()",
@@ -273184,7 +273316,7 @@
       "source_location": "L95"
     },
     {
-      "community": 670,
+      "community": 671,
       "file_type": "code",
       "id": "possessionitems_requiresessionitemstoreaccess",
       "label": "requireSessionItemStoreAccess()",
@@ -273193,7 +273325,7 @@
       "source_location": "L64"
     },
     {
-      "community": 670,
+      "community": 671,
       "file_type": "code",
       "id": "possessionitems_usererrorfromsessionitemfailure",
       "label": "userErrorFromSessionItemFailure()",
@@ -273202,7 +273334,7 @@
       "source_location": "L36"
     },
     {
-      "community": 671,
+      "community": 672,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessions_trace_test_ts",
       "label": "posSessions.trace.test.ts",
@@ -273211,7 +273343,7 @@
       "source_location": "L1"
     },
     {
-      "community": 671,
+      "community": 672,
       "file_type": "code",
       "id": "possessions_trace_test_buildsession",
       "label": "buildSession()",
@@ -273220,7 +273352,7 @@
       "source_location": "L613"
     },
     {
-      "community": 671,
+      "community": 672,
       "file_type": "code",
       "id": "possessions_trace_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -273229,7 +273361,7 @@
       "source_location": "L240"
     },
     {
-      "community": 671,
+      "community": 672,
       "file_type": "code",
       "id": "possessions_trace_test_gethandler",
       "label": "getHandler()",
@@ -273238,7 +273370,7 @@
       "source_location": "L637"
     },
     {
-      "community": 672,
+      "community": 673,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_skusearch_test_ts",
       "label": "skuSearch.test.ts",
@@ -273247,7 +273379,7 @@
       "source_location": "L1"
     },
     {
-      "community": 672,
+      "community": 673,
       "file_type": "code",
       "id": "skusearch_test_baseseed",
       "label": "baseSeed()",
@@ -273256,7 +273388,7 @@
       "source_location": "L275"
     },
     {
-      "community": 672,
+      "community": 673,
       "file_type": "code",
       "id": "skusearch_test_createctx",
       "label": "createCtx()",
@@ -273265,7 +273397,7 @@
       "source_location": "L62"
     },
     {
-      "community": 672,
+      "community": 673,
       "file_type": "code",
       "id": "skusearch_test_gethandler",
       "label": "getHandler()",
@@ -273274,7 +273406,7 @@
       "source_location": "L58"
     },
     {
-      "community": 673,
+      "community": 674,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stores_test_ts",
       "label": "stores.test.ts",
@@ -273283,7 +273415,7 @@
       "source_location": "L1"
     },
     {
-      "community": 673,
+      "community": 674,
       "file_type": "code",
       "id": "stores_test_createstorewithcurrency",
       "label": "createStoreWithCurrency()",
@@ -273292,7 +273424,7 @@
       "source_location": "L76"
     },
     {
-      "community": 673,
+      "community": 674,
       "file_type": "code",
       "id": "stores_test_seedstore",
       "label": "seedStore()",
@@ -273301,7 +273433,7 @@
       "source_location": "L28"
     },
     {
-      "community": 673,
+      "community": 674,
       "file_type": "code",
       "id": "stores_test_weeklyrowcounts",
       "label": "weeklyRowCounts()",
@@ -273310,7 +273442,7 @@
       "source_location": "L45"
     },
     {
-      "community": 674,
+      "community": 675,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stores_ts",
       "label": "stores.ts",
@@ -273319,7 +273451,7 @@
       "source_location": "L1"
     },
     {
-      "community": 674,
+      "community": 675,
       "file_type": "code",
       "id": "stores_deleteweeklyreportingforstorewithctx",
       "label": "deleteWeeklyReportingForStoreWithCtx()",
@@ -273328,7 +273460,7 @@
       "source_location": "L47"
     },
     {
-      "community": 674,
+      "community": 675,
       "file_type": "code",
       "id": "stores_removestorewithctx",
       "label": "removeStoreWithCtx()",
@@ -273337,7 +273469,7 @@
       "source_location": "L80"
     },
     {
-      "community": 674,
+      "community": 675,
       "file_type": "code",
       "id": "stores_tov2onlyconfig",
       "label": "toV2OnlyConfig()",
@@ -273346,7 +273478,7 @@
       "source_location": "L105"
     },
     {
-      "community": 675,
+      "community": 676,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventoryledger_valuation_test_ts",
       "label": "valuation.test.ts",
@@ -273355,7 +273487,7 @@
       "source_location": "L1"
     },
     {
-      "community": 675,
+      "community": 676,
       "file_type": "code",
       "id": "valuation_test_deficitlot",
       "label": "deficitLot()",
@@ -273364,7 +273496,7 @@
       "source_location": "L38"
     },
     {
-      "community": 675,
+      "community": 676,
       "file_type": "code",
       "id": "valuation_test_knownposition",
       "label": "knownPosition()",
@@ -273373,7 +273505,7 @@
       "source_location": "L23"
     },
     {
-      "community": 675,
+      "community": 676,
       "file_type": "code",
       "id": "valuation_test_outboundbasis",
       "label": "outboundBasis()",
@@ -273382,7 +273514,7 @@
       "source_location": "L51"
     },
     {
-      "community": 676,
+      "community": 677,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_marketing_walkthroughrequestretention_ts",
       "label": "walkthroughRequestRetention.ts",
@@ -273391,7 +273523,7 @@
       "source_location": "L1"
     },
     {
-      "community": 676,
+      "community": 677,
       "file_type": "code",
       "id": "walkthroughrequestretention_boundedauditvalue",
       "label": "boundedAuditValue()",
@@ -273400,7 +273532,7 @@
       "source_location": "L70"
     },
     {
-      "community": 676,
+      "community": 677,
       "file_type": "code",
       "id": "walkthroughrequestretention_consumeprivacychallenge",
       "label": "consumePrivacyChallenge()",
@@ -273409,7 +273541,7 @@
       "source_location": "L76"
     },
     {
-      "community": 676,
+      "community": 677,
       "file_type": "code",
       "id": "walkthroughrequestretention_retentiondecision",
       "label": "retentionDecision()",
@@ -273418,7 +273550,7 @@
       "source_location": "L16"
     },
     {
-      "community": 677,
+      "community": 678,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_marketing_walkthroughrequests_ts",
       "label": "walkthroughRequests.ts",
@@ -273427,7 +273559,7 @@
       "source_location": "L1"
     },
     {
-      "community": 677,
+      "community": 678,
       "file_type": "code",
       "id": "walkthroughrequests_audit",
       "label": "audit()",
@@ -273436,7 +273568,7 @@
       "source_location": "L165"
     },
     {
-      "community": 677,
+      "community": 678,
       "file_type": "code",
       "id": "walkthroughrequests_boundedtext",
       "label": "boundedText()",
@@ -273445,7 +273577,7 @@
       "source_location": "L22"
     },
     {
-      "community": 677,
+      "community": 678,
       "file_type": "code",
       "id": "walkthroughrequests_keyedfingerprint",
       "label": "keyedFingerprint()",
@@ -273454,7 +273586,7 @@
       "source_location": "L28"
     },
     {
-      "community": 678,
+      "community": 679,
       "file_type": "code",
       "id": "backfillstorecurrencycase_test_createctx",
       "label": "createCtx()",
@@ -273463,7 +273595,7 @@
       "source_location": "L13"
     },
     {
-      "community": 678,
+      "community": 679,
       "file_type": "code",
       "id": "backfillstorecurrencycase_test_finishbackfill",
       "label": "finishBackfill()",
@@ -273472,7 +273604,7 @@
       "source_location": "L51"
     },
     {
-      "community": 678,
+      "community": 679,
       "file_type": "code",
       "id": "backfillstorecurrencycase_test_finishverification",
       "label": "finishVerification()",
@@ -273481,48 +273613,12 @@
       "source_location": "L72"
     },
     {
-      "community": 678,
+      "community": 679,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_backfillstorecurrencycase_test_ts",
       "label": "backfillStoreCurrencyCase.test.ts",
       "norm_label": "backfillstorecurrencycase.test.ts",
       "source_file": "packages/athena-webapp/convex/migrations/backfillStoreCurrencyCase.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "collections_getcachedtokenrecord",
-      "label": "getCachedTokenRecord()",
-      "norm_label": "getcachedtokenrecord()",
-      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "collections_resolveaccesstokenforstore",
-      "label": "resolveAccessTokenForStore()",
-      "norm_label": "resolveaccesstokenforstore()",
-      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
-      "source_location": "L79"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "collections_resolveconfigforstore",
-      "label": "resolveConfigForStore()",
-      "norm_label": "resolveconfigforstore()",
-      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_collections_ts",
-      "label": "collections.ts",
-      "norm_label": "collections.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
       "source_location": "L1"
     },
     {
@@ -273744,6 +273840,42 @@
     {
       "community": 680,
       "file_type": "code",
+      "id": "collections_getcachedtokenrecord",
+      "label": "getCachedTokenRecord()",
+      "norm_label": "getcachedtokenrecord()",
+      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 680,
+      "file_type": "code",
+      "id": "collections_resolveaccesstokenforstore",
+      "label": "resolveAccessTokenForStore()",
+      "norm_label": "resolveaccesstokenforstore()",
+      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
+      "source_location": "L79"
+    },
+    {
+      "community": 680,
+      "file_type": "code",
+      "id": "collections_resolveconfigforstore",
+      "label": "resolveConfigForStore()",
+      "norm_label": "resolveconfigforstore()",
+      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 680,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_collections_ts",
+      "label": "collections.ts",
+      "norm_label": "collections.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 681,
+      "file_type": "code",
       "id": "normalize_maskmtnpartyid",
       "label": "maskMtnPartyId()",
       "norm_label": "maskmtnpartyid()",
@@ -273751,7 +273883,7 @@
       "source_location": "L10"
     },
     {
-      "community": 680,
+      "community": 681,
       "file_type": "code",
       "id": "normalize_normalizecollectionstransaction",
       "label": "normalizeCollectionsTransaction()",
@@ -273760,7 +273892,7 @@
       "source_location": "L18"
     },
     {
-      "community": 680,
+      "community": 681,
       "file_type": "code",
       "id": "normalize_parsecollectionsnotificationrequest",
       "label": "parseCollectionsNotificationRequest()",
@@ -273769,49 +273901,13 @@
       "source_location": "L52"
     },
     {
-      "community": 680,
+      "community": 681,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_ts",
       "label": "normalize.ts",
       "norm_label": "normalize.ts",
       "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 681,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_notifications_registry_ts",
-      "label": "registry.ts",
-      "norm_label": "registry.ts",
-      "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 681,
-      "file_type": "code",
-      "id": "registry_findnotificationkind",
-      "label": "findNotificationKind()",
-      "norm_label": "findnotificationkind()",
-      "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
-      "source_location": "L395"
-    },
-    {
-      "community": 681,
-      "file_type": "code",
-      "id": "registry_getnotificationkind",
-      "label": "getNotificationKind()",
-      "norm_label": "getnotificationkind()",
-      "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
-      "source_location": "L405"
-    },
-    {
-      "community": 681,
-      "file_type": "code",
-      "id": "registry_listnotificationkinds",
-      "label": "listNotificationKinds()",
-      "norm_label": "listnotificationkinds()",
-      "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
-      "source_location": "L413"
     },
     {
       "community": 682,
@@ -274500,42 +274596,6 @@
     {
       "community": 695,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_register_test_ts",
-      "label": "register.test.ts",
-      "norm_label": "register.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 695,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_public_register_test_ts",
-      "label": "register.test.ts",
-      "norm_label": "register.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 695,
-      "file_type": "code",
-      "id": "register_test_buildctx",
-      "label": "buildCtx()",
-      "norm_label": "buildctx()",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 695,
-      "file_type": "code",
-      "id": "register_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 696,
-      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
       "label": "register.ts",
       "norm_label": "register.ts",
@@ -274543,7 +274603,7 @@
       "source_location": "L1"
     },
     {
-      "community": 696,
+      "community": 695,
       "file_type": "code",
       "id": "register_mapopendrawerusererror",
       "label": "mapOpenDrawerUserError()",
@@ -274552,7 +274612,7 @@
       "source_location": "L34"
     },
     {
-      "community": 696,
+      "community": 695,
       "file_type": "code",
       "id": "register_normalizeregisternumber",
       "label": "normalizeRegisterNumber()",
@@ -274561,7 +274621,7 @@
       "source_location": "L29"
     },
     {
-      "community": 696,
+      "community": 695,
       "file_type": "code",
       "id": "register_opendrawer",
       "label": "openDrawer()",
@@ -274570,7 +274630,7 @@
       "source_location": "L56"
     },
     {
-      "community": 697,
+      "community": 696,
       "file_type": "code",
       "id": "opendrawer_test_createdbgetmock",
       "label": "createDbGetMock()",
@@ -274579,7 +274639,7 @@
       "source_location": "L39"
     },
     {
-      "community": 697,
+      "community": 696,
       "file_type": "code",
       "id": "opendrawer_test_createdbmock",
       "label": "createDbMock()",
@@ -274588,7 +274648,7 @@
       "source_location": "L99"
     },
     {
-      "community": 697,
+      "community": 696,
       "file_type": "code",
       "id": "opendrawer_test_createdbquerymock",
       "label": "createDbQueryMock()",
@@ -274597,7 +274657,7 @@
       "source_location": "L74"
     },
     {
-      "community": 697,
+      "community": 696,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_opendrawer_test_ts",
       "label": "openDrawer.test.ts",
@@ -274606,7 +274666,7 @@
       "source_location": "L1"
     },
     {
-      "community": 698,
+      "community": 697,
       "file_type": "code",
       "id": "getregisterstate_buildregisterstate",
       "label": "buildRegisterState()",
@@ -274615,7 +274675,7 @@
       "source_location": "L21"
     },
     {
-      "community": 698,
+      "community": 697,
       "file_type": "code",
       "id": "getregisterstate_getactivesessionconflictforregisterstate",
       "label": "getActiveSessionConflictForRegisterState()",
@@ -274624,7 +274684,7 @@
       "source_location": "L42"
     },
     {
-      "community": 698,
+      "community": 697,
       "file_type": "code",
       "id": "getregisterstate_getregisterstate",
       "label": "getRegisterState()",
@@ -274633,7 +274693,7 @@
       "source_location": "L80"
     },
     {
-      "community": 698,
+      "community": 697,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
       "label": "getRegisterState.ts",
@@ -274642,7 +274702,7 @@
       "source_location": "L1"
     },
     {
-      "community": 699,
+      "community": 698,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_storepulse_test_ts",
       "label": "storePulse.test.ts",
@@ -274651,7 +274711,7 @@
       "source_location": "L1"
     },
     {
-      "community": 699,
+      "community": 698,
       "file_type": "code",
       "id": "storepulse_test_createdb",
       "label": "createDb()",
@@ -274660,7 +274720,7 @@
       "source_location": "L12"
     },
     {
-      "community": 699,
+      "community": 698,
       "file_type": "code",
       "id": "storepulse_test_item",
       "label": "item()",
@@ -274669,13 +274729,49 @@
       "source_location": "L127"
     },
     {
-      "community": 699,
+      "community": 698,
       "file_type": "code",
       "id": "storepulse_test_transaction",
       "label": "transaction()",
       "norm_label": "transaction()",
       "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.test.ts",
       "source_location": "L99"
+    },
+    {
+      "community": 699,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_sync_posregistersessionactivity_test_ts",
+      "label": "posRegisterSessionActivity.test.ts",
+      "norm_label": "posregistersessionactivity.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 699,
+      "file_type": "code",
+      "id": "posregistersessionactivity_test_buildactivity",
+      "label": "buildActivity()",
+      "norm_label": "buildactivity()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
+      "source_location": "L457"
+    },
+    {
+      "community": 699,
+      "file_type": "code",
+      "id": "posregistersessionactivity_test_buildreport",
+      "label": "buildReport()",
+      "norm_label": "buildreport()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
+      "source_location": "L436"
+    },
+    {
+      "community": 699,
+      "file_type": "code",
+      "id": "posregistersessionactivity_test_createfakerepository",
+      "label": "createFakeRepository()",
+      "norm_label": "createfakerepository()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
+      "source_location": "L476"
     },
     {
       "community": 7,
@@ -275526,42 +275622,6 @@
     {
       "community": 700,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sync_posregistersessionactivity_test_ts",
-      "label": "posRegisterSessionActivity.test.ts",
-      "norm_label": "posregistersessionactivity.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 700,
-      "file_type": "code",
-      "id": "posregistersessionactivity_test_buildactivity",
-      "label": "buildActivity()",
-      "norm_label": "buildactivity()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
-      "source_location": "L457"
-    },
-    {
-      "community": 700,
-      "file_type": "code",
-      "id": "posregistersessionactivity_test_buildreport",
-      "label": "buildReport()",
-      "norm_label": "buildreport()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
-      "source_location": "L436"
-    },
-    {
-      "community": 700,
-      "file_type": "code",
-      "id": "posregistersessionactivity_test_createfakerepository",
-      "label": "createFakeRepository()",
-      "norm_label": "createfakerepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
-      "source_location": "L476"
-    },
-    {
-      "community": 701,
-      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_registercatalogrevision_ts",
       "label": "registerCatalogRevision.ts",
       "norm_label": "registercatalogrevision.ts",
@@ -275569,7 +275629,7 @@
       "source_location": "L1"
     },
     {
-      "community": 701,
+      "community": 700,
       "file_type": "code",
       "id": "registercatalogrevision_advanceregistercatalogrevision",
       "label": "advanceRegisterCatalogRevision()",
@@ -275578,7 +275638,7 @@
       "source_location": "L24"
     },
     {
-      "community": 701,
+      "community": 700,
       "file_type": "code",
       "id": "registercatalogrevision_readregistercatalogrevision",
       "label": "readRegisterCatalogRevision()",
@@ -275587,7 +275647,7 @@
       "source_location": "L16"
     },
     {
-      "community": 701,
+      "community": 700,
       "file_type": "code",
       "id": "registercatalogrevision_readregistercatalogrevisionrow",
       "label": "readRegisterCatalogRevisionRow()",
@@ -275596,7 +275656,7 @@
       "source_location": "L6"
     },
     {
-      "community": 702,
+      "community": 701,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_sequencegappolicy_ts",
       "label": "sequenceGapPolicy.ts",
@@ -275605,7 +275665,7 @@
       "source_location": "L1"
     },
     {
-      "community": 702,
+      "community": 701,
       "file_type": "code",
       "id": "sequencegappolicy_decidesequencegapaction",
       "label": "decideSequenceGapAction()",
@@ -275614,7 +275674,7 @@
       "source_location": "L115"
     },
     {
-      "community": 702,
+      "community": 701,
       "file_type": "code",
       "id": "sequencegappolicy_issequencegapresolved",
       "label": "isSequenceGapResolved()",
@@ -275623,7 +275683,7 @@
       "source_location": "L219"
     },
     {
-      "community": 702,
+      "community": 701,
       "file_type": "code",
       "id": "sequencegappolicy_recordsequencegapobservation",
       "label": "recordSequenceGapObservation()",
@@ -275632,7 +275692,7 @@
       "source_location": "L190"
     },
     {
-      "community": 703,
+      "community": 702,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_staffproof_ts",
       "label": "staffProof.ts",
@@ -275641,7 +275701,7 @@
       "source_location": "L1"
     },
     {
-      "community": 703,
+      "community": 702,
       "file_type": "code",
       "id": "staffproof_createposlocalstaffprooftoken",
       "label": "createPosLocalStaffProofToken()",
@@ -275650,7 +275710,7 @@
       "source_location": "L10"
     },
     {
-      "community": 703,
+      "community": 702,
       "file_type": "code",
       "id": "staffproof_hashposlocalstaffprooftoken",
       "label": "hashPosLocalStaffProofToken()",
@@ -275659,7 +275719,7 @@
       "source_location": "L16"
     },
     {
-      "community": 703,
+      "community": 702,
       "file_type": "code",
       "id": "staffproof_tohex",
       "label": "toHex()",
@@ -275668,7 +275728,7 @@
       "source_location": "L4"
     },
     {
-      "community": 704,
+      "community": 703,
       "file_type": "code",
       "id": "cloudrepairpolicy_test_buildconflict",
       "label": "buildConflict()",
@@ -275677,7 +275737,7 @@
       "source_location": "L387"
     },
     {
-      "community": 704,
+      "community": 703,
       "file_type": "code",
       "id": "cloudrepairpolicy_test_buildevent",
       "label": "buildEvent()",
@@ -275686,7 +275746,7 @@
       "source_location": "L407"
     },
     {
-      "community": 704,
+      "community": 703,
       "file_type": "code",
       "id": "cloudrepairpolicy_test_createrepairprojectionrepository",
       "label": "createRepairProjectionRepository()",
@@ -275695,7 +275755,7 @@
       "source_location": "L282"
     },
     {
-      "community": 704,
+      "community": 703,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_cloudrepairpolicy_test_ts",
       "label": "cloudRepairPolicy.test.ts",
@@ -275704,7 +275764,7 @@
       "source_location": "L1"
     },
     {
-      "community": 705,
+      "community": 704,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_terminalcommandservice_test_ts",
       "label": "terminalCommandService.test.ts",
@@ -275713,7 +275773,7 @@
       "source_location": "L1"
     },
     {
-      "community": 705,
+      "community": 704,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildcommand",
       "label": "buildCommand()",
@@ -275722,7 +275782,7 @@
       "source_location": "L1731"
     },
     {
-      "community": 705,
+      "community": 704,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildrepository",
       "label": "buildRepository()",
@@ -275731,7 +275791,7 @@
       "source_location": "L1666"
     },
     {
-      "community": 705,
+      "community": 704,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildruntimestatus",
       "label": "buildRuntimeStatus()",
@@ -275740,7 +275800,7 @@
       "source_location": "L1755"
     },
     {
-      "community": 706,
+      "community": 705,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
       "label": "sessionCommandRepository.ts",
@@ -275749,7 +275809,7 @@
       "source_location": "L1"
     },
     {
-      "community": 706,
+      "community": 705,
       "file_type": "code",
       "id": "sessioncommandrepository_collectsessionitemsfrompages",
       "label": "collectSessionItemsFromPages()",
@@ -275758,7 +275818,7 @@
       "source_location": "L177"
     },
     {
-      "community": 706,
+      "community": 705,
       "file_type": "code",
       "id": "sessioncommandrepository_createsessioncommandrepository",
       "label": "createSessionCommandRepository()",
@@ -275767,13 +275827,49 @@
       "source_location": "L68"
     },
     {
-      "community": 706,
+      "community": 705,
       "file_type": "code",
       "id": "sessioncommandrepository_scansessionitembyskuinpages",
       "label": "scanSessionItemBySkuInPages()",
       "norm_label": "scansessionitembyskuinpages()",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
       "source_location": "L195"
+    },
+    {
+      "community": 706,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_register_test_ts",
+      "label": "register.test.ts",
+      "norm_label": "register.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 706,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_public_register_test_ts",
+      "label": "register.test.ts",
+      "norm_label": "register.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 706,
+      "file_type": "code",
+      "id": "register_test_buildctx",
+      "label": "buildCtx()",
+      "norm_label": "buildctx()",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 706,
+      "file_type": "code",
+      "id": "register_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L38"
     },
     {
       "community": 707,

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -47435,7 +47435,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_emit_ts",
       "source_file": "packages/athena-webapp/convex/notifications/emit.ts",
-      "source_location": "L38",
+      "source_location": "L39",
       "target": "emit_emitnotificationwithctx",
       "weight": 1
     },
@@ -47447,7 +47447,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_emit_ts",
       "source_file": "packages/athena-webapp/convex/notifications/emit.ts",
-      "source_location": "L21",
+      "source_location": "L22",
       "target": "emit_schedulenotificationwithctx",
       "weight": 1
     },
@@ -47459,7 +47459,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_rail_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L2524",
+      "source_location": "L2602",
       "target": "rail_test_emitapprovalrequestcreated",
       "weight": 1
     },
@@ -47471,7 +47471,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_rail_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L2833",
+      "source_location": "L2911",
       "target": "rail_test_emitverificationdiscrepancy",
       "weight": 1
     },
@@ -47483,7 +47483,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_rail_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L1581",
+      "source_location": "L1659",
       "target": "rail_test_insertdelivery",
       "weight": 1
     },
@@ -47531,7 +47531,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_rail_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L959",
+      "source_location": "L1037",
       "target": "rail_test_reserveone",
       "weight": 1
     },
@@ -47555,7 +47555,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_rail_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L2495",
+      "source_location": "L2573",
       "target": "rail_test_seedpendingapprovalrequest",
       "weight": 1
     },
@@ -47567,7 +47567,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_rail_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L1609",
+      "source_location": "L1687",
       "target": "rail_test_seedsweeperfixture",
       "weight": 1
     },
@@ -47591,7 +47591,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_rail_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L2781",
+      "source_location": "L2859",
       "target": "rail_test_seedverificationrun",
       "weight": 1
     },
@@ -47603,7 +47603,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_rail_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L2764",
+      "source_location": "L2842",
       "target": "rail_test_stubprodtransport",
       "weight": 1
     },
@@ -47615,7 +47615,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_registry_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/registry.test.ts",
-      "source_location": "L609",
+      "source_location": "L641",
       "target": "registry_test_dedupekey",
       "weight": 1
     },
@@ -47627,7 +47627,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_notifications_registry_test_ts",
       "source_file": "packages/athena-webapp/convex/notifications/registry.test.ts",
-      "source_location": "L794",
+      "source_location": "L826",
       "target": "registry_test_keyfor",
       "weight": 1
     },
@@ -49391,7 +49391,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L6335",
+      "source_location": "L6363",
       "target": "dailyclose_test_createcommandargs",
       "weight": 1
     },
@@ -50711,7 +50711,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L510",
+      "source_location": "L511",
       "target": "dailymanagerreportemail_test_ask",
       "weight": 1
     },
@@ -50723,7 +50723,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L749",
+      "source_location": "L762",
       "target": "dailymanagerreportemail_test_askforday",
       "weight": 1
     },
@@ -50735,7 +50735,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L602",
+      "source_location": "L615",
       "target": "dailymanagerreportemail_test_insertcompletedclose",
       "weight": 1
     },
@@ -50759,7 +50759,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L652",
+      "source_location": "L665",
       "target": "dailymanagerreportemail_test_insertreportday",
       "weight": 1
     },
@@ -50783,7 +50783,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L686",
+      "source_location": "L699",
       "target": "dailymanagerreportemail_test_insertskuday",
       "weight": 1
     },
@@ -50807,7 +50807,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L582",
+      "source_location": "L595",
       "target": "dailymanagerreportemail_test_seedstore",
       "weight": 1
     },
@@ -50831,7 +50831,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailymanagerreportemail_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L740",
+      "source_location": "L753",
       "target": "dailymanagerreportemail_test_unitsmetric",
       "weight": 1
     },
@@ -55331,7 +55331,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.test.ts",
-      "source_location": "L13",
+      "source_location": "L14",
       "target": "oweddailyclosesweep_test_fullwindow",
       "weight": 1
     },
@@ -55343,7 +55343,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L155",
+      "source_location": "L177",
       "target": "oweddailyclosesweep_completedoperatingdatesforstore",
       "weight": 1
     },
@@ -55367,7 +55367,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L388",
+      "source_location": "L416",
       "target": "oweddailyclosesweep_daysbetweenoperatingdates",
       "weight": 1
     },
@@ -55379,7 +55379,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L141",
+      "source_location": "L163",
       "target": "oweddailyclosesweep_listenabledeodpolicies",
       "weight": 1
     },
@@ -55391,8 +55391,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L89",
+      "source_location": "L111",
       "target": "oweddailyclosesweep_selectoweddailyclosedates",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
+      "_tgt": "oweddailyclosesweep_selectrotatingoweddailycloseattempt",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
+      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
+      "source_location": "L84",
+      "target": "oweddailyclosesweep_selectrotatingoweddailycloseattempt",
       "weight": 1
     },
     {
@@ -147539,7 +147551,7 @@
       "relation": "calls",
       "source": "registry_test_dedupekey",
       "source_file": "packages/athena-webapp/convex/notifications/registry.test.ts",
-      "source_location": "L795",
+      "source_location": "L827",
       "target": "registry_test_keyfor",
       "weight": 1
     },
@@ -192088,7 +192100,7 @@
       "label": "fullWindow()",
       "norm_label": "fullwindow()",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.test.ts",
-      "source_location": "L13"
+      "source_location": "L14"
     },
     {
       "community": 1196,
@@ -210817,7 +210829,7 @@
       "label": "emitApprovalRequestCreated()",
       "norm_label": "emitapprovalrequestcreated()",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L2524"
+      "source_location": "L2602"
     },
     {
       "community": 170,
@@ -210826,7 +210838,7 @@
       "label": "emitVerificationDiscrepancy()",
       "norm_label": "emitverificationdiscrepancy()",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L2833"
+      "source_location": "L2911"
     },
     {
       "community": 170,
@@ -210835,7 +210847,7 @@
       "label": "insertDelivery()",
       "norm_label": "insertdelivery()",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L1581"
+      "source_location": "L1659"
     },
     {
       "community": 170,
@@ -210871,7 +210883,7 @@
       "label": "reserveOne()",
       "norm_label": "reserveone()",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L959"
+      "source_location": "L1037"
     },
     {
       "community": 170,
@@ -210889,7 +210901,7 @@
       "label": "seedPendingApprovalRequest()",
       "norm_label": "seedpendingapprovalrequest()",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L2495"
+      "source_location": "L2573"
     },
     {
       "community": 170,
@@ -210898,7 +210910,7 @@
       "label": "seedSweeperFixture()",
       "norm_label": "seedsweeperfixture()",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L1609"
+      "source_location": "L1687"
     },
     {
       "community": 170,
@@ -210916,7 +210928,7 @@
       "label": "seedVerificationRun()",
       "norm_label": "seedverificationrun()",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L2781"
+      "source_location": "L2859"
     },
     {
       "community": 170,
@@ -210925,7 +210937,7 @@
       "label": "stubProdTransport()",
       "norm_label": "stubprodtransport()",
       "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L1150"
+      "source_location": "L1228"
     },
     {
       "community": 1700,
@@ -211141,7 +211153,7 @@
       "label": "createCommandArgs()",
       "norm_label": "createcommandargs()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L6335"
+      "source_location": "L6363"
     },
     {
       "community": 171,
@@ -215358,119 +215370,119 @@
     {
       "community": 187,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
-      "source_location": "L1"
+      "id": "backfillstoreschedules_backfillstoreschedulesfromlegacypolicywithctx",
+      "label": "backfillStoreSchedulesFromLegacyPolicyWithCtx()",
+      "norm_label": "backfillstoreschedulesfromlegacypolicywithctx()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L324"
     },
     {
       "community": 187,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
+      "id": "backfillstoreschedules_buildbackfillrow",
+      "label": "buildBackfillRow()",
+      "norm_label": "buildbackfillrow()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L187"
     },
     {
       "community": 187,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L1"
+      "id": "backfillstoreschedules_buildcandidateweeklywindows",
+      "label": "buildCandidateWeeklyWindows()",
+      "norm_label": "buildcandidateweeklywindows()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L163"
     },
     {
       "community": 187,
       "file_type": "code",
-      "id": "utils_formatdeliveryaddress",
-      "label": "formatDeliveryAddress()",
-      "norm_label": "formatdeliveryaddress()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L74"
+      "id": "backfillstoreschedules_compatibilitymetadata",
+      "label": "compatibilityMetadata()",
+      "norm_label": "compatibilitymetadata()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L133"
     },
     {
       "community": 187,
       "file_type": "code",
-      "id": "utils_getamountpaidfororder",
-      "label": "getAmountPaidForOrder()",
-      "norm_label": "getamountpaidfororder()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L191"
+      "id": "backfillstoreschedules_compatibilityonlyrow",
+      "label": "compatibilityOnlyRow()",
+      "norm_label": "compatibilityonlyrow()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L174"
     },
     {
       "community": 187,
       "file_type": "code",
-      "id": "utils_getdiscountvalue",
-      "label": "getDiscountValue()",
-      "norm_label": "getdiscountvalue()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L17"
+      "id": "backfillstoreschedules_findexistingscheduletoskip",
+      "label": "findExistingScheduleToSkip()",
+      "norm_label": "findexistingscheduletoskip()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L114"
     },
     {
       "community": 187,
       "file_type": "code",
-      "id": "utils_getonlineorderplacedat",
-      "label": "getOnlineOrderPlacedAt()",
-      "norm_label": "getonlineorderplacedat()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "utils_getorderamount",
-      "label": "getOrderAmount()",
-      "norm_label": "getorderamount()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "utils_getorderstate",
-      "label": "getOrderState()",
-      "norm_label": "getorderstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "utils_getpickupactionstate",
-      "label": "getPickupActionState()",
-      "norm_label": "getpickupactionstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "utils_getpotentialpoints",
-      "label": "getPotentialPoints()",
-      "norm_label": "getpotentialpoints()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 187,
-      "file_type": "code",
-      "id": "utils_getproductdiscountvalue",
-      "label": "getProductDiscountValue()",
-      "norm_label": "getproductdiscountvalue()",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "id": "backfillstoreschedules_firstpolicy",
+      "label": "firstPolicy()",
+      "norm_label": "firstpolicy()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
       "source_location": "L75"
     },
     {
       "community": 187,
       "file_type": "code",
-      "id": "utils_shouldshowpickupexceptionaction",
-      "label": "shouldShowPickupExceptionAction()",
-      "norm_label": "shouldshowpickupexceptionaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L116"
+      "id": "backfillstoreschedules_isvalidminute",
+      "label": "isValidMinute()",
+      "norm_label": "isvalidminute()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 187,
+      "file_type": "code",
+      "id": "backfillstoreschedules_listpoliciesforstoreaction",
+      "label": "listPoliciesForStoreAction()",
+      "norm_label": "listpoliciesforstoreaction()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L81"
+    },
+    {
+      "community": 187,
+      "file_type": "code",
+      "id": "backfillstoreschedules_listschedulesforstorebystatus",
+      "label": "listSchedulesForStoreByStatus()",
+      "norm_label": "listschedulesforstorebystatus()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L99"
+    },
+    {
+      "community": 187,
+      "file_type": "code",
+      "id": "backfillstoreschedules_normalizelimit",
+      "label": "normalizeLimit()",
+      "norm_label": "normalizelimit()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 187,
+      "file_type": "code",
+      "id": "backfillstoreschedules_trustedtimezoneforstore",
+      "label": "trustedTimezoneForStore()",
+      "norm_label": "trustedtimezoneforstore()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L126"
+    },
+    {
+      "community": 187,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_migrations_backfillstoreschedules_ts",
+      "label": "backfillStoreSchedules.ts",
+      "norm_label": "backfillstoreschedules.ts",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L1"
     },
     {
       "community": 1870,
@@ -215565,119 +215577,119 @@
     {
       "community": 188,
       "file_type": "code",
-      "id": "backfillstoreschedules_backfillstoreschedulesfromlegacypolicywithctx",
-      "label": "backfillStoreSchedulesFromLegacyPolicyWithCtx()",
-      "norm_label": "backfillstoreschedulesfromlegacypolicywithctx()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L324"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "backfillstoreschedules_buildbackfillrow",
-      "label": "buildBackfillRow()",
-      "norm_label": "buildbackfillrow()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L187"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "backfillstoreschedules_buildcandidateweeklywindows",
-      "label": "buildCandidateWeeklyWindows()",
-      "norm_label": "buildcandidateweeklywindows()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L163"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "backfillstoreschedules_compatibilitymetadata",
-      "label": "compatibilityMetadata()",
-      "norm_label": "compatibilitymetadata()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L133"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "backfillstoreschedules_compatibilityonlyrow",
-      "label": "compatibilityOnlyRow()",
-      "norm_label": "compatibilityonlyrow()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L174"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "backfillstoreschedules_findexistingscheduletoskip",
-      "label": "findExistingScheduleToSkip()",
-      "norm_label": "findexistingscheduletoskip()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L114"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "backfillstoreschedules_firstpolicy",
-      "label": "firstPolicy()",
-      "norm_label": "firstpolicy()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "backfillstoreschedules_isvalidminute",
-      "label": "isValidMinute()",
-      "norm_label": "isvalidminute()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "backfillstoreschedules_listpoliciesforstoreaction",
-      "label": "listPoliciesForStoreAction()",
-      "norm_label": "listpoliciesforstoreaction()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L81"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "backfillstoreschedules_listschedulesforstorebystatus",
-      "label": "listSchedulesForStoreByStatus()",
-      "norm_label": "listschedulesforstorebystatus()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L99"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "backfillstoreschedules_normalizelimit",
-      "label": "normalizeLimit()",
-      "norm_label": "normalizelimit()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "backfillstoreschedules_trustedtimezoneforstore",
-      "label": "trustedTimezoneForStore()",
-      "norm_label": "trustedtimezoneforstore()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L126"
-    },
-    {
-      "community": 188,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_migrations_backfillstoreschedules_ts",
-      "label": "backfillStoreSchedules.ts",
-      "norm_label": "backfillstoreschedules.ts",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "id": "packages_athena_webapp_convex_operationadmission_readdefinitions_ts",
+      "label": "readDefinitions.ts",
+      "norm_label": "readdefinitions.ts",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "readdefinitions_definecashcontrolsread",
+      "label": "defineCashControlsRead()",
+      "norm_label": "definecashcontrolsread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "readdefinitions_definedailycloseread",
+      "label": "defineDailyCloseRead()",
+      "norm_label": "definedailycloseread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "readdefinitions_definedailyoperationsread",
+      "label": "defineDailyOperationsRead()",
+      "norm_label": "definedailyoperationsread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "readdefinitions_defineinventorycatalogread",
+      "label": "defineInventoryCatalogRead()",
+      "norm_label": "defineinventorycatalogread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "readdefinitions_defineinventorycostoverlayread",
+      "label": "defineInventoryCostOverlayRead()",
+      "norm_label": "defineinventorycostoverlayread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L639"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "readdefinitions_defineonlineordersread",
+      "label": "defineOnlineOrdersRead()",
+      "norm_label": "defineonlineordersread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "readdefinitions_defineoperationalworkread",
+      "label": "defineOperationalWorkRead()",
+      "norm_label": "defineoperationalworkread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "readdefinitions_defineorganizationread",
+      "label": "defineOrganizationRead()",
+      "norm_label": "defineorganizationread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L94"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "readdefinitions_defineposread",
+      "label": "definePosRead()",
+      "norm_label": "defineposread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "readdefinitions_definereadoperation",
+      "label": "defineReadOperation()",
+      "norm_label": "definereadoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "readdefinitions_definestockadjustmentsread",
+      "label": "defineStockAdjustmentsRead()",
+      "norm_label": "definestockadjustmentsread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L60"
+    },
+    {
+      "community": 188,
+      "file_type": "code",
+      "id": "readdefinitions_validatereadoperationdefinition",
+      "label": "validateReadOperationDefinition()",
+      "norm_label": "validatereadoperationdefinition()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L781"
     },
     {
       "community": 1880,
@@ -215772,119 +215784,119 @@
     {
       "community": 189,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operationadmission_readdefinitions_ts",
-      "label": "readDefinitions.ts",
-      "norm_label": "readdefinitions.ts",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "id": "frozenmetricauthority_closecandidateoperatingrange",
+      "label": "closeCandidateOperatingRange()",
+      "norm_label": "closecandidateoperatingrange()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L199"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "frozenmetricauthority_emptyclosesummary",
+      "label": "emptyCloseSummary()",
+      "norm_label": "emptyclosesummary()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "frozenmetricauthority_exactstatuses",
+      "label": "exactStatuses()",
+      "norm_label": "exactstatuses()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "frozenmetricauthority_finitenumber",
+      "label": "finiteNumber()",
+      "norm_label": "finitenumber()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L91"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "frozenmetricauthority_frozenfinancialsourcecounts",
+      "label": "frozenFinancialSourceCounts()",
+      "norm_label": "frozenfinancialsourcecounts()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L133"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "frozenmetricauthority_frozenweekmetricfordate",
+      "label": "frozenWeekMetricForDate()",
+      "norm_label": "frozenweekmetricfordate()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L481"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "frozenmetricauthority_matchesrequestedoperatingrange",
+      "label": "matchesRequestedOperatingRange()",
+      "norm_label": "matchesrequestedoperatingrange()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L102"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "frozenmetricauthority_normalizefrozenpaymenttotals",
+      "label": "normalizeFrozenPaymentTotals()",
+      "norm_label": "normalizefrozenpaymenttotals()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L241"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "frozenmetricauthority_recordvalue",
+      "label": "recordValue()",
+      "norm_label": "recordvalue()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "frozenmetricauthority_resolvefrozendailycloseauthority",
+      "label": "resolveFrozenDailyCloseAuthority()",
+      "norm_label": "resolvefrozendailycloseauthority()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L393"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "frozenmetricauthority_samedailycloseid",
+      "label": "sameDailyCloseId()",
+      "norm_label": "samedailycloseid()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L386"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "frozenmetricauthority_usablefrozenweeksummary",
+      "label": "usableFrozenWeekSummary()",
+      "norm_label": "usablefrozenweeksummary()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L273"
+    },
+    {
+      "community": 189,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_dailyoperations_frozenmetricauthority_ts",
+      "label": "frozenMetricAuthority.ts",
+      "norm_label": "frozenmetricauthority.ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "readdefinitions_definecashcontrolsread",
-      "label": "defineCashControlsRead()",
-      "norm_label": "definecashcontrolsread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L50"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "readdefinitions_definedailycloseread",
-      "label": "defineDailyCloseRead()",
-      "norm_label": "definedailycloseread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "readdefinitions_definedailyoperationsread",
-      "label": "defineDailyOperationsRead()",
-      "norm_label": "definedailyoperationsread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "readdefinitions_defineinventorycatalogread",
-      "label": "defineInventoryCatalogRead()",
-      "norm_label": "defineinventorycatalogread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "readdefinitions_defineinventorycostoverlayread",
-      "label": "defineInventoryCostOverlayRead()",
-      "norm_label": "defineinventorycostoverlayread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L639"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "readdefinitions_defineonlineordersread",
-      "label": "defineOnlineOrdersRead()",
-      "norm_label": "defineonlineordersread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L84"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "readdefinitions_defineoperationalworkread",
-      "label": "defineOperationalWorkRead()",
-      "norm_label": "defineoperationalworkread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "readdefinitions_defineorganizationread",
-      "label": "defineOrganizationRead()",
-      "norm_label": "defineorganizationread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L94"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "readdefinitions_defineposread",
-      "label": "definePosRead()",
-      "norm_label": "defineposread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "readdefinitions_definereadoperation",
-      "label": "defineReadOperation()",
-      "norm_label": "definereadoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "readdefinitions_definestockadjustmentsread",
-      "label": "defineStockAdjustmentsRead()",
-      "norm_label": "definestockadjustmentsread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L60"
-    },
-    {
-      "community": 189,
-      "file_type": "code",
-      "id": "readdefinitions_validatereadoperationdefinition",
-      "label": "validateReadOperationDefinition()",
-      "norm_label": "validatereadoperationdefinition()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L781"
     },
     {
       "community": 1890,
@@ -216348,118 +216360,118 @@
     {
       "community": 190,
       "file_type": "code",
-      "id": "frozenmetricauthority_closecandidateoperatingrange",
-      "label": "closeCandidateOperatingRange()",
-      "norm_label": "closecandidateoperatingrange()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L199"
+      "id": "openworkinventoryreviews_test_buildctx",
+      "label": "buildCtx()",
+      "norm_label": "buildctx()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L956"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "frozenmetricauthority_emptyclosesummary",
-      "label": "emptyCloseSummary()",
-      "norm_label": "emptyclosesummary()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L62"
+      "id": "openworkinventoryreviews_test_buildinventorymovement",
+      "label": "buildInventoryMovement()",
+      "norm_label": "buildinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1109"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "frozenmetricauthority_exactstatuses",
-      "label": "exactStatuses()",
-      "norm_label": "exactstatuses()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L96"
+      "id": "openworkinventoryreviews_test_buildmapping",
+      "label": "buildMapping()",
+      "norm_label": "buildmapping()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1213"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "frozenmetricauthority_finitenumber",
-      "label": "finiteNumber()",
-      "norm_label": "finitenumber()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L91"
+      "id": "openworkinventoryreviews_test_buildproductsku",
+      "label": "buildProductSku()",
+      "norm_label": "buildproductsku()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1130"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "frozenmetricauthority_frozenfinancialsourcecounts",
-      "label": "frozenFinancialSourceCounts()",
-      "norm_label": "frozenfinancialsourcecounts()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L133"
+      "id": "openworkinventoryreviews_test_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1169"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "frozenmetricauthority_frozenweekmetricfordate",
-      "label": "frozenWeekMetricForDate()",
-      "norm_label": "frozenweekmetricfordate()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L481"
+      "id": "openworkinventoryreviews_test_buildstaffprofile",
+      "label": "buildStaffProfile()",
+      "norm_label": "buildstaffprofile()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1065"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "frozenmetricauthority_matchesrequestedoperatingrange",
-      "label": "matchesRequestedOperatingRange()",
-      "norm_label": "matchesrequestedoperatingrange()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L102"
+      "id": "openworkinventoryreviews_test_buildstore",
+      "label": "buildStore()",
+      "norm_label": "buildstore()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1052"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "frozenmetricauthority_normalizefrozenpaymenttotals",
-      "label": "normalizeFrozenPaymentTotals()",
-      "norm_label": "normalizefrozenpaymenttotals()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L241"
+      "id": "openworkinventoryreviews_test_buildterminal",
+      "label": "buildTerminal()",
+      "norm_label": "buildterminal()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1149"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "frozenmetricauthority_recordvalue",
-      "label": "recordValue()",
-      "norm_label": "recordvalue()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L85"
+      "id": "openworkinventoryreviews_test_buildtransaction",
+      "label": "buildTransaction()",
+      "norm_label": "buildtransaction()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1189"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "frozenmetricauthority_resolvefrozendailycloseauthority",
-      "label": "resolveFrozenDailyCloseAuthority()",
-      "norm_label": "resolvefrozendailycloseauthority()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L393"
+      "id": "openworkinventoryreviews_test_buildworkitem",
+      "label": "buildWorkItem()",
+      "norm_label": "buildworkitem()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1079"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "frozenmetricauthority_samedailycloseid",
-      "label": "sameDailyCloseId()",
-      "norm_label": "samedailycloseid()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L386"
+      "id": "openworkinventoryreviews_test_defaultargs",
+      "label": "defaultArgs()",
+      "norm_label": "defaultargs()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L909"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "frozenmetricauthority_usablefrozenweeksummary",
-      "label": "usableFrozenWeekSummary()",
-      "norm_label": "usablefrozenweeksummary()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L273"
+      "id": "openworkinventoryreviews_test_expectrejectedcontext",
+      "label": "expectRejectedContext()",
+      "norm_label": "expectrejectedcontext()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L891"
     },
     {
       "community": 190,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_dailyoperations_frozenmetricauthority_ts",
-      "label": "frozenMetricAuthority.ts",
-      "norm_label": "frozenmetricauthority.ts",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "id": "packages_athena_webapp_convex_operations_openworkinventoryreviews_test_ts",
+      "label": "openWorkInventoryReviews.test.ts",
+      "norm_label": "openworkinventoryreviews.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
       "source_location": "L1"
     },
     {
@@ -216555,118 +216567,118 @@
     {
       "community": 191,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildctx",
-      "label": "buildCtx()",
-      "norm_label": "buildctx()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L956"
+      "id": "assigncustomer_createcustomer",
+      "label": "createCustomer()",
+      "norm_label": "createcustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L132"
     },
     {
       "community": 191,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildinventorymovement",
-      "label": "buildInventoryMovement()",
-      "norm_label": "buildinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1109"
+      "id": "assigncustomer_fullnamefromparts",
+      "label": "fullNameFromParts()",
+      "norm_label": "fullnamefromparts()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L58"
     },
     {
       "community": 191,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildmapping",
-      "label": "buildMapping()",
-      "norm_label": "buildmapping()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1213"
+      "id": "assigncustomer_guestresult",
+      "label": "guestResult()",
+      "norm_label": "guestresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L111"
     },
     {
       "community": 191,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildproductsku",
-      "label": "buildProductSku()",
-      "norm_label": "buildproductsku()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1130"
+      "id": "assigncustomer_linktoguest",
+      "label": "linkToGuest()",
+      "norm_label": "linktoguest()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L348"
     },
     {
       "community": 191,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1169"
+      "id": "assigncustomer_linktostorefrontuser",
+      "label": "linkToStoreFrontUser()",
+      "norm_label": "linktostorefrontuser()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L290"
     },
     {
       "community": 191,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildstaffprofile",
-      "label": "buildStaffProfile()",
-      "norm_label": "buildstaffprofile()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1065"
+      "id": "assigncustomer_poscustomerresult",
+      "label": "posCustomerResult()",
+      "norm_label": "poscustomerresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L71"
     },
     {
       "community": 191,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildstore",
-      "label": "buildStore()",
-      "norm_label": "buildstore()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1052"
+      "id": "assigncustomer_resolveguestmatch",
+      "label": "resolveGuestMatch()",
+      "norm_label": "resolveguestmatch()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L478"
     },
     {
       "community": 191,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildterminal",
-      "label": "buildTerminal()",
-      "norm_label": "buildterminal()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1149"
+      "id": "assigncustomer_resolveposcustomerselection",
+      "label": "resolvePosCustomerSelection()",
+      "norm_label": "resolveposcustomerselection()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L267"
     },
     {
       "community": 191,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildtransaction",
-      "label": "buildTransaction()",
-      "norm_label": "buildtransaction()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1189"
+      "id": "assigncustomer_resolvestorefrontusermatch",
+      "label": "resolveStoreFrontUserMatch()",
+      "norm_label": "resolvestorefrontusermatch()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L384"
     },
     {
       "community": 191,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildworkitem",
-      "label": "buildWorkItem()",
-      "norm_label": "buildworkitem()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1079"
+      "id": "assigncustomer_storefrontresult",
+      "label": "storefrontResult()",
+      "norm_label": "storefrontresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L90"
     },
     {
       "community": 191,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_defaultargs",
-      "label": "defaultArgs()",
-      "norm_label": "defaultargs()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L909"
+      "id": "assigncustomer_updatecustomer",
+      "label": "updateCustomer()",
+      "norm_label": "updatecustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L220"
     },
     {
       "community": 191,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_expectrejectedcontext",
-      "label": "expectRejectedContext()",
-      "norm_label": "expectrejectedcontext()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L891"
+      "id": "assigncustomer_updatecustomerstats",
+      "label": "updateCustomerStats()",
+      "norm_label": "updatecustomerstats()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L251"
     },
     {
       "community": 191,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_openworkinventoryreviews_test_ts",
-      "label": "openWorkInventoryReviews.test.ts",
-      "norm_label": "openworkinventoryreviews.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_ts",
+      "label": "assignCustomer.ts",
+      "norm_label": "assigncustomer.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
       "source_location": "L1"
     },
     {
@@ -216762,118 +216774,118 @@
     {
       "community": 192,
       "file_type": "code",
-      "id": "assigncustomer_createcustomer",
-      "label": "createCustomer()",
-      "norm_label": "createcustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L132"
+      "id": "catalogrepository_findactivependingcheckoutlookupaliasbycode",
+      "label": "findActivePendingCheckoutLookupAliasByCode()",
+      "norm_label": "findactivependingcheckoutlookupaliasbycode()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L97"
     },
     {
       "community": 192,
       "file_type": "code",
-      "id": "assigncustomer_fullnamefromparts",
-      "label": "fullNameFromParts()",
-      "norm_label": "fullnamefromparts()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L58"
+      "id": "catalogrepository_findactiveprovisionalimportskuforstoresku",
+      "label": "findActiveProvisionalImportSkuForStoreSku()",
+      "norm_label": "findactiveprovisionalimportskuforstoresku()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L120"
     },
     {
       "community": 192,
       "file_type": "code",
-      "id": "assigncustomer_guestresult",
-      "label": "guestResult()",
-      "norm_label": "guestresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L111"
+      "id": "catalogrepository_findstoreskubybarcode",
+      "label": "findStoreSkuByBarcode()",
+      "norm_label": "findstoreskubybarcode()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L62"
     },
     {
       "community": 192,
       "file_type": "code",
-      "id": "assigncustomer_linktoguest",
-      "label": "linkToGuest()",
-      "norm_label": "linktoguest()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L348"
+      "id": "catalogrepository_findstoreskubysku",
+      "label": "findStoreSkuBySku()",
+      "norm_label": "findstoreskubysku()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L77"
     },
     {
       "community": 192,
       "file_type": "code",
-      "id": "assigncustomer_linktostorefrontuser",
-      "label": "linkToStoreFrontUser()",
-      "norm_label": "linktostorefrontuser()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L290"
+      "id": "catalogrepository_getcategorybyid",
+      "label": "getCategoryById()",
+      "norm_label": "getcategorybyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L29"
     },
     {
       "community": 192,
       "file_type": "code",
-      "id": "assigncustomer_poscustomerresult",
-      "label": "posCustomerResult()",
-      "norm_label": "poscustomerresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L71"
+      "id": "catalogrepository_getcolorbyid",
+      "label": "getColorById()",
+      "norm_label": "getcolorbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L40"
     },
     {
       "community": 192,
       "file_type": "code",
-      "id": "assigncustomer_resolveguestmatch",
-      "label": "resolveGuestMatch()",
-      "norm_label": "resolveguestmatch()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L478"
+      "id": "catalogrepository_getproductbyid",
+      "label": "getProductById()",
+      "norm_label": "getproductbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L25"
     },
     {
       "community": 192,
       "file_type": "code",
-      "id": "assigncustomer_resolveposcustomerselection",
-      "label": "resolvePosCustomerSelection()",
-      "norm_label": "resolveposcustomerselection()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L267"
+      "id": "catalogrepository_isconvexproductid",
+      "label": "isConvexProductId()",
+      "norm_label": "isconvexproductid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L11"
     },
     {
       "community": 192,
       "file_type": "code",
-      "id": "assigncustomer_resolvestorefrontusermatch",
-      "label": "resolveStoreFrontUserMatch()",
-      "norm_label": "resolvestorefrontusermatch()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L384"
+      "id": "catalogrepository_listmatchingstoreskus",
+      "label": "listMatchingStoreSkus()",
+      "norm_label": "listmatchingstoreskus()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L140"
     },
     {
       "community": 192,
       "file_type": "code",
-      "id": "assigncustomer_storefrontresult",
-      "label": "storefrontResult()",
-      "norm_label": "storefrontresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L90"
+      "id": "catalogrepository_listproductskusbyproductid",
+      "label": "listProductSkusByProductId()",
+      "norm_label": "listproductskusbyproductid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L51"
     },
     {
       "community": 192,
       "file_type": "code",
-      "id": "assigncustomer_updatecustomer",
-      "label": "updateCustomer()",
-      "norm_label": "updatecustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L220"
+      "id": "catalogrepository_normalizelookupcode",
+      "label": "normalizeLookupCode()",
+      "norm_label": "normalizelookupcode()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L92"
     },
     {
       "community": 192,
       "file_type": "code",
-      "id": "assigncustomer_updatecustomerstats",
-      "label": "updateCustomerStats()",
-      "norm_label": "updatecustomerstats()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L251"
+      "id": "catalogrepository_readallqueryresults",
+      "label": "readAllQueryResults()",
+      "norm_label": "readallqueryresults()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L15"
     },
     {
       "community": 192,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_ts",
-      "label": "assignCustomer.ts",
-      "norm_label": "assigncustomer.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_catalogrepository_ts",
+      "label": "catalogRepository.ts",
+      "norm_label": "catalogrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
       "source_location": "L1"
     },
     {
@@ -216969,119 +216981,119 @@
     {
       "community": 193,
       "file_type": "code",
-      "id": "catalogrepository_findactivependingcheckoutlookupaliasbycode",
-      "label": "findActivePendingCheckoutLookupAliasByCode()",
-      "norm_label": "findactivependingcheckoutlookupaliasbycode()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L97"
+      "id": "packages_athena_webapp_convex_reports_skumovementrange_test_ts",
+      "label": "skuMovementRange.test.ts",
+      "norm_label": "skumovementrange.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L1"
     },
     {
       "community": 193,
       "file_type": "code",
-      "id": "catalogrepository_findactiveprovisionalimportskuforstoresku",
-      "label": "findActiveProvisionalImportSkuForStoreSku()",
-      "norm_label": "findactiveprovisionalimportskuforstoresku()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L120"
+      "id": "skumovementrange_test_admitone",
+      "label": "admitOne()",
+      "norm_label": "admitone()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L352"
     },
     {
       "community": 193,
       "file_type": "code",
-      "id": "catalogrepository_findstoreskubybarcode",
-      "label": "findStoreSkuByBarcode()",
-      "norm_label": "findstoreskubybarcode()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L62"
+      "id": "skumovementrange_test_allow",
+      "label": "allow()",
+      "norm_label": "allow()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L113"
     },
     {
       "community": 193,
       "file_type": "code",
-      "id": "catalogrepository_findstoreskubysku",
-      "label": "findStoreSkuBySku()",
-      "norm_label": "findstoreskubysku()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L77"
+      "id": "skumovementrange_test_certifyday",
+      "label": "certifyDay()",
+      "norm_label": "certifyday()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L238"
     },
     {
       "community": 193,
       "file_type": "code",
-      "id": "catalogrepository_getcategorybyid",
-      "label": "getCategoryById()",
-      "norm_label": "getcategorybyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L29"
+      "id": "skumovementrange_test_dailyfor",
+      "label": "dailyFor()",
+      "norm_label": "dailyfor()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L656"
     },
     {
       "community": 193,
       "file_type": "code",
-      "id": "catalogrepository_getcolorbyid",
-      "label": "getColorById()",
-      "norm_label": "getcolorbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L40"
+      "id": "skumovementrange_test_drive",
+      "label": "drive()",
+      "norm_label": "drive()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L322"
     },
     {
       "community": 193,
       "file_type": "code",
-      "id": "catalogrepository_getproductbyid",
-      "label": "getProductById()",
-      "norm_label": "getproductbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L25"
+      "id": "skumovementrange_test_ensure",
+      "label": "ensure()",
+      "norm_label": "ensure()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L283"
     },
     {
       "community": 193,
       "file_type": "code",
-      "id": "catalogrepository_isconvexproductid",
-      "label": "isConvexProductId()",
-      "norm_label": "isconvexproductid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L11"
+      "id": "skumovementrange_test_handlerof",
+      "label": "handlerOf()",
+      "norm_label": "handlerof()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L108"
     },
     {
       "community": 193,
       "file_type": "code",
-      "id": "catalogrepository_listmatchingstoreskus",
-      "label": "listMatchingStoreSkus()",
-      "norm_label": "listmatchingstoreskus()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "id": "skumovementrange_test_headerbykey",
+      "label": "headerByKey()",
+      "norm_label": "headerbykey()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L304"
+    },
+    {
+      "community": 193,
+      "file_type": "code",
+      "id": "skumovementrange_test_seedskus",
+      "label": "seedSkus()",
+      "norm_label": "seedskus()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L162"
+    },
+    {
+      "community": 193,
+      "file_type": "code",
+      "id": "skumovementrange_test_seedstore",
+      "label": "seedStore()",
+      "norm_label": "seedstore()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
       "source_location": "L140"
     },
     {
       "community": 193,
       "file_type": "code",
-      "id": "catalogrepository_listproductskusbyproductid",
-      "label": "listProductSkusByProductId()",
-      "norm_label": "listproductskusbyproductid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L51"
+      "id": "skumovementrange_test_step",
+      "label": "step()",
+      "norm_label": "step()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L955"
     },
     {
       "community": 193,
       "file_type": "code",
-      "id": "catalogrepository_normalizelookupcode",
-      "label": "normalizeLookupCode()",
-      "norm_label": "normalizelookupcode()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L92"
-    },
-    {
-      "community": 193,
-      "file_type": "code",
-      "id": "catalogrepository_readallqueryresults",
-      "label": "readAllQueryResults()",
-      "norm_label": "readallqueryresults()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 193,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_catalogrepository_ts",
-      "label": "catalogRepository.ts",
-      "norm_label": "catalogrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L1"
+      "id": "skumovementrange_test_twodayfixture",
+      "label": "twoDayFixture()",
+      "norm_label": "twodayfixture()",
+      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "source_location": "L939"
     },
     {
       "community": 1930,
@@ -217176,119 +217188,119 @@
     {
       "community": 194,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_skumovementrange_test_ts",
-      "label": "skuMovementRange.test.ts",
-      "norm_label": "skumovementrange.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
+      "id": "packages_athena_webapp_src_components_add_product_productview_tsx",
+      "label": "ProductView.tsx",
+      "norm_label": "productview.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L1"
     },
     {
       "community": 194,
       "file_type": "code",
-      "id": "skumovementrange_test_admitone",
-      "label": "admitOne()",
-      "norm_label": "admitone()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L352"
+      "id": "productview_archivedproductnestedorigin",
+      "label": "archivedProductNestedOrigin()",
+      "norm_label": "archivedproductnestedorigin()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L107"
     },
     {
       "community": 194,
       "file_type": "code",
-      "id": "skumovementrange_test_allow",
-      "label": "allow()",
-      "norm_label": "allow()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L113"
+      "id": "productview_buildvariantskumoneypayload",
+      "label": "buildVariantSkuMoneyPayload()",
+      "norm_label": "buildvariantskumoneypayload()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L67"
     },
     {
       "community": 194,
       "file_type": "code",
-      "id": "skumovementrange_test_certifyday",
-      "label": "certifyDay()",
-      "norm_label": "certifyday()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L238"
+      "id": "productview_createvariantsku",
+      "label": "createVariantSku()",
+      "norm_label": "createvariantsku()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L346"
     },
     {
       "community": 194,
       "file_type": "code",
-      "id": "skumovementrange_test_dailyfor",
-      "label": "dailyFor()",
-      "norm_label": "dailyfor()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L656"
+      "id": "productview_decodeoriginvalue",
+      "label": "decodeOriginValue()",
+      "norm_label": "decodeoriginvalue()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L93"
     },
     {
       "community": 194,
       "file_type": "code",
-      "id": "skumovementrange_test_drive",
-      "label": "drive()",
-      "norm_label": "drive()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L322"
+      "id": "productview_deleteactiveproduct",
+      "label": "deleteActiveProduct()",
+      "norm_label": "deleteactiveproduct()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L177"
     },
     {
       "community": 194,
       "file_type": "code",
-      "id": "skumovementrange_test_ensure",
-      "label": "ensure()",
-      "norm_label": "ensure()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L283"
+      "id": "productview_getarchivedproductredirect",
+      "label": "getArchivedProductRedirect()",
+      "norm_label": "getarchivedproductredirect()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L74"
     },
     {
       "community": 194,
       "file_type": "code",
-      "id": "skumovementrange_test_handlerof",
-      "label": "handlerOf()",
-      "norm_label": "handlerof()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L108"
+      "id": "productview_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L506"
     },
     {
       "community": 194,
       "file_type": "code",
-      "id": "skumovementrange_test_headerbykey",
-      "label": "headerByKey()",
-      "norm_label": "headerbykey()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L304"
+      "id": "productview_modifyproduct",
+      "label": "modifyProduct()",
+      "norm_label": "modifyproduct()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L271"
     },
     {
       "community": 194,
       "file_type": "code",
-      "id": "skumovementrange_test_seedskus",
-      "label": "seedSkus()",
-      "norm_label": "seedskus()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L162"
+      "id": "productview_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L490"
     },
     {
       "community": 194,
       "file_type": "code",
-      "id": "skumovementrange_test_seedstore",
-      "label": "seedStore()",
-      "norm_label": "seedstore()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L140"
+      "id": "productview_resolvelegacytaxonomysavegate",
+      "label": "resolveLegacyTaxonomySaveGate()",
+      "norm_label": "resolvelegacytaxonomysavegate()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L40"
     },
     {
       "community": 194,
       "file_type": "code",
-      "id": "skumovementrange_test_step",
-      "label": "step()",
-      "norm_label": "step()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L955"
+      "id": "productview_saveproduct",
+      "label": "saveProduct()",
+      "norm_label": "saveproduct()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L217"
     },
     {
       "community": 194,
       "file_type": "code",
-      "id": "skumovementrange_test_twodayfixture",
-      "label": "twoDayFixture()",
-      "norm_label": "twodayfixture()",
-      "source_file": "packages/athena-webapp/convex/reports/skuMovementRange.test.ts",
-      "source_location": "L939"
+      "id": "productview_updatevariantsku",
+      "label": "updateVariantSku()",
+      "norm_label": "updatevariantsku()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L404"
     },
     {
       "community": 1940,
@@ -217383,119 +217395,119 @@
     {
       "community": 195,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productview_tsx",
-      "label": "ProductView.tsx",
-      "norm_label": "productview.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "id": "packages_athena_webapp_convex_inventory_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
       "source_location": "L1"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "productview_archivedproductnestedorigin",
-      "label": "archivedProductNestedOrigin()",
-      "norm_label": "archivedproductnestedorigin()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L107"
+      "id": "packages_athena_webapp_src_components_orders_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "productview_buildvariantskumoneypayload",
-      "label": "buildVariantSkuMoneyPayload()",
-      "norm_label": "buildvariantskumoneypayload()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L67"
+      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "productview_createvariantsku",
-      "label": "createVariantSku()",
-      "norm_label": "createvariantsku()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L346"
-    },
-    {
-      "community": 195,
-      "file_type": "code",
-      "id": "productview_decodeoriginvalue",
-      "label": "decodeOriginValue()",
-      "norm_label": "decodeoriginvalue()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L93"
-    },
-    {
-      "community": 195,
-      "file_type": "code",
-      "id": "productview_deleteactiveproduct",
-      "label": "deleteActiveProduct()",
-      "norm_label": "deleteactiveproduct()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L177"
-    },
-    {
-      "community": 195,
-      "file_type": "code",
-      "id": "productview_getarchivedproductredirect",
-      "label": "getArchivedProductRedirect()",
-      "norm_label": "getarchivedproductredirect()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "id": "utils_formatdeliveryaddress",
+      "label": "formatDeliveryAddress()",
+      "norm_label": "formatdeliveryaddress()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L74"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "productview_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L506"
+      "id": "utils_getamountpaidfororder",
+      "label": "getAmountPaidForOrder()",
+      "norm_label": "getamountpaidfororder()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L191"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "productview_modifyproduct",
-      "label": "modifyProduct()",
-      "norm_label": "modifyproduct()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L271"
+      "id": "utils_getdiscountvalue",
+      "label": "getDiscountValue()",
+      "norm_label": "getdiscountvalue()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L17"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "productview_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L490"
+      "id": "utils_getonlineorderplacedat",
+      "label": "getOnlineOrderPlacedAt()",
+      "norm_label": "getonlineorderplacedat()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "productview_resolvelegacytaxonomysavegate",
-      "label": "resolveLegacyTaxonomySaveGate()",
-      "norm_label": "resolvelegacytaxonomysavegate()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "id": "utils_getorderamount",
+      "label": "getOrderAmount()",
+      "norm_label": "getorderamount()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 195,
+      "file_type": "code",
+      "id": "utils_getorderstate",
+      "label": "getOrderState()",
+      "norm_label": "getorderstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
       "source_location": "L40"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "productview_saveproduct",
-      "label": "saveProduct()",
-      "norm_label": "saveproduct()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L217"
+      "id": "utils_getpickupactionstate",
+      "label": "getPickupActionState()",
+      "norm_label": "getpickupactionstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L102"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "productview_updatevariantsku",
-      "label": "updateVariantSku()",
-      "norm_label": "updatevariantsku()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L404"
+      "id": "utils_getpotentialpoints",
+      "label": "getPotentialPoints()",
+      "norm_label": "getpotentialpoints()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 195,
+      "file_type": "code",
+      "id": "utils_getproductdiscountvalue",
+      "label": "getProductDiscountValue()",
+      "norm_label": "getproductdiscountvalue()",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 195,
+      "file_type": "code",
+      "id": "utils_shouldshowpickupexceptionaction",
+      "label": "shouldShowPickupExceptionAction()",
+      "norm_label": "shouldshowpickupexceptionaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L116"
     },
     {
       "community": 1950,
@@ -221455,7 +221467,7 @@
       "label": "askForDay()",
       "norm_label": "askforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L749"
+      "source_location": "L762"
     },
     {
       "community": 209,
@@ -221464,7 +221476,7 @@
       "label": "insertCompletedClose()",
       "norm_label": "insertcompletedclose()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L602"
+      "source_location": "L615"
     },
     {
       "community": 209,
@@ -221482,7 +221494,7 @@
       "label": "insertReportDay()",
       "norm_label": "insertreportday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L652"
+      "source_location": "L665"
     },
     {
       "community": 209,
@@ -221500,7 +221512,7 @@
       "label": "insertSkuDay()",
       "norm_label": "insertskuday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L686"
+      "source_location": "L699"
     },
     {
       "community": 209,
@@ -221536,7 +221548,7 @@
       "label": "unitsMetric()",
       "norm_label": "unitsmetric()",
       "source_file": "packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts",
-      "source_location": "L740"
+      "source_location": "L753"
     },
     {
       "community": 209,
@@ -230172,92 +230184,92 @@
     {
       "community": 247,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_marketing_walkthroughconfig_ts",
-      "label": "walkthroughConfig.ts",
-      "norm_label": "walkthroughconfig.ts",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "id": "index_resolveverificationcoderecipient",
+      "label": "resolveVerificationCodeRecipient()",
+      "norm_label": "resolveverificationcoderecipient()",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "index_senddailymanagerreportemail",
+      "label": "sendDailyManagerReportEmail()",
+      "norm_label": "senddailymanagerreportemail()",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "source_location": "L373"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "index_senddiscountcodeemail",
+      "label": "sendDiscountCodeEmail()",
+      "norm_label": "senddiscountcodeemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L255"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "index_senddiscountreminderemail",
+      "label": "sendDiscountReminderEmail()",
+      "norm_label": "senddiscountreminderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L334"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "index_sendfeedbackrequestemail",
+      "label": "sendFeedbackRequestEmail()",
+      "norm_label": "sendfeedbackrequestemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "index_sendneworderemail",
+      "label": "sendNewOrderEmail()",
+      "norm_label": "sendneworderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L117"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "index_sendorderemail",
+      "label": "sendOrderEmail()",
+      "norm_label": "sendorderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "index_sendverificationcode",
+      "label": "sendVerificationCode()",
+      "norm_label": "sendverificationcode()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
       "source_location": "L1"
     },
     {
       "community": 247,
       "file_type": "code",
-      "id": "walkthroughconfig_landingfunnelhourlylimit",
-      "label": "landingFunnelHourlyLimit()",
-      "norm_label": "landingfunnelhourlylimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "walkthroughconfig_parseboundedpositiveinteger",
-      "label": "parseBoundedPositiveInteger()",
-      "norm_label": "parseboundedpositiveinteger()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "walkthroughconfig_resolvewalkthroughallowedorigins",
-      "label": "resolveWalkthroughAllowedOrigins()",
-      "norm_label": "resolvewalkthroughallowedorigins()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughallowedorigins",
-      "label": "walkthroughAllowedOrigins()",
-      "norm_label": "walkthroughallowedorigins()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughdailyperemaillimit",
-      "label": "walkthroughDailyPerEmailLimit()",
-      "norm_label": "walkthroughdailyperemaillimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L55"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughhourlygloballimit",
-      "label": "walkthroughHourlyGlobalLimit()",
-      "norm_label": "walkthroughhourlygloballimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughhourlynotificationlimit",
-      "label": "walkthroughHourlyNotificationLimit()",
-      "norm_label": "walkthroughhourlynotificationlimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughmaxbodybytes",
-      "label": "walkthroughMaxBodyBytes()",
-      "norm_label": "walkthroughmaxbodybytes()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughprivacycontact",
-      "label": "walkthroughPrivacyContact()",
-      "norm_label": "walkthroughprivacycontact()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L95"
+      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L1"
     },
     {
       "community": 2470,
@@ -230352,92 +230364,92 @@
     {
       "community": 248,
       "file_type": "code",
-      "id": "definitions_costoverlaystorewriteoperation",
-      "label": "costOverlayStoreWriteOperation()",
-      "norm_label": "costoverlaystorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L569"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "definitions_cyclecountdraftstorewriteoperation",
-      "label": "cycleCountDraftStoreWriteOperation()",
-      "norm_label": "cyclecountdraftstorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L383"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "definitions_defineoperation",
-      "label": "defineOperation()",
-      "norm_label": "defineoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "definitions_inventoryimportreviewpayloadwriteoperation",
-      "label": "inventoryImportReviewPayloadWriteOperation()",
-      "norm_label": "inventoryimportreviewpayloadwriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L544"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "definitions_notificationsubscriptionrowwriteoperation",
-      "label": "notificationSubscriptionRowWriteOperation()",
-      "norm_label": "notificationsubscriptionrowwriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L629"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "definitions_orderstorewriteoperation",
-      "label": "orderStoreWriteOperation()",
-      "norm_label": "orderstorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L155"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "definitions_storewriteoperation",
-      "label": "storeWriteOperation()",
-      "norm_label": "storewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L108"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "definitions_transactionstorewriteoperation",
-      "label": "transactionStoreWriteOperation()",
-      "norm_label": "transactionstorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "definitions_validateoperationdefinition",
-      "label": "validateOperationDefinition()",
-      "norm_label": "validateoperationdefinition()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L724"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operationadmission_definitions_ts",
-      "label": "definitions.ts",
-      "norm_label": "definitions.ts",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "id": "packages_athena_webapp_convex_marketing_walkthroughconfig_ts",
+      "label": "walkthroughConfig.ts",
+      "norm_label": "walkthroughconfig.ts",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "walkthroughconfig_landingfunnelhourlylimit",
+      "label": "landingFunnelHourlyLimit()",
+      "norm_label": "landingfunnelhourlylimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "walkthroughconfig_parseboundedpositiveinteger",
+      "label": "parseBoundedPositiveInteger()",
+      "norm_label": "parseboundedpositiveinteger()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "walkthroughconfig_resolvewalkthroughallowedorigins",
+      "label": "resolveWalkthroughAllowedOrigins()",
+      "norm_label": "resolvewalkthroughallowedorigins()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughallowedorigins",
+      "label": "walkthroughAllowedOrigins()",
+      "norm_label": "walkthroughallowedorigins()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughdailyperemaillimit",
+      "label": "walkthroughDailyPerEmailLimit()",
+      "norm_label": "walkthroughdailyperemaillimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughhourlygloballimit",
+      "label": "walkthroughHourlyGlobalLimit()",
+      "norm_label": "walkthroughhourlygloballimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughhourlynotificationlimit",
+      "label": "walkthroughHourlyNotificationLimit()",
+      "norm_label": "walkthroughhourlynotificationlimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughmaxbodybytes",
+      "label": "walkthroughMaxBodyBytes()",
+      "norm_label": "walkthroughmaxbodybytes()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughprivacycontact",
+      "label": "walkthroughPrivacyContact()",
+      "norm_label": "walkthroughprivacycontact()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L95"
     },
     {
       "community": 2480,
@@ -230532,91 +230544,91 @@
     {
       "community": 249,
       "file_type": "code",
-      "id": "adjustmentreports_adjustmentappliedat",
-      "label": "adjustmentAppliedAt()",
-      "norm_label": "adjustmentappliedat()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L101"
+      "id": "definitions_costoverlaystorewriteoperation",
+      "label": "costOverlayStoreWriteOperation()",
+      "norm_label": "costoverlaystorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L569"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "adjustmentreports_adjustmentsalesdelta",
-      "label": "adjustmentSalesDelta()",
-      "norm_label": "adjustmentsalesdelta()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L116"
+      "id": "definitions_cyclecountdraftstorewriteoperation",
+      "label": "cycleCountDraftStoreWriteOperation()",
+      "norm_label": "cyclecountdraftstorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L383"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "adjustmentreports_adjustmentsettlementamount",
-      "label": "adjustmentSettlementAmount()",
-      "norm_label": "adjustmentsettlementamount()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L143"
+      "id": "definitions_defineoperation",
+      "label": "defineOperation()",
+      "norm_label": "defineoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L11"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "adjustmentreports_adjustmenttransactionid",
-      "label": "adjustmentTransactionId()",
-      "norm_label": "adjustmenttransactionid()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L110"
+      "id": "definitions_inventoryimportreviewpayloadwriteoperation",
+      "label": "inventoryImportReviewPayloadWriteOperation()",
+      "norm_label": "inventoryimportreviewpayloadwriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L544"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "adjustmentreports_buildadjustmentpaymenttotals",
-      "label": "buildAdjustmentPaymentTotals()",
-      "norm_label": "buildadjustmentpaymenttotals()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L242"
+      "id": "definitions_notificationsubscriptionrowwriteoperation",
+      "label": "notificationSubscriptionRowWriteOperation()",
+      "norm_label": "notificationsubscriptionrowwriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L629"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "adjustmentreports_buildadjustmentreporttotals",
-      "label": "buildAdjustmentReportTotals()",
-      "norm_label": "buildadjustmentreporttotals()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L275"
+      "id": "definitions_orderstorewriteoperation",
+      "label": "orderStoreWriteOperation()",
+      "norm_label": "orderstorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L155"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "adjustmentreports_listappliedtransactionadjustmentsforday",
-      "label": "listAppliedTransactionAdjustmentsForDay()",
-      "norm_label": "listappliedtransactionadjustmentsforday()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L229"
+      "id": "definitions_storewriteoperation",
+      "label": "storeWriteOperation()",
+      "norm_label": "storewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L108"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "adjustmentreports_readappliedtransactionadjustmentsforday",
-      "label": "readAppliedTransactionAdjustmentsForDay()",
-      "norm_label": "readappliedtransactionadjustmentsforday()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L173"
+      "id": "definitions_transactionstorewriteoperation",
+      "label": "transactionStoreWriteOperation()",
+      "norm_label": "transactionstorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L128"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "adjustmentreports_sourcecompletenessentry",
-      "label": "sourceCompletenessEntry()",
-      "norm_label": "sourcecompletenessentry()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L76"
+      "id": "definitions_validateoperationdefinition",
+      "label": "validateOperationDefinition()",
+      "norm_label": "validateoperationdefinition()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L724"
     },
     {
       "community": 249,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_dailyclose_adjustmentreports_ts",
-      "label": "adjustmentReports.ts",
-      "norm_label": "adjustmentreports.ts",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "id": "packages_athena_webapp_convex_operationadmission_definitions_ts",
+      "label": "definitions.ts",
+      "norm_label": "definitions.ts",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
       "source_location": "L1"
     },
     {
@@ -231063,91 +231075,91 @@
     {
       "community": 250,
       "file_type": "code",
-      "id": "inventorymovements_assertnobusinesseventconflict",
-      "label": "assertNoBusinessEventConflict()",
-      "norm_label": "assertnobusinesseventconflict()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L178"
+      "id": "adjustmentreports_adjustmentappliedat",
+      "label": "adjustmentAppliedAt()",
+      "norm_label": "adjustmentappliedat()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L101"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "inventorymovements_buildinventorymovement",
-      "label": "buildInventoryMovement()",
-      "norm_label": "buildinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L124"
+      "id": "adjustmentreports_adjustmentsalesdelta",
+      "label": "adjustmentSalesDelta()",
+      "norm_label": "adjustmentsalesdelta()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L116"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "inventorymovements_buildskuactivityforinventorymovement",
-      "label": "buildSkuActivityForInventoryMovement()",
-      "norm_label": "buildskuactivityforinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L66"
+      "id": "adjustmentreports_adjustmentsettlementamount",
+      "label": "adjustmentSettlementAmount()",
+      "norm_label": "adjustmentsettlementamount()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L143"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "inventorymovements_getskuactivitytypeformovement",
-      "label": "getSkuActivityTypeForMovement()",
-      "norm_label": "getskuactivitytypeformovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L49"
+      "id": "adjustmentreports_adjustmenttransactionid",
+      "label": "adjustmentTransactionId()",
+      "norm_label": "adjustmenttransactionid()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L110"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "inventorymovements_matchesexistingmovement",
-      "label": "matchesExistingMovement()",
-      "norm_label": "matchesexistingmovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L150"
+      "id": "adjustmentreports_buildadjustmentpaymenttotals",
+      "label": "buildAdjustmentPaymentTotals()",
+      "norm_label": "buildadjustmentpaymenttotals()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L242"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "inventorymovements_recordinventorymovementwithctx",
-      "label": "recordInventoryMovementWithCtx()",
-      "norm_label": "recordinventorymovementwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L200"
+      "id": "adjustmentreports_buildadjustmentreporttotals",
+      "label": "buildAdjustmentReportTotals()",
+      "norm_label": "buildadjustmentreporttotals()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L275"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "inventorymovements_recordinventorymovementwithdispositionwithctx",
-      "label": "recordInventoryMovementWithDispositionWithCtx()",
-      "norm_label": "recordinventorymovementwithdispositionwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L245"
+      "id": "adjustmentreports_listappliedtransactionadjustmentsforday",
+      "label": "listAppliedTransactionAdjustmentsForDay()",
+      "norm_label": "listappliedtransactionadjustmentsforday()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L229"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "inventorymovements_recordskuactivityforinventorymovementwithctx",
-      "label": "recordSkuActivityForInventoryMovementWithCtx()",
-      "norm_label": "recordskuactivityforinventorymovementwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L111"
+      "id": "adjustmentreports_readappliedtransactionadjustmentsforday",
+      "label": "readAppliedTransactionAdjustmentsForDay()",
+      "norm_label": "readappliedtransactionadjustmentsforday()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L173"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "inventorymovements_summarizeinventorymovements",
-      "label": "summarizeInventoryMovements()",
-      "norm_label": "summarizeinventorymovements()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L135"
+      "id": "adjustmentreports_sourcecompletenessentry",
+      "label": "sourceCompletenessEntry()",
+      "norm_label": "sourcecompletenessentry()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L76"
     },
     {
       "community": 250,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
-      "label": "inventoryMovements.ts",
-      "norm_label": "inventorymovements.ts",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "id": "packages_athena_webapp_convex_operations_dailyclose_adjustmentreports_ts",
+      "label": "adjustmentReports.ts",
+      "norm_label": "adjustmentreports.ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
       "source_location": "L1"
     },
     {
@@ -231243,91 +231255,91 @@
     {
       "community": 251,
       "file_type": "code",
-      "id": "operationalevents_buildoperationalevent",
-      "label": "buildOperationalEvent()",
-      "norm_label": "buildoperationalevent()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L43"
+      "id": "inventorymovements_assertnobusinesseventconflict",
+      "label": "assertNoBusinessEventConflict()",
+      "norm_label": "assertnobusinesseventconflict()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L178"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "operationalevents_buildtracemetadata",
-      "label": "buildTraceMetadata()",
-      "norm_label": "buildtracemetadata()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L96"
+      "id": "inventorymovements_buildinventorymovement",
+      "label": "buildInventoryMovement()",
+      "norm_label": "buildinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L124"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "operationalevents_isrecord",
-      "label": "isRecord()",
-      "norm_label": "isrecord()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L145"
+      "id": "inventorymovements_buildskuactivityforinventorymovement",
+      "label": "buildSkuActivityForInventoryMovement()",
+      "norm_label": "buildskuactivityforinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L66"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "operationalevents_listproductoperationaltimelinewithctx",
-      "label": "listProductOperationalTimelineWithCtx()",
-      "norm_label": "listproductoperationaltimelinewithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L246"
+      "id": "inventorymovements_getskuactivitytypeformovement",
+      "label": "getSkuActivityTypeForMovement()",
+      "norm_label": "getskuactivitytypeformovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L49"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "operationalevents_matchesexistingevent",
-      "label": "matchesExistingEvent()",
-      "norm_label": "matchesexistingevent()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L149"
+      "id": "inventorymovements_matchesexistingmovement",
+      "label": "matchesExistingMovement()",
+      "norm_label": "matchesexistingmovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L150"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "operationalevents_metadatadedupekeysmatch",
-      "label": "metadataDedupeKeysMatch()",
-      "norm_label": "metadatadedupekeysmatch()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L205"
+      "id": "inventorymovements_recordinventorymovementwithctx",
+      "label": "recordInventoryMovementWithCtx()",
+      "norm_label": "recordinventorymovementwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L200"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "operationalevents_normalizeoperationaleventtracefields",
-      "label": "normalizeOperationalEventTraceFields()",
-      "norm_label": "normalizeoperationaleventtracefields()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L60"
+      "id": "inventorymovements_recordinventorymovementwithdispositionwithctx",
+      "label": "recordInventoryMovementWithDispositionWithCtx()",
+      "norm_label": "recordinventorymovementwithdispositionwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L245"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "operationalevents_recordoperationaleventwithctx",
-      "label": "recordOperationalEventWithCtx()",
-      "norm_label": "recordoperationaleventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L215"
+      "id": "inventorymovements_recordskuactivityforinventorymovementwithctx",
+      "label": "recordSkuActivityForInventoryMovementWithCtx()",
+      "norm_label": "recordskuactivityforinventorymovementwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L111"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "operationalevents_shouldnormalizepostrace",
-      "label": "shouldNormalizePosTrace()",
-      "norm_label": "shouldnormalizepostrace()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L118"
+      "id": "inventorymovements_summarizeinventorymovements",
+      "label": "summarizeInventoryMovements()",
+      "norm_label": "summarizeinventorymovements()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L135"
     },
     {
       "community": 251,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
-      "label": "operationalEvents.ts",
-      "norm_label": "operationalevents.ts",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
+      "label": "inventoryMovements.ts",
+      "norm_label": "inventorymovements.ts",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
       "source_location": "L1"
     },
     {
@@ -231423,91 +231435,91 @@
     {
       "community": 252,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_amendrepairwithctx",
-      "label": "amendRepairWithCtx()",
-      "norm_label": "amendrepairwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L430"
+      "id": "operationalevents_buildoperationalevent",
+      "label": "buildOperationalEvent()",
+      "norm_label": "buildoperationalevent()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L43"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_createrepairwithctx",
-      "label": "createRepairWithCtx()",
-      "norm_label": "createrepairwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L160"
+      "id": "operationalevents_buildtracemetadata",
+      "label": "buildTraceMetadata()",
+      "norm_label": "buildtracemetadata()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L96"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_pauserepair",
-      "label": "pauseRepair()",
-      "norm_label": "pauserepair()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L231"
+      "id": "operationalevents_isrecord",
+      "label": "isRecord()",
+      "norm_label": "isrecord()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L145"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_processrepairbatchwithctx",
-      "label": "processRepairBatchWithCtx()",
-      "norm_label": "processrepairbatchwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L249"
+      "id": "operationalevents_listproductoperationaltimelinewithctx",
+      "label": "listProductOperationalTimelineWithCtx()",
+      "norm_label": "listproductoperationaltimelinewithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L246"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_readcurrentgroup",
-      "label": "readCurrentGroup()",
-      "norm_label": "readcurrentgroup()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L49"
+      "id": "operationalevents_matchesexistingevent",
+      "label": "matchesExistingEvent()",
+      "norm_label": "matchesexistingevent()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L149"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_recordrepairauditevent",
-      "label": "recordRepairAuditEvent()",
-      "norm_label": "recordrepairauditevent()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L85"
+      "id": "operationalevents_metadatadedupekeysmatch",
+      "label": "metadataDedupeKeysMatch()",
+      "norm_label": "metadatadedupekeysmatch()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L205"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_requireevidence",
-      "label": "requireEvidence()",
-      "norm_label": "requireevidence()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L37"
+      "id": "operationalevents_normalizeoperationaleventtracefields",
+      "label": "normalizeOperationalEventTraceFields()",
+      "norm_label": "normalizeoperationaleventtracefields()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L60"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_resumerepairwithctx",
-      "label": "resumeRepairWithCtx()",
-      "norm_label": "resumerepairwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L472"
+      "id": "operationalevents_recordoperationaleventwithctx",
+      "label": "recordOperationalEventWithCtx()",
+      "norm_label": "recordoperationaleventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L215"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_schedulenextbatch",
-      "label": "scheduleNextBatch()",
-      "norm_label": "schedulenextbatch()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L153"
+      "id": "operationalevents_shouldnormalizepostrace",
+      "label": "shouldNormalizePosTrace()",
+      "norm_label": "shouldnormalizepostrace()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L118"
     },
     {
       "community": 252,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_oversizedoperationalworkrepair_ts",
-      "label": "oversizedOperationalWorkRepair.ts",
-      "norm_label": "oversizedoperationalworkrepair.ts",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
+      "label": "operationalEvents.ts",
+      "norm_label": "operationalevents.ts",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
       "source_location": "L1"
     },
     {
@@ -231603,92 +231615,92 @@
     {
       "community": 253,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
-      "label": "registerSessionTracing.ts",
-      "norm_label": "registersessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "id": "oversizedoperationalworkrepair_amendrepairwithctx",
+      "label": "amendRepairWithCtx()",
+      "norm_label": "amendrepairwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L430"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_createrepairwithctx",
+      "label": "createRepairWithCtx()",
+      "norm_label": "createrepairwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L160"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_pauserepair",
+      "label": "pauseRepair()",
+      "norm_label": "pauserepair()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L231"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_processrepairbatchwithctx",
+      "label": "processRepairBatchWithCtx()",
+      "norm_label": "processrepairbatchwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L249"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_readcurrentgroup",
+      "label": "readCurrentGroup()",
+      "norm_label": "readcurrentgroup()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_recordrepairauditevent",
+      "label": "recordRepairAuditEvent()",
+      "norm_label": "recordrepairauditevent()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_requireevidence",
+      "label": "requireEvidence()",
+      "norm_label": "requireevidence()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_resumerepairwithctx",
+      "label": "resumeRepairWithCtx()",
+      "norm_label": "resumerepairwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L472"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_schedulenextbatch",
+      "label": "scheduleNextBatch()",
+      "norm_label": "schedulenextbatch()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L153"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_oversizedoperationalworkrepair_ts",
+      "label": "oversizedOperationalWorkRepair.ts",
+      "norm_label": "oversizedoperationalworkrepair.ts",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "registersessiontracing_buildactorrefs",
-      "label": "buildActorRefs()",
-      "norm_label": "buildactorrefs()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "registersessiontracing_buildtraceevent",
-      "label": "buildTraceEvent()",
-      "norm_label": "buildtraceevent()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L196"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "registersessiontracing_buildtracerecord",
-      "label": "buildTraceRecord()",
-      "norm_label": "buildtracerecord()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L161"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "registersessiontracing_displaytraceamount",
-      "label": "displayTraceAmount()",
-      "norm_label": "displaytraceamount()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L114"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "registersessiontracing_formattransactionlabel",
-      "label": "formatTransactionLabel()",
-      "norm_label": "formattransactionlabel()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L132"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "registersessiontracing_recordregistersessiontracebesteffort",
-      "label": "recordRegisterSessionTraceBestEffort()",
-      "norm_label": "recordregistersessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L407"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "registersessiontracing_resolveoccurredat",
-      "label": "resolveOccurredAt()",
-      "norm_label": "resolveoccurredat()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L76"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "registersessiontracing_resolvestorecurrency",
-      "label": "resolveStoreCurrency()",
-      "norm_label": "resolvestorecurrency()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L146"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "registersessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L92"
     },
     {
       "community": 2530,
@@ -231783,92 +231795,92 @@
     {
       "community": 254,
       "file_type": "code",
-      "id": "finalizedlineageremediation_classifyfinalizedlineagerepairconflicts",
-      "label": "classifyFinalizedLineageRepairConflicts()",
-      "norm_label": "classifyfinalizedlineagerepairconflicts()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L222"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_classifyrepaircandidate",
-      "label": "classifyRepairCandidate()",
-      "norm_label": "classifyrepaircandidate()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L164"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_countrepairablefinalizedlineagelines",
-      "label": "countRepairableFinalizedLineageLines()",
-      "norm_label": "countrepairablefinalizedlineagelines()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L284"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_getprovisionalimportsku",
-      "label": "getProvisionalImportSku()",
-      "norm_label": "getprovisionalimportsku()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L318"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_isclosedregisterrepairreplayconflict",
-      "label": "isClosedRegisterRepairReplayConflict()",
-      "norm_label": "isclosedregisterrepairreplayconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L273"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_isfinalizedlineagerepairconflict",
-      "label": "isFinalizedLineageRepairConflict()",
-      "norm_label": "isfinalizedlineagerepairconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L258"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_isprovisionalrowchangedconflict",
-      "label": "isProvisionalRowChangedConflict()",
-      "norm_label": "isprovisionalrowchangedconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L265"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_recordfinalizedlineagerepairevent",
-      "label": "recordFinalizedLineageRepairEvent()",
-      "norm_label": "recordfinalizedlineagerepairevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L358"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_skipped",
-      "label": "skipped()",
-      "norm_label": "skipped()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L346"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sync_finalizedlineageremediation_ts",
-      "label": "finalizedLineageRemediation.ts",
-      "norm_label": "finalizedlineageremediation.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "id": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
+      "label": "registerSessionTracing.ts",
+      "norm_label": "registersessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "registersessiontracing_buildactorrefs",
+      "label": "buildActorRefs()",
+      "norm_label": "buildactorrefs()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "registersessiontracing_buildtraceevent",
+      "label": "buildTraceEvent()",
+      "norm_label": "buildtraceevent()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L196"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "registersessiontracing_buildtracerecord",
+      "label": "buildTraceRecord()",
+      "norm_label": "buildtracerecord()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L161"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "registersessiontracing_displaytraceamount",
+      "label": "displayTraceAmount()",
+      "norm_label": "displaytraceamount()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L114"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "registersessiontracing_formattransactionlabel",
+      "label": "formatTransactionLabel()",
+      "norm_label": "formattransactionlabel()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L132"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "registersessiontracing_recordregistersessiontracebesteffort",
+      "label": "recordRegisterSessionTraceBestEffort()",
+      "norm_label": "recordregistersessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L407"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "registersessiontracing_resolveoccurredat",
+      "label": "resolveOccurredAt()",
+      "norm_label": "resolveoccurredat()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "registersessiontracing_resolvestorecurrency",
+      "label": "resolveStoreCurrency()",
+      "norm_label": "resolvestorecurrency()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L146"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "registersessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L92"
     },
     {
       "community": 2540,
@@ -231963,92 +231975,92 @@
     {
       "community": 255,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_terminalrecoveryrepository_ts",
-      "label": "terminalRecoveryRepository.ts",
-      "norm_label": "terminalrecoveryrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_createterminalrecoverycommandreadrepository",
-      "label": "createTerminalRecoveryCommandReadRepository()",
-      "norm_label": "createterminalrecoverycommandreadrepository()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_createterminalrecoverycommandrepository",
-      "label": "createTerminalRecoveryCommandRepository()",
-      "norm_label": "createterminalrecoverycommandrepository()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L127"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_deduperecoverycommandsbyid",
-      "label": "dedupeRecoveryCommandsById()",
-      "norm_label": "deduperecoverycommandsbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_deduperecoveryconflictsbyid",
-      "label": "dedupeRecoveryConflictsById()",
-      "norm_label": "deduperecoveryconflictsbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L193"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_getterminalrecoverysourceevent",
-      "label": "getTerminalRecoverySourceEvent()",
-      "norm_label": "getterminalrecoverysourceevent()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "id": "finalizedlineageremediation_classifyfinalizedlineagerepairconflicts",
+      "label": "classifyFinalizedLineageRepairConflicts()",
+      "norm_label": "classifyfinalizedlineagerepairconflicts()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
       "source_location": "L222"
     },
     {
       "community": 255,
       "file_type": "code",
-      "id": "terminalrecoveryrepository_iscurrentterminalrecoveryconflict",
-      "label": "isCurrentTerminalRecoveryConflict()",
-      "norm_label": "iscurrentterminalrecoveryconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L206"
+      "id": "finalizedlineageremediation_classifyrepaircandidate",
+      "label": "classifyRepairCandidate()",
+      "norm_label": "classifyrepaircandidate()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L164"
     },
     {
       "community": 255,
       "file_type": "code",
-      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsforrepair",
-      "label": "listTerminalRecoveryConflictsForRepair()",
-      "norm_label": "listterminalrecoveryconflictsforrepair()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L141"
+      "id": "finalizedlineageremediation_countrepairablefinalizedlineagelines",
+      "label": "countRepairableFinalizedLineageLines()",
+      "norm_label": "countrepairablefinalizedlineagelines()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L284"
     },
     {
       "community": 255,
       "file_type": "code",
-      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsources",
-      "label": "listTerminalRecoveryConflictSources()",
-      "norm_label": "listterminalrecoveryconflictsources()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L162"
+      "id": "finalizedlineageremediation_getprovisionalimportsku",
+      "label": "getProvisionalImportSku()",
+      "norm_label": "getprovisionalimportsku()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L318"
     },
     {
       "community": 255,
       "file_type": "code",
-      "id": "terminalrecoveryrepository_patchterminalrecoveryconflict",
-      "label": "patchTerminalRecoveryConflict()",
-      "norm_label": "patchterminalrecoveryconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L241"
+      "id": "finalizedlineageremediation_isclosedregisterrepairreplayconflict",
+      "label": "isClosedRegisterRepairReplayConflict()",
+      "norm_label": "isclosedregisterrepairreplayconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L273"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_isfinalizedlineagerepairconflict",
+      "label": "isFinalizedLineageRepairConflict()",
+      "norm_label": "isfinalizedlineagerepairconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L258"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_isprovisionalrowchangedconflict",
+      "label": "isProvisionalRowChangedConflict()",
+      "norm_label": "isprovisionalrowchangedconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L265"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_recordfinalizedlineagerepairevent",
+      "label": "recordFinalizedLineageRepairEvent()",
+      "norm_label": "recordfinalizedlineagerepairevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L358"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_skipped",
+      "label": "skipped()",
+      "norm_label": "skipped()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L346"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_sync_finalizedlineageremediation_ts",
+      "label": "finalizedLineageRemediation.ts",
+      "norm_label": "finalizedlineageremediation.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L1"
     },
     {
       "community": 2550,
@@ -232143,92 +232155,92 @@
     {
       "community": 256,
       "file_type": "code",
-      "id": "contract_test_day",
-      "label": "day()",
-      "norm_label": "day()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L1308"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "contract_test_fieldsof",
-      "label": "fieldsOf()",
-      "norm_label": "fieldsof()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L86"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "contract_test_headerfor",
-      "label": "headerFor()",
-      "norm_label": "headerfor()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L972"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "contract_test_inclusivedays",
-      "label": "inclusiveDays()",
-      "norm_label": "inclusivedays()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L1216"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "contract_test_movementidentityargs",
-      "label": "movementIdentityArgs()",
-      "norm_label": "movementidentityargs()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L602"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "contract_test_probe",
-      "label": "probe()",
-      "norm_label": "probe()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L1312"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "contract_test_seedproductsku",
-      "label": "seedProductSku()",
-      "norm_label": "seedproductsku()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L561"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "contract_test_seedstore",
-      "label": "seedStore()",
-      "norm_label": "seedstore()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L542"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "contract_test_unionliterals",
-      "label": "unionLiterals()",
-      "norm_label": "unionliterals()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L92"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_contract_test_ts",
-      "label": "contract.test.ts",
-      "norm_label": "contract.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_terminalrecoveryrepository_ts",
+      "label": "terminalRecoveryRepository.ts",
+      "norm_label": "terminalrecoveryrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_createterminalrecoverycommandreadrepository",
+      "label": "createTerminalRecoveryCommandReadRepository()",
+      "norm_label": "createterminalrecoverycommandreadrepository()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_createterminalrecoverycommandrepository",
+      "label": "createTerminalRecoveryCommandRepository()",
+      "norm_label": "createterminalrecoverycommandrepository()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L127"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_deduperecoverycommandsbyid",
+      "label": "dedupeRecoveryCommandsById()",
+      "norm_label": "deduperecoverycommandsbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L116"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_deduperecoveryconflictsbyid",
+      "label": "dedupeRecoveryConflictsById()",
+      "norm_label": "deduperecoveryconflictsbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L193"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_getterminalrecoverysourceevent",
+      "label": "getTerminalRecoverySourceEvent()",
+      "norm_label": "getterminalrecoverysourceevent()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L222"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_iscurrentterminalrecoveryconflict",
+      "label": "isCurrentTerminalRecoveryConflict()",
+      "norm_label": "iscurrentterminalrecoveryconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L206"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsforrepair",
+      "label": "listTerminalRecoveryConflictsForRepair()",
+      "norm_label": "listterminalrecoveryconflictsforrepair()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L141"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsources",
+      "label": "listTerminalRecoveryConflictSources()",
+      "norm_label": "listterminalrecoveryconflictsources()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L162"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_patchterminalrecoveryconflict",
+      "label": "patchTerminalRecoveryConflict()",
+      "norm_label": "patchterminalrecoveryconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L241"
     },
     {
       "community": 2560,
@@ -232323,91 +232335,91 @@
     {
       "community": 257,
       "file_type": "code",
-      "id": "customrange_aggregateskudays",
-      "label": "aggregateSkuDays()",
-      "norm_label": "aggregateskudays()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L217"
+      "id": "contract_test_day",
+      "label": "day()",
+      "norm_label": "day()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L1308"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "customrange_computerange",
-      "label": "computeRange()",
-      "norm_label": "computerange()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L253"
+      "id": "contract_test_fieldsof",
+      "label": "fieldsOf()",
+      "norm_label": "fieldsof()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L86"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "customrange_computerequestkey",
-      "label": "computeRequestKey()",
-      "norm_label": "computerequestkey()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L84"
+      "id": "contract_test_headerfor",
+      "label": "headerFor()",
+      "norm_label": "headerfor()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L972"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "customrange_inclusivedayspan",
-      "label": "inclusiveDaySpan()",
-      "norm_label": "inclusivedayspan()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L52"
+      "id": "contract_test_inclusivedays",
+      "label": "inclusiveDays()",
+      "norm_label": "inclusivedays()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L1216"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "customrange_isvalidoperatingdate",
-      "label": "isValidOperatingDate()",
-      "norm_label": "isvalidoperatingdate()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L35"
+      "id": "contract_test_movementidentityargs",
+      "label": "movementIdentityArgs()",
+      "norm_label": "movementidentityargs()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L602"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "customrange_requestrangecore",
-      "label": "requestRangeCore()",
-      "norm_label": "requestrangecore()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L112"
+      "id": "contract_test_probe",
+      "label": "probe()",
+      "norm_label": "probe()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L1312"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "customrange_sumdays",
-      "label": "sumDays()",
-      "norm_label": "sumdays()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L189"
+      "id": "contract_test_seedproductsku",
+      "label": "seedProductSku()",
+      "norm_label": "seedproductsku()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L561"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "customrange_utcmillisforlabel",
-      "label": "utcMillisForLabel()",
-      "norm_label": "utcmillisforlabel()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L46"
+      "id": "contract_test_seedstore",
+      "label": "seedStore()",
+      "norm_label": "seedstore()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L542"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "customrange_validaterangeargs",
-      "label": "validateRangeArgs()",
-      "norm_label": "validaterangeargs()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L58"
+      "id": "contract_test_unionliterals",
+      "label": "unionLiterals()",
+      "norm_label": "unionliterals()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L92"
     },
     {
       "community": 257,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_customrange_ts",
-      "label": "customRange.ts",
-      "norm_label": "customrange.ts",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "id": "packages_athena_webapp_convex_reports_contract_test_ts",
+      "label": "contract.test.ts",
+      "norm_label": "contract.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
       "source_location": "L1"
     },
     {
@@ -232503,92 +232515,92 @@
     {
       "community": 258,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_rangesnapshotlifecycle_test_ts",
-      "label": "rangeSnapshotLifecycle.test.ts",
-      "norm_label": "rangesnapshotlifecycle.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "id": "customrange_aggregateskudays",
+      "label": "aggregateSkuDays()",
+      "norm_label": "aggregateskudays()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L217"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "customrange_computerange",
+      "label": "computeRange()",
+      "norm_label": "computerange()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L253"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "customrange_computerequestkey",
+      "label": "computeRequestKey()",
+      "norm_label": "computerequestkey()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "customrange_inclusivedayspan",
+      "label": "inclusiveDaySpan()",
+      "norm_label": "inclusivedayspan()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "customrange_isvalidoperatingdate",
+      "label": "isValidOperatingDate()",
+      "norm_label": "isvalidoperatingdate()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "customrange_requestrangecore",
+      "label": "requestRangeCore()",
+      "norm_label": "requestrangecore()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L112"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "customrange_sumdays",
+      "label": "sumDays()",
+      "norm_label": "sumdays()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L189"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "customrange_utcmillisforlabel",
+      "label": "utcMillisForLabel()",
+      "norm_label": "utcmillisforlabel()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "customrange_validaterangeargs",
+      "label": "validateRangeArgs()",
+      "norm_label": "validaterangeargs()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_reports_customrange_ts",
+      "label": "customRange.ts",
+      "norm_label": "customrange.ts",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_allow",
-      "label": "allow()",
-      "norm_label": "allow()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L53"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_certifyday",
-      "label": "certifyDay()",
-      "norm_label": "certifyday()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L109"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_consume",
-      "label": "consume()",
-      "norm_label": "consume()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L296"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_drive",
-      "label": "drive()",
-      "norm_label": "drive()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L247"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_ensuresynthetic",
-      "label": "ensureSynthetic()",
-      "norm_label": "ensuresynthetic()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L208"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_headerbykey",
-      "label": "headerByKey()",
-      "norm_label": "headerbykey()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L230"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_insertkindedheader",
-      "label": "insertKindedHeader()",
-      "norm_label": "insertkindedheader()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L612"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_seedstore",
-      "label": "seedStore()",
-      "norm_label": "seedstore()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "rangesnapshotlifecycle_test_synthetickind",
-      "label": "syntheticKind()",
-      "norm_label": "synthetickind()",
-      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
-      "source_location": "L150"
     },
     {
       "community": 2580,
@@ -232683,92 +232695,92 @@
     {
       "community": 259,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_verificationclassify_ts",
-      "label": "verificationClassify.ts",
-      "norm_label": "verificationclassify.ts",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "id": "packages_athena_webapp_convex_reports_rangesnapshotlifecycle_test_ts",
+      "label": "rangeSnapshotLifecycle.test.ts",
+      "norm_label": "rangesnapshotlifecycle.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
       "source_location": "L1"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "verificationclassify_buildclassification",
-      "label": "buildClassification()",
-      "norm_label": "buildclassification()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L448"
+      "id": "rangesnapshotlifecycle_test_allow",
+      "label": "allow()",
+      "norm_label": "allow()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L53"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "verificationclassify_classifydayresult",
-      "label": "classifyDayResult()",
-      "norm_label": "classifydayresult()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L481"
+      "id": "rangesnapshotlifecycle_test_certifyday",
+      "label": "certifyDay()",
+      "norm_label": "certifyday()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L109"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "verificationclassify_classifyweekresult",
-      "label": "classifyWeekResult()",
-      "norm_label": "classifyweekresult()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L562"
+      "id": "rangesnapshotlifecycle_test_consume",
+      "label": "consume()",
+      "norm_label": "consume()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L296"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "verificationclassify_confirmsclean",
-      "label": "confirmsClean()",
-      "norm_label": "confirmsclean()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L681"
+      "id": "rangesnapshotlifecycle_test_drive",
+      "label": "drive()",
+      "norm_label": "drive()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L247"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "verificationclassify_explainmetricdifference",
-      "label": "explainMetricDifference()",
-      "norm_label": "explainmetricdifference()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L378"
+      "id": "rangesnapshotlifecycle_test_ensuresynthetic",
+      "label": "ensureSynthetic()",
+      "norm_label": "ensuresynthetic()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L208"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "verificationclassify_fingerprintdifferences",
-      "label": "fingerprintDifferences()",
-      "norm_label": "fingerprintdifferences()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L354"
+      "id": "rangesnapshotlifecycle_test_headerbykey",
+      "label": "headerByKey()",
+      "norm_label": "headerbykey()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L230"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "verificationclassify_initialstreakstate",
-      "label": "initialStreakState()",
-      "norm_label": "initialstreakstate()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L658"
+      "id": "rangesnapshotlifecycle_test_insertkindedheader",
+      "label": "insertKindedHeader()",
+      "norm_label": "insertkindedheader()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L612"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "verificationclassify_nextstreakstate",
-      "label": "nextStreakState()",
-      "norm_label": "nextstreakstate()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L707"
+      "id": "rangesnapshotlifecycle_test_seedstore",
+      "label": "seedStore()",
+      "norm_label": "seedstore()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L73"
     },
     {
       "community": 259,
       "file_type": "code",
-      "id": "verificationclassify_partitiondifferences",
-      "label": "partitionDifferences()",
-      "norm_label": "partitiondifferences()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
-      "source_location": "L434"
+      "id": "rangesnapshotlifecycle_test_synthetickind",
+      "label": "syntheticKind()",
+      "norm_label": "synthetickind()",
+      "source_file": "packages/athena-webapp/convex/reports/rangeSnapshotLifecycle.test.ts",
+      "source_location": "L150"
     },
     {
       "community": 2590,
@@ -233205,92 +233217,92 @@
     {
       "community": 260,
       "file_type": "code",
-      "id": "index_resolveverificationcoderecipient",
-      "label": "resolveVerificationCodeRecipient()",
-      "norm_label": "resolveverificationcoderecipient()",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "index_senddailymanagerreportemail",
-      "label": "sendDailyManagerReportEmail()",
-      "norm_label": "senddailymanagerreportemail()",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
-      "source_location": "L373"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "index_senddiscountcodeemail",
-      "label": "sendDiscountCodeEmail()",
-      "norm_label": "senddiscountcodeemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L255"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "index_senddiscountreminderemail",
-      "label": "sendDiscountReminderEmail()",
-      "norm_label": "senddiscountreminderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L334"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "index_sendfeedbackrequestemail",
-      "label": "sendFeedbackRequestEmail()",
-      "norm_label": "sendfeedbackrequestemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L167"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "index_sendneworderemail",
-      "label": "sendNewOrderEmail()",
-      "norm_label": "sendneworderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L117"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "index_sendorderemail",
-      "label": "sendOrderEmail()",
-      "norm_label": "sendorderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "index_sendverificationcode",
-      "label": "sendVerificationCode()",
-      "norm_label": "sendverificationcode()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 260,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "id": "packages_athena_webapp_convex_reports_verificationclassify_ts",
+      "label": "verificationClassify.ts",
+      "norm_label": "verificationclassify.ts",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
       "source_location": "L1"
     },
     {
       "community": 260,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L1"
+      "id": "verificationclassify_buildclassification",
+      "label": "buildClassification()",
+      "norm_label": "buildclassification()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L448"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "verificationclassify_classifydayresult",
+      "label": "classifyDayResult()",
+      "norm_label": "classifydayresult()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L481"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "verificationclassify_classifyweekresult",
+      "label": "classifyWeekResult()",
+      "norm_label": "classifyweekresult()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L562"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "verificationclassify_confirmsclean",
+      "label": "confirmsClean()",
+      "norm_label": "confirmsclean()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L681"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "verificationclassify_explainmetricdifference",
+      "label": "explainMetricDifference()",
+      "norm_label": "explainmetricdifference()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L378"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "verificationclassify_fingerprintdifferences",
+      "label": "fingerprintDifferences()",
+      "norm_label": "fingerprintdifferences()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L354"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "verificationclassify_initialstreakstate",
+      "label": "initialStreakState()",
+      "norm_label": "initialstreakstate()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L658"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "verificationclassify_nextstreakstate",
+      "label": "nextStreakState()",
+      "norm_label": "nextstreakstate()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L707"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "verificationclassify_partitiondifferences",
+      "label": "partitionDifferences()",
+      "norm_label": "partitiondifferences()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
+      "source_location": "L434"
     },
     {
       "community": 2600,
@@ -242358,6 +242370,87 @@
     {
       "community": 318,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 318,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 318,
+      "file_type": "code",
+      "id": "productutils_getpreferredsku",
+      "label": "getPreferredSku()",
+      "norm_label": "getpreferredsku()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 318,
+      "file_type": "code",
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 318,
+      "file_type": "code",
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 318,
+      "file_type": "code",
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 318,
+      "file_type": "code",
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L82"
+    },
+    {
+      "community": 318,
+      "file_type": "code",
+      "id": "productutils_sortskusbyavailabilitythenlength",
+      "label": "sortSkusByAvailabilityThenLength()",
+      "norm_label": "sortskusbyavailabilitythenlength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 318,
+      "file_type": "code",
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
       "id": "applyremoteassistcontrolintent_applyacceptedcontrolresult",
       "label": "applyAcceptedControlResult()",
       "norm_label": "applyacceptedcontrolresult()",
@@ -242365,7 +242458,7 @@
       "source_location": "L84"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_applykeyevent",
       "label": "applyKeyEvent()",
@@ -242374,7 +242467,7 @@
       "source_location": "L155"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_applypointerevent",
       "label": "applyPointerEvent()",
@@ -242383,7 +242476,7 @@
       "source_location": "L116"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_applyremoteassistcontrolintent",
       "label": "applyRemoteAssistControlIntent()",
@@ -242392,7 +242485,7 @@
       "source_location": "L17"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_getrecentcontrolresult",
       "label": "getRecentControlResult()",
@@ -242401,7 +242494,7 @@
       "source_location": "L95"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_getremoteassistcontroltarget",
       "label": "getRemoteAssistControlTarget()",
@@ -242410,7 +242503,7 @@
       "source_location": "L145"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_prepareremoteassistcontrolintent",
       "label": "prepareRemoteAssistControlIntent()",
@@ -242419,7 +242512,7 @@
       "source_location": "L27"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_remembercontrolresult",
       "label": "rememberControlResult()",
@@ -242428,94 +242521,13 @@
       "source_location": "L101"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_remote_assist_runtime_applyremoteassistcontrolintent_ts",
       "label": "applyRemoteAssistControlIntent.ts",
       "norm_label": "applyremoteassistcontrolintent.ts",
       "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_offline_posofflinereadiness_ts",
-      "label": "posOfflineReadiness.ts",
-      "norm_label": "posofflinereadiness.ts",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "posofflinereadiness_buildposofflinereadinesssummary",
-      "label": "buildPosOfflineReadinessSummary()",
-      "norm_label": "buildposofflinereadinesssummary()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L152"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "posofflinereadiness_buildsignal",
-      "label": "buildSignal()",
-      "norm_label": "buildsignal()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L178"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "posofflinereadiness_formatage",
-      "label": "formatAge()",
-      "norm_label": "formatage()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L290"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsignaldescription",
-      "label": "getSignalDescription()",
-      "norm_label": "getsignaldescription()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L221"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsignalstatus",
-      "label": "getSignalStatus()",
-      "norm_label": "getsignalstatus()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L201"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsummarydescription",
-      "label": "getSummaryDescription()",
-      "norm_label": "getsummarydescription()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L262"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsummarytitle",
-      "label": "getSummaryTitle()",
-      "norm_label": "getsummarytitle()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L256"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "posofflinereadiness_isreadylike",
-      "label": "isReadyLike()",
-      "norm_label": "isreadylike()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L286"
     },
     {
       "community": 32,
@@ -242844,6 +242856,87 @@
     {
       "community": 320,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_offline_posofflinereadiness_ts",
+      "label": "posOfflineReadiness.ts",
+      "norm_label": "posofflinereadiness.ts",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "posofflinereadiness_buildposofflinereadinesssummary",
+      "label": "buildPosOfflineReadinessSummary()",
+      "norm_label": "buildposofflinereadinesssummary()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L152"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "posofflinereadiness_buildsignal",
+      "label": "buildSignal()",
+      "norm_label": "buildsignal()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L178"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "posofflinereadiness_formatage",
+      "label": "formatAge()",
+      "norm_label": "formatage()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L290"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsignaldescription",
+      "label": "getSignalDescription()",
+      "norm_label": "getsignaldescription()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L221"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsignalstatus",
+      "label": "getSignalStatus()",
+      "norm_label": "getsignalstatus()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L201"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsummarydescription",
+      "label": "getSummaryDescription()",
+      "norm_label": "getsummarydescription()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L262"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsummarytitle",
+      "label": "getSummaryTitle()",
+      "norm_label": "getsummarytitle()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L256"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "posofflinereadiness_isreadylike",
+      "label": "isReadyLike()",
+      "norm_label": "isreadylike()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L286"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
       "id": "foundations_content_colorrolecard",
       "label": "ColorRoleCard()",
       "norm_label": "colorrolecard()",
@@ -242851,7 +242944,7 @@
       "source_location": "L222"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "foundations_content_densitycard",
       "label": "DensityCard()",
@@ -242860,7 +242953,7 @@
       "source_location": "L283"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "foundations_content_detailviewrolecard",
       "label": "DetailViewRoleCard()",
@@ -242869,7 +242962,7 @@
       "source_location": "L363"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "foundations_content_hslvar",
       "label": "hslVar()",
@@ -242878,7 +242971,7 @@
       "source_location": "L214"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "foundations_content_motioncard",
       "label": "MotionCard()",
@@ -242887,7 +242980,7 @@
       "source_location": "L342"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "foundations_content_spacetokenrow",
       "label": "SpaceTokenRow()",
@@ -242896,7 +242989,7 @@
       "source_location": "L265"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "foundations_content_textvar",
       "label": "textVar()",
@@ -242905,7 +242998,7 @@
       "source_location": "L218"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "foundations_content_typespecimencard",
       "label": "TypeSpecimenCard()",
@@ -242914,7 +243007,7 @@
       "source_location": "L246"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_foundations_content_tsx",
       "label": "foundations-content.tsx",
@@ -242923,169 +243016,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_utils_versionchecker_ts",
-      "label": "versionChecker.ts",
-      "norm_label": "versionchecker.ts",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 321,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
-      "label": "versionChecker.ts",
-      "norm_label": "versionchecker.ts",
-      "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 321,
-      "file_type": "code",
-      "id": "versionchecker_buildidfromscripts",
-      "label": "buildIdFromScripts()",
-      "norm_label": "buildidfromscripts()",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
-      "source_location": "L192"
-    },
-    {
-      "community": 321,
-      "file_type": "code",
-      "id": "versionchecker_createversionchecker",
-      "label": "createVersionChecker()",
-      "norm_label": "createversionchecker()",
-      "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 321,
-      "file_type": "code",
-      "id": "versionchecker_getinitialdeploybuildid",
-      "label": "getInitialDeployBuildId()",
-      "norm_label": "getinitialdeploybuildid()",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
-      "source_location": "L135"
-    },
-    {
-      "community": 321,
-      "file_type": "code",
-      "id": "versionchecker_readdeploybuildid",
-      "label": "readDeployBuildId()",
-      "norm_label": "readdeploybuildid()",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
-      "source_location": "L141"
-    },
-    {
-      "community": 321,
-      "file_type": "code",
-      "id": "versionchecker_readdocumentscriptsources",
-      "label": "readDocumentScriptSources()",
-      "norm_label": "readdocumentscriptsources()",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
-      "source_location": "L174"
-    },
-    {
-      "community": 321,
-      "file_type": "code",
-      "id": "versionchecker_readentryhtmlscripts",
-      "label": "readEntryHtmlScripts()",
-      "norm_label": "readentryhtmlscripts()",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
-      "source_location": "L151"
-    },
-    {
-      "community": 321,
-      "file_type": "code",
-      "id": "versionchecker_readscriptsources",
-      "label": "readScriptSources()",
-      "norm_label": "readscriptsources()",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
-      "source_location": "L182"
-    },
-    {
       "community": 322,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 322,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 322,
-      "file_type": "code",
-      "id": "productutils_getpreferredsku",
-      "label": "getPreferredSku()",
-      "norm_label": "getpreferredsku()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 322,
-      "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 322,
-      "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 322,
-      "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 322,
-      "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L82"
-    },
-    {
-      "community": 322,
-      "file_type": "code",
-      "id": "productutils_sortskusbyavailabilitythenlength",
-      "label": "sortSkusByAvailabilityThenLength()",
-      "norm_label": "sortskusbyavailabilitythenlength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 322,
-      "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 323,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontobservability_ts",
       "label": "storefrontObservability.ts",
@@ -243094,7 +243025,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 322,
       "file_type": "code",
       "id": "storefrontobservability_createstorefrontobservabilitycontext",
       "label": "createStorefrontObservabilityContext()",
@@ -243103,7 +243034,7 @@
       "source_location": "L182"
     },
     {
-      "community": 323,
+      "community": 322,
       "file_type": "code",
       "id": "storefrontobservability_createstorefrontobservabilitypayload",
       "label": "createStorefrontObservabilityPayload()",
@@ -243112,7 +243043,7 @@
       "source_location": "L229"
     },
     {
-      "community": 323,
+      "community": 322,
       "file_type": "code",
       "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
       "label": "getOrCreateStorefrontObservabilitySessionId()",
@@ -243121,7 +243052,7 @@
       "source_location": "L157"
     },
     {
-      "community": 323,
+      "community": 322,
       "file_type": "code",
       "id": "storefrontobservability_isbrowserautomationcontext",
       "label": "isBrowserAutomationContext()",
@@ -243130,7 +243061,7 @@
       "source_location": "L125"
     },
     {
-      "community": 323,
+      "community": 322,
       "file_type": "code",
       "id": "storefrontobservability_issyntheticmonitororigin",
       "label": "isSyntheticMonitorOrigin()",
@@ -243139,7 +243070,7 @@
       "source_location": "L121"
     },
     {
-      "community": 323,
+      "community": 322,
       "file_type": "code",
       "id": "storefrontobservability_resolvestorefrontanalyticsorigin",
       "label": "resolveStorefrontAnalyticsOrigin()",
@@ -243148,7 +243079,7 @@
       "source_location": "L135"
     },
     {
-      "community": 323,
+      "community": 322,
       "file_type": "code",
       "id": "storefrontobservability_resolveviewportbucket",
       "label": "resolveViewportBucket()",
@@ -243157,13 +243088,94 @@
       "source_location": "L211"
     },
     {
-      "community": 323,
+      "community": 322,
       "file_type": "code",
       "id": "storefrontobservability_trackstorefrontevent",
       "label": "trackStorefrontEvent()",
       "norm_label": "trackstorefrontevent()",
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L265"
+    },
+    {
+      "community": 323,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_utils_versionchecker_ts",
+      "label": "versionChecker.ts",
+      "norm_label": "versionchecker.ts",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 323,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
+      "label": "versionChecker.ts",
+      "norm_label": "versionchecker.ts",
+      "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 323,
+      "file_type": "code",
+      "id": "versionchecker_buildidfromscripts",
+      "label": "buildIdFromScripts()",
+      "norm_label": "buildidfromscripts()",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
+      "source_location": "L192"
+    },
+    {
+      "community": 323,
+      "file_type": "code",
+      "id": "versionchecker_createversionchecker",
+      "label": "createVersionChecker()",
+      "norm_label": "createversionchecker()",
+      "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 323,
+      "file_type": "code",
+      "id": "versionchecker_getinitialdeploybuildid",
+      "label": "getInitialDeployBuildId()",
+      "norm_label": "getinitialdeploybuildid()",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 323,
+      "file_type": "code",
+      "id": "versionchecker_readdeploybuildid",
+      "label": "readDeployBuildId()",
+      "norm_label": "readdeploybuildid()",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
+      "source_location": "L141"
+    },
+    {
+      "community": 323,
+      "file_type": "code",
+      "id": "versionchecker_readdocumentscriptsources",
+      "label": "readDocumentScriptSources()",
+      "norm_label": "readdocumentscriptsources()",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
+      "source_location": "L174"
+    },
+    {
+      "community": 323,
+      "file_type": "code",
+      "id": "versionchecker_readentryhtmlscripts",
+      "label": "readEntryHtmlScripts()",
+      "norm_label": "readentryhtmlscripts()",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
+      "source_location": "L151"
+    },
+    {
+      "community": 323,
+      "file_type": "code",
+      "id": "versionchecker_readscriptsources",
+      "label": "readScriptSources()",
+      "norm_label": "readscriptsources()",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
+      "source_location": "L182"
     },
     {
       "community": 324,
@@ -249351,6 +249363,69 @@
     {
       "community": 386,
       "file_type": "code",
+      "id": "oweddailyclosesweep_completedoperatingdatesforstore",
+      "label": "completedOperatingDatesForStore()",
+      "norm_label": "completedoperatingdatesforstore()",
+      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
+      "source_location": "L177"
+    },
+    {
+      "community": 386,
+      "file_type": "code",
+      "id": "oweddailyclosesweep_dailyclosesweepresultsettled",
+      "label": "dailyCloseSweepResultSettled()",
+      "norm_label": "dailyclosesweepresultsettled()",
+      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 386,
+      "file_type": "code",
+      "id": "oweddailyclosesweep_daysbetweenoperatingdates",
+      "label": "daysBetweenOperatingDates()",
+      "norm_label": "daysbetweenoperatingdates()",
+      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
+      "source_location": "L416"
+    },
+    {
+      "community": 386,
+      "file_type": "code",
+      "id": "oweddailyclosesweep_listenabledeodpolicies",
+      "label": "listEnabledEodPolicies()",
+      "norm_label": "listenabledeodpolicies()",
+      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
+      "source_location": "L163"
+    },
+    {
+      "community": 386,
+      "file_type": "code",
+      "id": "oweddailyclosesweep_selectoweddailyclosedates",
+      "label": "selectOwedDailyCloseDates()",
+      "norm_label": "selectoweddailyclosedates()",
+      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
+      "source_location": "L111"
+    },
+    {
+      "community": 386,
+      "file_type": "code",
+      "id": "oweddailyclosesweep_selectrotatingoweddailycloseattempt",
+      "label": "selectRotatingOwedDailyCloseAttempt()",
+      "norm_label": "selectrotatingoweddailycloseattempt()",
+      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 386,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
+      "label": "owedDailyCloseSweep.ts",
+      "norm_label": "oweddailyclosesweep.ts",
+      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 387,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessionauthorityrevision_ts",
       "label": "registerSessionAuthorityRevision.ts",
       "norm_label": "registersessionauthorityrevision.ts",
@@ -249358,7 +249433,7 @@
       "source_location": "L1"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "registersessionauthorityrevision_buildregistersessionauthoritypatch",
       "label": "buildRegisterSessionAuthorityPatch()",
@@ -249367,7 +249442,7 @@
       "source_location": "L16"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "registersessionauthorityrevision_deleteregistersessionwithauthority",
       "label": "deleteRegisterSessionWithAuthority()",
@@ -249376,7 +249451,7 @@
       "source_location": "L66"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "registersessionauthorityrevision_initialregistersessionauthorityrevision",
       "label": "initialRegisterSessionAuthorityRevision()",
@@ -249385,7 +249460,7 @@
       "source_location": "L12"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "registersessionauthorityrevision_insertregistersessionwithauthority",
       "label": "insertRegisterSessionWithAuthority()",
@@ -249394,7 +249469,7 @@
       "source_location": "L39"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "registersessionauthorityrevision_patchregistersessionwithauthority",
       "label": "patchRegisterSessionWithAuthority()",
@@ -249403,7 +249478,7 @@
       "source_location": "L49"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "registersessionauthorityrevision_replaceregistersessionwithauthority",
       "label": "replaceRegisterSessionWithAuthority()",
@@ -249412,7 +249487,7 @@
       "source_location": "L75"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessioncloseoutgate_ts",
       "label": "registerSessionCloseoutGate.ts",
@@ -249421,7 +249496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "registersessioncloseoutgate_areregistersessioncloseoutreviewfactsequivalent",
       "label": "areRegisterSessionCloseoutReviewFactsEquivalent()",
@@ -249430,7 +249505,7 @@
       "source_location": "L119"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "registersessioncloseoutgate_asboolean",
       "label": "asBoolean()",
@@ -249439,7 +249514,7 @@
       "source_location": "L35"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "registersessioncloseoutgate_asnumber",
       "label": "asNumber()",
@@ -249448,7 +249523,7 @@
       "source_location": "L39"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "registersessioncloseoutgate_asrecord",
       "label": "asRecord()",
@@ -249457,7 +249532,7 @@
       "source_location": "L27"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "registersessioncloseoutgate_buildregistersessioncloseoutreview",
       "label": "buildRegisterSessionCloseoutReview()",
@@ -249466,7 +249541,7 @@
       "source_location": "L64"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "registersessioncloseoutgate_getcashcontrolsconfig",
       "label": "getCashControlsConfig()",
@@ -249475,7 +249550,7 @@
       "source_location": "L43"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "expensesessiontracing_buildexpensesessiontraceevent",
       "label": "buildExpenseSessionTraceEvent()",
@@ -249484,7 +249559,7 @@
       "source_location": "L150"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "expensesessiontracing_buildexpensesessiontracerecord",
       "label": "buildExpenseSessionTraceRecord()",
@@ -249493,7 +249568,7 @@
       "source_location": "L101"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "expensesessiontracing_buildtracesummary",
       "label": "buildTraceSummary()",
@@ -249502,7 +249577,7 @@
       "source_location": "L71"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "expensesessiontracing_createexpensesessiontracerecorder",
       "label": "createExpenseSessionTraceRecorder()",
@@ -249511,7 +249586,7 @@
       "source_location": "L293"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "expensesessiontracing_recordexpensesessiontracebesteffort",
       "label": "recordExpenseSessionTraceBestEffort()",
@@ -249520,7 +249595,7 @@
       "source_location": "L266"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "expensesessiontracing_safetracewrite",
       "label": "safeTraceWrite()",
@@ -249529,76 +249604,13 @@
       "source_location": "L258"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_expensesessiontracing_ts",
       "label": "expenseSessionTracing.ts",
       "norm_label": "expensesessiontracing.ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/expenseSessionTracing.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_queries_searchcustomers_ts",
-      "label": "searchCustomers.ts",
-      "norm_label": "searchcustomers.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "searchcustomers_findbystorefrontuser",
-      "label": "findByStoreFrontUser()",
-      "norm_label": "findbystorefrontuser()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "searchcustomers_findpotentialmatches",
-      "label": "findPotentialMatches()",
-      "norm_label": "findpotentialmatches()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L122"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "searchcustomers_getcustomerbyid",
-      "label": "getCustomerById()",
-      "norm_label": "getcustomerbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "searchcustomers_getcustomerprofileidforposcustomer",
-      "label": "getCustomerProfileIdForPosCustomer()",
-      "norm_label": "getcustomerprofileidforposcustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "searchcustomers_getcustomertransactions",
-      "label": "getCustomerTransactions()",
-      "norm_label": "getcustomertransactions()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "searchcustomers_searchcustomers",
-      "label": "searchCustomers()",
-      "norm_label": "searchcustomers()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
-      "source_location": "L27"
     },
     {
       "community": 39,
@@ -249891,6 +249903,69 @@
     {
       "community": 390,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_queries_searchcustomers_ts",
+      "label": "searchCustomers.ts",
+      "norm_label": "searchcustomers.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "searchcustomers_findbystorefrontuser",
+      "label": "findByStoreFrontUser()",
+      "norm_label": "findbystorefrontuser()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "searchcustomers_findpotentialmatches",
+      "label": "findPotentialMatches()",
+      "norm_label": "findpotentialmatches()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L122"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "searchcustomers_getcustomerbyid",
+      "label": "getCustomerById()",
+      "norm_label": "getcustomerbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "searchcustomers_getcustomerprofileidforposcustomer",
+      "label": "getCustomerProfileIdForPosCustomer()",
+      "norm_label": "getcustomerprofileidforposcustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "searchcustomers_getcustomertransactions",
+      "label": "getCustomerTransactions()",
+      "norm_label": "getcustomertransactions()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "searchcustomers_searchcustomers",
+      "label": "searchCustomers()",
+      "norm_label": "searchcustomers()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_projectionpolicies_ts",
       "label": "projectionPolicies.ts",
       "norm_label": "projectionpolicies.ts",
@@ -249898,7 +249973,7 @@
       "source_location": "L1"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "projectionpolicies_classifyprovisionalimportlineage",
       "label": "classifyProvisionalImportLineage()",
@@ -249907,7 +249982,7 @@
       "source_location": "L54"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "projectionpolicies_findmixedtrustedandprovisionalskuid",
       "label": "findMixedTrustedAndProvisionalSkuId()",
@@ -249916,7 +249991,7 @@
       "source_location": "L109"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "projectionpolicies_isfinalizationclosed",
       "label": "isFinalizationClosed()",
@@ -249925,7 +250000,7 @@
       "source_location": "L179"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "projectionpolicies_istrustedinventorysaleitem",
       "label": "isTrustedInventorySaleItem()",
@@ -249934,7 +250009,7 @@
       "source_location": "L148"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "projectionpolicies_saleinventorylinekey",
       "label": "saleInventoryLineKey()",
@@ -249943,7 +250018,7 @@
       "source_location": "L45"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "projectionpolicies_shouldrecordprovisionalimportsaleevidence",
       "label": "shouldRecordProvisionalImportSaleEvidence()",
@@ -249952,7 +250027,7 @@
       "source_location": "L168"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_registermappingauthorityrevision_ts",
       "label": "registerMappingAuthorityRevision.ts",
@@ -249961,7 +250036,7 @@
       "source_location": "L1"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "registermappingauthorityrevision_advanceregistermappingauthority",
       "label": "advanceRegisterMappingAuthority()",
@@ -249970,7 +250045,7 @@
       "source_location": "L36"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "registermappingauthorityrevision_buildnextregistermappingauthority",
       "label": "buildNextRegisterMappingAuthority()",
@@ -249979,7 +250054,7 @@
       "source_location": "L17"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "registermappingauthorityrevision_createposlocalsyncmappingwithauthority",
       "label": "createPosLocalSyncMappingWithAuthority()",
@@ -249988,7 +250063,7 @@
       "source_location": "L76"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "registermappingauthorityrevision_markregistermappingauthorityambiguous",
       "label": "markRegisterMappingAuthorityAmbiguous()",
@@ -249997,7 +250072,7 @@
       "source_location": "L145"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "registermappingauthorityrevision_markregistermappingauthoritymapped",
       "label": "markRegisterMappingAuthorityMapped()",
@@ -250006,7 +250081,7 @@
       "source_location": "L155"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "registermappingauthorityrevision_tombstoneregistermappingauthority",
       "label": "tombstoneRegisterMappingAuthority()",
@@ -250015,7 +250090,7 @@
       "source_location": "L135"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessionrepository_ts",
       "label": "sessionRepository.ts",
@@ -250024,7 +250099,7 @@
       "source_location": "L1"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "sessionrepository_getactivesessionforregisterstate",
       "label": "getActiveSessionForRegisterState()",
@@ -250033,7 +250108,7 @@
       "source_location": "L18"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "sessionrepository_listheldsessionsforregisterstate",
       "label": "listHeldSessionsForRegisterState()",
@@ -250042,7 +250117,7 @@
       "source_location": "L26"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "sessionrepository_matchesregisteridentity",
       "label": "matchesRegisterIdentity()",
@@ -250051,7 +250126,7 @@
       "source_location": "L119"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "sessionrepository_querysessionsbystatus",
       "label": "querySessionsByStatus()",
@@ -250060,7 +250135,7 @@
       "source_location": "L33"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "sessionrepository_selectregisterstatelookupstrategy",
       "label": "selectRegisterStateLookupStrategy()",
@@ -250069,7 +250144,7 @@
       "source_location": "L83"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "sessionrepository_summarizeregisterstatesessions",
       "label": "summarizeRegisterStateSessions()",
@@ -250078,7 +250153,7 @@
       "source_location": "L97"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_terminalregisterconflictresolution_ts",
       "label": "terminalRegisterConflictResolution.ts",
@@ -250087,7 +250162,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "terminalregisterconflictresolution_getblockingregistersessionidfromconflict",
       "label": "getBlockingRegisterSessionIdFromConflict()",
@@ -250096,7 +250171,7 @@
       "source_location": "L122"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "terminalregisterconflictresolution_iscurrentterminalregisterconflict",
       "label": "isCurrentTerminalRegisterConflict()",
@@ -250105,7 +250180,7 @@
       "source_location": "L109"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "terminalregisterconflictresolution_isregistersessionconflict",
       "label": "isRegisterSessionConflict()",
@@ -250114,7 +250189,7 @@
       "source_location": "L115"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "terminalregisterconflictresolution_resolvescopedregistersession",
       "label": "resolveScopedRegisterSession()",
@@ -250123,7 +250198,7 @@
       "source_location": "L136"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "terminalregisterconflictresolution_resolveterminalregisterconflict",
       "label": "resolveTerminalRegisterConflict()",
@@ -250132,7 +250207,7 @@
       "source_location": "L22"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "terminalregisterconflictresolution_resolveterminalregistersessionconflict",
       "label": "resolveTerminalRegisterSessionConflict()",
@@ -250141,7 +250216,7 @@
       "source_location": "L54"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_terminalappsessions_ts",
       "label": "terminalAppSessions.ts",
@@ -250150,7 +250225,7 @@
       "source_location": "L1"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "terminalappsessions_blocked",
       "label": "blocked()",
@@ -250159,7 +250234,7 @@
       "source_location": "L106"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "terminalappsessions_buildrecoveryattemptid",
       "label": "buildRecoveryAttemptId()",
@@ -250168,7 +250243,7 @@
       "source_location": "L116"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "terminalappsessions_getorganizationmemberforaccount",
       "label": "getOrganizationMemberForAccount()",
@@ -250177,7 +250252,7 @@
       "source_location": "L158"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "terminalappsessions_recordrecoveryevent",
       "label": "recordRecoveryEvent()",
@@ -250186,7 +250261,7 @@
       "source_location": "L130"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "terminalappsessions_validateposappaccount",
       "label": "validatePosAppAccount()",
@@ -250195,7 +250270,7 @@
       "source_location": "L176"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "terminalappsessions_validateterminalappsessionrecoverywithctx",
       "label": "validateTerminalAppSessionRecoveryWithCtx()",
@@ -250204,7 +250279,7 @@
       "source_location": "L196"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_application_sessionservice_ts",
       "label": "sessionService.ts",
@@ -250213,7 +250288,7 @@
       "source_location": "L1"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "sessionservice_approveattendedremoteassistsession",
       "label": "approveAttendedRemoteAssistSession()",
@@ -250222,7 +250297,7 @@
       "source_location": "L224"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "sessionservice_claimremoteassistsession",
       "label": "claimRemoteAssistSession()",
@@ -250231,7 +250306,7 @@
       "source_location": "L148"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "sessionservice_disconnectremoteassistruntimesession",
       "label": "disconnectRemoteAssistRuntimeSession()",
@@ -250240,7 +250315,7 @@
       "source_location": "L321"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "sessionservice_endremoteassistsession",
       "label": "endRemoteAssistSession()",
@@ -250249,7 +250324,7 @@
       "source_location": "L282"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "sessionservice_findreusableremoteassistsession",
       "label": "findReusableRemoteAssistSession()",
@@ -250258,7 +250333,7 @@
       "source_location": "L367"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "sessionservice_startremoteassistsession",
       "label": "startRemoteAssistSession()",
@@ -250267,7 +250342,7 @@
       "source_location": "L41"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "liveday_test_daymetrics",
       "label": "dayMetrics()",
@@ -250276,7 +250351,7 @@
       "source_location": "L38"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "liveday_test_handlerof",
       "label": "handlerOf()",
@@ -250285,7 +250360,7 @@
       "source_location": "L23"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "liveday_test_seedsku",
       "label": "seedSku()",
@@ -250294,7 +250369,7 @@
       "source_location": "L88"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "liveday_test_seedstore",
       "label": "seedStore()",
@@ -250303,7 +250378,7 @@
       "source_location": "L67"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "liveday_test_skuidentity",
       "label": "skuIdentity()",
@@ -250312,7 +250387,7 @@
       "source_location": "L139"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "liveday_test_skumetrics",
       "label": "skuMetrics()",
@@ -250321,7 +250396,7 @@
       "source_location": "L54"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_liveday_test_ts",
       "label": "liveDay.test.ts",
@@ -250330,7 +250405,7 @@
       "source_location": "L1"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_weeklycloseevidence_ts",
       "label": "weeklyCloseEvidence.ts",
@@ -250339,7 +250414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "weeklycloseevidence_aggregateweeklycloseevidence",
       "label": "aggregateWeeklyCloseEvidence()",
@@ -250348,7 +250423,7 @@
       "source_location": "L168"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "weeklycloseevidence_completeexpenseevidence",
       "label": "completeExpenseEvidence()",
@@ -250357,7 +250432,7 @@
       "source_location": "L103"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "weeklycloseevidence_coverage",
       "label": "coverage()",
@@ -250366,7 +250441,7 @@
       "source_location": "L90"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "weeklycloseevidence_isnonnegativesafeinteger",
       "label": "isNonnegativeSafeInteger()",
@@ -250375,7 +250450,7 @@
       "source_location": "L75"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "weeklycloseevidence_remainder",
       "label": "remainder()",
@@ -250384,7 +250459,7 @@
       "source_location": "L149"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "weeklycloseevidence_safesum",
       "label": "safeSum()",
@@ -250393,7 +250468,7 @@
       "source_location": "L79"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_weeklyperiods_ts",
       "label": "weeklyPeriods.ts",
@@ -250402,7 +250477,7 @@
       "source_location": "L1"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "weeklyperiods_isincludeddate",
       "label": "isIncludedDate()",
@@ -250411,7 +250486,7 @@
       "source_location": "L55"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "weeklyperiods_parsedate",
       "label": "parseDate()",
@@ -250420,7 +250495,7 @@
       "source_location": "L19"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "weeklyperiods_resolveweeklyperiod",
       "label": "resolveWeeklyPeriod()",
@@ -250429,7 +250504,7 @@
       "source_location": "L91"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "weeklyperiods_schedulefordate",
       "label": "scheduleForDate()",
@@ -250438,7 +250513,7 @@
       "source_location": "L36"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "weeklyperiods_shiftdate",
       "label": "shiftDate()",
@@ -250447,76 +250522,13 @@
       "source_location": "L24"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "weeklyperiods_weekday",
       "label": "weekday()",
       "norm_label": "weekday()",
       "source_file": "packages/athena-webapp/convex/reports/weeklyPeriods.ts",
       "source_location": "L30"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "catalog_buildposservicecatalogrow",
-      "label": "buildPosServiceCatalogRow()",
-      "norm_label": "buildposservicecatalogrow()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/catalog.ts",
-      "source_location": "L94"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "catalog_buildposservicecheckoutreadiness",
-      "label": "buildPosServiceCheckoutReadiness()",
-      "norm_label": "buildposservicecheckoutreadiness()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/catalog.ts",
-      "source_location": "L141"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "catalog_buildservicecatalogitem",
-      "label": "buildServiceCatalogItem()",
-      "norm_label": "buildservicecatalogitem()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/catalog.ts",
-      "source_location": "L196"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "catalog_listposservicecatalogsnapshotwithctx",
-      "label": "listPosServiceCatalogSnapshotWithCtx()",
-      "norm_label": "listposservicecatalogsnapshotwithctx()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/catalog.ts",
-      "source_location": "L117"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "catalog_normalizeservicecatalognamekey",
-      "label": "normalizeServiceCatalogNameKey()",
-      "norm_label": "normalizeservicecatalognamekey()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/catalog.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "catalog_suggesteddepositamount",
-      "label": "suggestedDepositAmount()",
-      "norm_label": "suggesteddepositamount()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/catalog.ts",
-      "source_location": "L180"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_serviceops_catalog_ts",
-      "label": "catalog.ts",
-      "norm_label": "catalog.ts",
-      "source_file": "packages/athena-webapp/convex/serviceOps/catalog.ts",
-      "source_location": "L1"
     },
     {
       "community": 4,
@@ -251502,6 +251514,69 @@
     {
       "community": 400,
       "file_type": "code",
+      "id": "catalog_buildposservicecatalogrow",
+      "label": "buildPosServiceCatalogRow()",
+      "norm_label": "buildposservicecatalogrow()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/catalog.ts",
+      "source_location": "L94"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "catalog_buildposservicecheckoutreadiness",
+      "label": "buildPosServiceCheckoutReadiness()",
+      "norm_label": "buildposservicecheckoutreadiness()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/catalog.ts",
+      "source_location": "L141"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "catalog_buildservicecatalogitem",
+      "label": "buildServiceCatalogItem()",
+      "norm_label": "buildservicecatalogitem()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/catalog.ts",
+      "source_location": "L196"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "catalog_listposservicecatalogsnapshotwithctx",
+      "label": "listPosServiceCatalogSnapshotWithCtx()",
+      "norm_label": "listposservicecatalogsnapshotwithctx()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/catalog.ts",
+      "source_location": "L117"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "catalog_normalizeservicecatalognamekey",
+      "label": "normalizeServiceCatalogNameKey()",
+      "norm_label": "normalizeservicecatalognamekey()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/catalog.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "catalog_suggesteddepositamount",
+      "label": "suggestedDepositAmount()",
+      "norm_label": "suggesteddepositamount()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/catalog.ts",
+      "source_location": "L180"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_serviceops_catalog_ts",
+      "label": "catalog.ts",
+      "norm_label": "catalog.ts",
+      "source_file": "packages/athena-webapp/convex/serviceOps/catalog.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_purchaseordertracing_ts",
       "label": "purchaseOrderTracing.ts",
       "norm_label": "purchaseordertracing.ts",
@@ -251509,7 +251584,7 @@
       "source_location": "L1"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "purchaseordertracing_besteffortrecordpurchaseorderreceivingtracewithctx",
       "label": "bestEffortRecordPurchaseOrderReceivingTraceWithCtx()",
@@ -251518,7 +251593,7 @@
       "source_location": "L155"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "purchaseordertracing_besteffortrecordpurchaseorderstatustracewithctx",
       "label": "bestEffortRecordPurchaseOrderStatusTraceWithCtx()",
@@ -251527,7 +251602,7 @@
       "source_location": "L106"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "purchaseordertracing_compactdetails",
       "label": "compactDetails()",
@@ -251536,7 +251611,7 @@
       "source_location": "L49"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "purchaseordertracing_ensurepurchaseordertracewithctx",
       "label": "ensurePurchaseOrderTraceWithCtx()",
@@ -251545,7 +251620,7 @@
       "source_location": "L72"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "purchaseordertracing_getpurchaseordertracestatusat",
       "label": "getPurchaseOrderTraceStatusAt()",
@@ -251554,7 +251629,7 @@
       "source_location": "L57"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "purchaseordertracing_refsfromentries",
       "label": "refsFromEntries()",
@@ -251563,7 +251638,7 @@
       "source_location": "L41"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "analytics_extractpromocodeid",
       "label": "extractPromoCodeId()",
@@ -251572,7 +251647,7 @@
       "source_location": "L49"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "analytics_getanalyticsbystoreandactionquery",
       "label": "getAnalyticsByStoreAndActionQuery()",
@@ -251581,7 +251656,7 @@
       "source_location": "L154"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "analytics_getanalyticsbystorequery",
       "label": "getAnalyticsByStoreQuery()",
@@ -251590,7 +251665,7 @@
       "source_location": "L59"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "analytics_getcompletedordersquery",
       "label": "getCompletedOrdersQuery()",
@@ -251599,7 +251674,7 @@
       "source_location": "L107"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "analytics_getskumapforproducts",
       "label": "getSkuMapForProducts()",
@@ -251608,7 +251683,7 @@
       "source_location": "L212"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "analytics_getstorefrontactor",
       "label": "getStoreFrontActor()",
@@ -251617,7 +251692,7 @@
       "source_location": "L30"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_analytics_ts",
       "label": "analytics.ts",
@@ -251626,7 +251701,7 @@
       "source_location": "L1"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "customerbehaviortimeline_getcustomeranalyticsquery",
       "label": "getCustomerAnalyticsQuery()",
@@ -251635,7 +251710,7 @@
       "source_location": "L27"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "customerbehaviortimeline_getcustomeroperationaltimelineevents",
       "label": "getCustomerOperationalTimelineEvents()",
@@ -251644,7 +251719,7 @@
       "source_location": "L153"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "customerbehaviortimeline_getproductinfomaps",
       "label": "getProductInfoMaps()",
@@ -251653,7 +251728,7 @@
       "source_location": "L71"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "customerbehaviortimeline_gettimefilterforrange",
       "label": "getTimeFilterForRange()",
@@ -251662,7 +251737,7 @@
       "source_location": "L12"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "customerbehaviortimeline_gettimelineuserdata",
       "label": "getTimelineUserData()",
@@ -251671,7 +251746,7 @@
       "source_location": "L47"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "customerbehaviortimeline_resolvecustomerprofileidfortimeline",
       "label": "resolveCustomerProfileIdForTimeline()",
@@ -251680,7 +251755,7 @@
       "source_location": "L115"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_ts",
       "label": "customerBehaviorTimeline.ts",
@@ -251689,7 +251764,7 @@
       "source_location": "L1"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "onlineorder_clearbagitems",
       "label": "clearBagItems()",
@@ -251698,7 +251773,7 @@
       "source_location": "L56"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "onlineorder_createorderfromcheckoutsession",
       "label": "createOrderFromCheckoutSession()",
@@ -251707,7 +251782,7 @@
       "source_location": "L157"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "onlineorder_findorderbyexternalreference",
       "label": "findOrderByExternalReference()",
@@ -251716,7 +251791,7 @@
       "source_location": "L32"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "onlineorder_findorderbyexternaltransactionid",
       "label": "findOrderByExternalTransactionId()",
@@ -251725,7 +251800,7 @@
       "source_location": "L44"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "onlineorder_generateordernumber",
       "label": "generateOrderNumber()",
@@ -251734,7 +251809,7 @@
       "source_location": "L25"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "onlineorder_returnorderitemstostock",
       "label": "returnOrderItemsToStock()",
@@ -251743,7 +251818,7 @@
       "source_location": "L68"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -251752,7 +251827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "orderupdateemails_formatorderitems",
       "label": "formatOrderItems()",
@@ -251761,7 +251836,7 @@
       "source_location": "L64"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "orderupdateemails_getdeliveryaddress",
       "label": "getDeliveryAddress()",
@@ -251770,7 +251845,7 @@
       "source_location": "L55"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "orderupdateemails_getlocationdetails",
       "label": "getLocationDetails()",
@@ -251779,7 +251854,7 @@
       "source_location": "L58"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "orderupdateemails_getpickuplocation",
       "label": "getPickupLocation()",
@@ -251788,7 +251863,7 @@
       "source_location": "L52"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "orderupdateemails_handleorderstatusupdate",
       "label": "handleOrderStatusUpdate()",
@@ -251797,7 +251872,7 @@
       "source_location": "L118"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "orderupdateemails_processorderupdateemail",
       "label": "processOrderUpdateEmail()",
@@ -251806,7 +251881,7 @@
       "source_location": "L297"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_orderupdateemails_ts",
       "label": "orderUpdateEmails.ts",
@@ -251815,7 +251890,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "core_appendworkflowtraceeventwithctx",
       "label": "appendWorkflowTraceEventWithCtx()",
@@ -251824,7 +251899,7 @@
       "source_location": "L142"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "core_createworkflowtracewithctx",
       "label": "createWorkflowTraceWithCtx()",
@@ -251833,7 +251908,7 @@
       "source_location": "L87"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "core_getworkflowtracebyidwithctx",
       "label": "getWorkflowTraceByIdWithCtx()",
@@ -251842,7 +251917,7 @@
       "source_location": "L23"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "core_getworkflowtracebylookupwithctx",
       "label": "getWorkflowTraceByLookupWithCtx()",
@@ -251851,7 +251926,7 @@
       "source_location": "L38"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "core_listworkflowtraceeventswithctx",
       "label": "listWorkflowTraceEventsWithCtx()",
@@ -251860,7 +251935,7 @@
       "source_location": "L71"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "core_registerworkflowtracelookupwithctx",
       "label": "registerWorkflowTraceLookupWithCtx()",
@@ -251869,7 +251944,7 @@
       "source_location": "L112"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_core_ts",
       "label": "core.ts",
@@ -251878,7 +251953,7 @@
       "source_location": "L1"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "eventbuilder_buildcontexteventenvelope",
       "label": "buildContextEventEnvelope()",
@@ -251887,7 +251962,7 @@
       "source_location": "L23"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "eventbuilder_buildcontexteventidempotencykey",
       "label": "buildContextEventIdempotencyKey()",
@@ -251896,7 +251971,7 @@
       "source_location": "L103"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "eventbuilder_compactcontextpayload",
       "label": "compactContextPayload()",
@@ -251905,7 +251980,7 @@
       "source_location": "L76"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "eventbuilder_compactcontextvalue",
       "label": "compactContextValue()",
@@ -251914,7 +251989,7 @@
       "source_location": "L132"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "eventbuilder_hashstablevalue",
       "label": "hashStableValue()",
@@ -251923,7 +251998,7 @@
       "source_location": "L119"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "eventbuilder_stablecontextstringify",
       "label": "stableContextStringify()",
@@ -251932,7 +252007,7 @@
       "source_location": "L89"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_intelligence_eventbuilder_ts",
       "label": "eventBuilder.ts",
@@ -251941,7 +252016,7 @@
       "source_location": "L1"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "inventoryimportreviewpayload_buildinventoryimportreviewpayload",
       "label": "buildInventoryImportReviewPayload()",
@@ -251950,7 +252025,7 @@
       "source_location": "L119"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "inventoryimportreviewpayload_getinventoryimportreviewpayloadchunkbytelength",
       "label": "getInventoryImportReviewPayloadChunkByteLength()",
@@ -251959,7 +252034,7 @@
       "source_location": "L28"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "inventoryimportreviewpayload_getutf8bytelength",
       "label": "getUtf8ByteLength()",
@@ -251968,7 +252043,7 @@
       "source_location": "L24"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "inventoryimportreviewpayload_ishighsurrogate",
       "label": "isHighSurrogate()",
@@ -251977,7 +252052,7 @@
       "source_location": "L158"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "inventoryimportreviewpayload_splitinventoryimportreviewrawcontent",
       "label": "splitInventoryImportReviewRawContent()",
@@ -251986,7 +252061,7 @@
       "source_location": "L38"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "inventoryimportreviewpayload_splitinventoryimportreviewrowdecisions",
       "label": "splitInventoryImportReviewRowDecisions()",
@@ -251995,7 +252070,7 @@
       "source_location": "L85"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_inventoryimportreviewpayload_ts",
       "label": "inventoryImportReviewPayload.ts",
@@ -252004,7 +252079,7 @@
       "source_location": "L1"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_shareddemostory_ts",
       "label": "sharedDemoStory.ts",
@@ -252013,7 +252088,7 @@
       "source_location": "L1"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "shareddemostory_shareddemopickuporderamount",
       "label": "sharedDemoPickupOrderAmount()",
@@ -252022,7 +252097,7 @@
       "source_location": "L215"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "shareddemostory_shareddemopickupordertimeline",
       "label": "sharedDemoPickupOrderTimeline()",
@@ -252031,7 +252106,7 @@
       "source_location": "L207"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "shareddemostory_shareddemoproductbysku",
       "label": "sharedDemoProductBySku()",
@@ -252040,7 +252115,7 @@
       "source_location": "L183"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "shareddemostory_shareddemoproductbyslug",
       "label": "sharedDemoProductBySlug()",
@@ -252049,7 +252124,7 @@
       "source_location": "L189"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "shareddemostory_shareddemoproductimageurl",
       "label": "sharedDemoProductImageUrl()",
@@ -252058,76 +252133,13 @@
       "source_location": "L167"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "shareddemostory_shareddemostaffshortname",
       "label": "sharedDemoStaffShortName()",
       "norm_label": "shareddemostaffshortname()",
       "source_file": "packages/athena-webapp/shared/sharedDemoStory.ts",
       "source_location": "L49"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_stockadjustment_ts",
-      "label": "stockAdjustment.ts",
-      "norm_label": "stockadjustment.ts",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "stockadjustment_assertstockadjustmentreasoncode",
-      "label": "assertStockAdjustmentReasonCode()",
-      "norm_label": "assertstockadjustmentreasoncode()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "stockadjustment_calculatecyclecountquantitydelta",
-      "label": "calculateCycleCountQuantityDelta()",
-      "norm_label": "calculatecyclecountquantitydelta()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "stockadjustment_hashighstockadjustmentvariance",
-      "label": "hasHighStockAdjustmentVariance()",
-      "norm_label": "hashighstockadjustmentvariance()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L104"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "stockadjustment_requiresstockadjustmentapproval",
-      "label": "requiresStockAdjustmentApproval()",
-      "norm_label": "requiresstockadjustmentapproval()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L122"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "stockadjustment_resolvestockadjustmentquantitydelta",
-      "label": "resolveStockAdjustmentQuantityDelta()",
-      "norm_label": "resolvestockadjustmentquantitydelta()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L50"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "stockadjustment_summarizestockadjustmentlineitems",
-      "label": "summarizeStockAdjustmentLineItems()",
-      "norm_label": "summarizestockadjustmentlineitems()",
-      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
-      "source_location": "L84"
     },
     {
       "community": 41,
@@ -252411,6 +252423,69 @@
     {
       "community": 410,
       "file_type": "code",
+      "id": "packages_athena_webapp_shared_stockadjustment_ts",
+      "label": "stockAdjustment.ts",
+      "norm_label": "stockadjustment.ts",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "stockadjustment_assertstockadjustmentreasoncode",
+      "label": "assertStockAdjustmentReasonCode()",
+      "norm_label": "assertstockadjustmentreasoncode()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "stockadjustment_calculatecyclecountquantitydelta",
+      "label": "calculateCycleCountQuantityDelta()",
+      "norm_label": "calculatecyclecountquantitydelta()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "stockadjustment_hashighstockadjustmentvariance",
+      "label": "hasHighStockAdjustmentVariance()",
+      "norm_label": "hashighstockadjustmentvariance()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L104"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "stockadjustment_requiresstockadjustmentapproval",
+      "label": "requiresStockAdjustmentApproval()",
+      "norm_label": "requiresstockadjustmentapproval()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L122"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "stockadjustment_resolvestockadjustmentquantitydelta",
+      "label": "resolveStockAdjustmentQuantityDelta()",
+      "norm_label": "resolvestockadjustmentquantitydelta()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "stockadjustment_summarizestockadjustmentlineitems",
+      "label": "summarizeStockAdjustmentLineItems()",
+      "norm_label": "summarizestockadjustmentlineitems()",
+      "source_file": "packages/athena-webapp/shared/stockAdjustment.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
       "id": "categorysubcategorymanager_removecategory",
       "label": "removeCategory()",
       "norm_label": "removecategory()",
@@ -252418,7 +252493,7 @@
       "source_location": "L189"
     },
     {
-      "community": 410,
+      "community": 411,
       "file_type": "code",
       "id": "categorysubcategorymanager_removesubcategory",
       "label": "removeSubcategory()",
@@ -252427,7 +252502,7 @@
       "source_location": "L546"
     },
     {
-      "community": 410,
+      "community": 411,
       "file_type": "code",
       "id": "categorysubcategorymanager_save",
       "label": "save()",
@@ -252436,7 +252511,7 @@
       "source_location": "L106"
     },
     {
-      "community": 410,
+      "community": 411,
       "file_type": "code",
       "id": "categorysubcategorymanager_sidebar",
       "label": "Sidebar()",
@@ -252445,7 +252520,7 @@
       "source_location": "L40"
     },
     {
-      "community": 410,
+      "community": 411,
       "file_type": "code",
       "id": "categorysubcategorymanager_update",
       "label": "update()",
@@ -252454,7 +252529,7 @@
       "source_location": "L131"
     },
     {
-      "community": 410,
+      "community": 411,
       "file_type": "code",
       "id": "categorysubcategorymanager_updatestorefrontvisibility",
       "label": "updateStorefrontVisibility()",
@@ -252463,7 +252538,7 @@
       "source_location": "L156"
     },
     {
-      "community": 410,
+      "community": 411,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
       "label": "CategorySubcategoryManager.tsx",
@@ -252472,7 +252547,7 @@
       "source_location": "L1"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_update_updatereadybanner_test_tsx",
       "label": "UpdateReadyBanner.test.tsx",
@@ -252481,7 +252556,7 @@
       "source_location": "L1"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "updatereadybanner_test_appmessageblockerprobe",
       "label": "AppMessageBlockerProbe()",
@@ -252490,7 +252565,7 @@
       "source_location": "L88"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "updatereadybanner_test_compatibilitytoastpreferenceprobe",
       "label": "CompatibilityToastPreferenceProbe()",
@@ -252499,7 +252574,7 @@
       "source_location": "L101"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "updatereadybanner_test_coordinatorsnapshotprobe",
       "label": "CoordinatorSnapshotProbe()",
@@ -252508,7 +252583,7 @@
       "source_location": "L122"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "updatereadybanner_test_legacyapplyblockerprobe",
       "label": "LegacyApplyBlockerProbe()",
@@ -252517,7 +252592,7 @@
       "source_location": "L110"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "updatereadybanner_test_probe",
       "label": "Probe()",
@@ -252526,7 +252601,7 @@
       "source_location": "L36"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "updatereadybanner_test_renderwithupdateproviders",
       "label": "renderWithUpdateProviders()",
@@ -252535,7 +252610,7 @@
       "source_location": "L133"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "inputotp_formatrequestdelay",
       "label": "formatRequestDelay()",
@@ -252544,7 +252619,7 @@
       "source_location": "L47"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "inputotp_handleauthsyncfailed",
       "label": "handleAuthSyncFailed()",
@@ -252553,7 +252628,7 @@
       "source_location": "L81"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "inputotp_handlepinchange",
       "label": "handlePinChange()",
@@ -252562,7 +252637,7 @@
       "source_location": "L117"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "inputotp_handlerequestnewcode",
       "label": "handleRequestNewCode()",
@@ -252571,7 +252646,7 @@
       "source_location": "L168"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "inputotp_normalizeotpcode",
       "label": "normalizeOtpCode()",
@@ -252580,7 +252655,7 @@
       "source_location": "L31"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "inputotp_onsubmit",
       "label": "onSubmit()",
@@ -252589,7 +252664,7 @@
       "source_location": "L127"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
       "label": "InputOTP.tsx",
@@ -252598,7 +252673,7 @@
       "source_location": "L1"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "inventoryimportview_test_buildcsvrow",
       "label": "buildCsvRow()",
@@ -252607,7 +252682,7 @@
       "source_location": "L82"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "inventoryimportview_test_getlastnavigatesearch",
       "label": "getLastNavigateSearch()",
@@ -252616,7 +252691,7 @@
       "source_location": "L115"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "inventoryimportview_test_getreviewoverlayelement",
       "label": "getReviewOverlayElement()",
@@ -252625,7 +252700,7 @@
       "source_location": "L108"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "inventoryimportview_test_getreviewoverlaysection",
       "label": "getReviewOverlaySection()",
@@ -252634,7 +252709,7 @@
       "source_location": "L104"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "inventoryimportview_test_getsourceimportfieldset",
       "label": "getSourceImportFieldset()",
@@ -252643,7 +252718,7 @@
       "source_location": "L93"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "inventoryimportview_test_getsourcepreviewsection",
       "label": "getSourcePreviewSection()",
@@ -252652,7 +252727,7 @@
       "source_location": "L86"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_inventoryimportview_test_tsx",
       "label": "InventoryImportView.test.tsx",
@@ -252661,7 +252736,7 @@
       "source_location": "L1"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "operationreviewworkspace_operationreviewbucketbody",
       "label": "OperationReviewBucketBody()",
@@ -252670,7 +252745,7 @@
       "source_location": "L77"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "operationreviewworkspace_operationreviewbucketheader",
       "label": "OperationReviewBucketHeader()",
@@ -252679,7 +252754,7 @@
       "source_location": "L62"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "operationreviewworkspace_operationreviewbucketshell",
       "label": "OperationReviewBucketShell()",
@@ -252688,7 +252763,7 @@
       "source_location": "L45"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "operationreviewworkspace_operationreviewbuckettabslist",
       "label": "OperationReviewBucketTabsList()",
@@ -252697,7 +252772,7 @@
       "source_location": "L15"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "operationreviewworkspace_operationreviewbuckettabtrigger",
       "label": "OperationReviewBucketTabTrigger()",
@@ -252706,7 +252781,7 @@
       "source_location": "L30"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "operationreviewworkspace_operationreviewrailshell",
       "label": "OperationReviewRailShell()",
@@ -252715,7 +252790,7 @@
       "source_location": "L94"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationreviewworkspace_tsx",
       "label": "OperationReviewWorkspace.tsx",
@@ -252724,7 +252799,7 @@
       "source_location": "L1"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_stockadjustmentworkspace_test_tsx",
       "label": "StockAdjustmentWorkspace.test.tsx",
@@ -252733,7 +252808,7 @@
       "source_location": "L1"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "stockadjustmentworkspace_test_controlledstockadjustmentworkspace",
       "label": "ControlledStockAdjustmentWorkspace()",
@@ -252742,7 +252817,7 @@
       "source_location": "L2252"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "stockadjustmentworkspace_test_renderstockadjustmentworkspace",
       "label": "renderStockAdjustmentWorkspace()",
@@ -252751,7 +252826,7 @@
       "source_location": "L144"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "stockadjustmentworkspace_test_resizeobserverstub",
       "label": "ResizeObserverStub",
@@ -252760,7 +252835,7 @@
       "source_location": "L14"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "stockadjustmentworkspace_test_resizeobserverstub_disconnect",
       "label": ".disconnect()",
@@ -252769,7 +252844,7 @@
       "source_location": "L17"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "stockadjustmentworkspace_test_resizeobserverstub_observe",
       "label": ".observe()",
@@ -252778,7 +252853,7 @@
       "source_location": "L15"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "stockadjustmentworkspace_test_resizeobserverstub_unobserve",
       "label": ".unobserve()",
@@ -252787,7 +252862,7 @@
       "source_location": "L16"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "cartitems_cartitemproductimage",
       "label": "CartItemProductImage()",
@@ -252796,7 +252871,7 @@
       "source_location": "L72"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "cartitems_cartitemquantitycontrol",
       "label": "CartItemQuantityControl()",
@@ -252805,7 +252880,7 @@
       "source_location": "L100"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "cartitems_cn",
       "label": "cn()",
@@ -252814,7 +252889,7 @@
       "source_location": "L366"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "cartitems_formatcartattributeparts",
       "label": "formatCartAttributeParts()",
@@ -252823,7 +252898,7 @@
       "source_location": "L60"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "cartitems_normalizecartattribute",
       "label": "normalizeCartAttribute()",
@@ -252832,7 +252907,7 @@
       "source_location": "L51"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "cartitems_normalizecartquantityinput",
       "label": "normalizeCartQuantityInput()",
@@ -252841,7 +252916,7 @@
       "source_location": "L40"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cartitems_tsx",
       "label": "CartItems.tsx",
@@ -252850,7 +252925,7 @@
       "source_location": "L1"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_paymentview_tsx",
       "label": "PaymentView.tsx",
@@ -252859,7 +252934,7 @@
       "source_location": "L1"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "paymentview_cn",
       "label": "cn()",
@@ -252868,7 +252943,7 @@
       "source_location": "L417"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "paymentview_handleaddpayment",
       "label": "handleAddPayment()",
@@ -252877,7 +252952,7 @@
       "source_location": "L188"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "paymentview_handleamountblur",
       "label": "handleAmountBlur()",
@@ -252886,7 +252961,7 @@
       "source_location": "L266"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "paymentview_handleamountchange",
       "label": "handleAmountChange()",
@@ -252895,7 +252970,7 @@
       "source_location": "L244"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "paymentview_handlekeypadpress",
       "label": "handleKeypadPress()",
@@ -252904,7 +252979,7 @@
       "source_location": "L288"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "paymentview_setamountfromtouch",
       "label": "setAmountFromTouch()",
@@ -252913,7 +252988,7 @@
       "source_location": "L272"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_receivingview_tsx",
       "label": "ReceivingView.tsx",
@@ -252922,7 +252997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "receivingview_builddefaultconfirmedunitcosts",
       "label": "buildDefaultConfirmedUnitCosts()",
@@ -252931,7 +253006,7 @@
       "source_location": "L89"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "receivingview_builddefaultreceivedquantities",
       "label": "buildDefaultReceivedQuantities()",
@@ -252940,7 +253015,7 @@
       "source_location": "L80"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "receivingview_buildreceivedquantitiesaftersubmission",
       "label": "buildReceivedQuantitiesAfterSubmission()",
@@ -252949,7 +253024,7 @@
       "source_location": "L100"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "receivingview_buildsubmissionkey",
       "label": "buildSubmissionKey()",
@@ -252958,7 +253033,7 @@
       "source_location": "L62"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "receivingview_parselineitemdescription",
       "label": "parseLineItemDescription()",
@@ -252967,76 +253042,13 @@
       "source_location": "L66"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "receivingview_receivingview",
       "label": "ReceivingView()",
       "norm_label": "receivingview()",
       "source_file": "packages/athena-webapp/src/components/procurement/ReceivingView.tsx",
       "source_location": "L126"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_quickaddproductdialog_test_tsx",
-      "label": "QuickAddProductDialog.test.tsx",
-      "norm_label": "quickaddproductdialog.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "quickaddproductdialog_test_buildskusearchresult",
-      "label": "buildSkuSearchResult()",
-      "norm_label": "buildskusearchresult()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.test.tsx",
-      "source_location": "L82"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "quickaddproductdialog_test_renderquickadddialog",
-      "label": "renderQuickAddDialog()",
-      "norm_label": "renderquickadddialog()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.test.tsx",
-      "source_location": "L26"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "quickaddproductdialog_test_resizeobserverstub",
-      "label": "ResizeObserverStub",
-      "norm_label": "resizeobserverstub",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.test.tsx",
-      "source_location": "L8"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "quickaddproductdialog_test_resizeobserverstub_disconnect",
-      "label": ".disconnect()",
-      "norm_label": ".disconnect()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.test.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "quickaddproductdialog_test_resizeobserverstub_observe",
-      "label": ".observe()",
-      "norm_label": ".observe()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.test.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "quickaddproductdialog_test_resizeobserverstub_unobserve",
-      "label": ".unobserve()",
-      "norm_label": ".unobserve()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.test.tsx",
-      "source_location": "L10"
     },
     {
       "community": 42,
@@ -253320,6 +253332,69 @@
     {
       "community": 420,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_quickaddproductdialog_test_tsx",
+      "label": "QuickAddProductDialog.test.tsx",
+      "norm_label": "quickaddproductdialog.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "quickaddproductdialog_test_buildskusearchresult",
+      "label": "buildSkuSearchResult()",
+      "norm_label": "buildskusearchresult()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.test.tsx",
+      "source_location": "L82"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "quickaddproductdialog_test_renderquickadddialog",
+      "label": "renderQuickAddDialog()",
+      "norm_label": "renderquickadddialog()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.test.tsx",
+      "source_location": "L26"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "quickaddproductdialog_test_resizeobserverstub",
+      "label": "ResizeObserverStub",
+      "norm_label": "resizeobserverstub",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.test.tsx",
+      "source_location": "L8"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "quickaddproductdialog_test_resizeobserverstub_disconnect",
+      "label": ".disconnect()",
+      "norm_label": ".disconnect()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.test.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "quickaddproductdialog_test_resizeobserverstub_observe",
+      "label": ".observe()",
+      "norm_label": ".observe()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.test.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "quickaddproductdialog_test_resizeobserverstub_unobserve",
+      "label": ".unobserve()",
+      "norm_label": ".unobserve()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.test.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_test_tsx",
       "label": "Products.test.tsx",
       "norm_label": "products.test.tsx",
@@ -253327,7 +253402,7 @@
       "source_location": "L1"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "products_test_makeproduct",
       "label": "makeProduct()",
@@ -253336,7 +253411,7 @@
       "source_location": "L863"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "products_test_makeskusearchresult",
       "label": "makeSkuSearchResult()",
@@ -253345,7 +253420,7 @@
       "source_location": "L936"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "products_test_resizeobserverstub",
       "label": "ResizeObserverStub",
@@ -253354,7 +253429,7 @@
       "source_location": "L42"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "products_test_resizeobserverstub_disconnect",
       "label": ".disconnect()",
@@ -253363,7 +253438,7 @@
       "source_location": "L45"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "products_test_resizeobserverstub_observe",
       "label": ".observe()",
@@ -253372,7 +253447,7 @@
       "source_location": "L43"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "products_test_resizeobserverstub_unobserve",
       "label": ".unobserve()",
@@ -253381,7 +253456,7 @@
       "source_location": "L44"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportdayspanel_tsx",
       "label": "ReportDaysPanel.tsx",
@@ -253390,7 +253465,7 @@
       "source_location": "L1"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "reportdayspanel_cn",
       "label": "cn()",
@@ -253399,7 +253474,7 @@
       "source_location": "L562"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "reportdayspanel_handlemixretry",
       "label": "handleMixRetry()",
@@ -253408,7 +253483,7 @@
       "source_location": "L434"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "reportdayspanel_isinselectedrange",
       "label": "isInSelectedRange()",
@@ -253417,7 +253492,7 @@
       "source_location": "L474"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "reportdayspanel_isselectedday",
       "label": "isSelectedDay()",
@@ -253426,7 +253501,7 @@
       "source_location": "L472"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "reportdayspanel_pagecontainingdate",
       "label": "pageContainingDate()",
@@ -253435,7 +253510,7 @@
       "source_location": "L58"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "reportdayspanel_selectday",
       "label": "selectDay()",
@@ -253444,7 +253519,7 @@
       "source_location": "L476"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceappointmentsview_tsx",
       "label": "ServiceAppointmentsView.tsx",
@@ -253453,7 +253528,7 @@
       "source_location": "L1"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "serviceappointmentsview_applycommandresult",
       "label": "applyCommandResult()",
@@ -253462,7 +253537,7 @@
       "source_location": "L143"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "serviceappointmentsview_async",
       "label": "async()",
@@ -253471,7 +253546,7 @@
       "source_location": "L439"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "serviceappointmentsview_formatdatetimelocal",
       "label": "formatDateTimeLocal()",
@@ -253480,7 +253555,7 @@
       "source_location": "L113"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "serviceappointmentsview_handlesubmit",
       "label": "handleSubmit()",
@@ -253489,7 +253564,7 @@
       "source_location": "L161"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "serviceappointmentsview_parsedatetimelocal",
       "label": "parseDateTimeLocal()",
@@ -253498,7 +253573,7 @@
       "source_location": "L108"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "serviceappointmentsview_withsavestate",
       "label": "withSaveState()",
@@ -253507,7 +253582,7 @@
       "source_location": "L578"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecatalogview_tsx",
       "label": "ServiceCatalogView.tsx",
@@ -253516,7 +253591,7 @@
       "source_location": "L1"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "servicecatalogview_cn",
       "label": "cn()",
@@ -253525,7 +253600,7 @@
       "source_location": "L467"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "servicecatalogview_handlechange",
       "label": "handleChange()",
@@ -253534,7 +253609,7 @@
       "source_location": "L137"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "servicecatalogview_handleedit",
       "label": "handleEdit()",
@@ -253543,7 +253618,7 @@
       "source_location": "L150"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "servicecatalogview_handlereset",
       "label": "handleReset()",
@@ -253552,7 +253627,7 @@
       "source_location": "L156"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "servicecatalogview_handlesubmit",
       "label": "handleSubmit()",
@@ -253561,7 +253636,7 @@
       "source_location": "L162"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "servicecatalogview_withsavestate",
       "label": "withSaveState()",
@@ -253570,7 +253645,7 @@
       "source_location": "L574"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_payments_ts",
       "label": "payments.ts",
@@ -253579,7 +253654,7 @@
       "source_location": "L1"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "payments_calculateposchange",
       "label": "calculatePosChange()",
@@ -253588,7 +253663,7 @@
       "source_location": "L8"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "payments_calculateposremainingdue",
       "label": "calculatePosRemainingDue()",
@@ -253597,7 +253672,7 @@
       "source_location": "L25"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "payments_calculatepostotalpaid",
       "label": "calculatePosTotalPaid()",
@@ -253606,7 +253681,7 @@
       "source_location": "L19"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "payments_ispospaymentsufficient",
       "label": "isPosPaymentSufficient()",
@@ -253615,7 +253690,7 @@
       "source_location": "L12"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "payments_normalizenoncashoverpayment",
       "label": "normalizeNonCashOverpayment()",
@@ -253624,7 +253699,7 @@
       "source_location": "L32"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "payments_roundposamount",
       "label": "roundPosAmount()",
@@ -253633,7 +253708,7 @@
       "source_location": "L83"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_domain_session_ts",
       "label": "session.ts",
@@ -253642,7 +253717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "session_deriveregisterphase",
       "label": "deriveRegisterPhase()",
@@ -253651,7 +253726,7 @@
       "source_location": "L3"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "session_hasactiveregistersession",
       "label": "hasActiveRegisterSession()",
@@ -253660,7 +253735,7 @@
       "source_location": "L33"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "session_hasresumableregistersession",
       "label": "hasResumableRegisterSession()",
@@ -253669,7 +253744,7 @@
       "source_location": "L39"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "session_isregisterreadytostart",
       "label": "isRegisterReadyToStart()",
@@ -253678,7 +253753,7 @@
       "source_location": "L45"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "session_requirescashier",
       "label": "requiresCashier()",
@@ -253687,7 +253762,7 @@
       "source_location": "L29"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "session_requiresterminal",
       "label": "requiresTerminal()",
@@ -253696,7 +253771,7 @@
       "source_location": "L25"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "localsyncdraincoordinator_buildruntimesyncdebug",
       "label": "buildRuntimeSyncDebug()",
@@ -253705,7 +253780,7 @@
       "source_location": "L50"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "localsyncdraincoordinator_compareuploadableeventorder",
       "label": "compareUploadableEventOrder()",
@@ -253714,7 +253789,7 @@
       "source_location": "L118"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "localsyncdraincoordinator_getreviewdiagnosticsevents",
       "label": "getReviewDiagnosticsEvents()",
@@ -253723,7 +253798,7 @@
       "source_location": "L131"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "localsyncdraincoordinator_getruntimeuploadtrigger",
       "label": "getRuntimeUploadTrigger()",
@@ -253732,7 +253807,7 @@
       "source_location": "L103"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "localsyncdraincoordinator_ispendinguploadcandidate",
       "label": "isPendingUploadCandidate()",
@@ -253741,7 +253816,7 @@
       "source_location": "L163"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "localsyncdraincoordinator_startstatusonlyruntimetriggers",
       "label": "startStatusOnlyRuntimeTriggers()",
@@ -253750,7 +253825,7 @@
       "source_location": "L27"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localsyncdraincoordinator_ts",
       "label": "localSyncDrainCoordinator.ts",
@@ -253759,7 +253834,7 @@
       "source_location": "L1"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registerlifecycleauthorityrollout_ts",
       "label": "registerLifecycleAuthorityRollout.ts",
@@ -253768,7 +253843,7 @@
       "source_location": "L1"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "registerlifecycleauthorityrollout_getregisterlifecycleauthorityrolloutpolicy",
       "label": "getRegisterLifecycleAuthorityRolloutPolicy()",
@@ -253777,7 +253852,7 @@
       "source_location": "L37"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "registerlifecycleauthorityrollout_isrolloutmode",
       "label": "isRolloutMode()",
@@ -253786,7 +253861,7 @@
       "source_location": "L78"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "registerlifecycleauthorityrollout_resolveregisterlifecycleauthorityrolloutcohort",
       "label": "resolveRegisterLifecycleAuthorityRolloutCohort()",
@@ -253795,7 +253870,7 @@
       "source_location": "L64"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "registerlifecycleauthorityrollout_resolveregisterlifecycleauthorityrolloutpolicy",
       "label": "resolveRegisterLifecycleAuthorityRolloutPolicy()",
@@ -253804,7 +253879,7 @@
       "source_location": "L14"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "registerlifecycleauthorityrollout_shouldapplyregisterlifecycleauthority",
       "label": "shouldApplyRegisterLifecycleAuthority()",
@@ -253813,7 +253888,7 @@
       "source_location": "L54"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "registerlifecycleauthorityrollout_shouldsubscribetoregisterlifecycleauthority",
       "label": "shouldSubscribeToRegisterLifecycleAuthority()",
@@ -253822,7 +253897,7 @@
       "source_location": "L48"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_syncstatuspresentation_ts",
       "label": "syncStatusPresentation.ts",
@@ -253831,7 +253906,7 @@
       "source_location": "L1"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "syncstatuspresentation_buildpossyncstatuspresentation",
       "label": "buildPosSyncStatusPresentation()",
@@ -253840,7 +253915,7 @@
       "source_location": "L200"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "syncstatuspresentation_formatposreconciliationtype",
       "label": "formatPosReconciliationType()",
@@ -253849,7 +253924,7 @@
       "source_location": "L231"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "syncstatuspresentation_isduplicatelocalidreviewitem",
       "label": "isDuplicateLocalIdReviewItem()",
@@ -253858,7 +253933,7 @@
       "source_location": "L170"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "syncstatuspresentation_isduplicatepossessionsalereviewitem",
       "label": "isDuplicatePosSessionSaleReviewItem()",
@@ -253867,7 +253942,7 @@
       "source_location": "L187"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "syncstatuspresentation_isregistercloseoutreviewitem",
       "label": "isRegisterCloseoutReviewItem()",
@@ -253876,76 +253951,13 @@
       "source_location": "L151"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "syncstatuspresentation_normalizestatus",
       "label": "normalizeStatus()",
       "norm_label": "normalizestatus()",
       "source_file": "packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.ts",
       "source_location": "L125"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "calculationservice_calculatecarttotals",
-      "label": "calculateCartTotals()",
-      "norm_label": "calculatecarttotals()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "calculationservice_calculatechange",
-      "label": "calculateChange()",
-      "norm_label": "calculatechange()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "calculationservice_calculateitemtotal",
-      "label": "calculateItemTotal()",
-      "norm_label": "calculateitemtotal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "calculationservice_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "calculationservice_geteffectiveprice",
-      "label": "getEffectivePrice()",
-      "norm_label": "geteffectiveprice()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "calculationservice_ispaymentsufficient",
-      "label": "isPaymentSufficient()",
-      "norm_label": "ispaymentsufficient()",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_services_calculationservice_ts",
-      "label": "calculationService.ts",
-      "norm_label": "calculationservice.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
-      "source_location": "L1"
     },
     {
       "community": 43,
@@ -254229,6 +254241,69 @@
     {
       "community": 430,
       "file_type": "code",
+      "id": "calculationservice_calculatecarttotals",
+      "label": "calculateCartTotals()",
+      "norm_label": "calculatecarttotals()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "calculationservice_calculatechange",
+      "label": "calculateChange()",
+      "norm_label": "calculatechange()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "calculationservice_calculateitemtotal",
+      "label": "calculateItemTotal()",
+      "norm_label": "calculateitemtotal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "calculationservice_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "calculationservice_geteffectiveprice",
+      "label": "getEffectivePrice()",
+      "norm_label": "geteffectiveprice()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "calculationservice_ispaymentsufficient",
+      "label": "isPaymentSufficient()",
+      "norm_label": "ispaymentsufficient()",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_services_calculationservice_ts",
+      "label": "calculationService.ts",
+      "norm_label": "calculationservice.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 431,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_tsx",
       "label": "reference-fixtures.tsx",
       "norm_label": "reference-fixtures.tsx",
@@ -254236,7 +254311,7 @@
       "source_location": "L1"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "reference_fixtures_compacttable",
       "label": "CompactTable()",
@@ -254245,7 +254320,7 @@
       "source_location": "L263"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "reference_fixtures_framecard",
       "label": "FrameCard()",
@@ -254254,7 +254329,7 @@
       "source_location": "L163"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "reference_fixtures_lanecard",
       "label": "LaneCard()",
@@ -254263,7 +254338,7 @@
       "source_location": "L213"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "reference_fixtures_metrictile",
       "label": "MetricTile()",
@@ -254272,7 +254347,7 @@
       "source_location": "L194"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "reference_fixtures_minitrendchart",
       "label": "MiniTrendChart()",
@@ -254281,7 +254356,7 @@
       "source_location": "L240"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "reference_fixtures_referencepageshell",
       "label": "ReferencePageShell()",
@@ -254290,7 +254365,7 @@
       "source_location": "L145"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_savedbag_ts",
       "label": "savedBag.ts",
@@ -254299,7 +254374,7 @@
       "source_location": "L1"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "savedbag_additemtosavedbag",
       "label": "addItemToSavedBag()",
@@ -254308,7 +254383,7 @@
       "source_location": "L25"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "savedbag_getactivesavedbag",
       "label": "getActiveSavedBag()",
@@ -254317,7 +254392,7 @@
       "source_location": "L10"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "savedbag_getbaseurl",
       "label": "getBaseUrl()",
@@ -254326,7 +254401,7 @@
       "source_location": "L8"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "savedbag_removeitemfromsavedbag",
       "label": "removeItemFromSavedBag()",
@@ -254335,7 +254410,7 @@
       "source_location": "L91"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "savedbag_updatesavedbagitem",
       "label": "updateSavedBagItem()",
@@ -254344,7 +254419,7 @@
       "source_location": "L61"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "savedbag_updatesavedbagowner",
       "label": "updateSavedBagOwner()",
@@ -254353,7 +254428,7 @@
       "source_location": "L109"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "delivery_diff_fingerprint_collectdeliverabledifffingerprint",
       "label": "collectDeliverableDiffFingerprint()",
@@ -254362,7 +254437,7 @@
       "source_location": "L60"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "delivery_diff_fingerprint_gitenv",
       "label": "gitEnv()",
@@ -254371,7 +254446,7 @@
       "source_location": "L52"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "delivery_diff_fingerprint_isdeliverablefingerprintpath",
       "label": "isDeliverableFingerprintPath()",
@@ -254380,7 +254455,7 @@
       "source_location": "L15"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "delivery_diff_fingerprint_normalizerepopath",
       "label": "normalizeRepoPath()",
@@ -254389,7 +254464,7 @@
       "source_location": "L5"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "delivery_diff_fingerprint_rungit",
       "label": "runGit()",
@@ -254398,7 +254473,7 @@
       "source_location": "L35"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "delivery_diff_fingerprint_sortuniquepaths",
       "label": "sortUniquePaths()",
@@ -254407,7 +254482,7 @@
       "source_location": "L9"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "scripts_delivery_diff_fingerprint_ts",
       "label": "delivery-diff-fingerprint.ts",
@@ -254416,7 +254491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "delivery_documentation_check_assertdeliverydocumentationcheck",
       "label": "assertDeliveryDocumentationCheck()",
@@ -254425,7 +254500,7 @@
       "source_location": "L78"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "delivery_documentation_check_changedfiles",
       "label": "changedFiles()",
@@ -254434,7 +254509,7 @@
       "source_location": "L124"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "delivery_documentation_check_evaluatedeliverydocumentationcheck",
       "label": "evaluateDeliveryDocumentationCheck()",
@@ -254443,7 +254518,7 @@
       "source_location": "L40"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "delivery_documentation_check_findingsfrom",
       "label": "findingsFrom()",
@@ -254452,7 +254527,7 @@
       "source_location": "L33"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "delivery_documentation_check_ispolicyfailure",
       "label": "isPolicyFailure()",
@@ -254461,7 +254536,7 @@
       "source_location": "L92"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "delivery_documentation_check_parseargs",
       "label": "parseArgs()",
@@ -254470,7 +254545,7 @@
       "source_location": "L96"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "scripts_delivery_documentation_check_ts",
       "label": "delivery-documentation-check.ts",
@@ -254479,7 +254554,7 @@
       "source_location": "L1"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "frontend_dependency_parity_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -254488,7 +254563,7 @@
       "source_location": "L13"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "frontend_dependency_parity_test_createpackage",
       "label": "createPackage()",
@@ -254497,7 +254572,7 @@
       "source_location": "L25"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "frontend_dependency_parity_test_installfixturepackages",
       "label": "installFixturePackages()",
@@ -254506,7 +254581,7 @@
       "source_location": "L70"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "frontend_dependency_parity_test_writefixtureinstaller",
       "label": "writeFixtureInstaller()",
@@ -254515,7 +254590,7 @@
       "source_location": "L111"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "frontend_dependency_parity_test_writefixturemanifests",
       "label": "writeFixtureManifests()",
@@ -254524,7 +254599,7 @@
       "source_location": "L40"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "frontend_dependency_parity_test_writejson",
       "label": "writeJson()",
@@ -254533,7 +254608,7 @@
       "source_location": "L19"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "scripts_frontend_dependency_parity_test_ts",
       "label": "frontend-dependency-parity.test.ts",
@@ -254542,7 +254617,7 @@
       "source_location": "L1"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
       "label": "storefront-runtime-api.ts",
@@ -254551,7 +254626,7 @@
       "source_location": "L1"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "storefront_runtime_api_emitsignal",
       "label": "emitSignal()",
@@ -254560,7 +254635,7 @@
       "source_location": "L210"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "storefront_runtime_api_handlecheckoutsessionfetch",
       "label": "handleCheckoutSessionFetch()",
@@ -254569,7 +254644,7 @@
       "source_location": "L214"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "storefront_runtime_api_handlecheckoutsessionupdate",
       "label": "handleCheckoutSessionUpdate()",
@@ -254578,7 +254653,7 @@
       "source_location": "L236"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "storefront_runtime_api_jsonresponse",
       "label": "jsonResponse()",
@@ -254587,7 +254662,7 @@
       "source_location": "L201"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "storefront_runtime_api_shutdown",
       "label": "shutdown()",
@@ -254596,7 +254671,7 @@
       "source_location": "L421"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "storefront_runtime_api_withcorsheaders",
       "label": "withCorsHeaders()",
@@ -254605,7 +254680,7 @@
       "source_location": "L186"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "harness_janitor_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -254614,7 +254689,7 @@
       "source_location": "L29"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "harness_janitor_test_overwritefreshgenerateddocs",
       "label": "overwriteFreshGeneratedDocs()",
@@ -254623,7 +254698,7 @@
       "source_location": "L46"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "harness_janitor_test_overwritefreshgraphifyartifacts",
       "label": "overwriteFreshGraphifyArtifacts()",
@@ -254632,7 +254707,7 @@
       "source_location": "L54"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "harness_janitor_test_seedartifacts",
       "label": "seedArtifacts()",
@@ -254641,7 +254716,7 @@
       "source_location": "L35"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "harness_janitor_test_sortpaths",
       "label": "sortPaths()",
@@ -254650,7 +254725,7 @@
       "source_location": "L61"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "harness_janitor_test_write",
       "label": "write()",
@@ -254659,7 +254734,7 @@
       "source_location": "L23"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "scripts_harness_janitor_test_ts",
       "label": "harness-janitor.test.ts",
@@ -254668,7 +254743,7 @@
       "source_location": "L1"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "harness_review_identity_computedeliverabletreeidentity",
       "label": "computeDeliverableTreeIdentity()",
@@ -254677,7 +254752,7 @@
       "source_location": "L149"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "harness_review_identity_digestdeliverableentries",
       "label": "digestDeliverableEntries()",
@@ -254686,7 +254761,7 @@
       "source_location": "L125"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "harness_review_identity_ispostgatevalidationneutralpath",
       "label": "isPostGateValidationNeutralPath()",
@@ -254695,7 +254770,7 @@
       "source_location": "L90"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "harness_review_identity_isreviewneutralpath",
       "label": "isReviewNeutralPath()",
@@ -254704,7 +254779,7 @@
       "source_location": "L76"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "harness_review_identity_normalizerepopath",
       "label": "normalizeRepoPath()",
@@ -254713,7 +254788,7 @@
       "source_location": "L72"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "harness_review_identity_parsetreeentries",
       "label": "parseTreeEntries()",
@@ -254722,7 +254797,7 @@
       "source_location": "L110"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "scripts_harness_review_identity_ts",
       "label": "harness-review-identity.ts",
@@ -254731,7 +254806,7 @@
       "source_location": "L1"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "harness_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -254740,7 +254815,7 @@
       "source_location": "L25"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "harness_review_test_error",
       "label": "error()",
@@ -254749,7 +254824,7 @@
       "source_location": "L293"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "harness_review_test_initializegithistory",
       "label": "initializeGitHistory()",
@@ -254758,7 +254833,7 @@
       "source_location": "L262"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "harness_review_test_log",
       "label": "log()",
@@ -254767,7 +254842,7 @@
       "source_location": "L292"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "harness_review_test_rungit",
       "label": "runGit()",
@@ -254776,7 +254851,7 @@
       "source_location": "L248"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "harness_review_test_write",
       "label": "write()",
@@ -254785,75 +254860,12 @@
       "source_location": "L19"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "scripts_harness_review_test_ts",
       "label": "harness-review.test.ts",
       "norm_label": "harness-review.test.ts",
       "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "landed_change_report_check_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/landed-change-report-check.test.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "landed_change_report_check_test_gitenv",
-      "label": "gitEnv()",
-      "norm_label": "gitenv()",
-      "source_file": "scripts/landed-change-report-check.test.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "landed_change_report_check_test_linechanges",
-      "label": "lineChanges()",
-      "norm_label": "linechanges()",
-      "source_file": "scripts/landed-change-report-check.test.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "landed_change_report_check_test_rungit",
-      "label": "runGit()",
-      "norm_label": "rungit()",
-      "source_file": "scripts/landed-change-report-check.test.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "landed_change_report_check_test_validreport",
-      "label": "validReport()",
-      "norm_label": "validreport()",
-      "source_file": "scripts/landed-change-report-check.test.ts",
-      "source_location": "L76"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "landed_change_report_check_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/landed-change-report-check.test.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "scripts_landed_change_report_check_test_ts",
-      "label": "landed-change-report-check.test.ts",
-      "norm_label": "landed-change-report-check.test.ts",
-      "source_file": "scripts/landed-change-report-check.test.ts",
       "source_location": "L1"
     },
     {
@@ -255138,6 +255150,69 @@
     {
       "community": 440,
       "file_type": "code",
+      "id": "landed_change_report_check_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/landed-change-report-check.test.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "landed_change_report_check_test_gitenv",
+      "label": "gitEnv()",
+      "norm_label": "gitenv()",
+      "source_file": "scripts/landed-change-report-check.test.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "landed_change_report_check_test_linechanges",
+      "label": "lineChanges()",
+      "norm_label": "linechanges()",
+      "source_file": "scripts/landed-change-report-check.test.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "landed_change_report_check_test_rungit",
+      "label": "runGit()",
+      "norm_label": "rungit()",
+      "source_file": "scripts/landed-change-report-check.test.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "landed_change_report_check_test_validreport",
+      "label": "validReport()",
+      "norm_label": "validreport()",
+      "source_file": "scripts/landed-change-report-check.test.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "landed_change_report_check_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/landed-change-report-check.test.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "scripts_landed_change_report_check_test_ts",
+      "label": "landed-change-report-check.test.ts",
+      "norm_label": "landed-change-report-check.test.ts",
+      "source_file": "scripts/landed-change-report-check.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_automation_scheduledrunledger_ts",
       "label": "scheduledRunLedger.ts",
       "norm_label": "scheduledrunledger.ts",
@@ -255145,7 +255220,7 @@
       "source_location": "L1"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "scheduledrunledger_besteffortrecordscheduledrunevidence",
       "label": "bestEffortRecordScheduledRunEvidence()",
@@ -255154,7 +255229,7 @@
       "source_location": "L152"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "scheduledrunledger_buildscheduledrunkey",
       "label": "buildScheduledRunKey()",
@@ -255163,7 +255238,7 @@
       "source_location": "L65"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "scheduledrunledger_derivescheduledrunoutcome",
       "label": "deriveScheduledRunOutcome()",
@@ -255172,7 +255247,7 @@
       "source_location": "L82"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "scheduledrunledger_recordscheduledrunevidencewithctx",
       "label": "recordScheduledRunEvidenceWithCtx()",
@@ -255181,7 +255256,7 @@
       "source_location": "L95"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "scheduledrunledger_resolvescheduledwindow",
       "label": "resolveScheduledWindow()",
@@ -255190,7 +255265,7 @@
       "source_location": "L51"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "index_valkeyclient",
       "label": "ValkeyClient",
@@ -255199,7 +255274,7 @@
       "source_location": "L4"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "index_valkeyclient_constructor",
       "label": ".constructor()",
@@ -255208,7 +255283,7 @@
       "source_location": "L11"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "index_valkeyclient_get",
       "label": ".get()",
@@ -255217,7 +255292,7 @@
       "source_location": "L20"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "index_valkeyclient_invalidate",
       "label": ".invalidate()",
@@ -255226,7 +255301,7 @@
       "source_location": "L75"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "index_valkeyclient_set",
       "label": ".set()",
@@ -255235,7 +255310,7 @@
       "source_location": "L48"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cache_index_ts",
       "label": "index.ts",
@@ -255244,7 +255319,7 @@
       "source_location": "L1"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "contextevents_appendcontexteventwithctx",
       "label": "appendContextEventWithCtx()",
@@ -255253,7 +255328,7 @@
       "source_location": "L65"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "contextevents_buildcontexteventsemanticenvelopehash",
       "label": "buildContextEventSemanticEnvelopeHash()",
@@ -255262,7 +255337,7 @@
       "source_location": "L33"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "contextevents_isallowedglobalcontextevent",
       "label": "isAllowedGlobalContextEvent()",
@@ -255271,7 +255346,7 @@
       "source_location": "L204"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "contextevents_iscontexteventwritequotaexceeded",
       "label": "isContextEventWriteQuotaExceeded()",
@@ -255280,7 +255355,7 @@
       "source_location": "L19"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "contextevents_selectcontexteventappendquotadecision",
       "label": "selectContextEventAppendQuotaDecision()",
@@ -255289,7 +255364,7 @@
       "source_location": "L23"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_contexttracking_contextevents_ts",
       "label": "contextEvents.ts",
@@ -255298,7 +255373,7 @@
       "source_location": "L1"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_registercloseoutvariancealert_tsx",
       "label": "RegisterCloseoutVarianceAlert.tsx",
@@ -255307,7 +255382,7 @@
       "source_location": "L1"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "registercloseoutvariancealert_registercloseoutvariancealert",
       "label": "RegisterCloseoutVarianceAlert()",
@@ -255316,7 +255391,7 @@
       "source_location": "L60"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "registercloseoutvariancealert_registercloseoutvariancealertemailpreview",
       "label": "RegisterCloseoutVarianceAlertEmailPreview()",
@@ -255325,7 +255400,7 @@
       "source_location": "L186"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "registercloseoutvariancealert_sectionheading",
       "label": "SectionHeading()",
@@ -255334,7 +255409,7 @@
       "source_location": "L194"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "registercloseoutvariancealert_statusbadge",
       "label": "StatusBadge()",
@@ -255343,7 +255418,7 @@
       "source_location": "L204"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "registercloseoutvariancealert_summaryvaluestylefor",
       "label": "summaryValueStyleFor()",
@@ -255352,7 +255427,7 @@
       "source_location": "L232"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_walkthroughrequests_ts",
       "label": "walkthroughRequests.ts",
@@ -255361,7 +255436,7 @@
       "source_location": "L1"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "walkthroughrequests_canonical",
       "label": "canonical()",
@@ -255370,7 +255445,7 @@
       "source_location": "L24"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "walkthroughrequests_evaluatewalkthroughingress",
       "label": "evaluateWalkthroughIngress()",
@@ -255379,7 +255454,7 @@
       "source_location": "L16"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "walkthroughrequests_isvalidbody",
       "label": "isValidBody()",
@@ -255388,7 +255463,7 @@
       "source_location": "L26"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "walkthroughrequests_sha256",
       "label": "sha256()",
@@ -255397,7 +255472,7 @@
       "source_location": "L25"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "walkthroughrequests_text",
       "label": "text()",
@@ -255406,7 +255481,7 @@
       "source_location": "L23"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_security_ts",
       "label": "security.ts",
@@ -255415,7 +255490,7 @@
       "source_location": "L1"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "security_buildcanonicalcheckoutproducts",
       "label": "buildCanonicalCheckoutProducts()",
@@ -255424,7 +255499,7 @@
       "source_location": "L42"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "security_hasvalidpositivequantity",
       "label": "hasValidPositiveQuantity()",
@@ -255433,7 +255508,7 @@
       "source_location": "L27"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "security_isamounttampered",
       "label": "isAmountTampered()",
@@ -255442,7 +255517,7 @@
       "source_location": "L65"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "security_isauthorizedresourceowner",
       "label": "isAuthorizedResourceOwner()",
@@ -255451,7 +255526,7 @@
       "source_location": "L31"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "security_isduplicatechargesuccess",
       "label": "isDuplicateChargeSuccess()",
@@ -255460,7 +255535,7 @@
       "source_location": "L76"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "catalogimport_test_buildtrustedconversionargs",
       "label": "buildTrustedConversionArgs()",
@@ -255469,7 +255544,7 @@
       "source_location": "L397"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "catalogimport_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -255478,7 +255553,7 @@
       "source_location": "L144"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "catalogimport_test_gethandler",
       "label": "getHandler()",
@@ -255487,7 +255562,7 @@
       "source_location": "L140"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "catalogimport_test_readtrustedconversionbinding",
       "label": "readTrustedConversionBinding()",
@@ -255496,7 +255571,7 @@
       "source_location": "L383"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "catalogimport_test_seedtrustedconversiondata",
       "label": "seedTrustedConversionData()",
@@ -255505,7 +255580,7 @@
       "source_location": "L289"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_catalogimport_test_ts",
       "label": "catalogImport.test.ts",
@@ -255514,7 +255589,7 @@
       "source_location": "L1"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "expensesessions_expensesessionerror",
       "label": "expenseSessionError()",
@@ -255523,7 +255598,7 @@
       "source_location": "L47"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "expensesessions_loadexpensesessionitems",
       "label": "loadExpenseSessionItems()",
@@ -255532,7 +255607,7 @@
       "source_location": "L114"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "expensesessions_mapexpensesessionvalidationerror",
       "label": "mapExpenseSessionValidationError()",
@@ -255541,7 +255616,7 @@
       "source_location": "L95"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "expensesessions_recordexpensesessionlifecycletrace",
       "label": "recordExpenseSessionLifecycleTrace()",
@@ -255550,7 +255625,7 @@
       "source_location": "L139"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "expensesessions_usererrorfromexpensesessioncommandfailure",
       "label": "userErrorFromExpenseSessionCommandFailure()",
@@ -255559,7 +255634,7 @@
       "source_location": "L61"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessions_ts",
       "label": "expenseSessions.ts",
@@ -255568,7 +255643,7 @@
       "source_location": "L1"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "backfillreportfactobservedat_test_createctx",
       "label": "createCtx()",
@@ -255577,7 +255652,7 @@
       "source_location": "L20"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "backfillreportfactobservedat_test_createstoreverificationctx",
       "label": "createStoreVerificationCtx()",
@@ -255586,7 +255661,7 @@
       "source_location": "L58"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "backfillreportfactobservedat_test_finishbackfill",
       "label": "finishBackfill()",
@@ -255595,7 +255670,7 @@
       "source_location": "L96"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "backfillreportfactobservedat_test_finishverification",
       "label": "finishVerification()",
@@ -255604,7 +255679,7 @@
       "source_location": "L116"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "backfillreportfactobservedat_test_observedatfield",
       "label": "observedAtField()",
@@ -255613,66 +255688,12 @@
       "source_location": "L264"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_backfillreportfactobservedat_test_ts",
       "label": "backfillReportFactObservedAt.test.ts",
       "norm_label": "backfillreportfactobservedat.test.ts",
       "source_file": "packages/athena-webapp/convex/migrations/backfillReportFactObservedAt.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "backfillstorecurrencycase_backfillstorecurrencycasewithctx",
-      "label": "backfillStoreCurrencyCaseWithCtx()",
-      "norm_label": "backfillstorecurrencycasewithctx()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreCurrencyCase.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "backfillstorecurrencycase_boundedlimit",
-      "label": "boundedLimit()",
-      "norm_label": "boundedlimit()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreCurrencyCase.ts",
-      "source_location": "L43"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "backfillstorecurrencycase_needsnormalization",
-      "label": "needsNormalization()",
-      "norm_label": "needsnormalization()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreCurrencyCase.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "backfillstorecurrencycase_storepage",
-      "label": "storePage()",
-      "norm_label": "storepage()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreCurrencyCase.ts",
-      "source_location": "L50"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "backfillstorecurrencycase_verifystorecurrencycasewithctx",
-      "label": "verifyStoreCurrencyCaseWithCtx()",
-      "norm_label": "verifystorecurrencycasewithctx()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreCurrencyCase.ts",
-      "source_location": "L133"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_migrations_backfillstorecurrencycase_ts",
-      "label": "backfillStoreCurrencyCase.ts",
-      "norm_label": "backfillstorecurrencycase.ts",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreCurrencyCase.ts",
       "source_location": "L1"
     },
     {
@@ -255948,6 +255969,60 @@
     {
       "community": 450,
       "file_type": "code",
+      "id": "backfillstorecurrencycase_backfillstorecurrencycasewithctx",
+      "label": "backfillStoreCurrencyCaseWithCtx()",
+      "norm_label": "backfillstorecurrencycasewithctx()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreCurrencyCase.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "backfillstorecurrencycase_boundedlimit",
+      "label": "boundedLimit()",
+      "norm_label": "boundedlimit()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreCurrencyCase.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "backfillstorecurrencycase_needsnormalization",
+      "label": "needsNormalization()",
+      "norm_label": "needsnormalization()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreCurrencyCase.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "backfillstorecurrencycase_storepage",
+      "label": "storePage()",
+      "norm_label": "storepage()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreCurrencyCase.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "backfillstorecurrencycase_verifystorecurrencycasewithctx",
+      "label": "verifyStoreCurrencyCaseWithCtx()",
+      "norm_label": "verifystorecurrencycasewithctx()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreCurrencyCase.ts",
+      "source_location": "L133"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_migrations_backfillstorecurrencycase_ts",
+      "label": "backfillStoreCurrencyCase.ts",
+      "norm_label": "backfillstorecurrencycase.ts",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreCurrencyCase.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_notifications_registry_ts",
       "label": "registry.ts",
       "norm_label": "registry.ts",
@@ -255955,7 +256030,7 @@
       "source_location": "L1"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "registry_findnotificationkind",
       "label": "findNotificationKind()",
@@ -255964,7 +256039,7 @@
       "source_location": "L420"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "registry_getnotificationkind",
       "label": "getNotificationKind()",
@@ -255973,7 +256048,7 @@
       "source_location": "L430"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "registry_isstaledailyclosepayload",
       "label": "isStaleDailyClosePayload()",
@@ -255982,7 +256057,7 @@
       "source_location": "L88"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "registry_listnotificationkinds",
       "label": "listNotificationKinds()",
@@ -255991,7 +256066,7 @@
       "source_location": "L438"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "registry_requirestaledailyclosepayload",
       "label": "requireStaleDailyClosePayload()",
@@ -256000,7 +256075,7 @@
       "source_location": "L101"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "actors_getoperationactorathenauserid",
       "label": "getOperationActorAthenaUserId()",
@@ -256009,7 +256084,7 @@
       "source_location": "L20"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "actors_isnormaluseroperationactor",
       "label": "isNormalUserOperationActor()",
@@ -256018,7 +256093,7 @@
       "source_location": "L8"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "actors_ispublicoperationactor",
       "label": "isPublicOperationActor()",
@@ -256027,7 +256102,7 @@
       "source_location": "L12"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "actors_isshareddemooperationactor",
       "label": "isSharedDemoOperationActor()",
@@ -256036,7 +256111,7 @@
       "source_location": "L4"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "actors_requireoperationactorathenauserid",
       "label": "requireOperationActorAthenaUserId()",
@@ -256045,7 +256120,7 @@
       "source_location": "L31"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_actors_ts",
       "label": "actors.ts",
@@ -256054,7 +256129,7 @@
       "source_location": "L1"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "approval_builddailycloseapprovalsubject",
       "label": "buildDailyCloseApprovalSubject()",
@@ -256063,7 +256138,7 @@
       "source_location": "L15"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "approval_builddailyclosecarryforwardapprovalrequirement",
       "label": "buildDailyCloseCarryForwardApprovalRequirement()",
@@ -256072,7 +256147,7 @@
       "source_location": "L101"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "approval_builddailyclosecarryforwardapprovalsubject",
       "label": "buildDailyCloseCarryForwardApprovalSubject()",
@@ -256081,7 +256156,7 @@
       "source_location": "L88"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "approval_builddailyclosecompletionapprovalrequirement",
       "label": "buildDailyCloseCompletionApprovalRequirement()",
@@ -256090,7 +256165,7 @@
       "source_location": "L26"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "approval_builddailyclosereopenapprovalrequirement",
       "label": "buildDailyCloseReopenApprovalRequirement()",
@@ -256099,7 +256174,7 @@
       "source_location": "L54"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_dailyclose_approval_ts",
       "label": "approval.ts",
@@ -256108,7 +256183,7 @@
       "source_location": "L1"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "eventbuilders_buildonlineorderoperationaleventmessage",
       "label": "buildOnlineOrderOperationalEventMessage()",
@@ -256117,7 +256192,7 @@
       "source_location": "L68"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "eventbuilders_buildoperationaleventmessage",
       "label": "buildOperationalEventMessage()",
@@ -256126,7 +256201,7 @@
       "source_location": "L1"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "eventbuilders_buildstockadjustmentoperationaleventmessage",
       "label": "buildStockAdjustmentOperationalEventMessage()",
@@ -256135,7 +256210,7 @@
       "source_location": "L93"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "eventbuilders_formatonlineorderlabel",
       "label": "formatOnlineOrderLabel()",
@@ -256144,7 +256219,7 @@
       "source_location": "L112"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "eventbuilders_formatstockadjustmentsubjectdetail",
       "label": "formatStockAdjustmentSubjectDetail()",
@@ -256153,66 +256228,12 @@
       "source_location": "L106"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_helpers_eventbuilders_ts",
       "label": "eventBuilders.ts",
       "norm_label": "eventbuilders.ts",
       "source_file": "packages/athena-webapp/convex/operations/helpers/eventBuilders.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 454,
-      "file_type": "code",
-      "id": "oweddailyclosesweep_completedoperatingdatesforstore",
-      "label": "completedOperatingDatesForStore()",
-      "norm_label": "completedoperatingdatesforstore()",
-      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L155"
-    },
-    {
-      "community": 454,
-      "file_type": "code",
-      "id": "oweddailyclosesweep_dailyclosesweepresultsettled",
-      "label": "dailyCloseSweepResultSettled()",
-      "norm_label": "dailyclosesweepresultsettled()",
-      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 454,
-      "file_type": "code",
-      "id": "oweddailyclosesweep_daysbetweenoperatingdates",
-      "label": "daysBetweenOperatingDates()",
-      "norm_label": "daysbetweenoperatingdates()",
-      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L388"
-    },
-    {
-      "community": 454,
-      "file_type": "code",
-      "id": "oweddailyclosesweep_listenabledeodpolicies",
-      "label": "listEnabledEodPolicies()",
-      "norm_label": "listenabledeodpolicies()",
-      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L141"
-    },
-    {
-      "community": 454,
-      "file_type": "code",
-      "id": "oweddailyclosesweep_selectoweddailyclosedates",
-      "label": "selectOwedDailyCloseDates()",
-      "norm_label": "selectoweddailyclosedates()",
-      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
-      "source_location": "L89"
-    },
-    {
-      "community": 454,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
-      "label": "owedDailyCloseSweep.ts",
-      "norm_label": "oweddailyclosesweep.ts",
-      "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts",
       "source_location": "L1"
     },
     {
@@ -265447,7 +265468,7 @@
       "label": "dedupeKey()",
       "norm_label": "dedupekey()",
       "source_file": "packages/athena-webapp/convex/notifications/registry.test.ts",
-      "source_location": "L609"
+      "source_location": "L641"
     },
     {
       "community": 563,
@@ -265456,7 +265477,7 @@
       "label": "keyFor()",
       "norm_label": "keyfor()",
       "source_file": "packages/athena-webapp/convex/notifications/registry.test.ts",
-      "source_location": "L794"
+      "source_location": "L826"
     },
     {
       "community": 563,
@@ -274596,6 +274617,42 @@
     {
       "community": 695,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_register_test_ts",
+      "label": "register.test.ts",
+      "norm_label": "register.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 695,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_public_register_test_ts",
+      "label": "register.test.ts",
+      "norm_label": "register.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 695,
+      "file_type": "code",
+      "id": "register_test_buildctx",
+      "label": "buildCtx()",
+      "norm_label": "buildctx()",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 695,
+      "file_type": "code",
+      "id": "register_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 696,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
       "label": "register.ts",
       "norm_label": "register.ts",
@@ -274603,7 +274660,7 @@
       "source_location": "L1"
     },
     {
-      "community": 695,
+      "community": 696,
       "file_type": "code",
       "id": "register_mapopendrawerusererror",
       "label": "mapOpenDrawerUserError()",
@@ -274612,7 +274669,7 @@
       "source_location": "L34"
     },
     {
-      "community": 695,
+      "community": 696,
       "file_type": "code",
       "id": "register_normalizeregisternumber",
       "label": "normalizeRegisterNumber()",
@@ -274621,7 +274678,7 @@
       "source_location": "L29"
     },
     {
-      "community": 695,
+      "community": 696,
       "file_type": "code",
       "id": "register_opendrawer",
       "label": "openDrawer()",
@@ -274630,7 +274687,7 @@
       "source_location": "L56"
     },
     {
-      "community": 696,
+      "community": 697,
       "file_type": "code",
       "id": "opendrawer_test_createdbgetmock",
       "label": "createDbGetMock()",
@@ -274639,7 +274696,7 @@
       "source_location": "L39"
     },
     {
-      "community": 696,
+      "community": 697,
       "file_type": "code",
       "id": "opendrawer_test_createdbmock",
       "label": "createDbMock()",
@@ -274648,7 +274705,7 @@
       "source_location": "L99"
     },
     {
-      "community": 696,
+      "community": 697,
       "file_type": "code",
       "id": "opendrawer_test_createdbquerymock",
       "label": "createDbQueryMock()",
@@ -274657,7 +274714,7 @@
       "source_location": "L74"
     },
     {
-      "community": 696,
+      "community": 697,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_opendrawer_test_ts",
       "label": "openDrawer.test.ts",
@@ -274666,7 +274723,7 @@
       "source_location": "L1"
     },
     {
-      "community": 697,
+      "community": 698,
       "file_type": "code",
       "id": "getregisterstate_buildregisterstate",
       "label": "buildRegisterState()",
@@ -274675,7 +274732,7 @@
       "source_location": "L21"
     },
     {
-      "community": 697,
+      "community": 698,
       "file_type": "code",
       "id": "getregisterstate_getactivesessionconflictforregisterstate",
       "label": "getActiveSessionConflictForRegisterState()",
@@ -274684,7 +274741,7 @@
       "source_location": "L42"
     },
     {
-      "community": 697,
+      "community": 698,
       "file_type": "code",
       "id": "getregisterstate_getregisterstate",
       "label": "getRegisterState()",
@@ -274693,7 +274750,7 @@
       "source_location": "L80"
     },
     {
-      "community": 697,
+      "community": 698,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
       "label": "getRegisterState.ts",
@@ -274702,7 +274759,7 @@
       "source_location": "L1"
     },
     {
-      "community": 698,
+      "community": 699,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_storepulse_test_ts",
       "label": "storePulse.test.ts",
@@ -274711,7 +274768,7 @@
       "source_location": "L1"
     },
     {
-      "community": 698,
+      "community": 699,
       "file_type": "code",
       "id": "storepulse_test_createdb",
       "label": "createDb()",
@@ -274720,7 +274777,7 @@
       "source_location": "L12"
     },
     {
-      "community": 698,
+      "community": 699,
       "file_type": "code",
       "id": "storepulse_test_item",
       "label": "item()",
@@ -274729,49 +274786,13 @@
       "source_location": "L127"
     },
     {
-      "community": 698,
+      "community": 699,
       "file_type": "code",
       "id": "storepulse_test_transaction",
       "label": "transaction()",
       "norm_label": "transaction()",
       "source_file": "packages/athena-webapp/convex/pos/application/queries/storePulse.test.ts",
       "source_location": "L99"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sync_posregistersessionactivity_test_ts",
-      "label": "posRegisterSessionActivity.test.ts",
-      "norm_label": "posregistersessionactivity.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "posregistersessionactivity_test_buildactivity",
-      "label": "buildActivity()",
-      "norm_label": "buildactivity()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
-      "source_location": "L457"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "posregistersessionactivity_test_buildreport",
-      "label": "buildReport()",
-      "norm_label": "buildreport()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
-      "source_location": "L436"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "posregistersessionactivity_test_createfakerepository",
-      "label": "createFakeRepository()",
-      "norm_label": "createfakerepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
-      "source_location": "L476"
     },
     {
       "community": 7,
@@ -275622,6 +275643,42 @@
     {
       "community": 700,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_sync_posregistersessionactivity_test_ts",
+      "label": "posRegisterSessionActivity.test.ts",
+      "norm_label": "posregistersessionactivity.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 700,
+      "file_type": "code",
+      "id": "posregistersessionactivity_test_buildactivity",
+      "label": "buildActivity()",
+      "norm_label": "buildactivity()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
+      "source_location": "L457"
+    },
+    {
+      "community": 700,
+      "file_type": "code",
+      "id": "posregistersessionactivity_test_buildreport",
+      "label": "buildReport()",
+      "norm_label": "buildreport()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
+      "source_location": "L436"
+    },
+    {
+      "community": 700,
+      "file_type": "code",
+      "id": "posregistersessionactivity_test_createfakerepository",
+      "label": "createFakeRepository()",
+      "norm_label": "createfakerepository()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
+      "source_location": "L476"
+    },
+    {
+      "community": 701,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_registercatalogrevision_ts",
       "label": "registerCatalogRevision.ts",
       "norm_label": "registercatalogrevision.ts",
@@ -275629,7 +275686,7 @@
       "source_location": "L1"
     },
     {
-      "community": 700,
+      "community": 701,
       "file_type": "code",
       "id": "registercatalogrevision_advanceregistercatalogrevision",
       "label": "advanceRegisterCatalogRevision()",
@@ -275638,7 +275695,7 @@
       "source_location": "L24"
     },
     {
-      "community": 700,
+      "community": 701,
       "file_type": "code",
       "id": "registercatalogrevision_readregistercatalogrevision",
       "label": "readRegisterCatalogRevision()",
@@ -275647,7 +275704,7 @@
       "source_location": "L16"
     },
     {
-      "community": 700,
+      "community": 701,
       "file_type": "code",
       "id": "registercatalogrevision_readregistercatalogrevisionrow",
       "label": "readRegisterCatalogRevisionRow()",
@@ -275656,7 +275713,7 @@
       "source_location": "L6"
     },
     {
-      "community": 701,
+      "community": 702,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_sequencegappolicy_ts",
       "label": "sequenceGapPolicy.ts",
@@ -275665,7 +275722,7 @@
       "source_location": "L1"
     },
     {
-      "community": 701,
+      "community": 702,
       "file_type": "code",
       "id": "sequencegappolicy_decidesequencegapaction",
       "label": "decideSequenceGapAction()",
@@ -275674,7 +275731,7 @@
       "source_location": "L115"
     },
     {
-      "community": 701,
+      "community": 702,
       "file_type": "code",
       "id": "sequencegappolicy_issequencegapresolved",
       "label": "isSequenceGapResolved()",
@@ -275683,7 +275740,7 @@
       "source_location": "L219"
     },
     {
-      "community": 701,
+      "community": 702,
       "file_type": "code",
       "id": "sequencegappolicy_recordsequencegapobservation",
       "label": "recordSequenceGapObservation()",
@@ -275692,7 +275749,7 @@
       "source_location": "L190"
     },
     {
-      "community": 702,
+      "community": 703,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_staffproof_ts",
       "label": "staffProof.ts",
@@ -275701,7 +275758,7 @@
       "source_location": "L1"
     },
     {
-      "community": 702,
+      "community": 703,
       "file_type": "code",
       "id": "staffproof_createposlocalstaffprooftoken",
       "label": "createPosLocalStaffProofToken()",
@@ -275710,7 +275767,7 @@
       "source_location": "L10"
     },
     {
-      "community": 702,
+      "community": 703,
       "file_type": "code",
       "id": "staffproof_hashposlocalstaffprooftoken",
       "label": "hashPosLocalStaffProofToken()",
@@ -275719,7 +275776,7 @@
       "source_location": "L16"
     },
     {
-      "community": 702,
+      "community": 703,
       "file_type": "code",
       "id": "staffproof_tohex",
       "label": "toHex()",
@@ -275728,7 +275785,7 @@
       "source_location": "L4"
     },
     {
-      "community": 703,
+      "community": 704,
       "file_type": "code",
       "id": "cloudrepairpolicy_test_buildconflict",
       "label": "buildConflict()",
@@ -275737,7 +275794,7 @@
       "source_location": "L387"
     },
     {
-      "community": 703,
+      "community": 704,
       "file_type": "code",
       "id": "cloudrepairpolicy_test_buildevent",
       "label": "buildEvent()",
@@ -275746,7 +275803,7 @@
       "source_location": "L407"
     },
     {
-      "community": 703,
+      "community": 704,
       "file_type": "code",
       "id": "cloudrepairpolicy_test_createrepairprojectionrepository",
       "label": "createRepairProjectionRepository()",
@@ -275755,7 +275812,7 @@
       "source_location": "L282"
     },
     {
-      "community": 703,
+      "community": 704,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_cloudrepairpolicy_test_ts",
       "label": "cloudRepairPolicy.test.ts",
@@ -275764,7 +275821,7 @@
       "source_location": "L1"
     },
     {
-      "community": 704,
+      "community": 705,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_terminalcommandservice_test_ts",
       "label": "terminalCommandService.test.ts",
@@ -275773,7 +275830,7 @@
       "source_location": "L1"
     },
     {
-      "community": 704,
+      "community": 705,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildcommand",
       "label": "buildCommand()",
@@ -275782,7 +275839,7 @@
       "source_location": "L1731"
     },
     {
-      "community": 704,
+      "community": 705,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildrepository",
       "label": "buildRepository()",
@@ -275791,7 +275848,7 @@
       "source_location": "L1666"
     },
     {
-      "community": 704,
+      "community": 705,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildruntimestatus",
       "label": "buildRuntimeStatus()",
@@ -275800,7 +275857,7 @@
       "source_location": "L1755"
     },
     {
-      "community": 705,
+      "community": 706,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
       "label": "sessionCommandRepository.ts",
@@ -275809,7 +275866,7 @@
       "source_location": "L1"
     },
     {
-      "community": 705,
+      "community": 706,
       "file_type": "code",
       "id": "sessioncommandrepository_collectsessionitemsfrompages",
       "label": "collectSessionItemsFromPages()",
@@ -275818,7 +275875,7 @@
       "source_location": "L177"
     },
     {
-      "community": 705,
+      "community": 706,
       "file_type": "code",
       "id": "sessioncommandrepository_createsessioncommandrepository",
       "label": "createSessionCommandRepository()",
@@ -275827,49 +275884,13 @@
       "source_location": "L68"
     },
     {
-      "community": 705,
+      "community": 706,
       "file_type": "code",
       "id": "sessioncommandrepository_scansessionitembyskuinpages",
       "label": "scanSessionItemBySkuInPages()",
       "norm_label": "scansessionitembyskuinpages()",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
       "source_location": "L195"
-    },
-    {
-      "community": 706,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_register_test_ts",
-      "label": "register.test.ts",
-      "norm_label": "register.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 706,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_public_register_test_ts",
-      "label": "register.test.ts",
-      "norm_label": "register.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 706,
-      "file_type": "code",
-      "id": "register_test_buildctx",
-      "label": "buildCtx()",
-      "norm_label": "buildctx()",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 706,
-      "file_type": "code",
-      "id": "register_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L38"
     },
     {
       "community": 707,
@@ -285598,7 +285619,7 @@
       "label": "emitNotificationWithCtx()",
       "norm_label": "emitnotificationwithctx()",
       "source_file": "packages/athena-webapp/convex/notifications/emit.ts",
-      "source_location": "L38"
+      "source_location": "L39"
     },
     {
       "community": 871,
@@ -285607,7 +285628,7 @@
       "label": "scheduleNotificationWithCtx()",
       "norm_label": "schedulenotificationwithctx()",
       "source_file": "packages/athena-webapp/convex/notifications/emit.ts",
-      "source_location": "L21"
+      "source_location": "L22"
     },
     {
       "community": 871,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2885
-- Graph nodes: 12274
-- Graph edges: 15116
+- Graph nodes: 12275
+- Graph edges: 15117
 - Communities: 2810
 
 ## Graph Hotspots

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2885
-- Graph nodes: 12270
-- Graph edges: 15111
+- Graph nodes: 12274
+- Graph edges: 15116
 - Communities: 2810
 
 ## Graph Hotspots

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,12 +8,12 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2885
-- Graph nodes: 12277
+- Graph nodes: 12278
 - Graph edges: 15128
 - Communities: 2810
 
 ## Graph Hotspots
-- `dailyClose.ts` (101 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
+- `dailyClose.ts` (102 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `harness-inferential-review.ts` (88 edges, Community 2) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 - `posLocalStore.ts` (87 edges, Community 1) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts)
 - `dailyOperations.ts` (76 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2885
-- Graph nodes: 12275
-- Graph edges: 15119
+- Graph nodes: 12276
+- Graph edges: 15122
 - Communities: 2810
 
 ## Graph Hotspots

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,13 +7,13 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 2883
-- Graph nodes: 12266
-- Graph edges: 15104
-- Communities: 2808
+- Code files discovered: 2885
+- Graph nodes: 12270
+- Graph edges: 15111
+- Communities: 2810
 
 ## Graph Hotspots
-- `dailyClose.ts` (98 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
+- `dailyClose.ts` (100 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `harness-inferential-review.ts` (88 edges, Community 2) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 - `posLocalStore.ts` (87 edges, Community 1) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts)
 - `dailyOperations.ts` (76 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,12 +8,12 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2885
-- Graph nodes: 12276
-- Graph edges: 15122
+- Graph nodes: 12277
+- Graph edges: 15128
 - Communities: 2810
 
 ## Graph Hotspots
-- `dailyClose.ts` (100 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
+- `dailyClose.ts` (101 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `harness-inferential-review.ts` (88 edges, Community 2) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 - `posLocalStore.ts` (87 edges, Community 1) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts)
 - `dailyOperations.ts` (76 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -9,7 +9,7 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 ## Repo Summary
 - Code files discovered: 2885
 - Graph nodes: 12275
-- Graph edges: 15117
+- Graph edges: 15119
 - Communities: 2810
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -17,7 +17,7 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - [validation-map.json](../../../packages/athena-webapp/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `dailyClose.ts` (101 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
+- `dailyClose.ts` (102 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `posLocalStore.ts` (87 edges, Community 1) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`](../../../packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts)
 - `dailyOperations.ts` (76 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../../packages/athena-webapp/convex/operations/dailyOperations.ts)
 - `terminalHealthPresentation.ts` (76 edges, Community 4) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -17,7 +17,7 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - [validation-map.json](../../../packages/athena-webapp/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `dailyClose.ts` (98 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
+- `dailyClose.ts` (100 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `posLocalStore.ts` (87 edges, Community 1) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`](../../../packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts)
 - `dailyOperations.ts` (76 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../../packages/athena-webapp/convex/operations/dailyOperations.ts)
 - `terminalHealthPresentation.ts` (76 edges, Community 4) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -17,7 +17,7 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - [validation-map.json](../../../packages/athena-webapp/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `dailyClose.ts` (100 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
+- `dailyClose.ts` (101 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `posLocalStore.ts` (87 edges, Community 1) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`](../../../packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts)
 - `dailyOperations.ts` (76 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../../packages/athena-webapp/convex/operations/dailyOperations.ts)
 - `terminalHealthPresentation.ts` (76 edges, Community 4) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)

--- a/packages/athena-webapp/convex/_generated/api.d.ts
+++ b/packages/athena-webapp/convex/_generated/api.d.ts
@@ -67,6 +67,7 @@ import type * as emails_RegisterCloseoutMatchReportPreview from "../emails/Regis
 import type * as emails_RegisterCloseoutVarianceAlert from "../emails/RegisterCloseoutVarianceAlert.js";
 import type * as emails_RegisterCloseoutVarianceAlertPreview from "../emails/RegisterCloseoutVarianceAlertPreview.js";
 import type * as emails_ReportVerificationAlert from "../emails/ReportVerificationAlert.js";
+import type * as emails_StaleDailyCloseAlert from "../emails/StaleDailyCloseAlert.js";
 import type * as emails_VerificationCode from "../emails/VerificationCode.js";
 import type * as emails_WalkthroughRequestNotification from "../emails/WalkthroughRequestNotification.js";
 import type * as emails_WeeklyManagerReport from "../emails/WeeklyManagerReport.js";
@@ -679,6 +680,7 @@ declare const fullApi: ApiFromModules<{
   "emails/RegisterCloseoutVarianceAlert": typeof emails_RegisterCloseoutVarianceAlert;
   "emails/RegisterCloseoutVarianceAlertPreview": typeof emails_RegisterCloseoutVarianceAlertPreview;
   "emails/ReportVerificationAlert": typeof emails_ReportVerificationAlert;
+  "emails/StaleDailyCloseAlert": typeof emails_StaleDailyCloseAlert;
   "emails/VerificationCode": typeof emails_VerificationCode;
   "emails/WalkthroughRequestNotification": typeof emails_WalkthroughRequestNotification;
   "emails/WeeklyManagerReport": typeof emails_WeeklyManagerReport;

--- a/packages/athena-webapp/convex/emails/StaleDailyCloseAlert.test.tsx
+++ b/packages/athena-webapp/convex/emails/StaleDailyCloseAlert.test.tsx
@@ -1,0 +1,40 @@
+import { render } from "@react-email/components";
+import { describe, expect, it } from "vitest";
+
+import StaleDailyCloseAlertPreview, {
+  StaleDailyCloseAlert,
+  staleDailyCloseAlertPreviewProps,
+} from "./StaleDailyCloseAlert";
+
+describe("StaleDailyCloseAlert", () => {
+  it("renders the agreed stale-day message and restrained action", async () => {
+    const html = await render(<StaleDailyCloseAlertPreview />);
+
+    expect(html).toContain("Wigclub<!-- --> · EOD Review");
+    expect(html).toContain("Still open after <!-- -->2");
+    expect(html).toContain("has remained open for 2 days");
+    expect(html.match(/Wednesday, Aug 12/g)).toHaveLength(1);
+    expect(html).toContain(
+      "Athena has continued checking it but cannot complete the close",
+    );
+    expect(html).toContain("An open register session is preventing automatic");
+    expect(html).toContain("Athena will continue retrying");
+    expect(html).toContain("Review EOD Review");
+    expect(html).toContain(staleDailyCloseAlertPreviewProps.reportUrl);
+    expect(html).toContain("background-color:transparent");
+    expect(html).toContain("border:1px solid #e2e3e6");
+  });
+
+  it("falls back to calm generic guidance when blockers are unavailable", async () => {
+    const html = await render(
+      <StaleDailyCloseAlert
+        {...staleDailyCloseAlertPreviewProps}
+        blockerSummaries={[]}
+      />,
+    );
+
+    expect(html).toContain(
+      "Review the remaining items before completing EOD Review.",
+    );
+  });
+});

--- a/packages/athena-webapp/convex/emails/StaleDailyCloseAlert.tsx
+++ b/packages/athena-webapp/convex/emails/StaleDailyCloseAlert.tsx
@@ -38,13 +38,12 @@ export function StaleDailyCloseAlert({
   storeName,
 }: StaleDailyCloseAlertProps) {
   const dayLabel = ageInDays === 1 ? "day" : "days";
+  const previewText = `This operating day has remained open for ${ageInDays} ${dayLabel}.`;
 
   return (
     <Html>
       <Head />
-      <Preview>
-        This operating day has remained open for {ageInDays} {dayLabel}.
-      </Preview>
+      <Preview>{previewText}</Preview>
       <Body style={styles.body}>
         <Container style={styles.shell}>
           <Section style={styles.header}>

--- a/packages/athena-webapp/convex/emails/StaleDailyCloseAlert.tsx
+++ b/packages/athena-webapp/convex/emails/StaleDailyCloseAlert.tsx
@@ -1,0 +1,179 @@
+import type { CSSProperties } from "react";
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Html,
+  Preview,
+  Section,
+  Text,
+} from "@react-email/components";
+import { operationalEmailOutlineButton } from "./emailOperationalCtaStyles";
+
+export interface StaleDailyCloseAlertProps {
+  ageInDays: number;
+  blockerSummaries: string[];
+  operatingDate: string;
+  reportUrl: string;
+  storeName: string;
+}
+
+export const staleDailyCloseAlertPreviewProps = {
+  ageInDays: 2,
+  blockerSummaries: [
+    "An open register session is preventing automatic completion.",
+  ],
+  operatingDate: "Wednesday, Aug 12",
+  reportUrl:
+    "https://athena-os.app/wigclub/store/wigclub/operations/daily-close?operatingDate=2026-08-12",
+  storeName: "Wigclub",
+} satisfies StaleDailyCloseAlertProps;
+
+export function StaleDailyCloseAlert({
+  ageInDays,
+  blockerSummaries,
+  operatingDate,
+  reportUrl,
+  storeName,
+}: StaleDailyCloseAlertProps) {
+  const dayLabel = ageInDays === 1 ? "day" : "days";
+
+  return (
+    <Html>
+      <Head />
+      <Preview>
+        This operating day has remained open for {ageInDays} {dayLabel}.
+      </Preview>
+      <Body style={styles.body}>
+        <Container style={styles.shell}>
+          <Section style={styles.header}>
+            <Text style={styles.eyebrow}>{storeName} · EOD Review</Text>
+            <Text style={styles.headline}>
+              Still open after {ageInDays} {dayLabel}
+            </Text>
+          </Section>
+
+          <Section style={styles.statusPanel}>
+            <Text style={styles.statusSummary}>
+              {operatingDate} has remained open for {ageInDays} {dayLabel}.
+              Athena has continued checking it but cannot complete the close
+              automatically.
+            </Text>
+          </Section>
+
+          <Section style={styles.details}>
+            <Text style={styles.sectionTitle}>What needs attention</Text>
+            {(blockerSummaries.length > 0
+              ? blockerSummaries
+              : ["Review the remaining items before completing EOD Review."]
+            ).map((summary) => (
+              <Text key={summary} style={styles.blocker}>
+                {summary}
+              </Text>
+            ))}
+            <Text style={styles.retryNote}>
+              Athena will continue retrying while this operating day remains
+              within the automatic recovery window.
+            </Text>
+          </Section>
+
+          <Section style={styles.action}>
+            <Button href={reportUrl} style={styles.button}>
+              Review EOD Review ↗
+            </Button>
+          </Section>
+        </Container>
+      </Body>
+    </Html>
+  );
+}
+
+export default function StaleDailyCloseAlertPreview() {
+  return <StaleDailyCloseAlert {...staleDailyCloseAlertPreviewProps} />;
+}
+
+const colors = {
+  background: "#f5f5f3",
+  border: "#e2e3e6",
+  foreground: "#1b1c1f",
+  muted: "#6f737b",
+  surface: "#fafaf8",
+  warning: "#b45309",
+};
+
+const fontFamily =
+  "-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif";
+
+const styles: Record<string, CSSProperties> = {
+  action: { padding: "8px 32px 32px", textAlign: "right" },
+  blocker: {
+    borderLeft: `2px solid ${colors.border}`,
+    color: colors.foreground,
+    fontSize: "14px",
+    lineHeight: "21px",
+    margin: "14px 0 0",
+    paddingLeft: "12px",
+  },
+  body: {
+    backgroundColor: colors.background,
+    color: colors.foreground,
+    fontFamily,
+    margin: 0,
+    padding: "36px 0",
+  },
+  button: { ...operationalEmailOutlineButton },
+  details: { padding: "26px 32px 18px" },
+  eyebrow: {
+    color: colors.muted,
+    fontSize: "10px",
+    fontWeight: 700,
+    letterSpacing: "0.11em",
+    lineHeight: "15px",
+    margin: "0 0 10px",
+    textTransform: "uppercase",
+  },
+  header: { padding: "36px 32px 24px" },
+  headline: {
+    color: colors.foreground,
+    fontSize: "24px",
+    fontWeight: 650,
+    letterSpacing: "-0.02em",
+    lineHeight: "29px",
+    margin: 0,
+  },
+  retryNote: {
+    color: colors.muted,
+    fontSize: "13px",
+    lineHeight: "20px",
+    margin: "24px 0 0",
+  },
+  sectionTitle: {
+    color: colors.muted,
+    fontSize: "10px",
+    fontWeight: 700,
+    letterSpacing: "0.08em",
+    lineHeight: "15px",
+    margin: 0,
+    textTransform: "uppercase",
+  },
+  shell: {
+    backgroundColor: "#ffffff",
+    margin: "0 auto",
+    maxWidth: "640px",
+    overflow: "hidden",
+  },
+  statusPanel: {
+    backgroundColor: colors.surface,
+    borderBottom: `1px solid ${colors.border}`,
+    borderLeft: `3px solid ${colors.warning}`,
+    borderTop: `1px solid ${colors.border}`,
+    padding: "20px 32px 21px 29px",
+  },
+  statusSummary: {
+    color: colors.foreground,
+    fontSize: "14px",
+    lineHeight: "22px",
+    margin: "7px 0 0",
+  },
+};

--- a/packages/athena-webapp/convex/notifications/emit.ts
+++ b/packages/athena-webapp/convex/notifications/emit.ts
@@ -47,6 +47,25 @@ export async function emitNotificationWithCtx(
     .withIndex("by_dedupeKey", (q) => q.eq("dedupeKey", dedupeKey))
     .unique();
   if (existing) {
+    // A stale-close alert remains true until the close completes. If its first
+    // dispatch found no EOD audience, let a later sweep re-arm the same intent
+    // after subscriptions are configured. The permanent dedupe key and
+    // recipient delivery keys still prevent duplicate sends.
+    if (
+      args.kind === "eod.stale_daily_close" &&
+      existing.status === "suppressed" &&
+      existing.suppressedReason === "no_recipients"
+    ) {
+      await ctx.db.patch("notificationIntent", existing._id, {
+        status: "pending",
+        suppressedReason: undefined,
+      });
+      await ctx.scheduler.runAfter(
+        0,
+        internal.notifications.dispatch.dispatchIntent,
+        { intentId: existing._id },
+      );
+    }
     return { intentId: existing._id, created: false };
   }
 

--- a/packages/athena-webapp/convex/notifications/emit.ts
+++ b/packages/athena-webapp/convex/notifications/emit.ts
@@ -78,6 +78,7 @@ export async function emitNotificationWithCtx(
         });
       }
       await ctx.db.patch("notificationIntent", existing._id, {
+        payload: args.payload,
         status: "pending",
         suppressedReason: undefined,
       });

--- a/packages/athena-webapp/convex/notifications/emit.ts
+++ b/packages/athena-webapp/convex/notifications/emit.ts
@@ -79,8 +79,10 @@ export async function emitNotificationWithCtx(
       }
       await ctx.db.patch("notificationIntent", existing._id, {
         payload: args.payload,
+        requeuedAt: now,
         status: "pending",
         suppressedReason: undefined,
+        sweepAttempts: 0,
       });
       await ctx.scheduler.runAfter(
         0,

--- a/packages/athena-webapp/convex/notifications/emit.ts
+++ b/packages/athena-webapp/convex/notifications/emit.ts
@@ -3,6 +3,7 @@ import { internal } from "../_generated/api";
 import { internalMutation, type MutationCtx } from "../_generated/server";
 import type { Id } from "../_generated/dataModel";
 import { getNotificationKind } from "./registry";
+import { SUBSCRIPTION_RESOLUTION_CAP } from "./deliveryPolicy";
 
 export type EmitNotificationArgs = {
   kind: string;
@@ -56,6 +57,26 @@ export async function emitNotificationWithCtx(
       existing.status === "suppressed" &&
       existing.suppressedReason === "no_recipients"
     ) {
+      const deliveries = await ctx.db
+        .query("notificationDelivery")
+        .withIndex("by_intentId", (q) => q.eq("intentId", existing._id))
+        .take(SUBSCRIPTION_RESOLUTION_CAP);
+      const now = Date.now();
+      for (const delivery of deliveries) {
+        if (
+          delivery.status !== "suppressed" ||
+          delivery.errorCode !== "no_recipients"
+        ) {
+          continue;
+        }
+        await ctx.db.patch("notificationDelivery", delivery._id, {
+          status: "retryable_failure",
+          errorCode: undefined,
+          nextAttemptAt: now,
+          terminalAt: undefined,
+          updatedAt: now,
+        });
+      }
       await ctx.db.patch("notificationIntent", existing._id, {
         status: "pending",
         suppressedReason: undefined,

--- a/packages/athena-webapp/convex/notifications/rail.test.ts
+++ b/packages/athena-webapp/convex/notifications/rail.test.ts
@@ -544,6 +544,191 @@ describe("reserveIntentDeliveries", () => {
     ).toHaveLength(1);
   });
 
+  it("restarts the abandonment clock when an aged stale-close intent is re-armed", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    try {
+      const t = convexTest(schema, modules);
+      const fixture = await t.run(seedOrgStore);
+      const subscriptionId = await t.run((ctx) =>
+        ctx.db.insert("notificationSubscription", {
+          organizationId: fixture.organizationId,
+          category: "eod",
+          channel: "email",
+          recipientEmail: "manager@example.com",
+          enabled: false,
+          createdAt: NOW,
+          updatedAt: NOW,
+        }),
+      );
+      const notification = {
+        kind: "eod.stale_daily_close",
+        organizationId: fixture.organizationId,
+        storeId: fixture.storeId,
+        subjectType: "dailyClose",
+        subjectId: `${fixture.storeId}:2026-07-21`,
+        payload: {
+          ageInDays: 8,
+          operatingDate: "2026-07-21",
+          storeId: fixture.storeId,
+        },
+      };
+      const emitted = await t.mutation(
+        internal.notifications.emit.emitNotification,
+        notification,
+      );
+      expect(
+        await t.mutation(
+          internal.notifications.dispatch.reserveIntentDeliveries,
+          { intentId: emitted.intentId },
+        ),
+      ).toBeNull();
+
+      const rearmAt = NOW + INTENT_ABANDON_AFTER_MS + 60_000;
+      vi.setSystemTime(rearmAt);
+      await t.run((ctx) =>
+        ctx.db.patch("notificationSubscription", subscriptionId, {
+          enabled: true,
+        }),
+      );
+      await t.mutation(
+        internal.notifications.emit.emitNotification,
+        notification,
+      );
+      expect(
+        await t.run((ctx) =>
+          ctx.db.get("notificationIntent", emitted.intentId),
+        ),
+      ).toMatchObject({
+        requeuedAt: rearmAt,
+        status: "pending",
+        sweepAttempts: 0,
+      });
+
+      await t.mutation(internal.notifications.sweeper.sweep, {
+        now: rearmAt + SWEEPER_INTENT_PICKUP_DELAY_MS,
+      });
+      expect(
+        await t.run((ctx) =>
+          ctx.db.get("notificationIntent", emitted.intentId),
+        ),
+      ).toMatchObject({ status: "pending", sweepAttempts: 1 });
+      expect(
+        await t.mutation(
+          internal.notifications.dispatch.reserveIntentDeliveries,
+          { intentId: emitted.intentId },
+        ),
+      ).toMatchObject({
+        leased: [expect.objectContaining({ recipientEmail: "manager@example.com" })],
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps sent recipients deduped while reviving only no-audience-suppressed deliveries", async () => {
+    const t = convexTest(schema, modules);
+    const fixture = await t.run(seedOrgStore);
+    const subscriptionIds = await t.run(async (ctx) => [
+      await ctx.db.insert("notificationSubscription", {
+        organizationId: fixture.organizationId,
+        category: "eod",
+        channel: "email",
+        recipientEmail: "sent@example.com",
+        enabled: true,
+        createdAt: NOW,
+        updatedAt: NOW,
+      }),
+      await ctx.db.insert("notificationSubscription", {
+        organizationId: fixture.organizationId,
+        category: "eod",
+        channel: "email",
+        recipientEmail: "retry@example.com",
+        enabled: true,
+        createdAt: NOW,
+        updatedAt: NOW,
+      }),
+    ]);
+    const notification = {
+      kind: "eod.stale_daily_close",
+      organizationId: fixture.organizationId,
+      storeId: fixture.storeId,
+      subjectType: "dailyClose",
+      subjectId: `${fixture.storeId}:2026-07-21`,
+      payload: {
+        ageInDays: 7,
+        operatingDate: "2026-07-21",
+        storeId: fixture.storeId,
+      },
+    };
+    const emitted = await t.mutation(
+      internal.notifications.emit.emitNotification,
+      notification,
+    );
+    const initial = await t.mutation(
+      internal.notifications.dispatch.reserveIntentDeliveries,
+      { intentId: emitted.intentId },
+    );
+    const sentLease = initial!.leased.find(
+      (lease) => lease.recipientEmail === "sent@example.com",
+    )!;
+    const retryLease = initial!.leased.find(
+      (lease) => lease.recipientEmail === "retry@example.com",
+    )!;
+    await t.mutation(internal.notifications.dispatch.completeDelivery, {
+      deliveryId: sentLease.deliveryId,
+      leaseToken: sentLease.leaseToken,
+      state: "sent",
+      errorCode: "sent",
+    });
+    await t.run(async (ctx) => {
+      await ctx.db.patch("notificationDelivery", retryLease.deliveryId, {
+        status: "retryable_failure",
+        leaseToken: undefined,
+        leaseExpiresAt: undefined,
+        nextAttemptAt: NOW - 1,
+      });
+      for (const subscriptionId of subscriptionIds) {
+        await ctx.db.patch("notificationSubscription", subscriptionId, {
+          enabled: false,
+        });
+      }
+    });
+    expect(
+      await t.mutation(
+        internal.notifications.dispatch.reserveIntentDeliveries,
+        { intentId: emitted.intentId },
+      ),
+    ).toBeNull();
+
+    await t.run(async (ctx) => {
+      for (const subscriptionId of subscriptionIds) {
+        await ctx.db.patch("notificationSubscription", subscriptionId, {
+          enabled: true,
+        });
+      }
+    });
+    await t.mutation(
+      internal.notifications.emit.emitNotification,
+      notification,
+    );
+    const revived = await t.mutation(
+      internal.notifications.dispatch.reserveIntentDeliveries,
+      { intentId: emitted.intentId },
+    );
+    expect(revived?.leased).toEqual([
+      expect.objectContaining({
+        deliveryId: retryLease.deliveryId,
+        recipientEmail: "retry@example.com",
+      }),
+    ]);
+    const deliveries = await listDeliveries(t);
+    expect(
+      deliveries.filter((delivery) => delivery.recipientEmail === "sent@example.com"),
+    ).toEqual([expect.objectContaining({ status: "sent" })]);
+    expect(deliveries).toHaveLength(2);
+  });
+
   it("does not fall back to ADMIN_EMAILS when rows exist but are scoped to another store", async () => {
     const t = convexTest(schema, modules);
     const fixture = await t.run(seedOrgStore);

--- a/packages/athena-webapp/convex/notifications/rail.test.ts
+++ b/packages/athena-webapp/convex/notifications/rail.test.ts
@@ -415,7 +415,7 @@ describe("reserveIntentDeliveries", () => {
       subjectType: "dailyClose",
       subjectId: `${fixture.storeId}:2026-07-21`,
       payload: {
-        ageInDays: 4,
+        ageInDays: 2,
         operatingDate: "2026-07-21",
         storeId: fixture.storeId,
       },
@@ -477,7 +477,7 @@ describe("reserveIntentDeliveries", () => {
       subjectType: "dailyClose",
       subjectId: `${fixture.storeId}:2026-07-21`,
       payload: {
-        ageInDays: 4,
+        ageInDays: 2,
         operatingDate: "2026-07-21",
         storeId: fixture.storeId,
       },
@@ -517,7 +517,17 @@ describe("reserveIntentDeliveries", () => {
         enabled: true,
       }),
     );
-    await t.mutation(internal.notifications.emit.emitNotification, notification);
+    const rearmedNotification = {
+      ...notification,
+      payload: { ...notification.payload, ageInDays: 7 },
+    };
+    await t.mutation(
+      internal.notifications.emit.emitNotification,
+      rearmedNotification,
+    );
+    expect(
+      await t.run((ctx) => ctx.db.get("notificationIntent", emitted.intentId)),
+    ).toMatchObject({ payload: { ageInDays: 7 } });
     const revived = await t.mutation(
       internal.notifications.dispatch.reserveIntentDeliveries,
       { intentId: emitted.intentId },

--- a/packages/athena-webapp/convex/notifications/rail.test.ts
+++ b/packages/athena-webapp/convex/notifications/rail.test.ts
@@ -456,6 +456,84 @@ describe("reserveIntentDeliveries", () => {
     ]);
   });
 
+  it("revives a no-audience-suppressed retry for the same recipient exactly once", async () => {
+    const t = convexTest(schema, modules);
+    const fixture = await t.run(seedOrgStore);
+    const subscriptionId = await t.run((ctx) =>
+      ctx.db.insert("notificationSubscription", {
+        organizationId: fixture.organizationId,
+        category: "eod",
+        channel: "email",
+        recipientEmail: "manager@example.com",
+        enabled: true,
+        createdAt: NOW,
+        updatedAt: NOW,
+      }),
+    );
+    const notification = {
+      kind: "eod.stale_daily_close",
+      organizationId: fixture.organizationId,
+      storeId: fixture.storeId,
+      subjectType: "dailyClose",
+      subjectId: `${fixture.storeId}:2026-07-21`,
+      payload: {
+        ageInDays: 4,
+        operatingDate: "2026-07-21",
+        storeId: fixture.storeId,
+      },
+    };
+    const emitted = await t.mutation(
+      internal.notifications.emit.emitNotification,
+      notification,
+    );
+    const initial = await t.mutation(
+      internal.notifications.dispatch.reserveIntentDeliveries,
+      { intentId: emitted.intentId },
+    );
+    const deliveryId = initial!.leased[0]!.deliveryId;
+    await t.run(async (ctx) => {
+      await ctx.db.patch("notificationDelivery", deliveryId, {
+        status: "retryable_failure",
+        leaseToken: undefined,
+        leaseExpiresAt: undefined,
+        nextAttemptAt: NOW - 1,
+      });
+      await ctx.db.patch("notificationSubscription", subscriptionId, {
+        enabled: false,
+      });
+    });
+    expect(
+      await t.mutation(
+        internal.notifications.dispatch.reserveIntentDeliveries,
+        { intentId: emitted.intentId },
+      ),
+    ).toBeNull();
+    expect(
+      await t.run((ctx) => ctx.db.get("notificationDelivery", deliveryId)),
+    ).toMatchObject({ status: "suppressed", errorCode: "no_recipients" });
+
+    await t.run((ctx) =>
+      ctx.db.patch("notificationSubscription", subscriptionId, {
+        enabled: true,
+      }),
+    );
+    await t.mutation(internal.notifications.emit.emitNotification, notification);
+    const revived = await t.mutation(
+      internal.notifications.dispatch.reserveIntentDeliveries,
+      { intentId: emitted.intentId },
+    );
+    expect(revived?.leased).toHaveLength(1);
+    expect(revived?.leased[0]).toMatchObject({
+      deliveryId,
+      recipientEmail: "manager@example.com",
+    });
+    expect(
+      (await listDeliveries(t)).filter(
+        (delivery) => delivery.recipientEmail === "manager@example.com",
+      ),
+    ).toHaveLength(1);
+  });
+
   it("does not fall back to ADMIN_EMAILS when rows exist but are scoped to another store", async () => {
     const t = convexTest(schema, modules);
     const fixture = await t.run(seedOrgStore);

--- a/packages/athena-webapp/convex/notifications/rail.test.ts
+++ b/packages/athena-webapp/convex/notifications/rail.test.ts
@@ -394,6 +394,68 @@ describe("reserveIntentDeliveries", () => {
     });
   });
 
+  it("re-arms a stale-close intent after an EOD subscriber is added", async () => {
+    const t = convexTest(schema, modules);
+    const fixture = await t.run(seedOrgStore);
+    await t.run((ctx) =>
+      ctx.db.insert("notificationSubscription", {
+        organizationId: fixture.organizationId,
+        category: "eod",
+        channel: "email",
+        recipientEmail: "disabled@example.com",
+        enabled: false,
+        createdAt: NOW,
+        updatedAt: NOW,
+      }),
+    );
+    const notification = {
+      kind: "eod.stale_daily_close",
+      organizationId: fixture.organizationId,
+      storeId: fixture.storeId,
+      subjectType: "dailyClose",
+      subjectId: `${fixture.storeId}:2026-07-21`,
+      payload: {
+        ageInDays: 4,
+        operatingDate: "2026-07-21",
+        storeId: fixture.storeId,
+      },
+    };
+    const emitted = await t.mutation(
+      internal.notifications.emit.emitNotification,
+      notification,
+    );
+    expect(
+      await t.mutation(
+        internal.notifications.dispatch.reserveIntentDeliveries,
+        { intentId: emitted.intentId },
+      ),
+    ).toBeNull();
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("notificationSubscription", {
+        organizationId: fixture.organizationId,
+        category: "eod",
+        channel: "email",
+        recipientEmail: "manager@example.com",
+        enabled: true,
+        createdAt: NOW + 1,
+        updatedAt: NOW + 1,
+      });
+    });
+    const replay = await t.mutation(
+      internal.notifications.emit.emitNotification,
+      notification,
+    );
+    expect(replay).toEqual({ intentId: emitted.intentId, created: false });
+    const reserved = await t.mutation(
+      internal.notifications.dispatch.reserveIntentDeliveries,
+      { intentId: emitted.intentId },
+    );
+    expect(reserved?.leased.map((lease) => lease.recipientEmail)).toEqual([
+      "manager@example.com",
+    ]);
+  });
+
   it("does not fall back to ADMIN_EMAILS when rows exist but are scoped to another store", async () => {
     const t = convexTest(schema, modules);
     const fixture = await t.run(seedOrgStore);

--- a/packages/athena-webapp/convex/notifications/registry.test.ts
+++ b/packages/athena-webapp/convex/notifications/registry.test.ts
@@ -475,6 +475,38 @@ describe("eod.daily_manager_report payload branching", () => {
 });
 
 describe("eod.stale_daily_close preparation", () => {
+  it.each([
+    ["missing store", { ageInDays: 2, operatingDate: "2026-07-28" }],
+    [
+      "malformed date",
+      { ageInDays: 2, operatingDate: "July 28", storeId: STORE_ID },
+    ],
+    [
+      "negative age",
+      { ageInDays: -1, operatingDate: "2026-07-28", storeId: STORE_ID },
+    ],
+    [
+      "non-numeric age",
+      {
+        ageInDays: "2",
+        operatingDate: "2026-07-28",
+        storeId: STORE_ID,
+      },
+    ],
+  ])("rejects and suppresses invalid durable payload: %s", async (_, payload) => {
+    const definition = getNotificationKind("eod.stale_daily_close");
+    expect(() => definition.dedupeKey(payload)).toThrow(
+      "Invalid eod.stale_daily_close payload",
+    );
+    const { prepared, calls } = await prepare(
+      "eod.stale_daily_close",
+      payload,
+      [dailyReport],
+    );
+    expect(prepared).toBeNull();
+    expect(calls).toEqual([]);
+  });
+
   it("builds the aligned still-open email from a fresh daily-close read", async () => {
     const { prepared, calls, callArgs } = await prepare(
       "eod.stale_daily_close",

--- a/packages/athena-webapp/convex/notifications/registry.test.ts
+++ b/packages/athena-webapp/convex/notifications/registry.test.ts
@@ -493,6 +493,30 @@ describe("eod.stale_daily_close preparation", () => {
         storeId: STORE_ID,
       },
     ],
+    [
+      "NaN age",
+      { ageInDays: Number.NaN, operatingDate: "2026-07-28", storeId: STORE_ID },
+    ],
+    [
+      "infinite age",
+      {
+        ageInDays: Number.POSITIVE_INFINITY,
+        operatingDate: "2026-07-28",
+        storeId: STORE_ID,
+      },
+    ],
+    [
+      "negative infinite age",
+      {
+        ageInDays: Number.NEGATIVE_INFINITY,
+        operatingDate: "2026-07-28",
+        storeId: STORE_ID,
+      },
+    ],
+    [
+      "fractional age",
+      { ageInDays: 2.5, operatingDate: "2026-07-28", storeId: STORE_ID },
+    ],
   ])("rejects and suppresses invalid durable payload: %s", async (_, payload) => {
     const definition = getNotificationKind("eod.stale_daily_close");
     expect(() => definition.dedupeKey(payload)).toThrow(

--- a/packages/athena-webapp/convex/notifications/registry.test.ts
+++ b/packages/athena-webapp/convex/notifications/registry.test.ts
@@ -75,10 +75,11 @@ const dailyReport = {
 };
 
 describe("registry catalog", () => {
-  it("registers exactly the seven shipped kinds with their categories and channels", () => {
+  it("registers exactly the eight shipped kinds with their categories and channels", () => {
     expect(listNotificationKinds().sort()).toEqual([
       "approvals.request_created",
       "eod.daily_manager_report",
+      "eod.stale_daily_close",
       "eod.weekly_manager_report",
       "pos.terminal_health",
       "register.closeout_match",
@@ -105,6 +106,7 @@ describe("registry catalog", () => {
     expect(getNotificationKind("eod.daily_manager_report").category).toBe(
       "eod",
     );
+    expect(getNotificationKind("eod.stale_daily_close").category).toBe("eod");
     expect(getNotificationKind("eod.weekly_manager_report").category).toBe(
       "eod",
     );
@@ -472,6 +474,55 @@ describe("eod.daily_manager_report payload branching", () => {
   });
 });
 
+describe("eod.stale_daily_close preparation", () => {
+  it("builds the aligned still-open email from a fresh daily-close read", async () => {
+    const { prepared, calls, callArgs } = await prepare(
+      "eod.stale_daily_close",
+      {
+        ageInDays: 2,
+        operatingDate: "2026-07-28",
+        storeId: STORE_ID,
+      },
+      [
+        {
+          ...dailyReport,
+          blockers: [
+            {
+              message:
+                "Close or review the register, then complete EOD Review.",
+              title: "Open register session",
+            },
+          ],
+        },
+      ],
+    );
+
+    expect(calls).toEqual([
+      "operations/dailyManagerReportEmail:getStaleDailyManagerReportPayloadForDate",
+    ]);
+    expect(callArgs).toEqual([
+      { operatingDate: "2026-07-28", storeId: STORE_ID },
+    ]);
+    expect(prepared?.subject).toBe("Still open: Accra EOD Review - 2026-07-28");
+    expect(prepared?.html).toContain("Open register session");
+    expect(prepared?.html).toContain("has remained open for 2 days");
+  });
+
+  it("suppresses the stale email when the day has since closed", async () => {
+    const { prepared } = await prepare(
+      "eod.stale_daily_close",
+      {
+        ageInDays: 2,
+        operatingDate: "2026-07-28",
+        storeId: STORE_ID,
+      },
+      [null],
+    );
+
+    expect(prepared).toBeNull();
+  });
+});
+
 describe("report verification discrepancy preparation", () => {
   const payload = {
     storeId: STORE_ID,
@@ -625,6 +676,16 @@ describe("registry dedupe key recipes", () => {
     expect(
       dedupeKey("eod.daily_manager_report", { ...base, status: "failed" }),
     ).toBe(`${prefix}:action_required`);
+  });
+
+  it("keys a stale close email once per store day", () => {
+    expect(
+      dedupeKey("eod.stale_daily_close", {
+        ageInDays: 2,
+        operatingDate: "2026-07-28",
+        storeId: STORE_ID,
+      }),
+    ).toBe(`eod.stale_daily_close:${STORE_ID}:2026-07-28`);
   });
 
   it("keys the weekly report by its immutable accepted baseline", () => {

--- a/packages/athena-webapp/convex/notifications/registry.ts
+++ b/packages/athena-webapp/convex/notifications/registry.ts
@@ -85,6 +85,28 @@ type StaleDailyClosePayload = {
   storeId: Id<"store">;
 };
 
+function isStaleDailyClosePayload(
+  payload: NotificationPayload,
+): payload is StaleDailyClosePayload {
+  return (
+    typeof payload.storeId === "string" &&
+    typeof payload.operatingDate === "string" &&
+    /^\d{4}-\d{2}-\d{2}$/.test(payload.operatingDate) &&
+    typeof payload.ageInDays === "number" &&
+    Number.isFinite(payload.ageInDays) &&
+    payload.ageInDays >= 0
+  );
+}
+
+function requireStaleDailyClosePayload(
+  payload: NotificationPayload,
+): StaleDailyClosePayload {
+  if (!isStaleDailyClosePayload(payload)) {
+    throw new Error("Invalid eod.stale_daily_close payload");
+  }
+  return payload;
+}
+
 // Refs only. `fingerprint` identifies the unexplained difference set,
 // `reArmEpoch` the run row's re-arm generation, and `alertSeq` the subject's
 // monotonic alert count. All three are dedupe components; the first two are
@@ -331,7 +353,7 @@ const NOTIFICATION_KINDS: Record<string, NotificationKindDefinition> = {
     category: "eod",
     channels: ["email"],
     dedupeKey: (payload) => {
-      const p = payload as StaleDailyClosePayload;
+      const p = requireStaleDailyClosePayload(payload);
       return joinKeyComponents([
         "eod.stale_daily_close",
         String(p.storeId),
@@ -339,7 +361,10 @@ const NOTIFICATION_KINDS: Record<string, NotificationKindDefinition> = {
       ]);
     },
     prepareEmail: async (ctx, payload) => {
-      const p = payload as StaleDailyClosePayload;
+      // Persisted notification payloads predate this registry entry's static
+      // type, so validate the durable boundary before issuing fresh reads.
+      if (!isStaleDailyClosePayload(payload)) return null;
+      const p = payload;
       const report = await ctx.runQuery(
         internal.operations.dailyManagerReportEmail
           .getStaleDailyManagerReportPayloadForDate,

--- a/packages/athena-webapp/convex/notifications/registry.ts
+++ b/packages/athena-webapp/convex/notifications/registry.ts
@@ -13,12 +13,10 @@ import { WeeklyManagerReport } from "../emails/WeeklyManagerReport";
 import { PosTerminalHealthAlert } from "../emails/PosTerminalHealthAlert";
 import { RegisterCloseoutVarianceAlert } from "../emails/RegisterCloseoutVarianceAlert";
 import { ReportVerificationAlert } from "../emails/ReportVerificationAlert";
+import { StaleDailyCloseAlert } from "../emails/StaleDailyCloseAlert";
 
 export type NotificationCategory =
-  | "cash_controls"
-  | "eod"
-  | "system_health"
-  | "approvals";
+  "cash_controls" | "eod" | "system_health" | "approvals";
 export type NotificationChannel = "email" | "in_app";
 export type NotificationPayload = Record<string, unknown>;
 export type PreparedNotificationEmail = { subject: string; html: string };
@@ -67,10 +65,7 @@ type CloseoutMatchPayload = {
 };
 
 export type DailyManagerReportSendStatus =
-  | "applied"
-  | "prepared"
-  | "skipped"
-  | "failed";
+  "applied" | "prepared" | "skipped" | "failed";
 
 type DailyManagerReportPayload = {
   storeId: Id<"store">;
@@ -82,6 +77,12 @@ type DailyManagerReportPayload = {
 
 type WeeklyManagerReportPayload = {
   acceptedWeekId: Id<"reportWeekAccepted">;
+};
+
+type StaleDailyClosePayload = {
+  ageInDays: number;
+  operatingDate: string;
+  storeId: Id<"store">;
 };
 
 // Refs only. `fingerprint` identifies the unexplained difference set,
@@ -326,6 +327,42 @@ const NOTIFICATION_KINDS: Record<string, NotificationKindDefinition> = {
       };
     },
   },
+  "eod.stale_daily_close": {
+    category: "eod",
+    channels: ["email"],
+    dedupeKey: (payload) => {
+      const p = payload as StaleDailyClosePayload;
+      return joinKeyComponents([
+        "eod.stale_daily_close",
+        String(p.storeId),
+        p.operatingDate,
+      ]);
+    },
+    prepareEmail: async (ctx, payload) => {
+      const p = payload as StaleDailyClosePayload;
+      const report = await ctx.runQuery(
+        internal.operations.dailyManagerReportEmail
+          .getStaleDailyManagerReportPayloadForDate,
+        { operatingDate: p.operatingDate, storeId: p.storeId },
+      );
+      if (!report) return null;
+
+      return {
+        subject: `Still open: ${report.storeName} EOD Review - ${report.operatingDate}`,
+        html: await render(
+          StaleDailyCloseAlert({
+            ageInDays: p.ageInDays,
+            blockerSummaries: (report.blockers ?? []).map(
+              (blocker) => `${blocker.title}. ${blocker.message}`,
+            ),
+            operatingDate: report.operatingDate,
+            reportUrl: report.reportUrl,
+            storeName: report.storeName,
+          }),
+        ),
+      };
+    },
+  },
   "eod.weekly_manager_report": {
     category: "eod",
     channels: ["email"],
@@ -389,7 +426,9 @@ export const weeklyReportCorrectionPreview = internalAction({
   handler: async (
     ctx,
     args,
-  ): Promise<(PreparedNotificationEmail & { contentDigest: string }) | null> => {
+  ): Promise<
+    (PreparedNotificationEmail & { contentDigest: string }) | null
+  > => {
     const report = await ctx.runQuery(
       internal.operations.weeklyManagerReportEmail
         .getCorrectedWeeklyManagerReportPayload,

--- a/packages/athena-webapp/convex/notifications/registry.ts
+++ b/packages/athena-webapp/convex/notifications/registry.ts
@@ -94,6 +94,7 @@ function isStaleDailyClosePayload(
     /^\d{4}-\d{2}-\d{2}$/.test(payload.operatingDate) &&
     typeof payload.ageInDays === "number" &&
     Number.isFinite(payload.ageInDays) &&
+    Number.isInteger(payload.ageInDays) &&
     payload.ageInDays >= 0
   );
 }

--- a/packages/athena-webapp/convex/operations/dailyClose.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.test.ts
@@ -5388,6 +5388,18 @@ describe("end-of-day review backend foundation", () => {
         },
       },
     });
+    if (humanResult.kind !== "ok") throw new Error("Expected human close");
+    expect(humanResult.data.dailyClose.readiness.carryForwardCount).toBe(500);
+    expect(
+      humanResult.data.dailyClose.reportSnapshot?.summary
+        .carryForwardWorkItemCount,
+    ).toBe(500);
+    expect(
+      humanResult.data.dailyClose.reportSnapshot?.carryForwardItems,
+    ).toEqual([]);
+    expect(
+      humanResult.data.dailyClose.reportSnapshot?.carryForwardGroups,
+    ).toEqual([]);
 
     const automationDb = createDb({
       operationalWorkItem: openOperationalWorkItems(501, "in_progress"),
@@ -5429,6 +5441,22 @@ describe("end-of-day review backend foundation", () => {
         },
       },
     });
+    if (automationResult.kind !== "ok") {
+      throw new Error("Expected automation close");
+    }
+    expect(automationResult.data.dailyClose.readiness.carryForwardCount).toBe(
+      500,
+    );
+    expect(
+      automationResult.data.dailyClose.reportSnapshot?.summary
+        .carryForwardWorkItemCount,
+    ).toBe(500);
+    expect(
+      automationResult.data.dailyClose.reportSnapshot?.carryForwardItems,
+    ).toEqual([]);
+    expect(
+      automationResult.data.dailyClose.reportSnapshot?.carryForwardGroups,
+    ).toEqual([]);
   });
 
   it("fails human and automation completion when another source is incomplete alongside operational work", async () => {

--- a/packages/athena-webapp/convex/operations/dailyClose.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.test.ts
@@ -5187,10 +5187,10 @@ describe("end-of-day review backend foundation", () => {
     ).toHaveLength(0);
   });
 
-  it("fails closed when carry-forward source evidence exceeds the EOD probe", async () => {
+  it("completes with incomplete open-work evidence without duplicating a carry-forward beyond the snapshot probe", async () => {
     vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 4, 7, 22));
     const nonMatchingCarryForwardItems = Array.from(
-      { length: 200 },
+      { length: 500 },
       (_, index) => ({
         _id: `work-existing-${index}`,
         approvalState: "not_required",
@@ -5252,11 +5252,16 @@ describe("end-of-day review backend foundation", () => {
     );
 
     expect(result).toMatchObject({
-      kind: "user_error",
-      error: {
-        code: "precondition_failed",
-        message:
-          "EOD Review cannot complete until all source evidence is loaded.",
+      kind: "ok",
+      data: {
+        action: "completed",
+        dailyClose: {
+          reportSnapshot: {
+            openWorkMembership: {
+              completeness: "incomplete",
+            },
+          },
+        },
       },
     });
     expect(
@@ -5272,10 +5277,10 @@ describe("end-of-day review backend foundation", () => {
   });
 
   it.each(["open", "in_progress"] as const)(
-    "treats exactly 200 %s operational work rows as complete and a 201st row as an incomplete sentinel",
+    "treats exactly 500 %s operational work rows as complete and a 501st row as an incomplete sentinel",
     async (status) => {
       const completeDb = createDb({
-        operationalWorkItem: openOperationalWorkItems(200, status),
+        operationalWorkItem: openOperationalWorkItems(500, status),
         store: [store],
       });
       const completeSnapshot = await buildDailyCloseSnapshotWithCtx(
@@ -5289,15 +5294,15 @@ describe("end-of-day review backend foundation", () => {
       expect(completeSnapshot.sourceCompleteness.entries).toContainEqual(
         expect.objectContaining({
           complete: true,
-          limit: 200,
-          recordCount: 200,
+          limit: 500,
+          recordCount: 500,
           source: "operational_work_item",
         }),
       );
-      expect(completeSnapshot.summary.openWorkItemCount).toBe(200);
+      expect(completeSnapshot.summary.openWorkItemCount).toBe(500);
       expect(completeSnapshot.openWorkMembership).toEqual({
         completeness: "complete",
-        observedLogicalCount: 200,
+        observedLogicalCount: 500,
       });
       expect(
         completeSnapshot.carryForwardItems.every(
@@ -5306,7 +5311,7 @@ describe("end-of-day review backend foundation", () => {
       ).toBe(true);
 
       const incompleteDb = createDb({
-        operationalWorkItem: openOperationalWorkItems(201, status),
+        operationalWorkItem: openOperationalWorkItems(501, status),
         store: [store],
       });
       const incompleteSnapshot = await buildDailyCloseSnapshotWithCtx(
@@ -5320,16 +5325,16 @@ describe("end-of-day review backend foundation", () => {
       expect(incompleteSnapshot.sourceCompleteness.entries).toContainEqual(
         expect.objectContaining({
           complete: false,
-          limit: 200,
-          recordCount: 200,
+          limit: 500,
+          recordCount: 500,
           reason: "operational_work_item_source_cap_reached",
           source: "operational_work_item",
         }),
       );
-      expect(incompleteSnapshot.summary.openWorkItemCount).toBe(200);
+      expect(incompleteSnapshot.summary.openWorkItemCount).toBe(500);
       expect(incompleteSnapshot.openWorkMembership).toEqual({
         completeness: "incomplete",
-        observedLogicalCount: 200,
+        observedLogicalCount: 500,
       });
       expect(
         incompleteSnapshot.carryForwardItems.every(
@@ -5342,9 +5347,11 @@ describe("end-of-day review backend foundation", () => {
     },
   );
 
-  it("fails human and automation completion closed when an operational-work lane has a 201st row", async () => {
+  it("allows human and automation completion when only operational-work evidence exceeds the probe", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 4, 7, 22));
     const humanDb = createDb({
-      operationalWorkItem: openOperationalWorkItems(201, "open"),
+      approvalProof: [dailyCloseApprovalProof()],
+      operationalWorkItem: openOperationalWorkItems(501, "open"),
       store: [store],
     });
     const humanResult = await completeDailyCloseWithCtx(
@@ -5352,30 +5359,38 @@ describe("end-of-day review backend foundation", () => {
       {
         actorStaffProfileId: "staff-1" as Id<"staffProfile">,
         actorUserId: "user-1" as Id<"athenaUser">,
+        approvalProofId: "approval-proof-1" as Id<"approvalProof">,
         operatingDate: "2026-05-07",
         storeId: "store-1" as Id<"store">,
       },
     );
 
     expect(humanResult).toMatchObject({
-      kind: "user_error",
-      error: {
-        code: "precondition_failed",
-        message:
-          "EOD Review cannot complete until all source evidence is loaded.",
-        metadata: {
-          incompleteSources: [
-            expect.objectContaining({
-              complete: false,
-              source: "operational_work_item",
-            }),
-          ],
+      kind: "ok",
+      data: {
+        action: "completed",
+        dailyClose: {
+          reportSnapshot: {
+            openWorkMembership: {
+              completeness: "incomplete",
+              observedLogicalCount: 500,
+            },
+          },
+          sourceCompleteness: {
+            complete: false,
+            entries: expect.arrayContaining([
+              expect.objectContaining({
+                complete: false,
+                source: "operational_work_item",
+              }),
+            ]),
+          },
         },
       },
     });
 
     const automationDb = createDb({
-      operationalWorkItem: openOperationalWorkItems(201, "in_progress"),
+      operationalWorkItem: openOperationalWorkItems(501, "in_progress"),
       store: [store],
     });
     const automationResult = await completeDailyCloseForAutomationWithCtx(
@@ -5392,24 +5407,31 @@ describe("end-of-day review backend foundation", () => {
     );
 
     expect(automationResult).toMatchObject({
-      kind: "user_error",
-      error: {
-        code: "precondition_failed",
-        message:
-          "EOD Review automation cannot complete without complete source evidence.",
-        metadata: {
-          incompleteSources: [
-            expect.objectContaining({
-              complete: false,
-              source: "operational_work_item",
-            }),
-          ],
+      kind: "ok",
+      data: {
+        action: "completed",
+        dailyClose: {
+          reportSnapshot: {
+            openWorkMembership: {
+              completeness: "incomplete",
+              observedLogicalCount: 500,
+            },
+          },
+          sourceCompleteness: {
+            complete: false,
+            entries: expect.arrayContaining([
+              expect.objectContaining({
+                complete: false,
+                source: "operational_work_item",
+              }),
+            ]),
+          },
         },
       },
     });
   });
 
-  it("fails human and automation completion closed when an active-repair lane has a 201st row", async () => {
+  it("fails human and automation completion when another source is incomplete alongside operational work", async () => {
     const repairs = Array.from({ length: 201 }, (_, index) => ({
       _id: `repair-cap-${index + 1}`,
       groupKey: `synced_sale_inventory_review:store-1:sku-${index + 1}`,
@@ -5418,6 +5440,7 @@ describe("end-of-day review backend foundation", () => {
       storeId: "store-1",
     }));
     const humanDb = createDb({
+      operationalWorkItem: openOperationalWorkItems(501, "open"),
       oversizedOperationalWorkRepair: repairs,
       store: [store],
     });
@@ -5448,6 +5471,7 @@ describe("end-of-day review backend foundation", () => {
     });
 
     const automationDb = createDb({
+      operationalWorkItem: openOperationalWorkItems(501, "in_progress"),
       oversizedOperationalWorkRepair: repairs,
       store: [store],
     });

--- a/packages/athena-webapp/convex/operations/dailyClose.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.test.ts
@@ -5339,7 +5339,7 @@ describe("end-of-day review backend foundation", () => {
       expect(
         incompleteSnapshot.carryForwardItems.every(
           (item) =>
-            item.carryForwardWorkItemIds === undefined &&
+            item.carryForwardWorkItemIds?.length === 1 &&
             item.subject.type === "incomplete_logical_operational_work_group" &&
             item.metadata?.membershipCompleteness === "incomplete",
         ),
@@ -5350,7 +5350,13 @@ describe("end-of-day review backend foundation", () => {
   it("allows human and automation completion when only operational-work evidence exceeds the probe", async () => {
     vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 4, 7, 22));
     const humanDb = createDb({
-      approvalProof: [dailyCloseApprovalProof()],
+      approvalProof: [
+        dailyCloseApprovalProof(),
+        dailyCloseCarryForwardApprovalProof({
+          subjectId:
+            "dailyClose-1:work-source-boundary-open-1:completed",
+        }),
+      ],
       operationalWorkItem: openOperationalWorkItems(501, "open"),
       store: [store],
     });
@@ -5396,10 +5402,61 @@ describe("end-of-day review backend foundation", () => {
     ).toBe(500);
     expect(
       humanResult.data.dailyClose.reportSnapshot?.carryForwardItems,
-    ).toEqual([]);
+    ).toHaveLength(500);
     expect(
       humanResult.data.dailyClose.reportSnapshot?.carryForwardGroups,
-    ).toEqual([]);
+    ).toHaveLength(500);
+    expect(humanResult.data.dailyClose.carryForwardWorkItemIds).toHaveLength(
+      500,
+    );
+    const observedId = humanResult.data.dailyClose.carryForwardWorkItemIds[0]!;
+    const unobservedId = openOperationalWorkItems(501, "open")
+      .map((item) => item._id)
+      .find(
+        (workItemId) =>
+          !humanResult.data.dailyClose.carryForwardWorkItemIds.includes(
+            workItemId as Id<"operationalWorkItem">,
+          ),
+      )!;
+    expect(humanResult.data.dailyClose.carryForwardWorkItemIds).not.toContain(
+      unobservedId,
+    );
+    const openingContext = await getDailyCloseOpeningContextWithCtx(
+      { db: humanDb.db } as unknown as QueryCtx,
+      {
+        operatingDate: "2026-05-08",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+    expect(openingContext.carryForwardWorkItems).toHaveLength(500);
+    expect(
+      openingContext.carryForwardWorkItems.map((item) => item._id),
+    ).toContain(observedId);
+    expect(
+      openingContext.carryForwardWorkItems.map((item) => item._id),
+    ).not.toContain(unobservedId);
+
+    vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 4, 8, 10));
+    const resolution = await resolveDailyCloseCarryForwardWithCtx(
+      { db: humanDb.db } as unknown as MutationCtx,
+      {
+        actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+        actorUserId: "user-1" as Id<"athenaUser">,
+        approvalProofId:
+          "approval-proof-carry-forward-1" as Id<"approvalProof">,
+        businessDate: "2026-05-07",
+        dailyCloseId: humanResult.data.dailyClose._id,
+        outcome: "completed",
+        reason: "Observed handoff completed.",
+        sourceId: observedId,
+        storeId: "store-1" as Id<"store">,
+        workItemId: observedId,
+      },
+    );
+    expect(resolution).toMatchObject({
+      kind: "ok",
+      data: { action: "completed" },
+    });
 
     const automationDb = createDb({
       operationalWorkItem: openOperationalWorkItems(501, "in_progress"),
@@ -5453,10 +5510,13 @@ describe("end-of-day review backend foundation", () => {
     ).toBe(500);
     expect(
       automationResult.data.dailyClose.reportSnapshot?.carryForwardItems,
-    ).toEqual([]);
+    ).toHaveLength(500);
     expect(
       automationResult.data.dailyClose.reportSnapshot?.carryForwardGroups,
-    ).toEqual([]);
+    ).toHaveLength(500);
+    expect(
+      automationResult.data.dailyClose.carryForwardWorkItemIds,
+    ).toHaveLength(500);
   });
 
   it("fails human and automation completion when another source is incomplete alongside operational work", async () => {

--- a/packages/athena-webapp/convex/operations/dailyClose.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.ts
@@ -2408,15 +2408,22 @@ function incompleteSourceCompletenessEntries(snapshot: DailyCloseSnapshot) {
   return snapshot.sourceCompleteness.entries.filter((entry) => !entry.complete);
 }
 
+export function isToleratedIncompleteDailyCloseCompletionSource(entry: {
+  complete: boolean;
+  source: string;
+}) {
+  return !entry.complete && entry.source === "operational_work_item";
+}
+
 function completionBlockingIncompleteSources(snapshot: DailyCloseSnapshot) {
   return incompleteSourceCompletenessEntries(snapshot).filter(
-    (entry) => entry.source !== "operational_work_item",
+    (entry) => !isToleratedIncompleteDailyCloseCompletionSource(entry),
   );
 }
 
 function hasIncompleteOperationalWork(snapshot: DailyCloseSnapshot) {
-  return incompleteSourceCompletenessEntries(snapshot).some(
-    (entry) => entry.source === "operational_work_item",
+  return snapshot.sourceCompleteness.entries.some(
+    isToleratedIncompleteDailyCloseCompletionSource,
   );
 }
 

--- a/packages/athena-webapp/convex/operations/dailyClose.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.ts
@@ -1047,6 +1047,7 @@ function logicalGroupAsCarryForwardItem(
         status: group.status,
         type: group.representative.type,
       },
+      carryForwardWorkItemIds: group.items.map((item) => item._id),
     };
   }
 
@@ -1094,10 +1095,6 @@ async function patchDailyCloseCarryForwardWorkItemMetadata(
   },
 ) {
   for (const workItem of args.workItems) {
-    if (workItem.type !== DAILY_CLOSE_CARRY_FORWARD_TYPE) {
-      continue;
-    }
-
     await ctx.db.patch("operationalWorkItem", workItem._id, {
       metadata: {
         ...(workItem.metadata ?? {}),
@@ -2264,7 +2261,7 @@ function buildDailyCloseReportSnapshot(args: {
 }): DailyCloseReportSnapshot {
   const selectedWorkItemIds = new Set(args.carryForwardWorkItemIds);
   const selectedSnapshotItems = hasIncompleteOperationalWork(args.snapshot)
-    ? []
+    ? args.snapshot.carryForwardItems
     : args.snapshot.carryForwardItems.filter((item) => {
       const memberIds =
         item.carryForwardWorkItemIds ??
@@ -2380,6 +2377,17 @@ function buildDailyCloseReportSnapshot(args: {
     sourceCompleteness: args.snapshot.sourceCompleteness,
     sourceSubjects: args.snapshot.sourceSubjects,
   };
+}
+
+function observedIncompleteOperationalWorkItemIds(
+  snapshot: DailyCloseSnapshot,
+) {
+  if (!hasIncompleteOperationalWork(snapshot)) return [];
+  return uniqueOperationalWorkItemIds(
+    snapshot.carryForwardItems.flatMap(
+      (item) => item.carryForwardWorkItemIds ?? [],
+    ),
+  );
 }
 
 function snapshotReviewedItems(
@@ -4477,6 +4485,7 @@ export async function completeDailyCloseWithCtx(
   const reviewedItemKeys = snapshot.reviewItems.map((item) => item.key);
   const carryForwardWorkItemIds = uniqueOperationalWorkItemIds([
     ...(snapshot.existingClose?.carryForwardWorkItemIds ?? []),
+    ...observedIncompleteOperationalWorkItemIds(snapshot),
     ...linkedWorkItemResult.workItems.map((workItem) => workItem._id),
     ...createdWorkItemResult.workItems.map((workItem) => workItem._id),
   ] as Id<"operationalWorkItem">[]);
@@ -4793,7 +4802,23 @@ export async function completeDailyCloseForAutomationWithCtx(
   }
 
   const carryForwardResult = hasIncompleteOperationalWork(snapshot)
-    ? { ok: true as const, workItemIds: [], workItems: [] }
+    ? await validateCarryForwardWorkItemIds(ctx, {
+        storeId: args.storeId,
+        workItemIds: observedIncompleteOperationalWorkItemIds(snapshot),
+      }).then((result) =>
+        result.ok
+          ? {
+              ok: true as const,
+              workItemIds: result.workItems.map((item) => item._id),
+              workItems: result.workItems,
+            }
+          : {
+              ok: false as const,
+              message:
+                "Observed carry-forward work changed before EOD Review completed.",
+              metadata: { reason: "observed_carry_forward_unavailable" },
+            },
+      )
     : await validateAutomationCarryForwardWorkItems(ctx, {
         organizationId: store.organizationId,
         snapshot,
@@ -5047,12 +5072,6 @@ export async function resolveDailyCloseCarryForwardWithCtx(
   if (!dailyClose.carryForwardWorkItemIds.includes(workItem._id)) {
     return carryForwardResolutionValidationError(
       "Carry-forward work is not linked to this EOD Review.",
-    );
-  }
-
-  if (workItem.type !== DAILY_CLOSE_CARRY_FORWARD_TYPE) {
-    return carryForwardResolutionValidationError(
-      "Only Daily Close carry-forward work can be resolved here.",
     );
   }
 

--- a/packages/athena-webapp/convex/operations/dailyClose.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.ts
@@ -2264,7 +2264,7 @@ function buildDailyCloseReportSnapshot(args: {
 }): DailyCloseReportSnapshot {
   const selectedWorkItemIds = new Set(args.carryForwardWorkItemIds);
   const selectedSnapshotItems = hasIncompleteOperationalWork(args.snapshot)
-    ? args.snapshot.carryForwardItems
+    ? []
     : args.snapshot.carryForwardItems.filter((item) => {
       const memberIds =
         item.carryForwardWorkItemIds ??

--- a/packages/athena-webapp/convex/operations/dailyClose.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.ts
@@ -74,6 +74,7 @@ import { getOrderAmount } from "../inventory/utils";
 export { buildAdjustmentReportTotals, listAppliedTransactionAdjustmentsForDay };
 
 const DAILY_CLOSE_QUERY_LIMIT = 200;
+const OPEN_OPERATIONAL_WORK_ITEM_SOURCE_LIMIT = 500;
 const DAILY_CLOSE_CARRY_FORWARD_SOURCE_PROBE_LIMIT = 1_000;
 const REGISTER_SESSION_DAILY_CLOSE_SOURCE_LIMIT = 1000;
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -1624,11 +1625,11 @@ async function listOpenOperationalWorkItems(
         .withIndex("by_storeId_status", (q) =>
           q.eq("storeId", storeId).eq("status", status),
         )
-        .take(DAILY_CLOSE_QUERY_LIMIT + 1),
+        .take(OPEN_OPERATIONAL_WORK_ITEM_SOURCE_LIMIT + 1),
     ),
   );
   const boundedWorkItems = workItems.map((page) =>
-    page.slice(0, DAILY_CLOSE_QUERY_LIMIT),
+    page.slice(0, OPEN_OPERATIONAL_WORK_ITEM_SOURCE_LIMIT),
   );
 
   return {
@@ -1636,14 +1637,14 @@ async function listOpenOperationalWorkItems(
     completeness: sourceCompletenessEntry({
       source: "operational_work_item",
       complete: workItems.every(
-        (page) => page.length <= DAILY_CLOSE_QUERY_LIMIT,
+        (page) => page.length <= OPEN_OPERATIONAL_WORK_ITEM_SOURCE_LIMIT,
       ),
       readMode: "by_storeId_status",
       recordCount: boundedWorkItems.reduce(
         (count, page) => count + page.length,
         0,
       ),
-      limit: DAILY_CLOSE_QUERY_LIMIT,
+      limit: OPEN_OPERATIONAL_WORK_ITEM_SOURCE_LIMIT,
       reason: "operational_work_item_source_cap_reached",
       statuses: [...OPEN_OPERATIONAL_WORK_ITEM_STATUSES],
     }),
@@ -2262,16 +2263,16 @@ function buildDailyCloseReportSnapshot(args: {
   summary: Record<string, unknown>;
 }): DailyCloseReportSnapshot {
   const selectedWorkItemIds = new Set(args.carryForwardWorkItemIds);
-  const selectedSnapshotItems = args.snapshot.carryForwardItems.filter(
-    (item) => {
+  const selectedSnapshotItems = hasIncompleteOperationalWork(args.snapshot)
+    ? args.snapshot.carryForwardItems
+    : args.snapshot.carryForwardItems.filter((item) => {
       const memberIds =
         item.carryForwardWorkItemIds ??
         (item.subject.type === "operational_work_item"
           ? [item.subject.id as Id<"operationalWorkItem">]
           : []);
       return memberIds.some((memberId) => selectedWorkItemIds.has(memberId));
-    },
-  );
+      });
   const snapshotMemberIds = new Set(
     selectedSnapshotItems.flatMap((item) => item.carryForwardWorkItemIds ?? []),
   );
@@ -2397,6 +2398,18 @@ function snapshotReviewedItems(
 
 function incompleteSourceCompletenessEntries(snapshot: DailyCloseSnapshot) {
   return snapshot.sourceCompleteness.entries.filter((entry) => !entry.complete);
+}
+
+function completionBlockingIncompleteSources(snapshot: DailyCloseSnapshot) {
+  return incompleteSourceCompletenessEntries(snapshot).filter(
+    (entry) => entry.source !== "operational_work_item",
+  );
+}
+
+function hasIncompleteOperationalWork(snapshot: DailyCloseSnapshot) {
+  return incompleteSourceCompletenessEntries(snapshot).some(
+    (entry) => entry.source === "operational_work_item",
+  );
 }
 
 function completionAttributionForDailyClose(
@@ -4364,7 +4377,7 @@ export async function completeDailyCloseWithCtx(
     });
   }
 
-  const incompleteSources = incompleteSourceCompletenessEntries(snapshot);
+  const incompleteSources = completionBlockingIncompleteSources(snapshot);
   if (incompleteSources.length > 0) {
     return userError({
       code: "precondition_failed",
@@ -4479,13 +4492,16 @@ export async function completeDailyCloseWithCtx(
     snapshot,
     carryForwardWorkItemIds,
   );
+  const persistedCarryForwardCount = hasIncompleteOperationalWork(snapshot)
+    ? snapshot.openWorkMembership.observedLogicalCount
+    : logicalCarryForwardCount;
   const readiness = {
     ...snapshot.readiness,
-    carryForwardCount: logicalCarryForwardCount,
+    carryForwardCount: persistedCarryForwardCount,
   };
   const summary = {
     ...snapshot.summary,
-    carryForwardWorkItemCount: logicalCarryForwardCount,
+    carryForwardWorkItemCount: persistedCarryForwardCount,
   };
   const reportSnapshotArgs = {
     carryForwardWorkItemIds,
@@ -4722,7 +4738,7 @@ export async function completeDailyCloseForAutomationWithCtx(
     });
   }
 
-  const incompleteSources = incompleteSourceCompletenessEntries(snapshot);
+  const incompleteSources = completionBlockingIncompleteSources(snapshot);
   if (incompleteSources.length > 0) {
     return userError({
       code: "precondition_failed",
@@ -4776,14 +4792,13 @@ export async function completeDailyCloseForAutomationWithCtx(
     });
   }
 
-  const carryForwardResult = await validateAutomationCarryForwardWorkItems(
-    ctx,
-    {
-      organizationId: store.organizationId,
-      snapshot,
-      storeId: args.storeId,
-    },
-  );
+  const carryForwardResult = hasIncompleteOperationalWork(snapshot)
+    ? { ok: true as const, workItemIds: [], workItems: [] }
+    : await validateAutomationCarryForwardWorkItems(ctx, {
+        organizationId: store.organizationId,
+        snapshot,
+        storeId: args.storeId,
+      });
 
   if (!carryForwardResult.ok) {
     return userError({
@@ -4800,13 +4815,16 @@ export async function completeDailyCloseForAutomationWithCtx(
     snapshot,
     carryForwardWorkItemIds,
   );
+  const persistedCarryForwardCount = hasIncompleteOperationalWork(snapshot)
+    ? snapshot.openWorkMembership.observedLogicalCount
+    : logicalCarryForwardCount;
   const readiness = {
     ...snapshot.readiness,
-    carryForwardCount: logicalCarryForwardCount,
+    carryForwardCount: persistedCarryForwardCount,
   };
   const summary = {
     ...snapshot.summary,
-    carryForwardWorkItemCount: logicalCarryForwardCount,
+    carryForwardWorkItemCount: persistedCarryForwardCount,
   };
   const automationDecisionEvidence = buildEodAutomationDecisionEvidence({
     automationScheduleEvidence: args.automationScheduleEvidence,

--- a/packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts
@@ -486,10 +486,11 @@ describe("getStaleDailyManagerReportPayloadForDate", () => {
     seeded: Awaited<ReturnType<typeof seedStore>>,
     outcome: "dry_run" | "skipped" | "failed",
     updatedAt: number,
+    createdAt = updatedAt,
   ) {
     return ctx.db.insert("automationRun", {
       action: "eod.auto_complete",
-      createdAt: updatedAt,
+      createdAt,
       domain: "daily_operations",
       eventIds: [],
       idempotencyKey: `stale:${outcome}:${updatedAt}`,
@@ -542,6 +543,18 @@ describe("getStaleDailyManagerReportPayloadForDate", () => {
       await insertRun(ctx, seeded, "dry_run", 3);
     });
     expect(await ask(t, seeded.storeId)).toMatchObject({ status: "failed" });
+  });
+
+  it("selects qualifying runs by updated time rather than creation time", async () => {
+    const t = convexTest(schema, modules);
+    const seeded = await t.run(seedStore);
+    await t.run(async (ctx) => {
+      await insertRun(ctx, seeded, "failed", 10, 1);
+      await insertRun(ctx, seeded, "skipped", 5, 2);
+    });
+    expect(await ask(t, seeded.storeId)).toMatchObject({
+      status: "failed",
+    });
   });
 
   it("suppresses when an active completed close exists", async () => {

--- a/packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts
@@ -458,6 +458,123 @@ describe("wasActionRequiredNotifiedBeforeRail", () => {
   });
 });
 
+describe("getStaleDailyManagerReportPayloadForDate", () => {
+  const OPERATING_DATE = "2026-07-16";
+
+  async function seedStore(ctx: MutationCtx) {
+    const userId = await ctx.db.insert("athenaUser", {
+      email: "owner@example.com",
+      normalizedEmail: "owner@example.com",
+    });
+    const organizationId = await ctx.db.insert("organization", {
+      createdByUserId: userId,
+      name: "Accra",
+      slug: "accra",
+    });
+    const storeId = await ctx.db.insert("store", {
+      createdByUserId: userId,
+      currency: "GHS",
+      name: "Accra",
+      organizationId,
+      slug: "accra",
+    });
+    return { organizationId, storeId };
+  }
+
+  async function insertRun(
+    ctx: MutationCtx,
+    seeded: Awaited<ReturnType<typeof seedStore>>,
+    outcome: "dry_run" | "skipped" | "failed",
+    updatedAt: number,
+  ) {
+    return ctx.db.insert("automationRun", {
+      action: "eod.auto_complete",
+      createdAt: updatedAt,
+      domain: "daily_operations",
+      eventIds: [],
+      idempotencyKey: `stale:${outcome}:${updatedAt}`,
+      mutationBoundary: "daily_close",
+      operatingDate: OPERATING_DATE,
+      organizationId: seeded.organizationId,
+      outcome,
+      policyMode: outcome === "dry_run" ? "dry_run" : "enabled",
+      policyVersion: "daily-operations.v1",
+      snapshotCounts: {},
+      sourceSubjects: [],
+      storeId: seeded.storeId,
+      triggerType: "scheduled",
+      updatedAt,
+    });
+  }
+
+  const ask = (
+    t: ReturnType<typeof convexTest>,
+    storeId: Id<"store">,
+  ) =>
+    t.query(
+      internal.operations.dailyManagerReportEmail
+        .getStaleDailyManagerReportPayloadForDate,
+      { operatingDate: OPERATING_DATE, storeId },
+    );
+
+  it("returns null without a qualifying run", async () => {
+    const t = convexTest(schema, modules);
+    const seeded = await t.run(seedStore);
+    expect(await ask(t, seeded.storeId)).toBeNull();
+    await t.run((ctx) => insertRun(ctx, seeded, "dry_run", 2));
+    expect(await ask(t, seeded.storeId)).toBeNull();
+  });
+
+  for (const outcome of ["skipped", "failed"] as const) {
+    it(`prepares the open report from a ${outcome} run`, async () => {
+      const t = convexTest(schema, modules);
+      const seeded = await t.run(seedStore);
+      await t.run((ctx) => insertRun(ctx, seeded, outcome, 2));
+      expect(await ask(t, seeded.storeId)).toMatchObject({ status: outcome });
+    });
+  }
+
+  it("keeps the latest qualifying run when a later dry-run row exists", async () => {
+    const t = convexTest(schema, modules);
+    const seeded = await t.run(seedStore);
+    await t.run(async (ctx) => {
+      await insertRun(ctx, seeded, "failed", 2);
+      await insertRun(ctx, seeded, "dry_run", 3);
+    });
+    expect(await ask(t, seeded.storeId)).toMatchObject({ status: "failed" });
+  });
+
+  it("suppresses when an active completed close exists", async () => {
+    const t = convexTest(schema, modules);
+    const seeded = await t.run(seedStore);
+    await t.run(async (ctx) => {
+      await insertRun(ctx, seeded, "failed", 2);
+      await ctx.db.insert("dailyClose", {
+        carryForwardWorkItemIds: [],
+        completedAt: 3,
+        createdAt: 3,
+        isCurrent: false,
+        lifecycleStatus: "active",
+        operatingDate: OPERATING_DATE,
+        organizationId: seeded.organizationId,
+        readiness: {
+          blockerCount: 0,
+          carryForwardCount: 0,
+          readyCount: 0,
+          reviewCount: 0,
+          status: "ready",
+        },
+        sourceSubjects: [],
+        status: "completed",
+        storeId: seeded.storeId,
+        summary: {},
+        updatedAt: 3,
+      });
+    });
+    expect(await ask(t, seeded.storeId)).toBeNull();
+  });
+});
+
 describe("units sold in the closed-day report payload", () => {
   const OPERATING_DATE = "2026-07-16";
   const PRIOR_OPERATING_DATE = "2026-07-15";

--- a/packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts
+++ b/packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts
@@ -337,6 +337,65 @@ export const getActionRequiredDailyManagerReportPayloadForRun = internalQuery({
   },
 });
 
+export const getStaleDailyManagerReportPayloadForDate = internalQuery({
+  args: {
+    operatingDate: v.string(),
+    storeId: v.id("store"),
+  },
+  handler: async (ctx, args): Promise<DailyManagerReportPayload | null> => {
+    const completedClose = await ctx.db
+      .query("dailyClose")
+      .withIndex("by_storeId_operatingDate_lifecycleStatus", (q) =>
+        q
+          .eq("storeId", args.storeId)
+          .eq("operatingDate", args.operatingDate)
+          .eq("lifecycleStatus", "active"),
+      )
+      .first();
+    if (completedClose?.status === "completed") return null;
+
+    const run = await ctx.db
+      .query("automationRun")
+      .withIndex("by_storeId_operatingDate_domain_action", (q) =>
+        q
+          .eq("storeId", args.storeId)
+          .eq("operatingDate", args.operatingDate)
+          .eq("domain", "daily_operations")
+          .eq("action", "eod.auto_complete"),
+      )
+      .order("desc")
+      .first();
+
+    if (!run || (run.outcome !== "skipped" && run.outcome !== "failed")) {
+      return null;
+    }
+
+    const store = await resolveStore(ctx, { storeId: run.storeId });
+    const snapshot = await buildDailyCloseSnapshotWithCtx(ctx, {
+      operatingDate: run.operatingDate,
+      storeId: run.storeId,
+    });
+    const cashPositionSummary = await buildRegisterCashPositionSummary(ctx, {
+      endAt: snapshot.endAt,
+      operatingDate: snapshot.operatingDate,
+      startAt: snapshot.startAt,
+      storeId: store._id,
+    });
+
+    return buildOpenDailyManagerReportPayload({
+      cashPositionSummary,
+      completedTimezone: await resolveStoreScheduleTimezoneForAt(ctx, {
+        at: run.updatedAt,
+        storeId: store._id,
+      }),
+      snapshot,
+      status: run.outcome,
+      statusAt: run.updatedAt,
+      store,
+    });
+  },
+});
+
 export const sendMostRecentDailyManagerReport = action({
   args: {
     recipientEmail: v.string(),

--- a/packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts
+++ b/packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts
@@ -359,7 +359,7 @@ export const getStaleDailyManagerReportPayloadForDate = internalQuery({
         ctx.db
           .query("automationRun")
           .withIndex(
-            "by_storeId_operatingDate_domain_action_outcome",
+            "by_storeId_operatingDate_domain_action_outcome_updatedAt",
             (q) =>
               q
                 .eq("storeId", args.storeId)

--- a/packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts
+++ b/packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts
@@ -354,18 +354,27 @@ export const getStaleDailyManagerReportPayloadForDate = internalQuery({
       .first();
     if (completedClose?.status === "completed") return null;
 
-    const run = await ctx.db
-      .query("automationRun")
-      .withIndex("by_storeId_operatingDate_domain_action", (q) =>
-        q
-          .eq("storeId", args.storeId)
-          .eq("operatingDate", args.operatingDate)
-          .eq("domain", "daily_operations")
-          .eq("action", "eod.auto_complete"),
-      )
-      .order("desc")
-      .first();
-
+    const qualifyingRuns = await Promise.all(
+      (["skipped", "failed"] as const).map((outcome) =>
+        ctx.db
+          .query("automationRun")
+          .withIndex(
+            "by_storeId_operatingDate_domain_action_outcome",
+            (q) =>
+              q
+                .eq("storeId", args.storeId)
+                .eq("operatingDate", args.operatingDate)
+                .eq("domain", "daily_operations")
+                .eq("action", "eod.auto_complete")
+                .eq("outcome", outcome),
+          )
+          .order("desc")
+          .first(),
+      ),
+    );
+    const run = qualifyingRuns
+      .filter((candidate) => candidate !== null)
+      .sort((a, b) => b.updatedAt - a.updatedAt)[0];
     if (!run || (run.outcome !== "skipped" && run.outcome !== "failed")) {
       return null;
     }

--- a/packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts
@@ -2802,6 +2802,17 @@ describe("daily operations automation adapter", () => {
       inserts.find((insert) => insert.table === "dailyClose")?.value,
     ).toMatchObject({
       actorType: "automation",
+      carryForwardWorkItemIds: [],
+      readiness: { carryForwardCount: 500 },
+      reportSnapshot: {
+        carryForwardGroups: [],
+        carryForwardItems: [],
+        openWorkMembership: {
+          completeness: "incomplete",
+          observedLogicalCount: 500,
+        },
+        summary: { carryForwardWorkItemCount: 500 },
+      },
       sourceCompleteness: {
         complete: false,
         entries: expect.arrayContaining([

--- a/packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts
@@ -2760,6 +2760,61 @@ describe("daily operations automation adapter", () => {
     });
   });
 
+  it("historic automation completes when only open operational-work evidence exceeds the probe", async () => {
+    const operationalWorkItems = Array.from({ length: 501 }, (_, index) => ({
+      _id: `work-cap-${index + 1}`,
+      approvalState: "not_required",
+      createdAt: Date.UTC(2026, 5, 8, 12, index % 60),
+      organizationId: "org-1",
+      priority: "normal",
+      status: "open",
+      storeId: "store-1",
+      title: `Carry-forward ${index + 1}`,
+      type: "stock_adjustment_follow_up",
+    }));
+    const { db, inserts } = createDb({
+      automationPolicy: [
+        policy("eod.auto_complete", "enabled", {
+          eodCleanDayAutoCompleteEnabled: true,
+          eodLocalCompletionWindowMinutes: 0,
+          operatingTimezoneOffsetMinutes: 0,
+        }),
+      ],
+      operationalWorkItem: operationalWorkItems,
+      store: [store],
+      storeSchedule: [storeSchedule()],
+    });
+
+    const result = await runHistoricEodAutoCloseBatchWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        asOfOperatingDate: "2026-06-10",
+        endOperatingDate: "2026-06-08",
+        maxDays: 1,
+        mode: "apply",
+        startOperatingDate: "2026-06-08",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(result).toMatchObject({ applied: 1, candidates: 1, quarantined: 0 });
+    expect(
+      inserts.find((insert) => insert.table === "dailyClose")?.value,
+    ).toMatchObject({
+      actorType: "automation",
+      sourceCompleteness: {
+        complete: false,
+        entries: expect.arrayContaining([
+          expect.objectContaining({
+            complete: false,
+            source: "operational_work_item",
+          }),
+        ]),
+      },
+      status: "completed",
+    });
+  });
+
   it("preserves applied historic automation run evidence on apply and dry-run reruns", async () => {
     const appliedRun = {
       _id: "automation-run-applied",

--- a/packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts
@@ -870,7 +870,10 @@ describe("daily operations automation adapter", () => {
   it("skips EOD preparation when the review is already completed", async () => {
     const reportSnapshot = {
       carryForwardItems: [],
-      carryForwardWorkItemIds: [],
+      carryForwardWorkItemIds: expect.arrayContaining([
+        "work-cap-1",
+        "work-cap-500",
+      ]),
       closeMetadata: {
         completedAt: Date.UTC(2026, 5, 8, 22),
         completedByUserId: "user-1",
@@ -2802,11 +2805,22 @@ describe("daily operations automation adapter", () => {
       inserts.find((insert) => insert.table === "dailyClose")?.value,
     ).toMatchObject({
       actorType: "automation",
-      carryForwardWorkItemIds: [],
+      carryForwardWorkItemIds: expect.arrayContaining([
+        "work-cap-1",
+        "work-cap-500",
+      ]),
       readiness: { carryForwardCount: 500 },
       reportSnapshot: {
-        carryForwardGroups: [],
-        carryForwardItems: [],
+        carryForwardGroups: expect.arrayContaining([
+          expect.objectContaining({ memberWorkItemIds: ["work-cap-1"] }),
+        ]),
+        carryForwardItems: expect.arrayContaining([
+          expect.objectContaining({
+            metadata: expect.objectContaining({
+              membershipCompleteness: "incomplete",
+            }),
+          }),
+        ]),
         openWorkMembership: {
           completeness: "incomplete",
           observedLogicalCount: 500,

--- a/packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts
@@ -35,6 +35,7 @@ import {
 import {
   buildDailyCloseSnapshotWithCtx,
   completeDailyCloseForAutomationWithCtx,
+  isToleratedIncompleteDailyCloseCompletionSource,
 } from "./dailyClose";
 import { requireStoreFullAdminAccess } from "../stockOps/access";
 import { withOperationReadAdmission } from "../operationAdmission/publicQuery";
@@ -1186,7 +1187,9 @@ export async function runHistoricEodAutoCloseForDateWithCtx(
 
   const completionBlockingIncompleteSources =
     snapshot.sourceCompleteness.entries.filter(
-      (entry) => !entry.complete && entry.source !== "operational_work_item",
+      (entry) =>
+        !entry.complete &&
+        !isToleratedIncompleteDailyCloseCompletionSource(entry),
     );
 
   if (completionBlockingIncompleteSources.length > 0) {

--- a/packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts
@@ -1184,7 +1184,12 @@ export async function runHistoricEodAutoCloseForDateWithCtx(
     storeId: args.storeId,
   });
 
-  if (!snapshot.sourceCompleteness.complete) {
+  const completionBlockingIncompleteSources =
+    snapshot.sourceCompleteness.entries.filter(
+      (entry) => !entry.complete && entry.source !== "operational_work_item",
+    );
+
+  if (completionBlockingIncompleteSources.length > 0) {
     return recordHistoricEodQuarantineWithCtx(ctx, {
       classification: "quarantine_incomplete_source_reads",
       decisionReason:

--- a/packages/athena-webapp/convex/operations/owedDailyCloseSweep.integration.test.ts
+++ b/packages/athena-webapp/convex/operations/owedDailyCloseSweep.integration.test.ts
@@ -219,6 +219,26 @@ describe("owed daily close sweep", () => {
       reason: "daily_close_owed_stale",
     });
     expect(events[0]?.metadata).toMatchObject({ ageInDays: 4 });
+
+    const intents = await t.run(async (ctx) =>
+      ctx.db
+        .query("notificationIntent")
+        .withIndex("by_dedupeKey", (q) =>
+          q.eq("dedupeKey", `eod.stale_daily_close:${storeId}:2026-07-21`),
+        )
+        .collect(),
+    );
+    expect(intents).toHaveLength(1);
+    expect(intents[0]).toMatchObject({
+      category: "eod",
+      kind: "eod.stale_daily_close",
+      payload: {
+        ageInDays: 4,
+        operatingDate: "2026-07-21",
+        storeId,
+      },
+      status: "pending",
+    });
   });
 
   it("escalates a stuck day only once across repeated sweeps", async () => {
@@ -250,6 +270,16 @@ describe("owed daily close sweep", () => {
         .collect(),
     );
     expect(events).toHaveLength(1);
+
+    const intents = await t.run(async (ctx) =>
+      ctx.db
+        .query("notificationIntent")
+        .withIndex("by_dedupeKey", (q) =>
+          q.eq("dedupeKey", `eod.stale_daily_close:${storeId}:2026-07-21`),
+        )
+        .collect(),
+    );
+    expect(intents).toHaveLength(1);
   });
 
   it("does not escalate a recently owed day", async () => {

--- a/packages/athena-webapp/convex/operations/owedDailyCloseSweep.integration.test.ts
+++ b/packages/athena-webapp/convex/operations/owedDailyCloseSweep.integration.test.ts
@@ -322,13 +322,44 @@ describe("owed daily close sweep", () => {
 
     const second = await t.action(
       internal.operations.owedDailyCloseSweep.runOwedDailyCloseSweep,
-      { mode: "apply", now: NOW },
+      { mode: "apply", now: NOW + 30 * 60_000 },
     );
     expect(second.escalations.map((entry) => entry.operatingDate)).toEqual([
       "2026-07-21",
       "2026-07-22",
       "2026-07-23",
     ]);
+  });
+
+  it("rotates past permanently blocked oldest dates so later stale dates alert", async () => {
+    const t = convexTest(schema, modules);
+    const { storeId } = await seedStore(t);
+    const alerted = new Set<string>();
+
+    for (let slot = 0; slot < 7; slot += 1) {
+      const result = await t.action(
+        internal.operations.owedDailyCloseSweep.runOwedDailyCloseSweep,
+        { mode: "apply", now: NOW + slot * 15 * 60_000 },
+      );
+      for (const escalation of result.escalations) {
+        alerted.add(escalation.operatingDate);
+      }
+      expect(result.results).toHaveLength(3);
+    }
+
+    expect([...alerted].sort()).toEqual(WINDOW.slice(0, 6));
+    const intents = await t.run((ctx) =>
+      ctx.db
+        .query("notificationIntent")
+        .withIndex("by_storeId_and_emittedAt", (q) => q.eq("storeId", storeId))
+        .take(10),
+    );
+    expect(
+      intents
+        .filter((intent) => intent.category === "eod")
+        .map((intent) => intent.payload.operatingDate)
+        .sort(),
+    ).toEqual(WINDOW.slice(0, 6));
   });
 
   it("rechecks a completed active close before recording escalation", async () => {

--- a/packages/athena-webapp/convex/operations/owedDailyCloseSweep.integration.test.ts
+++ b/packages/athena-webapp/convex/operations/owedDailyCloseSweep.integration.test.ts
@@ -117,7 +117,6 @@ describe("owed daily close sweep", () => {
     expect(candidates[0]).toMatchObject({
       asOfOperatingDate: "2026-07-25",
       owed: ["2026-07-24"],
-      attempt: ["2026-07-24"],
       stale: [],
     });
   });

--- a/packages/athena-webapp/convex/operations/owedDailyCloseSweep.integration.test.ts
+++ b/packages/athena-webapp/convex/operations/owedDailyCloseSweep.integration.test.ts
@@ -201,7 +201,6 @@ describe("owed daily close sweep", () => {
     expect(result.scannedStoreCount).toBe(1);
 
     const events = await t.run(async (ctx) =>
-      // eslint-disable-next-line @convex-dev/no-collect-in-query -- test fixture
       ctx.db
         .query("operationalEvent")
         .withIndex("by_storeId_subject", (q) =>
@@ -210,7 +209,7 @@ describe("owed daily close sweep", () => {
             .eq("subjectType", "daily_close")
             .eq("subjectId", "2026-07-21"),
         )
-        .collect(),
+        .take(2),
     );
     expect(events).toHaveLength(1);
     expect(events[0]).toMatchObject({
@@ -226,7 +225,7 @@ describe("owed daily close sweep", () => {
         .withIndex("by_dedupeKey", (q) =>
           q.eq("dedupeKey", `eod.stale_daily_close:${storeId}:2026-07-21`),
         )
-        .collect(),
+        .take(2),
     );
     expect(intents).toHaveLength(1);
     expect(intents[0]).toMatchObject({
@@ -258,7 +257,6 @@ describe("owed daily close sweep", () => {
     );
 
     const events = await t.run(async (ctx) =>
-      // eslint-disable-next-line @convex-dev/no-collect-in-query -- test fixture
       ctx.db
         .query("operationalEvent")
         .withIndex("by_storeId_subject", (q) =>
@@ -267,7 +265,7 @@ describe("owed daily close sweep", () => {
             .eq("subjectType", "daily_close")
             .eq("subjectId", "2026-07-21"),
         )
-        .collect(),
+        .take(2),
     );
     expect(events).toHaveLength(1);
 
@@ -277,7 +275,7 @@ describe("owed daily close sweep", () => {
         .withIndex("by_dedupeKey", (q) =>
           q.eq("dedupeKey", `eod.stale_daily_close:${storeId}:2026-07-21`),
         )
-        .collect(),
+        .take(2),
     );
     expect(intents).toHaveLength(1);
   });

--- a/packages/athena-webapp/convex/operations/owedDailyCloseSweep.integration.test.ts
+++ b/packages/athena-webapp/convex/operations/owedDailyCloseSweep.integration.test.ts
@@ -303,10 +303,11 @@ describe("owed daily close sweep", () => {
   it("does not consume stale intents for backlog dates it did not attempt", async () => {
     const t = convexTest(schema, modules);
     const { organizationId, storeId } = await seedStore(t);
+    const sweepNow = Date.parse("2026-07-25T00:30:00.000Z");
 
     const first = await t.action(
       internal.operations.owedDailyCloseSweep.runOwedDailyCloseSweep,
-      { mode: "apply", now: NOW },
+      { mode: "apply", now: sweepNow },
     );
     expect(first.escalations.map((entry) => entry.operatingDate)).toEqual([
       "2026-07-18",
@@ -322,7 +323,7 @@ describe("owed daily close sweep", () => {
 
     const second = await t.action(
       internal.operations.owedDailyCloseSweep.runOwedDailyCloseSweep,
-      { mode: "apply", now: NOW + 30 * 60_000 },
+      { mode: "apply", now: sweepNow },
     );
     expect(second.escalations.map((entry) => entry.operatingDate)).toEqual([
       "2026-07-21",
@@ -335,11 +336,12 @@ describe("owed daily close sweep", () => {
     const t = convexTest(schema, modules);
     const { storeId } = await seedStore(t);
     const alerted = new Set<string>();
+    const sweepNow = Date.parse("2026-07-25T00:30:00.000Z");
 
     for (let slot = 0; slot < 7; slot += 1) {
       const result = await t.action(
         internal.operations.owedDailyCloseSweep.runOwedDailyCloseSweep,
-        { mode: "apply", now: NOW + slot * 15 * 60_000 },
+        { mode: "apply", now: sweepNow + slot * 60 * 60_000 },
       );
       for (const escalation of result.escalations) {
         alerted.add(escalation.operatingDate);

--- a/packages/athena-webapp/convex/operations/owedDailyCloseSweep.integration.test.ts
+++ b/packages/athena-webapp/convex/operations/owedDailyCloseSweep.integration.test.ts
@@ -398,4 +398,59 @@ describe("owed daily close sweep", () => {
     );
     expect(events).toEqual([]);
   });
+
+  it("continues past 50 enabled policies and escalates the tail store", async () => {
+    const t = convexTest(schema, modules);
+    const stores = [];
+    for (let index = 0; index < 51; index += 1) {
+      stores.push(await seedStore(t));
+    }
+    const tail = stores[50]!;
+    const firstPage = await t.query(
+      internal.operations.owedDailyCloseSweep.listOwedDailyCloseCandidatePage,
+      { now: NOW },
+    );
+    expect(firstPage.isDone).toBe(false);
+    expect(firstPage.candidates).toHaveLength(50);
+
+    await t.action(
+      internal.operations.owedDailyCloseSweep.runOwedDailyCloseSweep,
+      { mode: "apply", now: NOW },
+    );
+    const scheduled = await t.run((ctx) =>
+      ctx.db.system.query("_scheduled_functions").take(500),
+    );
+    expect(
+      scheduled.some(
+        (entry) =>
+          entry.args[0]?.cursor === firstPage.continueCursor,
+      ),
+    ).toBe(true);
+
+    const tailPage = await t.action(
+      internal.operations.owedDailyCloseSweep.runOwedDailyCloseSweep,
+      {
+        cursor: firstPage.continueCursor,
+        mode: "apply",
+        now: NOW,
+      },
+    );
+    expect(tailPage.scannedStoreCount).toBe(1);
+    expect(tailPage.results).toHaveLength(3);
+    expect(tailPage.results.every((result) => result.storeId === tail.storeId)).toBe(
+      true,
+    );
+    const tailIntents = await t.run((ctx) =>
+      ctx.db
+        .query("notificationIntent")
+        .withIndex("by_storeId_and_emittedAt", (q) =>
+          q.eq("storeId", tail.storeId),
+        )
+        .take(10),
+    );
+    expect(tailIntents).toHaveLength(3);
+    expect(
+      tailIntents.every((intent) => intent.kind === "eod.stale_daily_close"),
+    ).toBe(true);
+  }, 20_000);
 });

--- a/packages/athena-webapp/convex/operations/owedDailyCloseSweep.integration.test.ts
+++ b/packages/athena-webapp/convex/operations/owedDailyCloseSweep.integration.test.ts
@@ -299,4 +299,70 @@ describe("owed daily close sweep", () => {
     );
     expect(events).toEqual([]);
   });
+
+  it("does not consume stale intents for backlog dates it did not attempt", async () => {
+    const t = convexTest(schema, modules);
+    const { organizationId, storeId } = await seedStore(t);
+
+    const first = await t.action(
+      internal.operations.owedDailyCloseSweep.runOwedDailyCloseSweep,
+      { mode: "apply", now: NOW },
+    );
+    expect(first.escalations.map((entry) => entry.operatingDate)).toEqual([
+      "2026-07-18",
+      "2026-07-19",
+      "2026-07-20",
+    ]);
+
+    for (const operatingDate of first.escalations.map(
+      (entry) => entry.operatingDate,
+    )) {
+      await seedCompletedClose(t, { operatingDate, organizationId, storeId });
+    }
+
+    const second = await t.action(
+      internal.operations.owedDailyCloseSweep.runOwedDailyCloseSweep,
+      { mode: "apply", now: NOW },
+    );
+    expect(second.escalations.map((entry) => entry.operatingDate)).toEqual([
+      "2026-07-21",
+      "2026-07-22",
+      "2026-07-23",
+    ]);
+  });
+
+  it("rechecks a completed active close before recording escalation", async () => {
+    const t = convexTest(schema, modules);
+    const { organizationId, storeId } = await seedStore(t);
+    await seedCompletedClose(t, {
+      operatingDate: "2026-07-21",
+      organizationId,
+      storeId,
+    });
+
+    expect(
+      await t.mutation(
+        internal.operations.owedDailyCloseSweep
+          .recordOwedDailyCloseStaleEscalation,
+        {
+          ageInDays: 4,
+          operatingDate: "2026-07-21",
+          organizationId,
+          storeId,
+        },
+      ),
+    ).toBe(false);
+    const events = await t.run((ctx) =>
+      ctx.db
+        .query("operationalEvent")
+        .withIndex("by_storeId_subject", (q) =>
+          q
+            .eq("storeId", storeId)
+            .eq("subjectType", "daily_close")
+            .eq("subjectId", "2026-07-21"),
+        )
+        .take(1),
+    );
+    expect(events).toEqual([]);
+  });
 });

--- a/packages/athena-webapp/convex/operations/owedDailyCloseSweep.test.ts
+++ b/packages/athena-webapp/convex/operations/owedDailyCloseSweep.test.ts
@@ -28,21 +28,25 @@ describe("owed daily close selection", () => {
   it("persists continuation with one derived now before a store failure", async () => {
     const derivedNow = Date.parse("2026-07-25T00:30:00.000Z");
     vi.spyOn(Date, "now").mockReturnValue(derivedNow);
+    const queryArgs: Array<Record<string, unknown>> = [];
     const scheduled: Array<Record<string, unknown>> = [];
     const ctx = {
-      runQuery: async () => ({
-        candidates: [
-          {
-            asOfOperatingDate: AS_OF,
-            attempt: ["2026-07-21"],
-            owed: ["2026-07-21"],
-            stale: ["2026-07-21"],
-            storeId: "store-first",
-          },
-        ],
-        continueCursor: "tail-cursor",
-        isDone: false,
-      }),
+      runQuery: async (_reference: unknown, args: unknown) => {
+        queryArgs.push(args as Record<string, unknown>);
+        return {
+          candidates: [
+            {
+              asOfOperatingDate: AS_OF,
+              attempt: ["2026-07-21"],
+              owed: ["2026-07-21"],
+              stale: ["2026-07-21"],
+              storeId: "store-first",
+            },
+          ],
+          continueCursor: "tail-cursor",
+          isDone: false,
+        };
+      },
       runMutation: async () => {
         throw new Error("first store failed");
       },
@@ -57,6 +61,7 @@ describe("owed daily close selection", () => {
     await expect(
       runOwedDailyCloseSweepWithCtx(ctx as never, { mode: "apply" }),
     ).rejects.toThrow("first store failed");
+    expect(queryArgs).toEqual([{ now: derivedNow }]);
     expect(scheduled).toEqual([
       {
         cursor: "tail-cursor",

--- a/packages/athena-webapp/convex/operations/owedDailyCloseSweep.test.ts
+++ b/packages/athena-webapp/convex/operations/owedDailyCloseSweep.test.ts
@@ -4,6 +4,7 @@ import {
   OWED_DAILY_CLOSE_LOOKBACK_DAYS,
   OWED_DAILY_CLOSE_MAX_PER_SWEEP,
   dailyCloseSweepResultSettled,
+  selectRotatingOwedDailyCloseAttempt,
   selectOwedDailyCloseDates,
 } from "./owedDailyCloseSweep";
 
@@ -23,6 +24,23 @@ function fullWindow() {
 }
 
 describe("owed daily close selection", () => {
+  it("rotates the bounded attempt window across repeated sweep slots", () => {
+    const owed = fullWindow();
+    expect(
+      selectRotatingOwedDailyCloseAttempt({
+        asOfOperatingDate: AS_OF,
+        now: Date.parse(`${AS_OF}T03:30:00.000Z`),
+        owed,
+      }),
+    ).toEqual(owed.slice(0, 3));
+    expect(
+      selectRotatingOwedDailyCloseAttempt({
+        asOfOperatingDate: AS_OF,
+        now: Date.parse(`${AS_OF}T04:15:00.000Z`),
+        owed,
+      }),
+    ).toEqual(["2026-07-21", "2026-07-22", "2026-07-23"]);
+  });
   it("treats an applied historic close as settled in the same sweep", () => {
     expect(dailyCloseSweepResultSettled({ action: "applied" })).toBe(true);
     expect(dailyCloseSweepResultSettled({ action: "already_completed" })).toBe(

--- a/packages/athena-webapp/convex/operations/owedDailyCloseSweep.test.ts
+++ b/packages/athena-webapp/convex/operations/owedDailyCloseSweep.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   OWED_DAILY_CLOSE_LOOKBACK_DAYS,
-  OWED_DAILY_CLOSE_MAX_PER_SWEEP,
   dailyCloseSweepResultSettled,
   selectRotatingOwedDailyCloseAttempt,
   runOwedDailyCloseSweepWithCtx,
@@ -37,7 +36,6 @@ describe("owed daily close selection", () => {
           candidates: [
             {
               asOfOperatingDate: AS_OF,
-              attempt: ["2026-07-21"],
               owed: ["2026-07-21"],
               stale: ["2026-07-21"],
               storeId: "store-first",
@@ -108,7 +106,7 @@ describe("owed daily close selection", () => {
         asOfOperatingDate: AS_OF,
         completedOperatingDates: fullWindow(),
       }),
-    ).toEqual({ owed: [], attempt: [], stale: [] });
+    ).toEqual({ owed: [], stale: [] });
   });
 
   it("finds the one day that missed its window", () => {
@@ -122,7 +120,6 @@ describe("owed daily close selection", () => {
     });
 
     expect(result.owed).toEqual(["2026-07-24"]);
-    expect(result.attempt).toEqual(["2026-07-24"]);
     // One day old is well inside the transient-blocker band.
     expect(result.stale).toEqual([]);
   });
@@ -147,20 +144,6 @@ describe("owed daily close selection", () => {
     });
 
     expect(result.owed).not.toContain("2026-07-17");
-  });
-
-  it("drains a backlog oldest-first in bounded slices", () => {
-    const result = selectOwedDailyCloseDates({
-      asOfOperatingDate: AS_OF,
-      completedOperatingDates: [],
-    });
-
-    expect(result.attempt).toHaveLength(OWED_DAILY_CLOSE_MAX_PER_SWEEP);
-    expect(result.attempt).toEqual([
-      "2026-07-18",
-      "2026-07-19",
-      "2026-07-20",
-    ]);
   });
 
   it("escalates only the days past the staleness threshold", () => {
@@ -188,16 +171,14 @@ describe("owed daily close selection", () => {
     expect(result.stale).not.toContain("2026-07-24");
   });
 
-  it("honors explicit bounds", () => {
+  it("honors an explicit lookback bound", () => {
     const result = selectOwedDailyCloseDates({
       asOfOperatingDate: AS_OF,
       completedOperatingDates: [],
       lookbackDays: 2,
-      maxPerSweep: 1,
     });
 
     expect(result.owed).toEqual(["2026-07-23", "2026-07-24"]);
-    expect(result.attempt).toEqual(["2026-07-23"]);
   });
 
   it("selects nothing for a malformed operating date", () => {
@@ -206,7 +187,7 @@ describe("owed daily close selection", () => {
         asOfOperatingDate: "not-a-date",
         completedOperatingDates: [],
       }),
-    ).toEqual({ owed: [], attempt: [], stale: [] });
+    ).toEqual({ owed: [], stale: [] });
   });
 
   it("selects nothing when bounds are degenerate", () => {
@@ -216,7 +197,7 @@ describe("owed daily close selection", () => {
         completedOperatingDates: [],
         lookbackDays: 0,
       }),
-    ).toEqual({ owed: [], attempt: [], stale: [] });
+    ).toEqual({ owed: [], stale: [] });
   });
 
   it("crosses a month boundary correctly", () => {

--- a/packages/athena-webapp/convex/operations/owedDailyCloseSweep.test.ts
+++ b/packages/athena-webapp/convex/operations/owedDailyCloseSweep.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   OWED_DAILY_CLOSE_LOOKBACK_DAYS,
   OWED_DAILY_CLOSE_MAX_PER_SWEEP,
   dailyCloseSweepResultSettled,
   selectRotatingOwedDailyCloseAttempt,
+  runOwedDailyCloseSweepWithCtx,
   selectOwedDailyCloseDates,
 } from "./owedDailyCloseSweep";
 
@@ -24,6 +25,47 @@ function fullWindow() {
 }
 
 describe("owed daily close selection", () => {
+  it("persists continuation with one derived now before a store failure", async () => {
+    const derivedNow = Date.parse("2026-07-25T00:30:00.000Z");
+    vi.spyOn(Date, "now").mockReturnValue(derivedNow);
+    const scheduled: Array<Record<string, unknown>> = [];
+    const ctx = {
+      runQuery: async () => ({
+        candidates: [
+          {
+            asOfOperatingDate: AS_OF,
+            attempt: ["2026-07-21"],
+            owed: ["2026-07-21"],
+            stale: ["2026-07-21"],
+            storeId: "store-first",
+          },
+        ],
+        continueCursor: "tail-cursor",
+        isDone: false,
+      }),
+      runMutation: async () => {
+        throw new Error("first store failed");
+      },
+      scheduler: {
+        runAfter: async (_delay: number, _reference: unknown, args: unknown) => {
+          scheduled.push(args as Record<string, unknown>);
+          return "scheduled-id";
+        },
+      },
+    };
+
+    await expect(
+      runOwedDailyCloseSweepWithCtx(ctx as never, { mode: "apply" }),
+    ).rejects.toThrow("first store failed");
+    expect(scheduled).toEqual([
+      {
+        cursor: "tail-cursor",
+        mode: "apply",
+        now: derivedNow,
+      },
+    ]);
+    vi.restoreAllMocks();
+  });
   it.each([
     ["hourly", 1],
     ["two-hourly", 2],

--- a/packages/athena-webapp/convex/operations/owedDailyCloseSweep.test.ts
+++ b/packages/athena-webapp/convex/operations/owedDailyCloseSweep.test.ts
@@ -24,7 +24,7 @@ function fullWindow() {
 }
 
 describe("owed daily close selection", () => {
-  it("persists continuation with one derived now before a store failure", async () => {
+  it("persists continuation and attempts the next same-page store after a store failure", async () => {
     const derivedNow = Date.parse("2026-07-25T00:30:00.000Z");
     vi.spyOn(Date, "now").mockReturnValue(derivedNow);
     const queryArgs: Array<Record<string, unknown>> = [];
@@ -40,13 +40,23 @@ describe("owed daily close selection", () => {
               stale: ["2026-07-21"],
               storeId: "store-first",
             },
+            {
+              asOfOperatingDate: AS_OF,
+              owed: ["2026-07-22"],
+              stale: [],
+              storeId: "store-second",
+            },
           ],
           continueCursor: "tail-cursor",
           isDone: false,
         };
       },
-      runMutation: async () => {
-        throw new Error("first store failed");
+      runMutation: async (_reference: unknown, args: unknown) => {
+        const mutationArgs = args as { storeId: string };
+        if (mutationArgs.storeId === "store-first") {
+          throw new Error("first store failed");
+        }
+        return { action: "applied", classification: "completed" };
       },
       scheduler: {
         runAfter: async (_delay: number, _reference: unknown, args: unknown) => {
@@ -56,15 +66,30 @@ describe("owed daily close selection", () => {
       },
     };
 
-    await expect(
-      runOwedDailyCloseSweepWithCtx(ctx as never, { mode: "apply" }),
-    ).rejects.toThrow("first store failed");
+    const result = await runOwedDailyCloseSweepWithCtx(ctx as never, {
+      mode: "apply",
+    });
     expect(queryArgs).toEqual([{ now: derivedNow }]);
     expect(scheduled).toEqual([
       {
         cursor: "tail-cursor",
         mode: "apply",
         now: derivedNow,
+      },
+    ]);
+    expect(result.results).toEqual([
+      {
+        action: "failed",
+        classification: "owed_daily_close_candidate_failed",
+        error: "first store failed",
+        operatingDate: "2026-07-21",
+        storeId: "store-first",
+      },
+      {
+        action: "applied",
+        classification: "completed",
+        operatingDate: "2026-07-22",
+        storeId: "store-second",
       },
     ]);
     vi.restoreAllMocks();

--- a/packages/athena-webapp/convex/operations/owedDailyCloseSweep.test.ts
+++ b/packages/athena-webapp/convex/operations/owedDailyCloseSweep.test.ts
@@ -24,23 +24,30 @@ function fullWindow() {
 }
 
 describe("owed daily close selection", () => {
-  it("rotates the bounded attempt window across repeated sweep slots", () => {
-    const owed = fullWindow();
-    expect(
-      selectRotatingOwedDailyCloseAttempt({
-        asOfOperatingDate: AS_OF,
-        now: Date.parse(`${AS_OF}T03:30:00.000Z`),
-        owed,
-      }),
-    ).toEqual(owed.slice(0, 3));
-    expect(
-      selectRotatingOwedDailyCloseAttempt({
-        asOfOperatingDate: AS_OF,
-        now: Date.parse(`${AS_OF}T04:15:00.000Z`),
-        owed,
-      }),
-    ).toEqual(["2026-07-21", "2026-07-22", "2026-07-23"]);
-  });
+  it.each([
+    ["hourly", 1],
+    ["two-hourly", 2],
+  ] as const)(
+    "covers backlog lengths 4-7 at the real %s cadence",
+    (_, cadenceHours) => {
+      for (let backlogLength = 4; backlogLength <= 7; backlogLength += 1) {
+        const owed = fullWindow().slice(0, backlogLength);
+        const attempted = new Set<string>();
+        for (let run = 0; run < backlogLength; run += 1) {
+          for (const date of selectRotatingOwedDailyCloseAttempt({
+            asOfOperatingDate: AS_OF,
+            now:
+              Date.parse(`${AS_OF}T00:30:00.000Z`) +
+              run * cadenceHours * 60 * 60_000,
+            owed,
+          })) {
+            attempted.add(date);
+          }
+        }
+        expect([...attempted].sort()).toEqual(owed);
+      }
+    },
+  );
   it("treats an applied historic close as settled in the same sweep", () => {
     expect(dailyCloseSweepResultSettled({ action: "applied" })).toBe(true);
     expect(dailyCloseSweepResultSettled({ action: "already_completed" })).toBe(

--- a/packages/athena-webapp/convex/operations/owedDailyCloseSweep.test.ts
+++ b/packages/athena-webapp/convex/operations/owedDailyCloseSweep.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   OWED_DAILY_CLOSE_LOOKBACK_DAYS,
   OWED_DAILY_CLOSE_MAX_PER_SWEEP,
+  dailyCloseSweepResultSettled,
   selectOwedDailyCloseDates,
 } from "./owedDailyCloseSweep";
 
@@ -22,6 +23,13 @@ function fullWindow() {
 }
 
 describe("owed daily close selection", () => {
+  it("treats an applied historic close as settled in the same sweep", () => {
+    expect(dailyCloseSweepResultSettled({ action: "applied" })).toBe(true);
+    expect(dailyCloseSweepResultSettled({ action: "already_completed" })).toBe(
+      true,
+    );
+    expect(dailyCloseSweepResultSettled({ action: "quarantined" })).toBe(false);
+  });
   it("owes nothing when every day in the window is closed", () => {
     expect(
       selectOwedDailyCloseDates({

--- a/packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts
+++ b/packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts
@@ -39,6 +39,7 @@ import {
   internalAction,
   internalMutation,
   internalQuery,
+  type ActionCtx,
   type QueryCtx,
 } from "../_generated/server";
 import {
@@ -356,13 +357,14 @@ type OwedDailyCloseSweepResult = {
  * into its own module through `internal.`, and without it TypeScript cannot
  * break the inference cycle.
  */
-export const runOwedDailyCloseSweep = internalAction({
+export async function runOwedDailyCloseSweepWithCtx(
+  ctx: Pick<ActionCtx, "runMutation" | "runQuery" | "scheduler">,
   args: {
-    cursor: v.optional(v.string()),
-    mode: v.optional(v.union(v.literal("dry_run"), v.literal("apply"))),
-    now: v.optional(v.number()),
+    cursor?: string;
+    mode?: "dry_run" | "apply";
+    now?: number;
   },
-  handler: async (ctx, args): Promise<OwedDailyCloseSweepResult> => {
+): Promise<OwedDailyCloseSweepResult> {
     const mode = args.mode ?? "apply";
     const now = args.now ?? Date.now();
     const page: {
@@ -377,6 +379,24 @@ export const runOwedDailyCloseSweep = internalAction({
       },
     );
     const candidates = page.candidates;
+
+    // Persist continuation before touching any store on this page. Actions do
+    // not provide a transaction across scheduler writes and later mutations;
+    // queuing first ensures one malformed or transiently failing store cannot
+    // strand every policy behind it. Carry the single derived timestamp so
+    // every page makes operating-date and rotation decisions from one sweep
+    // snapshot even when the cron omitted `now`.
+    if (!page.isDone) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.operations.owedDailyCloseSweep.runOwedDailyCloseSweep,
+        {
+          cursor: page.continueCursor,
+          mode,
+          now,
+        },
+      );
+    }
 
     const results: OwedDailyCloseSweepResult["results"] = [];
     const escalations: Array<{ operatingDate: string; storeId: Id<"store"> }> =
@@ -450,25 +470,21 @@ export const runOwedDailyCloseSweep = internalAction({
       }
     }
 
-    if (!page.isDone) {
-      await ctx.scheduler.runAfter(
-        0,
-        internal.operations.owedDailyCloseSweep.runOwedDailyCloseSweep,
-        {
-          cursor: page.continueCursor,
-          mode,
-          ...(args.now === undefined ? {} : { now: args.now }),
-        },
-      );
-    }
-
     return {
       escalations,
       mode,
       results,
       scannedStoreCount: candidates.length,
     };
+}
+
+export const runOwedDailyCloseSweep = internalAction({
+  args: {
+    cursor: v.optional(v.string()),
+    mode: v.optional(v.union(v.literal("dry_run"), v.literal("apply"))),
+    now: v.optional(v.number()),
   },
+  handler: runOwedDailyCloseSweepWithCtx,
 });
 
 function daysBetweenOperatingDates(from: string, to: string) {

--- a/packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts
+++ b/packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts
@@ -165,19 +165,7 @@ type OwedDailyCloseStoreCandidate = {
   storeId: Id<"store">;
 } & OwedDailyCloseSelection;
 
-async function listEnabledEodPolicies(ctx: QueryCtx) {
-  const policies = await ctx.db
-    .query("automationPolicy")
-    .withIndex("by_domain_action_mode", (q) =>
-      q
-        .eq("domain", DAILY_OPERATIONS_AUTOMATION_DOMAIN)
-        .eq("action", EOD_AUTO_COMPLETE_ACTION)
-        .eq("mode", "enabled"),
-    )
-    .take(50);
-
-  return policies.filter((policy) => policy.paused !== true);
-}
+const OWED_DAILY_CLOSE_POLICY_PAGE_SIZE = 50;
 
 async function completedOperatingDatesForStore(
   ctx: QueryCtx,
@@ -204,14 +192,14 @@ async function completedOperatingDatesForStore(
     .map((close) => close.operatingDate);
 }
 
-export const listOwedDailyCloseCandidates = internalQuery({
-  args: { now: v.optional(v.number()) },
-  handler: async (ctx, args): Promise<OwedDailyCloseStoreCandidate[]> => {
-    const now = args.now ?? Date.now();
-    const policies = await listEnabledEodPolicies(ctx);
+async function candidatesForPolicies(
+  ctx: QueryCtx,
+  policies: Doc<"automationPolicy">[],
+  now: number,
+) {
     const candidates: OwedDailyCloseStoreCandidate[] = [];
 
-    for (const policy of policies) {
+    for (const policy of policies.filter((entry) => entry.paused !== true)) {
       const asOfOperatingDate = operatingDateForPolicy({
         now,
         operatingTimezoneOffsetMinutes: policy.operatingTimezoneOffsetMinutes,
@@ -247,7 +235,51 @@ export const listOwedDailyCloseCandidates = internalQuery({
       });
     }
 
-    return candidates;
+  return candidates;
+}
+
+export const listOwedDailyCloseCandidatePage = internalQuery({
+  args: { cursor: v.optional(v.string()), now: v.optional(v.number()) },
+  handler: async (ctx, args) => {
+    const page = await ctx.db
+      .query("automationPolicy")
+      .withIndex("by_domain_action_mode", (q) =>
+        q
+          .eq("domain", DAILY_OPERATIONS_AUTOMATION_DOMAIN)
+          .eq("action", EOD_AUTO_COMPLETE_ACTION)
+          .eq("mode", "enabled"),
+      )
+      .paginate({
+        cursor: args.cursor ?? null,
+        numItems: OWED_DAILY_CLOSE_POLICY_PAGE_SIZE,
+      });
+    return {
+      candidates: await candidatesForPolicies(
+        ctx,
+        page.page,
+        args.now ?? Date.now(),
+      ),
+      continueCursor: page.continueCursor,
+      isDone: page.isDone,
+    };
+  },
+});
+
+// Retained as a focused first-page inspection surface for existing tests and
+// support diagnostics. The action below owns continuation across every page.
+export const listOwedDailyCloseCandidates = internalQuery({
+  args: { now: v.optional(v.number()) },
+  handler: async (ctx, args): Promise<OwedDailyCloseStoreCandidate[]> => {
+    const page = await ctx.db
+      .query("automationPolicy")
+      .withIndex("by_domain_action_mode", (q) =>
+        q
+          .eq("domain", DAILY_OPERATIONS_AUTOMATION_DOMAIN)
+          .eq("action", EOD_AUTO_COMPLETE_ACTION)
+          .eq("mode", "enabled"),
+      )
+      .take(OWED_DAILY_CLOSE_POLICY_PAGE_SIZE);
+    return candidatesForPolicies(ctx, page, args.now ?? Date.now());
   },
 });
 
@@ -326,16 +358,25 @@ type OwedDailyCloseSweepResult = {
  */
 export const runOwedDailyCloseSweep = internalAction({
   args: {
+    cursor: v.optional(v.string()),
     mode: v.optional(v.union(v.literal("dry_run"), v.literal("apply"))),
     now: v.optional(v.number()),
   },
   handler: async (ctx, args): Promise<OwedDailyCloseSweepResult> => {
     const mode = args.mode ?? "apply";
     const now = args.now ?? Date.now();
-    const candidates: OwedDailyCloseStoreCandidate[] = await ctx.runQuery(
-      internal.operations.owedDailyCloseSweep.listOwedDailyCloseCandidates,
-      args.now === undefined ? {} : { now: args.now },
+    const page: {
+      candidates: OwedDailyCloseStoreCandidate[];
+      continueCursor: string;
+      isDone: boolean;
+    } = await ctx.runQuery(
+      internal.operations.owedDailyCloseSweep.listOwedDailyCloseCandidatePage,
+      {
+        ...(args.cursor ? { cursor: args.cursor } : {}),
+        ...(args.now === undefined ? {} : { now: args.now }),
+      },
     );
+    const candidates = page.candidates;
 
     const results: OwedDailyCloseSweepResult["results"] = [];
     const escalations: Array<{ operatingDate: string; storeId: Id<"store"> }> =
@@ -407,6 +448,18 @@ export const runOwedDailyCloseSweep = internalAction({
           escalations.push({ operatingDate, storeId: candidate.storeId });
         }
       }
+    }
+
+    if (!page.isDone) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.operations.owedDailyCloseSweep.runOwedDailyCloseSweep,
+        {
+          cursor: page.continueCursor,
+          mode,
+          ...(args.now === undefined ? {} : { now: args.now }),
+        },
+      );
     }
 
     return {

--- a/packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts
+++ b/packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts
@@ -338,6 +338,7 @@ type OwedDailyCloseSweepResult = {
   results: Array<{
     action: string;
     classification: string;
+    error?: string;
     operatingDate: string;
     storeId: Id<"store">;
   }>;
@@ -398,70 +399,83 @@ export async function runOwedDailyCloseSweepWithCtx(
       [];
 
     for (const candidate of candidates) {
-      const attempt = selectRotatingOwedDailyCloseAttempt({
-        asOfOperatingDate: candidate.asOfOperatingDate,
-        now,
-        owed: candidate.owed,
-      });
-      for (const operatingDate of attempt) {
-        const result = await ctx.runMutation(
-          internal.operations.dailyOperationsAutomation
-            .runHistoricEodAutoCloseForDate,
-          {
-            asOfOperatingDate: candidate.asOfOperatingDate,
-            mode,
+      let activeOperatingDate = candidate.owed[0] ?? candidate.asOfOperatingDate;
+      try {
+        const attempt = selectRotatingOwedDailyCloseAttempt({
+          asOfOperatingDate: candidate.asOfOperatingDate,
+          now,
+          owed: candidate.owed,
+        });
+        for (const operatingDate of attempt) {
+          activeOperatingDate = operatingDate;
+          const result = await ctx.runMutation(
+            internal.operations.dailyOperationsAutomation
+              .runHistoricEodAutoCloseForDate,
+            {
+              asOfOperatingDate: candidate.asOfOperatingDate,
+              mode,
+              operatingDate,
+              storeId: candidate.storeId,
+            },
+          );
+
+          results.push({
+            action: result.action,
+            classification: result.classification ?? "unknown",
             operatingDate,
             storeId: candidate.storeId,
-          },
-        );
-
-        results.push({
-          action: result.action,
-          classification: result.classification ?? "unknown",
-          operatingDate,
-          storeId: candidate.storeId,
-        });
-      }
+          });
+        }
 
       // Escalate only what this sweep could not settle, so a day that just
       // closed above never raises a stale alert on its way out.
-      const closedThisSweep = new Set(
-        results
-          .filter(
-            (result) =>
-              result.storeId === candidate.storeId &&
-              dailyCloseSweepResultSettled(result),
-          )
-          .map((result) => result.operatingDate),
-      );
-
-      const attemptedDates = new Set(attempt);
-      for (const operatingDate of candidate.stale) {
-        if (!attemptedDates.has(operatingDate)) continue;
-        if (closedThisSweep.has(operatingDate)) continue;
-        if (mode === "dry_run") {
-          escalations.push({ operatingDate, storeId: candidate.storeId });
-          continue;
-        }
-
-        const recorded = await ctx.runMutation(
-          internal.operations.owedDailyCloseSweep
-            .recordOwedDailyCloseStaleEscalation,
-          {
-            ageInDays: daysBetweenOperatingDates(
-              operatingDate,
-              candidate.asOfOperatingDate,
-            ),
-            operatingDate,
-            ...(candidate.organizationId
-              ? { organizationId: candidate.organizationId }
-              : {}),
-            storeId: candidate.storeId,
-          },
+        const closedThisSweep = new Set(
+          results
+            .filter(
+              (result) =>
+                result.storeId === candidate.storeId &&
+                dailyCloseSweepResultSettled(result),
+            )
+            .map((result) => result.operatingDate),
         );
-        if (recorded) {
-          escalations.push({ operatingDate, storeId: candidate.storeId });
+
+        const attemptedDates = new Set(attempt);
+        for (const operatingDate of candidate.stale) {
+          if (!attemptedDates.has(operatingDate)) continue;
+          if (closedThisSweep.has(operatingDate)) continue;
+          if (mode === "dry_run") {
+            escalations.push({ operatingDate, storeId: candidate.storeId });
+            continue;
+          }
+
+          activeOperatingDate = operatingDate;
+          const recorded = await ctx.runMutation(
+            internal.operations.owedDailyCloseSweep
+              .recordOwedDailyCloseStaleEscalation,
+            {
+              ageInDays: daysBetweenOperatingDates(
+                operatingDate,
+                candidate.asOfOperatingDate,
+              ),
+              operatingDate,
+              ...(candidate.organizationId
+                ? { organizationId: candidate.organizationId }
+                : {}),
+              storeId: candidate.storeId,
+            },
+          );
+          if (recorded) {
+            escalations.push({ operatingDate, storeId: candidate.storeId });
+          }
         }
+      } catch (error) {
+        results.push({
+          action: "failed",
+          classification: "owed_daily_close_candidate_failed",
+          error: error instanceof Error ? error.message : String(error),
+          operatingDate: activeOperatingDate,
+          storeId: candidate.storeId,
+        });
       }
     }
 

--- a/packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts
+++ b/packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts
@@ -75,6 +75,10 @@ export type OwedDailyCloseSelection = {
   stale: string[];
 };
 
+export function dailyCloseSweepResultSettled(result: { action: string }) {
+  return result.action === "applied" || result.action === "already_completed";
+}
+
 /**
  * Pure selection of which store days are still owed a close.
  *
@@ -228,6 +232,17 @@ export const recordOwedDailyCloseStaleEscalation = internalMutation({
     storeId: v.id("store"),
   },
   handler: async (ctx, args) => {
+    const completedClose = await ctx.db
+      .query("dailyClose")
+      .withIndex("by_storeId_operatingDate_lifecycleStatus", (q) =>
+        q
+          .eq("storeId", args.storeId)
+          .eq("operatingDate", args.operatingDate)
+          .eq("lifecycleStatus", "active"),
+      )
+      .first();
+    if (completedClose?.status === "completed") return false;
+
     // Dedupes on (store, subject, event type), so a day that stays stuck
     // escalates once rather than every sweep.
     await recordOperationalEventWithCtx(ctx, {
@@ -258,6 +273,7 @@ export const recordOwedDailyCloseStaleEscalation = internalMutation({
         storeId: args.storeId,
       },
     });
+    return true;
   },
 });
 
@@ -325,20 +341,21 @@ export const runOwedDailyCloseSweep = internalAction({
           .filter(
             (result) =>
               result.storeId === candidate.storeId &&
-              (result.action === "completed" ||
-                result.action === "already_completed"),
+              dailyCloseSweepResultSettled(result),
           )
           .map((result) => result.operatingDate),
       );
 
+      const attemptedDates = new Set(candidate.attempt);
       for (const operatingDate of candidate.stale) {
+        if (!attemptedDates.has(operatingDate)) continue;
         if (closedThisSweep.has(operatingDate)) continue;
         if (mode === "dry_run") {
           escalations.push({ operatingDate, storeId: candidate.storeId });
           continue;
         }
 
-        await ctx.runMutation(
+        const recorded = await ctx.runMutation(
           internal.operations.owedDailyCloseSweep
             .recordOwedDailyCloseStaleEscalation,
           {
@@ -353,7 +370,9 @@ export const runOwedDailyCloseSweep = internalAction({
             storeId: candidate.storeId,
           },
         );
-        escalations.push({ operatingDate, storeId: candidate.storeId });
+        if (recorded) {
+          escalations.push({ operatingDate, storeId: candidate.storeId });
+        }
       }
     }
 

--- a/packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts
+++ b/packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts
@@ -47,6 +47,7 @@ import {
   operatingDateForPolicy,
 } from "./dailyOperationsAutomation";
 import { recordOperationalEventWithCtx } from "./operationalEvents";
+import { emitNotificationWithCtx } from "../notifications/emit";
 
 const DAILY_OPERATIONS_AUTOMATION_DOMAIN = "daily_operations";
 const EOD_AUTO_COMPLETE_ACTION = "eod.auto_complete";
@@ -96,7 +97,8 @@ export function selectOwedDailyCloseDates(input: {
 
   const lookbackDays = input.lookbackDays ?? OWED_DAILY_CLOSE_LOOKBACK_DAYS;
   const maxPerSweep = input.maxPerSweep ?? OWED_DAILY_CLOSE_MAX_PER_SWEEP;
-  const staleAfterDays = input.staleAfterDays ?? OWED_DAILY_CLOSE_STALE_AFTER_DAYS;
+  const staleAfterDays =
+    input.staleAfterDays ?? OWED_DAILY_CLOSE_STALE_AFTER_DAYS;
 
   if (lookbackDays < 1 || maxPerSweep < 1) {
     return empty;
@@ -242,6 +244,19 @@ export const recordOwedDailyCloseStaleEscalation = internalMutation({
       subjectLabel: `End of day review ${args.operatingDate}`,
       subjectType: "daily_close",
       ...(args.organizationId ? { organizationId: args.organizationId } : {}),
+    });
+
+    await emitNotificationWithCtx(ctx, {
+      kind: "eod.stale_daily_close",
+      storeId: args.storeId,
+      ...(args.organizationId ? { organizationId: args.organizationId } : {}),
+      subjectId: `${args.storeId}:${args.operatingDate}`,
+      subjectType: "dailyClose",
+      payload: {
+        ageInDays: args.ageInDays,
+        operatingDate: args.operatingDate,
+        storeId: args.storeId,
+      },
     });
   },
 });

--- a/packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts
+++ b/packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts
@@ -79,7 +79,12 @@ export function dailyCloseSweepResultSettled(result: { action: string }) {
   return result.action === "applied" || result.action === "already_completed";
 }
 
-const OWED_DAILY_CLOSE_ROTATION_MS = 15 * 60_000;
+// Production runs hourly and non-production every two hours. An hour-based
+// slot advances the start by one in prod and two in non-prod; with a
+// three-date attempt window both cadences cover every backlog length allowed
+// by the seven-day lookback (including even lengths where a point cursor with
+// a two-step stride would otherwise starve one parity).
+const OWED_DAILY_CLOSE_ROTATION_MS = 60 * 60_000;
 
 export function selectRotatingOwedDailyCloseAttempt(input: {
   asOfOperatingDate: string;

--- a/packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts
+++ b/packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts
@@ -79,6 +79,28 @@ export function dailyCloseSweepResultSettled(result: { action: string }) {
   return result.action === "applied" || result.action === "already_completed";
 }
 
+const OWED_DAILY_CLOSE_ROTATION_MS = 15 * 60_000;
+
+export function selectRotatingOwedDailyCloseAttempt(input: {
+  asOfOperatingDate: string;
+  now: number;
+  owed: string[];
+  maxPerSweep?: number;
+}) {
+  if (input.owed.length === 0) return [];
+  const maxPerSweep = input.maxPerSweep ?? OWED_DAILY_CLOSE_MAX_PER_SWEEP;
+  const dayStart = Date.parse(`${input.asOfOperatingDate}T00:00:00.000Z`);
+  const slot = Math.max(
+    0,
+    Math.floor((input.now - dayStart) / OWED_DAILY_CLOSE_ROTATION_MS),
+  );
+  const start = slot % input.owed.length;
+  return Array.from(
+    { length: Math.min(maxPerSweep, input.owed.length) },
+    (_, offset) => input.owed[(start + offset) % input.owed.length],
+  );
+}
+
 /**
  * Pure selection of which store days are still owed a close.
  *
@@ -304,6 +326,7 @@ export const runOwedDailyCloseSweep = internalAction({
   },
   handler: async (ctx, args): Promise<OwedDailyCloseSweepResult> => {
     const mode = args.mode ?? "apply";
+    const now = args.now ?? Date.now();
     const candidates: OwedDailyCloseStoreCandidate[] = await ctx.runQuery(
       internal.operations.owedDailyCloseSweep.listOwedDailyCloseCandidates,
       args.now === undefined ? {} : { now: args.now },
@@ -314,7 +337,12 @@ export const runOwedDailyCloseSweep = internalAction({
       [];
 
     for (const candidate of candidates) {
-      for (const operatingDate of candidate.attempt) {
+      const attempt = selectRotatingOwedDailyCloseAttempt({
+        asOfOperatingDate: candidate.asOfOperatingDate,
+        now,
+        owed: candidate.owed,
+      });
+      for (const operatingDate of attempt) {
         const result = await ctx.runMutation(
           internal.operations.dailyOperationsAutomation
             .runHistoricEodAutoCloseForDate,
@@ -346,7 +374,7 @@ export const runOwedDailyCloseSweep = internalAction({
           .map((result) => result.operatingDate),
       );
 
-      const attemptedDates = new Set(candidate.attempt);
+      const attemptedDates = new Set(attempt);
       for (const operatingDate of candidate.stale) {
         if (!attemptedDates.has(operatingDate)) continue;
         if (closedThisSweep.has(operatingDate)) continue;

--- a/packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts
+++ b/packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts
@@ -375,7 +375,7 @@ export async function runOwedDailyCloseSweepWithCtx(
       internal.operations.owedDailyCloseSweep.listOwedDailyCloseCandidatePage,
       {
         ...(args.cursor ? { cursor: args.cursor } : {}),
-        ...(args.now === undefined ? {} : { now: args.now }),
+        now,
       },
     );
     const candidates = page.candidates;

--- a/packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts
+++ b/packages/athena-webapp/convex/operations/owedDailyCloseSweep.ts
@@ -70,8 +70,6 @@ const OWED_DAILY_CLOSE_STALE_EVENT_TYPE = "daily_close.owed_stale";
 export type OwedDailyCloseSelection = {
   /** Every unclosed date inside the lookback window, oldest first. */
   owed: string[];
-  /** The bounded slice this sweep will act on, oldest first. */
-  attempt: string[];
   /** Owed dates past the staleness threshold; these need a human. */
   stale: string[];
 };
@@ -118,21 +116,19 @@ export function selectOwedDailyCloseDates(input: {
   asOfOperatingDate: string;
   completedOperatingDates: string[];
   lookbackDays?: number;
-  maxPerSweep?: number;
   staleAfterDays?: number;
 }): OwedDailyCloseSelection {
-  const empty: OwedDailyCloseSelection = { owed: [], attempt: [], stale: [] };
+  const empty: OwedDailyCloseSelection = { owed: [], stale: [] };
 
   if (!isValidOperatingDate(input.asOfOperatingDate)) {
     return empty;
   }
 
   const lookbackDays = input.lookbackDays ?? OWED_DAILY_CLOSE_LOOKBACK_DAYS;
-  const maxPerSweep = input.maxPerSweep ?? OWED_DAILY_CLOSE_MAX_PER_SWEEP;
   const staleAfterDays =
     input.staleAfterDays ?? OWED_DAILY_CLOSE_STALE_AFTER_DAYS;
 
-  if (lookbackDays < 1 || maxPerSweep < 1) {
+  if (lookbackDays < 1) {
     return empty;
   }
 
@@ -155,7 +151,6 @@ export function selectOwedDailyCloseDates(input: {
 
   return {
     owed,
-    attempt: owed.slice(0, maxPerSweep),
     stale: owed.filter((operatingDate) => operatingDate <= staleOnOrBefore),
   };
 }

--- a/packages/athena-webapp/convex/schema.ts
+++ b/packages/athena-webapp/convex/schema.ts
@@ -359,6 +359,13 @@ const schema = defineSchema({
       "domain",
       "action",
     ])
+    .index("by_storeId_operatingDate_domain_action_outcome", [
+      "storeId",
+      "operatingDate",
+      "domain",
+      "action",
+      "outcome",
+    ])
     .index("by_storeId_domain_action_outcome", [
       "storeId",
       "domain",

--- a/packages/athena-webapp/convex/schema.ts
+++ b/packages/athena-webapp/convex/schema.ts
@@ -359,12 +359,13 @@ const schema = defineSchema({
       "domain",
       "action",
     ])
-    .index("by_storeId_operatingDate_domain_action_outcome", [
+    .index("by_storeId_operatingDate_domain_action_outcome_updatedAt", [
       "storeId",
       "operatingDate",
       "domain",
       "action",
       "outcome",
+      "updatedAt",
     ])
     .index("by_storeId_domain_action_outcome", [
       "storeId",

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -25,7 +25,7 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`convex/storeTime`](../../convex/storeTime) — Store timezone authority and operating-day resolution shared by reporting and operational surfaces. Currently 6 file(s); key children: ensureTimezoneAuthority.test.ts, ensureTimezoneAuthority.ts, operatingPeriods.test.ts, operatingPeriods.ts, storeTimeAuthority.test.ts.
 - [`convex/serviceOps`](../../convex/serviceOps) — Service catalog, appointment, and service-case workflows layered on operational work items. Currently 8 file(s); key children: appointments.ts, catalog.ts, catalogAppointments.test.ts, moduleWiring.test.ts, serviceCaseTracing.test.ts.
 - [`convex/workflowTraces`](../../convex/workflowTraces) — Shared workflow trace creation, lookup, presentation, and adapter helpers. Currently 19 file(s); key children: adapters, core.ts, presentation.test.ts, presentation.ts, public.ts.
-- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 955 file(s); key children: README.md, _generated, app.ts, auth, auth.config.js.
+- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 957 file(s); key children: README.md, _generated, app.ts, auth, auth.config.js.
 - [`src/tests`](../../src/tests) — Focused browser-facing regression tests. Currently 9 file(s); key children: README.md, SUMMARY.md, pos, prod.
 - [`src/test`](../../src/test) — Package test harness helpers and setup. Currently 1 file(s); key children: setup.ts.
 

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -58,6 +58,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`convex/emails/PosTerminalHealthAlert.test.tsx`](../../convex/emails/PosTerminalHealthAlert.test.tsx)
 - [`convex/emails/RegisterCloseoutVarianceAlert.test.tsx`](../../convex/emails/RegisterCloseoutVarianceAlert.test.tsx)
 - [`convex/emails/ReportVerificationAlert.test.tsx`](../../convex/emails/ReportVerificationAlert.test.tsx)
+- [`convex/emails/StaleDailyCloseAlert.test.tsx`](../../convex/emails/StaleDailyCloseAlert.test.tsx)
 - [`convex/emails/WalkthroughRequestNotification.test.tsx`](../../convex/emails/WalkthroughRequestNotification.test.tsx)
 - [`convex/emails/WeeklyManagerReport.test.tsx`](../../convex/emails/WeeklyManagerReport.test.tsx)
 - [`convex/http/domains/core/routes/bannerMessage.test.ts`](../../convex/http/domains/core/routes/bannerMessage.test.ts)

--- a/telemetry/delivery-runs/2026-08-14T10-07-14-993Z-codex-stale-eod-manager-email.json
+++ b/telemetry/delivery-runs/2026-08-14T10-07-14-993Z-codex-stale-eod-manager-email.json
@@ -1,0 +1,33 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-08-14T10:07:14.993Z",
+  "branch": "codex/stale-eod-manager-email",
+  "headSha": "25d73408e3fe0e0b028f2c5affc02594b9860499",
+  "deliverableDiffFingerprint": "ae53a0e83dda3f8c3ebcafe871cce5babefc5f2fb3486c990ce6b5afc13cbc29",
+  "status": "pass",
+  "proofState": "proof_recorded",
+  "summary": {
+    "commandCount": 5,
+    "failedCommandCount": 0,
+    "duplicateCommandCount": 0,
+    "duplicatePackageSuiteCount": 0,
+    "providerSkippedCount": 6,
+    "gateDecisionCount": 2,
+    "totalDurationMs": 745263.2063729999
+  },
+  "reviewLoop": {
+    "providerId": "ce-code-review",
+    "runId": "20260814-055500-final",
+    "finalPassId": "final-25d73408",
+    "recordedAt": "2026-08-14T09:54:49.561Z",
+    "iterationCount": 4,
+    "findingCounts": {
+      "P0": 0,
+      "P1": 0,
+      "P2": 0,
+      "P3": 0
+    },
+    "deferredExpansionCount": 0,
+    "deferredIssueIds": []
+  }
+}


### PR DESCRIPTION
## Summary

Daily Close can now finish when only operational-work membership is capped, while preserving explicit incomplete evidence and every safely observed handoff. Days that remain open for 2 days emit a deduplicated, manager-facing EOD alert through the existing notification rail with live blocker context and one EOD Review action.

The stale sweep remains bounded and recoverable: it rotates the 3-date attempt window, paginates enabled policies, isolates store failures, schedules continuations before page work, and re-arms no-recipient alerts without duplicating messages already sent.

## Why

Open operational work is designed to carry forward, but the previous shared read cap treated saturation like missing financial evidence and could indefinitely quarantine an otherwise closable day. The stale escalation also stopped at an internal operational event, leaving configured EOD recipients without a direct review prompt.

This keeps financial and transactional sources fail-closed, preserves saturation provenance, and routes communication through Athena's durable subscription, dedupe, retry, and send-time suppression machinery.

## Validation

- `bun run pr:athena` passed with reusable pre-push proof.
- Broad Athena coverage and repo suites passed, including 946 root harness tests.
- Final required review set passed with 0 actionable findings.
- Focused regression coverage includes 500/501 saturation boundaries, opening handoffs and resolution, stale intent recovery, mixed-recipient dedupe, fair rotation, same-page failure isolation, and paginated policy continuation.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)

https://linear.app/v26-labs/issue/V26-1225/alert-managers-when-daily-close-remains-stale
